### PR TITLE
chore: document branch protection rules

### DIFF
--- a/.claude/AGENTS.md
+++ b/.claude/AGENTS.md
@@ -51,9 +51,17 @@
 
 ## Git Workflow
 
+### Branch Protection
+
+**`main` branch is protected. All changes must go through pull requests.**
+
+- Direct pushes to `main` are blocked
+- All work happens on feature branches
+- PRs required even for solo development
+
 ### Branch Strategy
 
-**Always work on feature branches, never directly on `main`.**
+**Always work on feature branches.**
 
 ```bash
 # Create a new feature branch


### PR DESCRIPTION
## Summary
Update AGENTS.md to document that `main` is protected and all work must go through PRs.

## Changes
- Add "Branch Protection" section to Git Workflow
- Document that direct pushes to main are blocked
- Clarify PRs required even for solo development

## Next Step
After merging, enable branch protection on `main` via GitHub settings:
- Settings > Branches > Add rule
- Branch name pattern: `main`
- Check "Require a pull request before merging"

🤖 Generated with [Claude Code](https://claude.com/claude-code)