### PR TITLE
fix: configure Vercel for Nx monorepo build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "npx nx run maple-spruce:build",
+  "outputDirectory": "apps/maple-spruce/.next",
+  "installCommand": "npm install",
+  "framework": "nextjs"
+}


### PR DESCRIPTION
## Problem
Vercel was running npm install only in `apps/maple-spruce`, missing the `@nx/next` dependency at the root.

## Fix
- Add `vercel.json` at repo root with:
  - `buildCommand`: `npx nx run maple-spruce:build`
  - `outputDirectory`: `apps/maple-spruce/.next`
  - `installCommand`: `npm install`

## Required Vercel Setting Change
In Vercel project settings, change **Root Directory** from `apps/maple-spruce` to `.` (root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)