### PR TITLE
chore: switch to Workload Identity Federation for CI/CD

### DIFF
--- a/.claude/AGENTS.md
+++ b/.claude/AGENTS.md
@@ -100,7 +100,7 @@ See SESSION.md and [issue #3 comment](https://github.com/Maple-and-Spruce/maple-
 
 - **PR Build Check**: `.github/workflows/build-check.yml` - Builds web app and functions on every PR
 - **Functions Deploy**: `.github/workflows/firebase-functions-merge.yml` - Deploys only affected functions on merge to main
-- **Required Secret**: `FIREBASE_GCP_SA_KEY` - Service account JSON for Firebase deployment
+- **Auth**: Workload Identity Federation (keyless) - no secrets required
 
 ### External Dependencies
 

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -32,7 +32,24 @@
       "Bash(npx nx show:*)",
       "Bash(pkill:*)",
       "Bash(ls:*)",
-      "Bash(gh pr view:*)"
+      "Bash(gh pr view:*)",
+      "Bash(gcloud:*)",
+      "Bash(brew:*)",
+      "Bash(export PATH=\"/private/tmp/google-cloud-sdk/bin:$PATH\")",
+      "Bash(/bin/zsh -l -c \"gcloud --version\")",
+      "Bash(/usr/bin/head:*)",
+      "Bash(/usr/bin/grep:*)",
+      "Bash(/bin/mv:*)",
+      "Bash(/usr/bin/sed:*)",
+      "Bash(~/google-cloud-sdk/bin/gcloud --version)",
+      "Bash(~/google-cloud-sdk/bin/gcloud auth list)",
+      "Bash(~/google-cloud-sdk/bin/gcloud config set project maple-and-spruce)",
+      "Bash(~/google-cloud-sdk/bin/gcloud iam workload-identity-pools create \"github-pool\" --project=\"maple-and-spruce\" --location=\"global\" --display-name=\"GitHub Actions Pool\")",
+      "Bash(~/google-cloud-sdk/bin/gcloud iam workload-identity-pools providers create-oidc:*)",
+      "Bash(~/google-cloud-sdk/bin/gcloud iam service-accounts create \"github-deployer\" --project=\"maple-and-spruce\" --display-name=\"GitHub Deployer\")",
+      "Bash(~/google-cloud-sdk/bin/gcloud projects add-iam-policy-binding:*)",
+      "Bash(/usr/bin/tail:*)",
+      "Bash(~/google-cloud-sdk/bin/gcloud iam service-accounts add-iam-policy-binding:*)"
     ]
   }
 }

--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -129,6 +129,9 @@ jobs:
       needs.prepare_and_build.outputs.matrix != '' &&
       toJson(fromJson(needs.prepare_and_build.outputs.matrix).include) != '[]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       max-parallel: 1
       matrix: ${{ fromJson(needs.prepare_and_build.outputs.matrix) }}
@@ -136,6 +139,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/138840458966/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
+          service_account: 'github-deployer@maple-and-spruce.iam.gserviceaccount.com'
+          create_credentials_file: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -155,13 +166,8 @@ jobs:
         run: npm ci
 
       - name: Deploy functions group
-        id: deploy
         if: matrix.functions != ''
-        uses: w9jds/firebase-action@v13.16.0
-        with:
-          args: deploy --only ${{ matrix.functions }}
-        env:
-          GCP_SA_KEY: ${{ secrets.FIREBASE_GCP_SA_KEY }}
+        run: npx firebase-tools deploy --only ${{ matrix.functions }} --project maple-and-spruce
 
       - name: Skip empty function group
         if: matrix.functions == ''


### PR DESCRIPTION
## Summary
Switches from service account key authentication to Workload Identity Federation (WIF) for Firebase Functions deployment.

## Changes
- Use `google-github-actions/auth@v2` with OIDC token exchange
- No secrets required in GitHub repository
- More secure than long-lived service account keys

## WIF Setup Complete
- Workload Identity Pool: `github-pool`
- Provider: `github-provider` (restricted to this repo)
- Service Account: `github-deployer@maple-and-spruce.iam.gserviceaccount.com`
- Roles: `cloudfunctions.developer`, `firebase.admin`

🤖 Generated with [Claude Code](https://claude.ai/code)