### PR TITLE
fix: use gcloud access token for Firebase deploy

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -148,6 +148,9 @@ jobs:
           service_account: 'github-deployer@maple-and-spruce.iam.gserviceaccount.com'
           create_credentials_file: true
 
+      - name: Setup gcloud CLI
+        uses: google-github-actions/setup-gcloud@v2
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -167,7 +170,7 @@ jobs:
 
       - name: Deploy functions group
         if: matrix.functions != ''
-        run: npx firebase-tools deploy --only ${{ matrix.functions }} --project maple-and-spruce
+        run: npx firebase-tools deploy --only ${{ matrix.functions }} --project maple-and-spruce --token "$(gcloud auth print-access-token)"
 
       - name: Skip empty function group
         if: matrix.functions == ''


### PR DESCRIPTION
## Summary
Fixes Firebase deploy authentication failure in CI/CD pipeline.

## Problem
The deploy step was failing with:
```
Error: Failed to authenticate, have you run firebase login?
```

Firebase-tools doesn't automatically use the Workload Identity Federation credentials from the `GOOGLE_APPLICATION_CREDENTIALS` environment variable set by `google-github-actions/auth`.

## Solution
- Add `google-github-actions/setup-gcloud` step to configure the gcloud CLI
- Use `gcloud auth print-access-token` to get an access token from the WIF credentials
- Pass the token to firebase-tools via the `--token` flag

## References
- [google-github-actions/auth#307](https://github.com/google-github-actions/auth/issues/307)
- [firebase-tools#3926](https://github.com/firebase/firebase-tools/issues/3926)

## Testing
- CI build check should pass
- Once merged, the deploy workflow should authenticate successfully