### PR TITLE
fix: use codebase prefix in function deploy filter

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -75,7 +75,7 @@ jobs:
               if [ ! -z "$GROUP_FUNCTIONS" ]; then
                 GROUP_FUNCTIONS+=","
               fi
-              GROUP_FUNCTIONS+="functions:${FUNCTIONS[START+j]}"
+              GROUP_FUNCTIONS+="functions:maple-functions:${FUNCTIONS[START+j]}"
             done
 
             # Only add non-empty groups


### PR DESCRIPTION
## Summary
Fixes the "No function matches given --only filters" error during deploy.

## Problem
Firebase-tools with codebase configuration requires the codebase name in the filter:
```
functions:maple-functions:functionName  ✓
functions:functionName                   ✗
```

## Solution
Updated the matrix generation to include the codebase prefix `maple-functions:` in the function filter.

## References
- [firebase/firebase-tools#6008](https://github.com/firebase/firebase-tools/issues/6008)

## Testing
- Tested locally: `firebase deploy --only functions:maple-functions:getArtists` works