### PR TITLE
fix: add --force flag to deploy and redeploy getArtists to us-east4

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Deploy functions group
         if: matrix.functions != ''
-        run: npx firebase-tools deploy --only ${{ matrix.functions }} --project maple-and-spruce --token "$(gcloud auth print-access-token)"
+        run: npx firebase-tools deploy --only ${{ matrix.functions }} --project maple-and-spruce --force --token "$(gcloud auth print-access-token)"
 
       - name: Skip empty function group
         if: matrix.functions == ''

--- a/libs/firebase/maple-functions/get-artists/src/lib/get-artists.ts
+++ b/libs/firebase/maple-functions/get-artists/src/lib/get-artists.ts
@@ -2,7 +2,7 @@
  * Get Artists Cloud Function
  *
  * Retrieves all artists, optionally filtered by status.
- * Deployed via CI/CD pipeline with codebase filtering.
+ * Deployed to us-east4 via CI/CD pipeline.
  */
 import { createAuthenticatedFunction } from '@maple/firebase/functions';
 import { ArtistRepository } from '@maple/firebase/database';


### PR DESCRIPTION
## Summary
- Adds `--force` flag to firebase deploy to automatically set up cleanup policy for container images
- Triggers redeploy of `getArtists` function to move it from us-central1 to us-east4

## Test plan
- [ ] CI build passes
- [ ] Functions deploy without cleanup policy error
- [ ] getArtists deploys to us-east4

🤖 Generated with [Claude Code](https://claude.com/claude-code)