### PR TITLE
fix: add vest dependency to functions package.json

### DIFF
--- a/apps/functions/package.json
+++ b/apps/functions/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "firebase-admin": "^13.0.0",
-    "firebase-functions": "^6.0.0"
+    "firebase-functions": "^6.0.0",
+    "vest": "^5.5.1"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `vest` validation library to the functions package.json
- Fixes "Cannot find module 'vest'" runtime error in Cloud Functions

## Root cause
The vest library was being imported in the validation code that gets bundled into the functions, but vest wasn't listed as a dependency in the deployed package.json, so it wasn't installed at runtime.

## Test plan
- [ ] CI build passes
- [ ] getArtists function deploys successfully to us-east4
- [ ] Function starts without module errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)