### PR TITLE
fix: auto-generate functions package.json with dependencies

### DIFF
--- a/apps/functions/project.json
+++ b/apps/functions/project.json
@@ -12,21 +12,14 @@
         "outputPath": "dist/apps/functions",
         "main": "apps/functions/src/index.ts",
         "tsConfig": "apps/functions/tsconfig.app.json",
-        "generatePackageJson": false,
+        "generatePackageJson": true,
         "platform": "node",
         "bundle": true,
         "thirdParty": false,
         "dependenciesFieldType": "dependencies",
         "target": "node20",
         "format": ["cjs"],
-        "outputFileName": "index.js",
-        "assets": [
-          {
-            "input": "apps/functions",
-            "glob": "package.json",
-            "output": "."
-          }
-        ],
+        "outputFileName": "index.cjs",
         "esbuildOptions": {
           "sourcemap": true,
           "logLevel": "info"


### PR DESCRIPTION
## Summary
- Sets `generatePackageJson: true` in functions build config
- Removes manual assets copy of static package.json
- Nx will now auto-detect all required dependencies from imports

## Why
The previous approach required manually maintaining dependencies in a static package.json. This caused the "Cannot find module 'vest'" error because vest wasn't listed.

With `generatePackageJson: true`, Nx analyzes the imports and automatically includes all needed dependencies in the generated package.json.

## Test plan
- [ ] CI build passes
- [ ] Generated package.json includes vest and other dependencies
- [ ] Functions deploy successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)