### PR TITLE
chore: add Next.js API rewrites to proxy to Firebase Functions

### DIFF
--- a/.claude/SESSION.md
+++ b/.claude/SESSION.md
@@ -34,11 +34,23 @@ See [issue #3 comment](https://github.com/Maple-and-Spruce/maple-and-spruce/issu
 
 | Service | URL | Notes |
 |---------|-----|-------|
-| **Vercel** | (check Vercel dashboard) | Auto-deploys on push to main |
+| **Vercel** | mapleandsprucefolkarts.com | Web app + API proxy, auto-deploys on push to main |
 | **Firebase Functions** | `us-east4` | Auto-deploys on merge to main via GitHub Actions |
 
-**Why Vercel instead of Firebase App Hosting?**
-Firebase App Hosting requires a billing account (Blaze plan). Using Vercel free tier until business checking account is set up. The `apphosting.yaml` is ready for when we switch.
+### Domains
+
+| Domain | Status | Target |
+|--------|--------|--------|
+| mapleandsprucefolkarts.com | ✅ Configured | Vercel (web app) |
+| www.mapleandsprucefolkarts.com | ✅ Configured | Vercel (web app) |
+| mapleandsprucewv.com | Owned (Namecheap) | Redirect to primary (future) |
+
+### Architecture
+
+- **Vercel** hosts the Next.js web app and handles API routing
+- Next.js rewrites `/api/*` requests to Firebase Functions (`us-east4-maple-and-spruce.cloudfunctions.net`)
+- API calls use `www.mapleandsprucefolkarts.com/api/getArtists` etc.
+- No separate Firebase Hosting needed - Vercel handles everything
 
 ### Firebase Functions (us-east4)
 

--- a/apps/maple-spruce/next.config.js
+++ b/apps/maple-spruce/next.config.js
@@ -8,6 +8,9 @@ const path = require('path');
 /**
  * @type {import('@nx/next/plugins/with-nx').WithNxOptions}
  **/
+// Firebase Functions base URL
+const FUNCTIONS_BASE_URL = process.env.FUNCTIONS_BASE_URL || 'https://us-east4-maple-and-spruce.cloudfunctions.net';
+
 const nextConfig = {
   nx: {
     svgr: false,
@@ -18,6 +21,15 @@ const nextConfig = {
   // Type checking runs separately via `npx tsc --noEmit` or during dev
   typescript: {
     ignoreBuildErrors: true,
+  },
+  // Rewrite /api/* to Firebase Functions
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${FUNCTIONS_BASE_URL}/:path*`,
+      },
+    ];
   },
   // Transpile workspace packages
   transpilePackages: [


### PR DESCRIPTION
## Summary
- Add rewrites in next.config.js to route `/api/*` to Firebase Functions
- Allows clean URLs like `mapleandsprucefolkarts.com/api/getArtists`
- No separate Firebase Hosting needed - Vercel handles API proxy

## Changes
- `apps/maple-spruce/next.config.js` - Add rewrites configuration
- `.claude/SESSION.md` - Update domain and architecture documentation

## Test plan
- [ ] Verify Vercel build succeeds
- [ ] Test API calls through `/api/*` routes after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)