### PR TITLE
fix: configure Firebase Functions SDK to use us-east4 region

### DIFF
--- a/libs/ts/firebase/firebase-config/src/lib/maple-functions.ts
+++ b/libs/ts/firebase/firebase-config/src/lib/maple-functions.ts
@@ -3,9 +3,12 @@ import { getMapleApp } from './maple-app';
 
 let _mapleFunctions: ReturnType<typeof getFunctions> | undefined;
 
+// Functions are deployed to us-east4 (Northern Virginia - close to WV business)
+const FUNCTIONS_REGION = 'us-east4';
+
 export const getMapleFunctions = () => {
   if (!_mapleFunctions) {
-    _mapleFunctions = getFunctions(getMapleApp());
+    _mapleFunctions = getFunctions(getMapleApp(), FUNCTIONS_REGION);
 
     // Connect to local functions in development
     if (


### PR DESCRIPTION
## Summary
The Firebase SDK defaults to `us-central1` for Cloud Functions, but our functions are deployed to `us-east4`. This caused 404 errors when calling functions from the frontend.

## Changes
- Add `FUNCTIONS_REGION = 'us-east4'` to `getMapleFunctions()` configuration

## Root Cause
The `getFunctions()` call wasn't specifying a region, so it defaulted to `us-central1` while our functions are in `us-east4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)