### PR TITLE
fix: allow public HTTP access to Cloud Functions v2

### DIFF
--- a/libs/firebase/functions/src/lib/functions.utility.ts
+++ b/libs/firebase/functions/src/lib/functions.utility.ts
@@ -63,7 +63,15 @@ export function createFunction<TRequest, TResponse>(
   handler: (data: TRequest, context: FunctionContext) => Promise<TResponse>,
   options: FunctionOptions = {}
 ) {
-  return onCall({ region: 'us-east4' }, async (request: CallableRequest<TRequest>): Promise<TResponse> => {
+  return onCall(
+    {
+      region: 'us-east4',
+      // Allow CORS from all origins - Firebase SDK handles authentication
+      cors: true,
+      // Allow unauthenticated HTTP access - Firebase Auth is handled separately in the function
+      invoker: 'public',
+    },
+    async (request: CallableRequest<TRequest>): Promise<TResponse> => {
     const context: FunctionContext = {
       uid: request.auth?.uid,
       email: request.auth?.token?.email,


### PR DESCRIPTION
## Summary
Cloud Functions v2 require IAM invoker permissions by default, causing 403 errors when called from the browser.

## Changes
- Add `invoker: 'public'` to function options to allow unauthenticated HTTP access
- Add `cors: true` to handle CORS preflight requests

## Why This Is Safe
Firebase Auth is still enforced within the function logic via `createAuthenticatedFunction` and `createAdminFunction`. The IAM-level public access just allows the HTTP request to reach the function - user authentication is validated inside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)