### PR TITLE
fix: remove localhost from production CORS origins

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,1 @@
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:4200,http://127.0.0.1:3000,http://127.0.0.1:4200

--- a/.env.prod
+++ b/.env.prod
@@ -1,0 +1,1 @@
+ALLOWED_ORIGINS=https://www.mapleandsprucefolkarts.com,https://mapleandsprucefolkarts.com,https://www.mapleandsprucewv.com,https://mapleandsprucewv.com,https://maple-and-spruce-maple-spruce.vercel.app

--- a/libs/firebase/functions/src/lib/functions.utility.ts
+++ b/libs/firebase/functions/src/lib/functions.utility.ts
@@ -8,26 +8,18 @@
  * @see https://github.com/MountainSOLSchool/platform/blob/main/libs/firebase/functions/src/lib/utilities/functions.utility.ts
  */
 import { onRequest } from 'firebase-functions/v2/https';
+import { defineString } from 'firebase-functions/params';
 import type { Request } from 'firebase-functions/v2/https';
 import type { Response } from 'express';
 import { Role, hasRole } from './auth.utility';
 import { getAuth } from 'firebase-admin/auth';
 
-// Allowed origins for CORS
-// In production, this includes the Vercel domains
-// In development, localhost is allowed
-const ALLOWED_ORIGINS = [
-  // Production domains
-  'https://www.mapleandsprucefolkarts.com',
-  'https://mapleandsprucefolkarts.com',
-  'https://www.mapleandsprucewv.com',
-  'https://mapleandsprucewv.com',
-  // Vercel preview deployments
-  'https://maple-and-spruce-maple-spruce.vercel.app',
-  // Development
-  'http://localhost:3000',
-  'http://localhost:4200',
-];
+// Allowed origins for CORS - configured via Firebase environment
+// Set via: firebase functions:config:set or .env files
+// Production should NOT include localhost
+const ALLOWED_ORIGINS = defineString('ALLOWED_ORIGINS', {
+  default: 'https://www.mapleandsprucefolkarts.com,https://mapleandsprucefolkarts.com,https://www.mapleandsprucewv.com,https://mapleandsprucewv.com,https://maple-and-spruce-maple-spruce.vercel.app',
+});
 
 /**
  * CORS middleware - handles preflight and validates origins
@@ -45,7 +37,9 @@ const corsMiddleware = (
     return;
   }
 
-  if (ALLOWED_ORIGINS.includes(origin)) {
+  const allowedOrigins = ALLOWED_ORIGINS.value().split(',').map((o) => o.trim());
+
+  if (allowedOrigins.includes(origin)) {
     res.setHeader('Access-Control-Allow-Origin', origin);
     res.setHeader(
       'Access-Control-Allow-Methods',


### PR DESCRIPTION
## Summary
Security fix: localhost should not be allowed in production CORS origins as it could allow malicious local sites to make authenticated requests if a user is logged in.

## Changes
- Use `defineString` for `ALLOWED_ORIGINS` (Firebase params)
- Add `.env.prod` with production domains only (no localhost)
- Add `.env.dev` with localhost for development
- Default value excludes localhost (safe by default)

## Following Mountain SOL Pattern
Mountain SOL uses separate `.env.dev` and `.env.prod` files for this exact reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)