### PR TITLE
fix: copy .env.prod to dist for Firebase Functions deploy

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -104,6 +104,10 @@ jobs:
         if: steps.get_affected.outputs.has_changes == 'true'
         run: npx nx run functions:build
 
+      - name: Copy env file to dist
+        if: steps.get_affected.outputs.has_changes == 'true'
+        run: cp .env.prod dist/apps/functions/.env
+
       - name: Cache node_modules for deploy
         if: steps.get_affected.outputs.has_changes == 'true'
         uses: actions/cache/save@v4
@@ -120,6 +124,7 @@ jobs:
             dist/apps/functions/index.cjs
             dist/apps/functions/index.cjs.map
             dist/apps/functions/package.json
+            dist/apps/functions/.env
           retention-days: 1
 
   deploy:


### PR DESCRIPTION
## Summary
Firebase Functions deploy was failing with:
```
Error: In non-interactive mode but have no value for the following environment variables: ALLOWED_ORIGINS
```

Firebase looks for `.env` files in the functions source directory (`dist/apps/functions`), not the repo root.

## Fix
- Copy `.env.prod` to `dist/apps/functions/.env` during build
- Include `.env` in the upload artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)