### PR TITLE
chore: add env files to Nx affected calculation for functions

### DIFF
--- a/libs/firebase/functions/project.json
+++ b/libs/firebase/functions/project.json
@@ -4,6 +4,9 @@
   "sourceRoot": "libs/firebase/functions/src",
   "projectType": "library",
   "tags": ["scope:firebase", "type:util"],
+  "namedInputs": {
+    "default": ["{projectRoot}/**/*", "functionsEnv"]
+  },
   "targets": {
     "build": {
       "executor": "@nx/js:tsc",

--- a/libs/firebase/functions/src/lib/functions.utility.ts
+++ b/libs/firebase/functions/src/lib/functions.utility.ts
@@ -4,6 +4,9 @@
  * Provides a consistent pattern for creating HTTP functions with
  * CORS handling, authentication, and authorization.
  *
+ * Uses onRequest (HTTP functions) with manual CORS middleware for full
+ * control over CORS headers and preflight handling.
+ *
  * Pattern adapted from Mountain Sol Platform:
  * @see https://github.com/MountainSOLSchool/platform/blob/main/libs/firebase/functions/src/lib/utilities/functions.utility.ts
  */

--- a/nx.json
+++ b/nx.json
@@ -3,7 +3,8 @@
   "namedInputs": {
     "default": ["{projectRoot}/**/*", "sharedGlobals"],
     "production": ["default"],
-    "sharedGlobals": []
+    "sharedGlobals": [],
+    "functionsEnv": ["{workspaceRoot}/.env.prod", "{workspaceRoot}/.env.dev"]
   },
   "sync": {
     "applyChanges": false,


### PR DESCRIPTION
## Summary
- Add `functionsEnv` namedInput to `nx.json` for `.env.prod` and `.env.dev`
- Configure `firebase-functions` library to include env files in its inputs
- This ensures changes to environment files trigger function redeployments via the Nx affected calculation

## Background
Previously, changes to `.env.prod` (like adding CORS origins) wouldn't trigger function deployments because Nx's affected calculation only looks at project dependencies, not external files.

Now, the `firebase-functions` utility library depends on these env files. Since all `firebase-maple-functions-*` libraries depend on `firebase-functions`, they'll all be marked as affected when env files change.

## Test plan
- [x] Verified locally with `npx nx show projects --affected` - all 10 function libraries show as affected
- [ ] Merge will trigger function deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)