### PR TITLE
fix: include hidden files in artifact upload for .env

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -125,6 +125,7 @@ jobs:
             dist/apps/functions/index.cjs.map
             dist/apps/functions/package.json
             dist/apps/functions/.env
+          include-hidden-files: true
           retention-days: 1
 
   deploy:


### PR DESCRIPTION
## Summary
By default, `actions/upload-artifact@v4` excludes dotfiles (hidden files). Add `include-hidden-files: true` to ensure `.env` is uploaded with build artifacts for Firebase Functions deployment.

## Root Cause
The previous deploy failed because the `.env` file was not included in the artifact upload (only 3 files were uploaded instead of 4). Firebase Functions needs this file to read the `ALLOWED_ORIGINS` environment variable for CORS configuration.

## Test plan
- [ ] Merge will trigger function deployment with .env file included
- [ ] Functions should deploy successfully with CORS configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)