### PR TITLE
fix: add invoker: 'public' to make functions publicly accessible

### DIFF
--- a/libs/firebase/functions/src/lib/functions.utility.ts
+++ b/libs/firebase/functions/src/lib/functions.utility.ts
@@ -136,6 +136,8 @@ export function createFunction<TRequest, TResponse>(
   return onRequest(
     {
       region: 'us-east4',
+      // Allow public HTTP access - we handle auth via Firebase tokens in headers
+      invoker: 'public',
     },
     async (req: Request, res: Response) => {
       // Handle CORS


### PR DESCRIPTION
## Summary
Add `invoker: 'public'` to onRequest options to explicitly allow public HTTP access to Cloud Functions.

## Background
The GitHub deployer service account has `roles/functions.developer` but not `roles/functions.admin`, so it cannot set IAM policies on Cloud Run services. This caused the previous deploy to fail with:

```
Failed to set the IAM Policy on the Service projects/maple-and-spruce/locations/us-east4/services/...
Unable to set the invoker for the IAM policy on the following functions
```

By adding explicit `invoker: 'public'` in the function definition, Firebase can set the correct IAM policy during deployment without requiring additional permissions.

## Security
We handle authentication via Firebase tokens in request headers (Authorization: Bearer <token>), so public HTTP access is fine. The CORS middleware restricts origins, and the auth middleware verifies tokens before allowing access to protected operations.

## Test plan
- [ ] Functions deploy successfully
- [ ] CORS works from production domains
- [ ] Authentication still works (protected functions require valid token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)