### PR TITLE
fix: correct function names in Firebase Hosting rewrites

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -17,16 +17,17 @@
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "rewrites": [
       { "source": "/getArtists", "function": "getArtists" },
-      { "source": "/getArtistById", "function": "getArtistById" },
+      { "source": "/getArtist", "function": "getArtist" },
       { "source": "/createArtist", "function": "createArtist" },
       { "source": "/updateArtist", "function": "updateArtist" },
       { "source": "/deleteArtist", "function": "deleteArtist" },
       { "source": "/getProducts", "function": "getProducts" },
-      { "source": "/getProductById", "function": "getProductById" },
+      { "source": "/getProduct", "function": "getProduct" },
       { "source": "/createProduct", "function": "createProduct" },
       { "source": "/updateProduct", "function": "updateProduct" },
       { "source": "/deleteProduct", "function": "deleteProduct" },
-      { "source": "/uploadArtistImage", "function": "uploadArtistImage" }
+      { "source": "/uploadArtistImage", "function": "uploadArtistImage" },
+      { "source": "/healthCheck", "function": "healthCheck" }
     ]
   },
   "emulators": {


### PR DESCRIPTION
## Summary
Fix function names in Firebase Hosting rewrites to match actual exports.

## Changes
- `getArtistById` → `getArtist`
- `getProductById` → `getProduct`  
- Add `healthCheck` endpoint

## Context
The organization policy has been updated to allow public Cloud Run access, so new function deployments will now succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)