### PR TITLE
fix: restore invoker: 'public' for automatic public access on new functions

### DIFF
--- a/libs/firebase/functions/src/lib/functions.utility.ts
+++ b/libs/firebase/functions/src/lib/functions.utility.ts
@@ -136,9 +136,9 @@ export function createFunction<TRequest, TResponse>(
   return onRequest(
     {
       region: 'us-east4',
-      // Note: We don't set invoker: 'public' because the org policy restricts it.
-      // Instead, we use Firebase Hosting rewrites to proxy requests to functions.
-      // Firebase Hosting handles the public access layer.
+      // Allow public HTTP access - we handle auth via Firebase tokens in headers.
+      // The org policy was updated to allow allUsers as Cloud Run invokers.
+      invoker: 'public',
     },
     async (req: Request, res: Response) => {
       // Handle CORS


### PR DESCRIPTION
## Summary
Restore `invoker: 'public'` option to ensure new functions are automatically publicly accessible.

## Background
The Google Workspace organization policy (`iam.allowedPolicyMemberDomains`) was reset to allow all members at the project level. This means we can now use `invoker: 'public'` which will automatically set `allUsers` as a Cloud Run invoker when deploying new functions.

## Why This Matters
Without this, every new function would require manual IAM configuration after deployment. With this setting, new functions work automatically.

## Test plan
- [x] Org policy updated: `allowAll: true`
- [x] Existing functions work via Firebase Hosting
- [ ] New function deployment will verify `invoker: 'public'` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)