### PR TITLE
fix: ensure Firebase Admin is initialized in auth.utility.ts

### DIFF
--- a/libs/firebase/functions/src/lib/auth.utility.ts
+++ b/libs/firebase/functions/src/lib/auth.utility.ts
@@ -6,7 +6,14 @@
  * Pattern adapted from Mountain Sol Platform:
  * @see https://github.com/MountainSOLSchool/platform/blob/main/libs/firebase/functions/src/lib/utilities/auth.utility.ts
  */
+import admin from 'firebase-admin';
 import { getFirestore } from 'firebase-admin/firestore';
+
+// Ensure Firebase Admin is initialized before using getFirestore()
+// This is needed because auth.utility may be imported before the database module
+if (admin.apps.length === 0) {
+  admin.initializeApp();
+}
 
 /**
  * Roles available in the system


### PR DESCRIPTION
## Summary
- Fix "Missing or insufficient permissions" error in deployed functions
- Add explicit Firebase Admin initialization in `auth.utility.ts`

## Problem
The `auth.utility.ts` module uses `getFirestore()` directly from `firebase-admin/firestore`, but it could be imported before the database module (which initializes the Firebase Admin app). This caused `getFirestore()` to fail with a permissions error because no app was initialized yet.

## Solution
Add the same initialization pattern used in `database.config.ts`:
```typescript
if (admin.apps.length === 0) {
  admin.initializeApp();
}
```

This ensures the Firebase Admin app is ready before any Firestore operations during auth checks.

## Test plan
- [ ] Merge and let CI deploy functions
- [ ] Verify the production web app no longer shows "Missing or insufficient permissions" error
- [ ] Test authenticated endpoints (getArtists, getProducts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)