### PR TITLE
fix: include env files in functions affected graph

### DIFF
--- a/apps/functions/project.json
+++ b/apps/functions/project.json
@@ -7,6 +7,7 @@
   "targets": {
     "build": {
       "executor": "@nx/esbuild:esbuild",
+      "inputs": ["default", "functionsEnv"],
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/apps/functions",


### PR DESCRIPTION
## Summary
Changes to `.env.prod` or `.env.dev` now trigger function rebuilds in the Nx affected graph.

## Problem
The PR #63 changed CORS origins in `.env.prod` but functions didn't redeploy because env files weren't tracked as inputs to the functions build.

## Solution
Added `functionsEnv` named input to the functions build target. This input was already defined in `nx.json` but wasn't being used.

## Testing
- Verified with `nx show project functions --json` that inputs now include `functionsEnv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)