### PR TITLE
fix: deploy all functions when env files change

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -37,10 +37,24 @@ jobs:
       - name: Get affected functions
         id: get_affected
         run: |
-          # Get affected libraries comparing to previous commit
-          AFFECTED=$(npx nx show projects --affected --base=${{ steps.base.outputs.commit }} | grep 'firebase-maple-functions-' || true)
+          # Get all affected projects comparing to previous commit
+          ALL_AFFECTED=$(npx nx show projects --affected --base=${{ steps.base.outputs.commit }})
+
+          # Check if the functions app itself is affected (e.g., env file changes)
+          FUNCTIONS_APP_AFFECTED=$(echo "$ALL_AFFECTED" | grep '^functions$' || true)
+
+          # Get affected function libraries
+          AFFECTED_LIBS=$(echo "$ALL_AFFECTED" | grep 'firebase-maple-functions-' || true)
 
           FUNCTIONS=()
+
+          # If the functions app is affected but no specific libraries, deploy all functions
+          if [ -n "$FUNCTIONS_APP_AFFECTED" ] && [ -z "$AFFECTED_LIBS" ]; then
+            echo "Functions app affected (likely env change) - deploying all functions"
+            # Get all function libraries
+            AFFECTED_LIBS=$(npx nx show projects | grep 'firebase-maple-functions-' || true)
+          fi
+
           while IFS= read -r lib; do
             # Skip empty lines
             [ -z "$lib" ] && continue
@@ -49,7 +63,7 @@ jobs:
             # Convert kebab-case to camelCase
             FUNC_NAME=$(echo "$FUNC_NAME" | awk -F'-' '{for(i=1;i<=NF;i++){if(i==1){printf("%s",$i)}else{printf("%s%s",toupper(substr($i,1,1)),substr($i,2))}}}')
             FUNCTIONS+=("$FUNC_NAME")
-          done <<< "$AFFECTED"
+          done <<< "$AFFECTED_LIBS"
 
           if [ ${#FUNCTIONS[@]} -eq 0 ]; then
             echo "No functions were affected"


### PR DESCRIPTION
## Summary
Fix the CI/CD workflow to deploy all functions when `.env.prod` or `.env.dev` changes.

## Problem
PR #64 added env files to the functions build inputs, but the workflow only checked for affected `firebase-maple-functions-*` libraries. When only env files change, the `functions` app is affected but no individual libraries are - so nothing deployed.

## Solution
- Check if the `functions` app itself is affected
- If it is, but no specific function libraries are affected, deploy all functions
- This handles env file changes, shared utility changes, etc.

## Testing
This PR will trigger a deploy of all functions since it includes the workflow change and the functions app is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)