### PR TITLE
chore: add manual trigger to functions deploy workflow

### DIFF
--- a/.env.prod
+++ b/.env.prod
@@ -1,1 +1,2 @@
+# Production environment for Firebase Functions
 ALLOWED_ORIGINS=https://business.mapleandsprucefolkarts.com,https://business.mapleandsprucewv.com,https://maple-and-spruce-maple-spruce.vercel.app

--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      deploy_all:
+        description: 'Deploy all functions (ignore affected check)'
+        required: false
+        default: 'false'
+        type: boolean
 
 jobs:
   prepare_and_build:
@@ -37,23 +44,30 @@ jobs:
       - name: Get affected functions
         id: get_affected
         run: |
-          # Get all affected projects comparing to previous commit
-          ALL_AFFECTED=$(npx nx show projects --affected --base=${{ steps.base.outputs.commit }})
+          DEPLOY_ALL="${{ github.event.inputs.deploy_all }}"
 
-          # Check if the functions app itself is affected (e.g., env file changes)
-          FUNCTIONS_APP_AFFECTED=$(echo "$ALL_AFFECTED" | grep '^functions$' || true)
+          # If deploy_all is true (manual trigger), skip affected check
+          if [ "$DEPLOY_ALL" == "true" ]; then
+            echo "Manual deploy_all requested - deploying all functions"
+            AFFECTED_LIBS=$(npx nx show projects | grep 'firebase-maple-functions-' || true)
+          else
+            # Get all affected projects comparing to previous commit
+            ALL_AFFECTED=$(npx nx show projects --affected --base=${{ steps.base.outputs.commit }})
 
-          # Get affected function libraries
-          AFFECTED_LIBS=$(echo "$ALL_AFFECTED" | grep 'firebase-maple-functions-' || true)
+            # Check if the functions app itself is affected (e.g., env file changes)
+            FUNCTIONS_APP_AFFECTED=$(echo "$ALL_AFFECTED" | grep '^functions$' || true)
+
+            # Get affected function libraries
+            AFFECTED_LIBS=$(echo "$ALL_AFFECTED" | grep 'firebase-maple-functions-' || true)
+
+            # If the functions app is affected but no specific libraries, deploy all functions
+            if [ -n "$FUNCTIONS_APP_AFFECTED" ] && [ -z "$AFFECTED_LIBS" ]; then
+              echo "Functions app affected (likely env change) - deploying all functions"
+              AFFECTED_LIBS=$(npx nx show projects | grep 'firebase-maple-functions-' || true)
+            fi
+          fi
 
           FUNCTIONS=()
-
-          # If the functions app is affected but no specific libraries, deploy all functions
-          if [ -n "$FUNCTIONS_APP_AFFECTED" ] && [ -z "$AFFECTED_LIBS" ]; then
-            echo "Functions app affected (likely env change) - deploying all functions"
-            # Get all function libraries
-            AFFECTED_LIBS=$(npx nx show projects | grep 'firebase-maple-functions-' || true)
-          fi
 
           while IFS= read -r lib; do
             # Skip empty lines


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger with `deploy_all` option for manual deploys
- Touch `.env.prod` to trigger a full function deploy with the new CORS subdomain config

## Why
The CORS config change from PR #63 never deployed because subsequent PRs didn't affect the functions. This PR:
1. Adds manual trigger capability for the future
2. Forces a deploy now by touching the env file

🤖 Generated with [Claude Code](https://claude.com/claude-code)