### PR TITLE
refactor: simplify secrets to per-project pattern

### DIFF
--- a/libs/firebase/functions/src/lib/environment.utility.ts
+++ b/libs/firebase/functions/src/lib/environment.utility.ts
@@ -1,33 +1,29 @@
 /**
  * Environment utility for Firebase Functions
  *
- * Provides a consistent pattern for determining local vs production environment
- * and selecting the appropriate secrets/configuration.
+ * With separate Firebase projects for dev and prod, each project has its own
+ * secrets configured with the same names but different values:
+ * - Dev project (maple-and-spruce-dev): SQUARE_ACCESS_TOKEN = sandbox token
+ * - Prod project (maple-and-spruce): SQUARE_ACCESS_TOKEN = production token
  *
- * Two modes:
- * - LOCAL: Local development with sandbox/test credentials
- * - PROD: Production deployment with production credentials
+ * This eliminates the need for _PROD suffixes - the project itself determines
+ * which credentials are used.
  *
- * Pattern: Each service defines its own *_ENV string param (e.g., SQUARE_ENV)
- * that controls which credentials to use. This utility provides helpers
- * for implementing that pattern consistently.
- *
- * @example
- * ```typescript
- * // In a service class constructor:
- * const env = new ServiceEnvironment(strings.SQUARE_ENV);
- * const token = env.selectSecret(secrets, 'SQUARE_ACCESS_TOKEN');
- * ```
+ * The SQUARE_ENV string param is still used to control SDK behavior
+ * (e.g., using Square sandbox vs production API endpoints).
  */
 
 export type EnvironmentMode = 'LOCAL' | 'PROD';
 
 /**
- * Helper class for environment-aware secret/config selection
+ * Helper class for environment-aware configuration
  *
  * Two modes:
- * - LOCAL: Uses base secret names (e.g., SQUARE_ACCESS_TOKEN)
- * - PROD: Uses _PROD suffix (e.g., SQUARE_ACCESS_TOKEN_PROD)
+ * - LOCAL: Uses Square sandbox API endpoints
+ * - PROD: Uses Square production API endpoints
+ *
+ * Note: Secrets are now per-project, so no suffix selection is needed.
+ * The SQUARE_ENV only controls API endpoint selection.
  */
 export class ServiceEnvironment {
   public readonly isProd: boolean;
@@ -40,31 +36,20 @@ export class ServiceEnvironment {
   }
 
   /**
-   * Select the appropriate secret based on environment
+   * Get a secret by name
    *
-   * Convention: Production secrets have _PROD suffix
+   * With per-project secrets, we just return the secret directly.
+   * No suffix logic needed - the project determines which value is used.
    *
    * @param secrets - Record of all available secrets
-   * @param baseName - Base secret name (e.g., 'SQUARE_ACCESS_TOKEN')
-   * @returns The appropriate secret value for the current environment
+   * @param secretName - Secret name (e.g., 'SQUARE_ACCESS_TOKEN')
+   * @returns The secret value
    * @throws Error if the required secret is not found
-   *
-   * @example
-   * ```typescript
-   * const env = new ServiceEnvironment('PROD');
-   * // Returns secrets.SQUARE_ACCESS_TOKEN_PROD
-   * const token = env.selectSecret(secrets, 'SQUARE_ACCESS_TOKEN');
-   *
-   * const env2 = new ServiceEnvironment('LOCAL');
-   * // Returns secrets.SQUARE_ACCESS_TOKEN
-   * const token2 = env2.selectSecret(secrets, 'SQUARE_ACCESS_TOKEN');
-   * ```
    */
-  selectSecret<T extends Record<string, string>>(
+  getSecret<T extends Record<string, string>>(
     secrets: T,
-    baseName: string
+    secretName: string
   ): string {
-    const secretName = this.isProd ? `${baseName}_PROD` : baseName;
     const value = secrets[secretName as keyof T];
 
     if (!value) {
@@ -95,33 +80,4 @@ export class ServiceEnvironment {
   get label(): string {
     return this.isProd ? 'production' : 'local';
   }
-}
-
-/**
- * Standard secret name pairs for services
- *
- * Helper to generate the array of secret names needed for defineSecret()
- *
- * @example
- * ```typescript
- * const SQUARE_SECRETS = secretPair('SQUARE_ACCESS_TOKEN');
- * // Returns ['SQUARE_ACCESS_TOKEN', 'SQUARE_ACCESS_TOKEN_PROD']
- * ```
- */
-export function secretPair(baseName: string): [string, string] {
-  return [baseName, `${baseName}_PROD`];
-}
-
-/**
- * Flatten multiple secret pairs into a single array
- *
- * @example
- * ```typescript
- * const ALL_SECRETS = secretPairs('SQUARE_ACCESS_TOKEN', 'SQUARE_WEBHOOK_SECRET');
- * // Returns ['SQUARE_ACCESS_TOKEN', 'SQUARE_ACCESS_TOKEN_PROD',
- * //          'SQUARE_WEBHOOK_SECRET', 'SQUARE_WEBHOOK_SECRET_PROD']
- * ```
- */
-export function secretPairs(...baseNames: string[]): string[] {
-  return baseNames.flatMap((name) => secretPair(name));
 }

--- a/libs/firebase/functions/src/lib/index.ts
+++ b/libs/firebase/functions/src/lib/index.ts
@@ -42,7 +42,5 @@ export {
 // Environment utilities
 export {
   ServiceEnvironment,
-  secretPair,
-  secretPairs,
   type EnvironmentMode,
 } from './environment.utility';

--- a/libs/firebase/square/src/lib/square.utility.ts
+++ b/libs/firebase/square/src/lib/square.utility.ts
@@ -2,12 +2,15 @@
  * Square API utility
  *
  * Provides a wrapper around the Square SDK for catalog and inventory operations.
- * Follows the Mountain Sol Braintree pattern for secrets management.
+ *
+ * With separate Firebase projects for dev and prod, secrets are per-project:
+ * - Dev project (maple-and-spruce-dev): SQUARE_ACCESS_TOKEN = sandbox token
+ * - Prod project (maple-and-spruce): SQUARE_ACCESS_TOKEN = production token
  *
  * @see https://developer.squareup.com/docs/square-get-started
  */
 import { SquareClient, SquareEnvironment } from 'square';
-import { ServiceEnvironment, secretPair } from '@maple/firebase/functions';
+import { ServiceEnvironment } from '@maple/firebase/functions';
 import { CatalogService } from './catalog.service';
 import { InventoryService } from './inventory.service';
 
@@ -15,9 +18,11 @@ import { InventoryService } from './inventory.service';
  * Secret names for Firebase Functions secrets
  * Use with defineSecret() from firebase-functions/params
  *
- * Pattern: SQUARE_ACCESS_TOKEN for sandbox, SQUARE_ACCESS_TOKEN_PROD for production
+ * Each Firebase project has its own SQUARE_ACCESS_TOKEN with the appropriate value:
+ * - maple-and-spruce-dev: sandbox token
+ * - maple-and-spruce: production token
  */
-export const SQUARE_SECRET_NAMES = [...secretPair('SQUARE_ACCESS_TOKEN')] as const;
+export const SQUARE_SECRET_NAMES = ['SQUARE_ACCESS_TOKEN'] as const;
 
 /**
  * String parameter names for Firebase Functions
@@ -74,7 +79,8 @@ export class Square {
     private readonly strings: SquareStrings
   ) {
     this.env = new ServiceEnvironment(this.strings.SQUARE_ENV);
-    const accessToken = this.env.selectSecret(
+    // With per-project secrets, just get the token directly - no suffix needed
+    const accessToken = this.env.getSecret(
       this.secrets,
       'SQUARE_ACCESS_TOKEN'
     );

--- a/libs/ts/firebase/firebase-config/src/lib/maple-firebase-config.ts
+++ b/libs/ts/firebase/firebase-config/src/lib/maple-firebase-config.ts
@@ -28,17 +28,29 @@ const devConfig: FirebaseOptions = {
 
 /**
  * Determine if we're in development mode
- * - localhost or 127.0.0.1 = dev
+ * Uses environment detection based on hostname or env var:
+ * - localhost, 127.0.0.1, or *-dev.* hostname = dev
+ * - NEXT_PUBLIC_FIREBASE_ENV=dev = dev
  * - Everything else = prod
  */
 function isDevelopment(): boolean {
+  // Check environment variable first (works server and client side)
+  if (process.env['NEXT_PUBLIC_FIREBASE_ENV'] === 'dev') {
+    return true;
+  }
+
   if (typeof window === 'undefined') {
     // Server-side: check NODE_ENV
     return process.env['NODE_ENV'] === 'development';
   }
   // Client-side: check hostname
   const hostname = window.location.hostname;
-  return hostname === 'localhost' || hostname === '127.0.0.1';
+  return (
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname.includes('-dev.') ||      // business-dev.mapleandsprucefolkarts.com
+    hostname.includes('.dev.')          // dev.business.mapleandsprucefolkarts.com (alternate pattern)
+  );
 }
 
 /**

--- a/libs/ts/firebase/firebase-config/src/lib/maple-functions.ts
+++ b/libs/ts/firebase/firebase-config/src/lib/maple-functions.ts
@@ -10,10 +10,12 @@ export const getMapleFunctions = () => {
   if (!_mapleFunctions) {
     _mapleFunctions = getFunctions(getMapleApp(), FUNCTIONS_REGION);
 
-    // Connect to local functions in development
+    // Connect to local functions emulator only on localhost
+    // Note: business-dev.* hostname should hit deployed dev functions, not emulator
     if (
       typeof window !== 'undefined' &&
-      window.location.hostname === 'localhost'
+      (window.location.hostname === 'localhost' ||
+        window.location.hostname === '127.0.0.1')
     ) {
       connectFunctionsEmulator(_mapleFunctions, 'localhost', 5001);
     }


### PR DESCRIPTION
## Summary
- Remove `_PROD` suffix pattern from secrets management - each Firebase project now has its own secrets with the same names but appropriate values
- Add hostname-based environment detection for `business-dev.*` domains
- Clean up unused secrets from both dev and prod projects

## Changes
### Code
- `environment.utility.ts`: Remove `secretPair`/`secretPairs` utilities, rename `selectSecret()` to `getSecret()`
- `square.utility.ts`: Update `SQUARE_SECRET_NAMES` to single `'SQUARE_ACCESS_TOKEN'`
- `square-webhook.ts`: Use single `SQUARE_WEBHOOK_SIGNATURE_KEY` per project
- `maple-firebase-config.ts`: Add `business-dev.*` and `*.dev.*` hostname detection
- `maple-functions.ts`: Clarify emulator connection is localhost-only

### Infrastructure
- Cleaned up secrets in both projects:
  - **Dev**: Removed `SQUARE_ACCESS_TOKEN_PROD`, `SQUARE_LOCATION_ID_PROD`, `SQUARE_WEBHOOK_SIGNATURE_KEY_PROD`
  - **Prod**: Removed `_PROD`, `_SANDBOX` variants, kept only `SQUARE_ACCESS_TOKEN` and `SQUARE_WEBHOOK_SIGNATURE_KEY`
- Reset org policy on dev project (`iam.allowedPolicyMemberDomains`)
- Granted necessary IAM permissions to dev project compute service account
- All 13 functions deployed successfully to `maple-and-spruce-dev`

## Project Secret Structure (now clean)
```
maple-and-spruce-dev:
  - SQUARE_ACCESS_TOKEN (sandbox)
  - SQUARE_WEBHOOK_SIGNATURE_KEY (sandbox)

maple-and-spruce:
  - SQUARE_ACCESS_TOKEN (production)
  - SQUARE_WEBHOOK_SIGNATURE_KEY (production)
```

## Environment Detection
The UI now selects the correct Firebase project based on:
1. `NEXT_PUBLIC_FIREBASE_ENV=dev` env var (explicit)
2. `localhost` / `127.0.0.1` (local dev)
3. Hostname containing `-dev.` or `.dev.` (e.g., `business-dev.mapleandsprucefolkarts.com`)

## Test plan
- [x] Functions build locally
- [x] All functions deployed to dev project
- [ ] Create Vercel dev app at `business-dev.mapleandsprucefolkarts.com`
- [ ] Verify UI on dev hostname hits dev functions

🤖 Generated with [Claude Code](https://claude.ai/code)