### PR TITLE
chore: add Square env config and eslint setup

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,1 +1,8 @@
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:4200,http://127.0.0.1:3000,http://127.0.0.1:4200
+
+# Square Integration
+# SQUARE_ENV determines SDK environment (LOCAL=sandbox, PROD=production)
+# The actual access token comes from Firebase Secrets (per-project)
+SQUARE_ENV=LOCAL
+# Sandbox location ID from Square Developer Dashboard
+SQUARE_LOCATION_ID=LW0MMBZ5721QY

--- a/.env.prod
+++ b/.env.prod
@@ -1,2 +1,9 @@
 # Production environment for Firebase Functions
 ALLOWED_ORIGINS=https://business.mapleandsprucefolkarts.com,https://business.mapleandsprucewv.com,https://maple-and-spruce-maple-spruce.vercel.app
+
+# Square Integration
+# SQUARE_ENV determines SDK environment (LOCAL=sandbox, PROD=production)
+# The actual access token comes from Firebase Secrets (per-project)
+SQUARE_ENV=PROD
+# Get location ID from Square Dashboard > Locations (production account)
+SQUARE_LOCATION_ID=LEJBNPRGM99NV

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   "recommendations": [
     "nrwl.angular-console",
     "esbenp.prettier-vscode",
-    "ms-playwright.playwright"
+    "ms-playwright.playwright",
+    "dbaeumer.vscode-eslint"
   ]
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,42 @@
+import nx from '@nx/eslint-plugin';
+
+export default [
+  ...nx.configs['flat/base'],
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
+  {
+    ignores: ['**/dist', '**/out-tsc'],
+  },
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    rules: {
+      '@nx/enforce-module-boundaries': [
+        'error',
+        {
+          enforceBuildableLibDependency: true,
+          allow: ['^.*/eslint(\\.base)?\\.config\\.[cm]?[jt]s$'],
+          depConstraints: [
+            {
+              sourceTag: '*',
+              onlyDependOnLibsWithTags: ['*'],
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: [
+      '**/*.ts',
+      '**/*.tsx',
+      '**/*.cts',
+      '**/*.mts',
+      '**/*.js',
+      '**/*.jsx',
+      '**/*.cjs',
+      '**/*.mjs',
+    ],
+    // Override or add rules here
+    rules: {},
+  },
+];


### PR DESCRIPTION
## Summary
Add Square environment configuration to env files and set up ESLint tooling.

## Changes
- Add `SQUARE_ENV` and `SQUARE_LOCATION_ID` to `.env.dev` and `.env.prod`
- Update comments to reflect per-project secrets pattern
- Add ESLint extension to VS Code recommendations
- Add Nx ESLint flat config (`eslint.config.mjs`)

## Testing
- [x] Env files have correct values for each environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)