### PR TITLE
chore: simplify local dev setup and fix env loading

### DIFF
--- a/.claude/SESSION.md
+++ b/.claude/SESSION.md
@@ -26,8 +26,7 @@
   - Deployed all 13 functions to dev
   - Created Vercel dev app
 - Added hostname-based environment detection:
-  - `business-dev.*` or `*.dev.*` hostnames → dev Firebase project
-  - `NEXT_PUBLIC_FIREBASE_ENV=dev` env var → dev Firebase project
+  - `localhost` or `business-dev.*` hostnames → dev Firebase project
   - Everything else → prod Firebase project
 
 **Previous session** (2026-01-18):
@@ -76,11 +75,12 @@
 
 ### Environment Detection
 
-The UI automatically selects the correct Firebase project:
-1. `NEXT_PUBLIC_FIREBASE_ENV=dev` → dev project
-2. `localhost` / `127.0.0.1` → dev project (+ functions emulator)
-3. Hostname contains `-dev.` or `.dev.` → dev project
-4. Everything else → prod project
+The web app automatically selects the correct Firebase project based on hostname:
+1. `localhost` / `127.0.0.1` → dev project
+2. Hostname contains `-dev.` or `.dev.` → dev project
+3. Everything else → prod project
+
+**No `.env.local` needed** - Firebase client config is hardcoded.
 
 ### Secrets (per-project, same names)
 

--- a/apps/functions/project.json
+++ b/apps/functions/project.json
@@ -30,7 +30,13 @@
     "serve": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "npx nx run functions:build && (npx nx run functions:build --watch &) && sleep 1 && cp .env.dev dist/apps/functions/.env && firebase serve --only functions --project=dev --port=5001"
+        "commands": [
+          "npx nx run functions:build",
+          "cp .env.dev dist/apps/functions/.env",
+          "(npx nx run functions:build --watch &)",
+          "firebase serve --only functions --project=dev --port=5001"
+        ],
+        "parallel": false
       }
     },
     "deploy": {

--- a/apps/maple-spruce/.env.local.example
+++ b/apps/maple-spruce/.env.local.example
@@ -1,7 +1,0 @@
-# Development Firebase Configuration
-# Copy this file to .env.local and fill in values from Firebase Console
-# Project: maple-and-spruce-dev > Project Settings > Your apps > Web app
-
-NEXT_PUBLIC_FIREBASE_API_KEY=your-dev-api-key
-NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your-dev-sender-id
-NEXT_PUBLIC_FIREBASE_APP_ID=your-dev-app-id

--- a/docs/PATTERNS-AND-PRACTICES.md
+++ b/docs/PATTERNS-AND-PRACTICES.md
@@ -1031,27 +1031,9 @@ const bucket = admin.storage().bucket('maple-and-spruce.firebasestorage.app');
 
 ### Environment Variables
 
-```bash
-# .env.local
+**No `.env.local` required for local development.** Firebase client config is hardcoded in `libs/ts/firebase/firebase-config/` for both dev and prod environments. Environment detection is automatic based on hostname.
 
-# Firebase
-NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=
-NEXT_PUBLIC_FIREBASE_PROJECT_ID=
-NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=
-NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=
-NEXT_PUBLIC_FIREBASE_APP_ID=
-FIREBASE_ADMIN_SERVICE_ACCOUNT=  # JSON string for server-side
-
-# Stripe
-STRIPE_SECRET_KEY=
-STRIPE_WEBHOOK_SECRET=
-NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
-
-# Etsy
-ETSY_API_KEY=
-ETSY_ACCESS_TOKEN=
-ETSY_SHOP_ID=
-```
+Cloud Functions secrets (Square tokens, etc.) are managed per-project in Firebase - see [AGENTS.md](../.claude/AGENTS.md#per-project-secrets-pattern).
 
 ---
 

--- a/libs/firebase/functions/src/lib/functions.utility.ts
+++ b/libs/firebase/functions/src/lib/functions.utility.ts
@@ -25,12 +25,9 @@ import { getAuth } from 'firebase-admin/auth';
 /**
  * Allowed origins for CORS - configured via Firebase environment.
  * Set via .env files (.env.prod for production, .env.dev for development).
- * Production should NOT include localhost for security.
+ * The .env file must be present - no default to ensure explicit configuration.
  */
-const ALLOWED_ORIGINS = defineString('ALLOWED_ORIGINS', {
-  default:
-    'https://www.mapleandsprucefolkarts.com,https://mapleandsprucefolkarts.com,https://www.mapleandsprucewv.com,https://mapleandsprucewv.com,https://maple-and-spruce-maple-spruce.vercel.app',
-});
+const ALLOWED_ORIGINS = defineString('ALLOWED_ORIGINS');
 
 /**
  * CORS middleware - handles preflight and validates origins

--- a/libs/ts/firebase/firebase-config/src/lib/maple-firebase-config.ts
+++ b/libs/ts/firebase/firebase-config/src/lib/maple-firebase-config.ts
@@ -18,27 +18,22 @@ const prodConfig: FirebaseOptions = {
  * Uses maple-and-spruce-dev project for isolated testing
  */
 const devConfig: FirebaseOptions = {
-  apiKey: process.env['NEXT_PUBLIC_FIREBASE_API_KEY'] || '',
+  apiKey: 'AIzaSyAFCM6IHepC14MoMYQofiiye8v_gkYv5Cw',
   authDomain: 'maple-and-spruce-dev.firebaseapp.com',
   projectId: 'maple-and-spruce-dev',
   storageBucket: 'maple-and-spruce-dev.firebasestorage.app',
-  messagingSenderId: process.env['NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID'] || '',
-  appId: process.env['NEXT_PUBLIC_FIREBASE_APP_ID'] || '',
+  messagingSenderId: '1062803455357',
+  appId: '1:1062803455357:web:e1f3cf4cb54fb18dc6e014',
+  measurementId: 'G-XGYBP0X174',
 };
 
 /**
- * Determine if we're in development mode
- * Uses environment detection based on hostname or env var:
- * - localhost, 127.0.0.1, or *-dev.* hostname = dev
- * - NEXT_PUBLIC_FIREBASE_ENV=dev = dev
+ * Determine if we're in development mode based on hostname:
+ * - localhost, 127.0.0.1 = dev (local development)
+ * - *-dev.* hostname = dev (e.g., business-dev.mapleandsprucefolkarts.com)
  * - Everything else = prod
  */
 function isDevelopment(): boolean {
-  // Check environment variable first (works server and client side)
-  if (process.env['NEXT_PUBLIC_FIREBASE_ENV'] === 'dev') {
-    return true;
-  }
-
   if (typeof window === 'undefined') {
     // Server-side: check NODE_ENV
     return process.env['NODE_ENV'] === 'development';
@@ -48,8 +43,7 @@ function isDevelopment(): boolean {
   return (
     hostname === 'localhost' ||
     hostname === '127.0.0.1' ||
-    hostname.includes('-dev.') ||      // business-dev.mapleandsprucefolkarts.com
-    hostname.includes('.dev.')          // dev.business.mapleandsprucefolkarts.com (alternate pattern)
+    hostname.includes('-dev.')      // business-dev.mapleandsprucefolkarts.com
   );
 }
 


### PR DESCRIPTION
## Summary
- Hardcode dev Firebase config so no `.env.local` file is needed
- Fix functions serve command ordering for reliable `.env` loading
- Add troubleshooting documentation for local functions

## Changes
- Register web app in `maple-and-spruce-dev` Firebase project
- Hardcode dev config in `maple-firebase-config.ts` (same pattern as Mountain Sol)
- Restructure `functions:serve` command to ensure `.env.dev` is copied before emulator starts
- Remove `ALLOWED_ORIGINS` default value to fail fast if `.env` is missing
- Add troubleshooting section in AGENTS.md for common local dev issues
- Remove unused `.env.local.example`

## Testing
- [x] Local functions serve loads `.env` correctly
- [x] Prod functions redeployed and health check passes
- [x] Dev functions working

🤖 Generated with [Claude Code](https://claude.com/claude-code)