### PR TITLE
feat: integrate artist selection into product management (#3)

### DIFF
--- a/apps/maple-spruce/src/app/inventory/page.tsx
+++ b/apps/maple-spruce/src/app/inventory/page.tsx
@@ -1,16 +1,16 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { Box, Typography, Button } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
-import type { Product, CreateProductInput } from '@maple/ts/domain';
+import type { Product, CreateProductInput, Artist } from '@maple/ts/domain';
 import {
   ProductList,
   ProductForm,
   DeleteConfirmDialog,
 } from '../../components/inventory';
 import { AppShell } from '../../components/layout';
-import { useProducts } from '../../hooks';
+import { useProducts, useArtists } from '../../hooks';
 
 export default function InventoryPage() {
   // Product state from hook (fetches on mount)
@@ -20,6 +20,15 @@ export default function InventoryPage() {
     updateProduct,
     deleteProduct: deleteProductApi,
   } = useProducts();
+
+  // Artist state for dropdown and display
+  const { artistsState } = useArtists();
+
+  // Create artist lookup map for efficient name display
+  const artistMap = useMemo(() => {
+    if (artistsState.status !== 'success') return new Map<string, Artist>();
+    return new Map(artistsState.data.map((a) => [a.id, a]));
+  }, [artistsState]);
 
   // Form dialog state
   const [isFormOpen, setIsFormOpen] = useState(false);
@@ -106,6 +115,7 @@ export default function InventoryPage() {
 
       <ProductList
         productsState={productsState}
+        artistMap={artistMap}
         onEdit={handleOpenForm}
         onDelete={handleOpenDelete}
       />
@@ -115,6 +125,7 @@ export default function InventoryPage() {
         onClose={handleCloseForm}
         onSubmit={handleSubmitForm}
         product={editingProduct}
+        artists={artistsState.status === 'success' ? artistsState.data : []}
         isSubmitting={isSubmitting}
       />
 

--- a/apps/maple-spruce/src/components/inventory/ProductForm.tsx
+++ b/apps/maple-spruce/src/components/inventory/ProductForm.tsx
@@ -10,13 +10,14 @@ import {
   DialogActions,
   TextField,
   FormControl,
+  FormHelperText,
   InputLabel,
   Select,
   MenuItem,
   InputAdornment,
   Alert,
 } from '@mui/material';
-import type { Product, CreateProductInput, ProductStatus } from '@maple/ts/domain';
+import type { Product, CreateProductInput, ProductStatus, Artist } from '@maple/ts/domain';
 import { toCents } from '@maple/ts/domain';
 
 interface ProductFormProps {
@@ -24,6 +25,7 @@ interface ProductFormProps {
   onClose: () => void;
   onSubmit: (data: CreateProductInput) => Promise<void>;
   product?: Product;
+  artists: Artist[];
   isSubmitting?: boolean;
 }
 
@@ -91,8 +93,11 @@ export function ProductForm({
   onClose,
   onSubmit,
   product,
+  artists,
   isSubmitting = false,
 }: ProductFormProps) {
+  // Filter to only active artists for the dropdown
+  const activeArtists = artists.filter((a) => a.status === 'active');
   const [formData, setFormData] = useState<FormState>(defaultFormState);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -208,15 +213,21 @@ export function ProductForm({
             fullWidth
           />
 
-          <TextField
-            label="Artist ID"
-            value={formData.artistId}
-            onChange={(e) => handleChange('artistId', e.target.value)}
-            error={!!errors.artistId}
-            helperText={errors.artistId || 'Temporary: enter artist ID manually'}
-            required
-            fullWidth
-          />
+          <FormControl fullWidth required error={!!errors.artistId}>
+            <InputLabel>Artist</InputLabel>
+            <Select
+              value={formData.artistId}
+              label="Artist"
+              onChange={(e) => handleChange('artistId', e.target.value)}
+            >
+              {activeArtists.map((artist) => (
+                <MenuItem key={artist.id} value={artist.id}>
+                  {artist.name}
+                </MenuItem>
+              ))}
+            </Select>
+            {errors.artistId && <FormHelperText>{errors.artistId}</FormHelperText>}
+          </FormControl>
 
           <TextField
             label="Description"

--- a/apps/maple-spruce/src/components/inventory/ProductList.tsx
+++ b/apps/maple-spruce/src/components/inventory/ProductList.tsx
@@ -13,12 +13,13 @@ import {
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
-import type { Product } from '@maple/ts/domain';
+import type { Product, Artist } from '@maple/ts/domain';
 import type { RequestState } from '@maple/ts/domain';
 import { formatPrice } from '@maple/ts/domain';
 
 interface ProductListProps {
   productsState: RequestState<Product[]>;
+  artistMap: Map<string, Artist>;
   onEdit: (product: Product) => void;
   onDelete: (product: Product) => void;
 }
@@ -31,10 +32,12 @@ const statusColors: Record<string, 'success' | 'warning' | 'default'> = {
 
 function ProductCard({
   product,
+  artistName,
   onEdit,
   onDelete,
 }: {
   product: Product;
+  artistName?: string;
   onEdit: () => void;
   onDelete: () => void;
 }) {
@@ -52,6 +55,11 @@ function ProductCard({
             <Typography variant="h6" component="h3">
               {product.squareCache.name}
             </Typography>
+            {artistName && (
+              <Typography variant="body2" color="primary" sx={{ fontWeight: 500 }}>
+                by {artistName}
+              </Typography>
+            )}
             <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
               {product.squareCache.description || 'No description'}
             </Typography>
@@ -119,6 +127,7 @@ function LoadingSkeleton() {
 
 export function ProductList({
   productsState,
+  artistMap,
   onEdit,
   onDelete,
 }: ProductListProps) {
@@ -161,6 +170,7 @@ export function ProductList({
         <Grid size={{ xs: 12, sm: 6, md: 4 }} key={product.id}>
           <ProductCard
             product={product}
+            artistName={artistMap.get(product.artistId)?.name}
             onEdit={() => onEdit(product)}
             onDelete={() => onDelete(product)}
           />


### PR DESCRIPTION
## Summary
- Replace manual Artist ID text input with dropdown selector populated from active artists
- Display artist name ("by Artist Name") on product cards in the inventory list
- Load artists via `useArtists` hook in the inventory page and pass to components
- Create `artistMap` for efficient name lookups when rendering product list

## Changes
- `apps/maple-spruce/src/app/inventory/page.tsx` - Add useArtists hook, create artistMap, pass to components
- `apps/maple-spruce/src/components/inventory/ProductForm.tsx` - Replace TextField with Select dropdown, add artists prop
- `apps/maple-spruce/src/components/inventory/ProductList.tsx` - Add artistMap prop, display artist name in cards

## Test plan
- [ ] Open inventory page, verify artist dropdown shows active artists
- [ ] Create a new product, verify artist can be selected from dropdown
- [ ] Verify product cards show "by Artist Name" under product name
- [ ] Edit existing product, verify artist dropdown pre-selects correct artist

🤖 Generated with [Claude Code](https://claude.com/claude-code)