### PR TITLE
fix: use NEXT_PUBLIC_FIREBASE_ENV for Firebase config detection

### DIFF
--- a/libs/ts/firebase/firebase-config/src/lib/maple-firebase-config.ts
+++ b/libs/ts/firebase/firebase-config/src/lib/maple-firebase-config.ts
@@ -28,23 +28,29 @@ const devConfig: FirebaseOptions = {
 };
 
 /**
- * Determine if we're in development mode based on hostname:
- * - localhost, 127.0.0.1 = dev (local development)
- * - *-dev.* hostname = dev (e.g., business-dev.mapleandsprucefolkarts.com)
- * - Everything else = prod
+ * Determine if we're in development mode:
+ * 1. Check NEXT_PUBLIC_FIREBASE_ENV (set in Vercel for deployed apps)
+ * 2. Fall back to hostname detection (for local development)
  */
 function isDevelopment(): boolean {
-  if (typeof window === 'undefined') {
-    // Server-side: check NODE_ENV
-    return process.env['NODE_ENV'] === 'development';
+  // Check environment variable first (works on both server and client)
+  const firebaseEnv = process.env['NEXT_PUBLIC_FIREBASE_ENV'];
+  if (firebaseEnv) {
+    return firebaseEnv === 'dev';
   }
-  // Client-side: check hostname
-  const hostname = window.location.hostname;
-  return (
-    hostname === 'localhost' ||
-    hostname === '127.0.0.1' ||
-    hostname.includes('-dev.')      // business-dev.mapleandsprucefolkarts.com
-  );
+
+  // Fall back to hostname detection for local development
+  if (typeof window !== 'undefined') {
+    const hostname = window.location.hostname;
+    return (
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname.includes('-dev.')
+    );
+  }
+
+  // Server-side without env var: default to dev for safety
+  return true;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix `auth/invalid-api-key` error on dev site by using `NEXT_PUBLIC_FIREBASE_ENV` environment variable for Firebase config selection
- Falls back to hostname detection for local development

## Changes
- Check `NEXT_PUBLIC_FIREBASE_ENV` first (set in Vercel)
- Fall back to hostname detection (`localhost`, `127.0.0.1`, `*-dev.*`)
- Default to dev on server-side without env var (safer for local dev)

## Setup Required
- Dev Vercel project: `NEXT_PUBLIC_FIREBASE_ENV=dev` ✅ (already set)
- Prod Vercel project: `NEXT_PUBLIC_FIREBASE_ENV=prod` (needs to be added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)