### PR TITLE
fix: add dev site to CORS allowed origins

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,4 +1,4 @@
-ALLOWED_ORIGINS=http://localhost:3000,http://localhost:4200,http://127.0.0.1:3000,http://127.0.0.1:4200
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:4200,http://127.0.0.1:3000,http://127.0.0.1:4200,https://business-dev.mapleandsprucefolkarts.com
 
 # Square Integration
 # SQUARE_ENV determines SDK environment (LOCAL=sandbox, PROD=production)


### PR DESCRIPTION
## Summary
Add `https://business-dev.mapleandsprucefolkarts.com` to `.env.dev` ALLOWED_ORIGINS so the deployed dev functions accept requests from the dev Vercel app.

## Changes
- Add dev site URL to CORS allowed origins in `.env.dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)