### PR TITLE
feat: fix product CRUD with Square sync (#3)

### DIFF
--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -34,6 +34,7 @@ export { getProduct } from '@maple/firebase/maple-functions/get-product';
 export { createProduct } from '@maple/firebase/maple-functions/create-product';
 export { updateProduct } from '@maple/firebase/maple-functions/update-product';
 export { deleteProduct } from '@maple/firebase/maple-functions/delete-product';
+export { uploadProductImage } from '@maple/firebase/maple-functions/upload-product-image';
 
 // Square webhook (HTTP endpoint, not callable)
 export { squareWebhook } from '@maple/firebase/maple-functions/square-webhook';

--- a/apps/maple-spruce/next.config.js
+++ b/apps/maple-spruce/next.config.js
@@ -23,6 +23,37 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
+  // Configure image optimization for external domains
+  images: {
+    remotePatterns: [
+      // Square CDN - product images are stored in Square's catalog
+      {
+        protocol: 'https',
+        hostname: '*.squarecdn.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'square-catalog-sandbox.s3.amazonaws.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'square-catalog.s3.amazonaws.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'items-images-production.s3.us-west-2.amazonaws.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'items-images-sandbox.s3.us-west-2.amazonaws.com',
+      },
+      // Firebase Storage - artist images
+      {
+        protocol: 'https',
+        hostname: 'firebasestorage.googleapis.com',
+      },
+    ],
+  },
   // Rewrite /api/* to Firebase Functions
   async rewrites() {
     return [

--- a/docs/sessions/SESSION.md
+++ b/docs/sessions/SESSION.md
@@ -7,14 +7,18 @@
 ## Current Status
 
 **Date**: 2026-01-19
-**Status**: ✅ Dev environment fully operational
+**Status**: ✅ Product CRUD with Square sync working
 
-### Active Work
-None - ready for next task
+### Completed Today
+- Fixed ProductForm status enum mismatch
+- Added quantity field to ProductForm
+- Fixed Square batchUpsert duplicate object error (nest variations in items)
+- Fixed variation lookup (check both relatedObjects and itemData.variations)
 
 ### Next Steps
 1. Set `NEXT_PUBLIC_FIREBASE_ENV=prod` in production Vercel project
-2. Etsy Integration (#4) - waiting for app approval
+2. Deploy updated functions to prod
+3. Etsy Integration (#4) - waiting for app approval
 
 ### Blockers
 None

--- a/docs/sessions/history/2026-01-19.md
+++ b/docs/sessions/history/2026-01-19.md
@@ -58,7 +58,73 @@ Vercel sets `NODE_ENV=production` for all deployments (both prod and dev project
 | #77 | Add dev site to CORS allowed origins |
 | #78 | Update dev environment setup documentation |
 
+## Session 2 (afternoon)
+
+### Product CRUD with Square - Fixes
+
+#### Issue 1: Status Enum Mismatch
+- ProductForm was using string `"active"` but API types expected `ProductStatus.Active` enum
+- Fix: Import `ProductStatus` enum and use it in form submission
+
+#### Issue 2: Missing Quantity Field
+- ProductForm had no quantity input, but API expected `quantity` for inventory
+- Fix: Added TextField for quantity with number validation
+
+#### Issue 3: Square batchUpsert Duplicate Object Error
+- **Error**: `Duplicate object YP6YM3H2BYH2CHLINDEAL6Q2` when updating
+- **Cause**: Was sending variation as separate object in batch, but Square doesn't allow duplicate IDs
+- **Fix**: Nest the variation inside `itemData.variations` array instead of as a separate batch object
+
+```typescript
+// WRONG - sends variation as separate object
+batches: [{
+  objects: [
+    { type: 'ITEM', id: itemId, itemData: {...} },
+    { type: 'ITEM_VARIATION', id: variationId, ... }  // DUPLICATE!
+  ]
+}]
+
+// CORRECT - nest variation inside item
+batches: [{
+  objects: [
+    {
+      type: 'ITEM',
+      id: itemId,
+      itemData: {
+        ...itemData,
+        variations: [{ type: 'ITEM_VARIATION', id: variationId, ... }]
+      }
+    }
+  ]
+}]
+```
+
+#### Issue 4: Catalog Variation Not Found
+- **Error**: `Catalog variation not found: YP6YM3H2BYH2CHLINDEAL6Q2`
+- **Cause**: Square's `catalog.object.get()` with `includeRelatedObjects: true` doesn't always return variations in `relatedObjects`
+- **Fix**: Check both `relatedObjects` AND `itemData.variations` for the variation
+
+## Key Learnings
+
+### Square Catalog API Patterns
+
+1. **Variation Location**: When fetching a catalog item, the variation may be in:
+   - `response.relatedObjects[]` (sometimes)
+   - `response.object.itemData.variations[]` (always)
+
+   Always check both locations.
+
+2. **batchUpsert Structure**: Variations must be nested inside items, not sent as separate objects:
+   - Items and variations share the same ID space
+   - Sending both separately causes "Duplicate object" error
+   - Nest variations in `itemData.variations` array
+
+3. **Optimistic Locking**: Square uses `version` field for concurrency control:
+   - Include `version: BigInt(catalogVersion)` when updating
+   - Both item and variation need their versions specified
+
 ## Environment Status at End of Session
 - ✅ Dev site fully operational (auth, artists, products, Square)
+- ✅ Product create/update working with Square sync
 - ✅ Prod site operational
 - ⚠️ Prod Vercel needs `NEXT_PUBLIC_FIREBASE_ENV=prod` set

--- a/libs/firebase/maple-functions/upload-product-image/project.json
+++ b/libs/firebase/maple-functions/upload-product-image/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-upload-product-image",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/upload-product-image/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/upload-product-image/src/index.ts
+++ b/libs/firebase/maple-functions/upload-product-image/src/index.ts
@@ -1,0 +1,1 @@
+export { uploadProductImage } from './lib/upload-product-image';

--- a/libs/firebase/maple-functions/upload-product-image/src/lib/upload-product-image.ts
+++ b/libs/firebase/maple-functions/upload-product-image/src/lib/upload-product-image.ts
@@ -1,0 +1,136 @@
+/**
+ * Upload Product Image Cloud Function
+ *
+ * Uploads a product image to Square Catalog (admin only).
+ *
+ * Unlike artist images (stored in Firebase Storage), product images
+ * are stored in Square's CDN. This keeps product images in sync with
+ * the Square catalog and POS system.
+ *
+ * Flow:
+ * 1. Validate input (product must exist)
+ * 2. Upload image to Square via Catalog API
+ * 3. Update Firestore cache with the new image URL
+ */
+import { Functions, Role } from '@maple/firebase/functions';
+import { ProductRepository } from '@maple/firebase/database';
+import {
+  Square,
+  SQUARE_SECRET_NAMES,
+  SQUARE_STRING_NAMES,
+} from '@maple/firebase/square';
+import type {
+  UploadProductImageRequest,
+  UploadProductImageResponse,
+} from '@maple/ts/firebase/api-types';
+
+/**
+ * Allowed image MIME types (matches Square's supported formats)
+ */
+const ALLOWED_IMAGE_TYPES = [
+  'image/jpeg',
+  'image/pjpeg',
+  'image/png',
+  'image/gif',
+];
+
+/**
+ * Max file size: 15MB (Square's limit)
+ */
+const MAX_IMAGE_SIZE_BYTES = 15 * 1024 * 1024;
+
+export const uploadProductImage = Functions.endpoint
+  .usingSecrets(...SQUARE_SECRET_NAMES)
+  .usingStrings(...SQUARE_STRING_NAMES)
+  .requiringRole(Role.Admin)
+  .handle<UploadProductImageRequest, UploadProductImageResponse>(
+    async (data, _context, secrets, strings) => {
+      const { productId, imageBase64, contentType, caption } = data;
+
+      // Validate required fields
+      if (!productId) {
+        throw new Error('productId is required');
+      }
+
+      if (!imageBase64) {
+        throw new Error('imageBase64 is required');
+      }
+
+      if (!contentType) {
+        throw new Error('contentType is required');
+      }
+
+      // Validate content type
+      if (!ALLOWED_IMAGE_TYPES.includes(contentType)) {
+        throw new Error(
+          `Invalid content type. Allowed: ${ALLOWED_IMAGE_TYPES.join(', ')}`
+        );
+      }
+
+      // Validate base64 size (rough estimate)
+      const estimatedBytes = Math.ceil(imageBase64.length * 0.75);
+      if (estimatedBytes > MAX_IMAGE_SIZE_BYTES) {
+        throw new Error('Image too large. Maximum size is 15MB.');
+      }
+
+      // Find the product to get Square item ID
+      const product = await ProductRepository.findById(productId);
+      if (!product) {
+        throw new Error(`Product not found: ${productId}`);
+      }
+
+      if (!product.squareItemId) {
+        throw new Error(
+          'Product does not have a Square item ID. Cannot upload image.'
+        );
+      }
+
+      console.log('Uploading image for product:', {
+        productId,
+        squareItemId: product.squareItemId,
+        contentType,
+      });
+
+      // Initialize Square client
+      const square = new Square(
+        secrets as typeof secrets &
+          Record<(typeof SQUARE_SECRET_NAMES)[number], string>,
+        strings as typeof strings &
+          Record<(typeof SQUARE_STRING_NAMES)[number], string>
+      );
+
+      // Convert base64 to Blob for Square API
+      const buffer = Buffer.from(imageBase64, 'base64');
+      const blob = new Blob([buffer], { type: contentType });
+
+      // Generate filename from content type
+      const extension = contentType.split('/')[1] || 'jpg';
+      const filename = `product-${productId}.${extension}`;
+
+      // Upload to Square
+      const result = await square.catalogService.uploadImage({
+        squareItemId: product.squareItemId,
+        imageBlob: blob,
+        filename,
+        caption: caption || product.squareCache.name,
+        isPrimary: true,
+      });
+
+      console.log('Square image upload successful:', result);
+
+      // Update Firestore cache with the new image URL and catalog version
+      // IMPORTANT: Uploading an image changes the catalog version, so we must
+      // update it in Firestore to avoid version mismatch errors on subsequent updates
+      await ProductRepository.updateSquareCache(
+        productId,
+        { imageUrl: result.imageUrl },
+        result.squareCatalogVersion
+      );
+
+      return {
+        success: true,
+        imageUrl: result.imageUrl,
+        squareImageId: result.squareImageId,
+      };
+    }
+  );

--- a/libs/firebase/maple-functions/upload-product-image/tsconfig.json
+++ b/libs/firebase/maple-functions/upload-product-image/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/upload-product-image/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/upload-product-image/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/square/src/index.ts
+++ b/libs/firebase/square/src/index.ts
@@ -14,6 +14,8 @@ export {
   type CreateCatalogItemResult,
   type UpdateCatalogItemInput,
   type UpdateCatalogItemResult,
+  type UploadCatalogImageInput,
+  type UploadCatalogImageResult,
 } from './lib/catalog.service';
 
 // Inventory service

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -57,6 +57,8 @@ export type {
   UpdateProductResponse,
   DeleteProductRequest,
   DeleteProductResponse,
+  UploadProductImageRequest,
+  UploadProductImageResponse,
   SyncEtsyProductsRequest,
   SyncEtsyProductsResponse,
 } from './product.types';

--- a/libs/ts/firebase/api-types/src/lib/product.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/product.types.ts
@@ -71,6 +71,29 @@ export interface DeleteProductResponse {
 }
 
 // ============================================================================
+// Upload Product Image
+// ============================================================================
+
+export interface UploadProductImageRequest {
+  /** Product ID (required - product must exist in Firestore) */
+  productId: string;
+  /** Base64-encoded image data */
+  imageBase64: string;
+  /** MIME type of the image (e.g., 'image/jpeg', 'image/png') */
+  contentType: string;
+  /** Optional caption for the image */
+  caption?: string;
+}
+
+export interface UploadProductImageResponse {
+  success: boolean;
+  /** Public URL of the uploaded image (hosted by Square) */
+  imageUrl: string;
+  /** Square image ID */
+  squareImageId: string;
+}
+
+// ============================================================================
 // Sync from Etsy
 // ============================================================================
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -50,6 +50,9 @@
       "@maple/firebase/maple-functions/delete-product": [
         "libs/firebase/maple-functions/delete-product/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/upload-product-image": [
+        "libs/firebase/maple-functions/upload-product-image/src/index.ts"
+      ],
       "@maple/ts/domain": ["libs/ts/domain/src/index.ts"],
       "@maple/ts/firebase/api-types": [
         "libs/ts/firebase/api-types/src/index.ts"


### PR DESCRIPTION
## Summary
- Fix Product create/update to properly sync with Square Catalog API
- Add quantity field for inventory tracking
- Document Square API patterns learned

## Changes
- **ProductForm**: Fix status enum mismatch, add quantity field
- **CatalogService**: Fix batchUpsert to nest variations inside items (prevents "Duplicate object" error)
- **CatalogService**: Fix variation lookup to check both `relatedObjects` and `itemData.variations`
- **uploadProductImage**: New function for product image uploads
- **next.config.js**: Configure image optimization for Square CDN domains
- **squareWebhook**: Extract image URLs from catalog items
- **Documentation**: Add Square Catalog API patterns to PATTERNS-AND-PRACTICES.md

## Key Learnings (documented)
1. Square variations can be in two places - always check both
2. batchUpsert requires nesting variations inside items, not as separate objects
3. Square uses optimistic locking via version fields

## Testing
- [x] Product create works with Square sync
- [x] Product update works with Square sync
- [x] Tested on dev environment

Closes #3 (partial - remaining: artist dropdown, artist info display)

🤖 Generated with [Claude Code](https://claude.com/claude-code)