### PR TITLE
fix: image delete button not working in artist/product forms

### DIFF
--- a/apps/maple-spruce/src/components/artists/ArtistForm.tsx
+++ b/apps/maple-spruce/src/components/artists/ArtistForm.tsx
@@ -169,7 +169,7 @@ export function ArtistForm({
 
   const handleImageRemove = useCallback(() => {
     setPendingImageFile(null);
-    setImageUploadState({ status: 'idle' });
+    setImageUploadState({ status: 'removed' });
     setFormData((prev) => ({ ...prev, photoUrl: '' }));
   }, []);
 

--- a/apps/maple-spruce/src/components/common/ImageUpload.tsx
+++ b/apps/maple-spruce/src/components/common/ImageUpload.tsx
@@ -26,6 +26,7 @@ const MAX_SIZE_BYTES = 5 * 1024 * 1024;
  */
 export type ImageUploadState =
   | { status: 'idle' }
+  | { status: 'removed' } // User explicitly removed the image
   | { status: 'previewing'; previewUrl: string; file: File }
   | { status: 'uploading'; previewUrl: string }
   | { status: 'success'; url: string }
@@ -146,14 +147,17 @@ export function ImageUpload({
   }, []);
 
   // Determine what image to display
+  // If user explicitly removed the image, don't fall back to existingImageUrl
   const displayUrl =
-    state.status === 'success'
-      ? state.url
-      : state.status === 'previewing' || state.status === 'uploading'
-        ? state.previewUrl
-        : state.status === 'error' && state.previewUrl
+    state.status === 'removed'
+      ? undefined
+      : state.status === 'success'
+        ? state.url
+        : state.status === 'previewing' || state.status === 'uploading'
           ? state.previewUrl
-          : existingImageUrl;
+          : state.status === 'error' && state.previewUrl
+            ? state.previewUrl
+            : existingImageUrl;
 
   const isUploading = state.status === 'uploading';
   const hasImage = !!displayUrl;

--- a/apps/maple-spruce/src/components/inventory/ProductForm.tsx
+++ b/apps/maple-spruce/src/components/inventory/ProductForm.tsx
@@ -135,8 +135,6 @@ export function ProductForm({
     status: 'idle',
   });
   const [pendingImageFile, setPendingImageFile] = useState<File | null>(null);
-  // Track if user explicitly removed the existing image
-  const [imageWasRemoved, setImageWasRemoved] = useState(false);
 
   const isEdit = !!product;
 
@@ -168,7 +166,6 @@ export function ProductForm({
       setImageUploadState({ status: 'idle' });
     }
     setPendingImageFile(null);
-    setImageWasRemoved(false);
     setErrors({});
     setSubmitError(null);
   }, [product, open]);
@@ -176,13 +173,11 @@ export function ProductForm({
   const handleImageSelected = useCallback((file: File, previewUrl: string) => {
     setPendingImageFile(file);
     setImageUploadState({ status: 'previewing', previewUrl, file });
-    setImageWasRemoved(false); // User selected a new image, not removing
   }, []);
 
   const handleImageRemove = useCallback(() => {
     setPendingImageFile(null);
-    setImageUploadState({ status: 'idle' });
-    setImageWasRemoved(true);
+    setImageUploadState({ status: 'removed' });
   }, []);
 
   const handleChange = (
@@ -443,7 +438,7 @@ export function ProductForm({
               state={imageUploadState}
               onFileSelected={handleImageSelected}
               onRemove={handleImageRemove}
-              existingImageUrl={imageWasRemoved ? undefined : product?.squareCache.imageUrl}
+              existingImageUrl={product?.squareCache.imageUrl}
               label="Product Image"
             />
           ) : (


### PR DESCRIPTION
## Summary
- Fixed image delete button not responding in ArtistForm and ProductForm
- Added `removed` status to `ImageUploadState` discriminated union to explicitly track user image removal
- Cleaned up redundant `imageWasRemoved` state in ProductForm

## Test plan
- [ ] Edit an existing artist with a photo, click the delete icon on the image - image should disappear
- [ ] Edit an existing product with an image, click the delete icon - image should disappear
- [ ] Can still upload new images after removing existing ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)