### PR TITLE
fix: use dynamic storage bucket based on Firebase project

### DIFF
--- a/libs/firebase/functions/src/lib/index.ts
+++ b/libs/firebase/functions/src/lib/index.ts
@@ -41,6 +41,9 @@ export {
 
 // Environment utilities
 export {
+  FirebaseProject,
+  FIREBASE_PROJECTS,
   ServiceEnvironment,
   type EnvironmentMode,
+  type FirebaseProjectId,
 } from './environment.utility';

--- a/libs/firebase/maple-functions/square-webhook/src/lib/square-webhook.ts
+++ b/libs/firebase/maple-functions/square-webhook/src/lib/square-webhook.ts
@@ -23,6 +23,7 @@ import {
   SQUARE_SECRET_NAMES,
   SQUARE_STRING_NAMES,
 } from '@maple/firebase/square';
+import { FirebaseProject } from '@maple/firebase/functions';
 
 // Webhook signature secret - per-project, no _PROD suffix needed
 const SQUARE_WEBHOOK_SIGNATURE_KEY = defineSecret('SQUARE_WEBHOOK_SIGNATURE_KEY');
@@ -383,21 +384,15 @@ export const squareWebhook = onRequest(
       // Get the webhook signature key - per-project, so no suffix selection needed
       const signatureKey = SQUARE_WEBHOOK_SIGNATURE_KEY.value();
 
-      // Determine environment from string param (for logging)
-      const squareEnv = squareStrings.find((s) => s.name === 'SQUARE_ENV')?.value() ?? 'LOCAL';
-      const isProd = squareEnv === 'PROD';
-
       // Get the webhook URL (needed for signature verification)
       // Use the notification URL exactly as registered in Square Dashboard
-      // This URL differs per project
-      const projectId = isProd ? 'maple-and-spruce' : 'maple-and-spruce-dev';
-      const webhookUrl = `https://us-east4-${projectId}.cloudfunctions.net/squareWebhook`;
+      const webhookUrl = FirebaseProject.functionUrl('squareWebhook');
 
       console.log('Signature verification:', {
         receivedSignature: signature,
         webhookUrl,
         bodyLength: rawBody.length,
-        isProd,
+        projectId: FirebaseProject.projectId,
       });
 
       // Verify signature

--- a/libs/firebase/maple-functions/upload-artist-image/src/lib/upload-artist-image.ts
+++ b/libs/firebase/maple-functions/upload-artist-image/src/lib/upload-artist-image.ts
@@ -7,7 +7,7 @@
  * Images are stored in Firebase Storage and made publicly accessible.
  * The returned URL can be stored in the artist's photoUrl field.
  */
-import { createAdminFunction } from '@maple/firebase/functions';
+import { createAdminFunction, FirebaseProject } from '@maple/firebase/functions';
 import admin from 'firebase-admin';
 import type {
   UploadArtistImageRequest,
@@ -42,8 +42,8 @@ export const uploadArtistImage = createAdminFunction<
     );
   }
 
-  // Get Firebase Storage bucket (explicit name required for local functions)
-  const bucket = admin.storage().bucket('maple-and-spruce.firebasestorage.app');
+  // Get Firebase Storage bucket for current project
+  const bucket = admin.storage().bucket(FirebaseProject.storageBucket);
 
   // Generate unique file name
   const timestamp = Date.now();


### PR DESCRIPTION
## Summary
- Fixed `uploadArtistImage` function to use the correct storage bucket based on the Firebase project
- Previously hardcoded to production bucket (`maple-and-spruce.firebasestorage.app`)
- Now dynamically determines bucket from `GCLOUD_PROJECT` or `FIREBASE_CONFIG` environment variables

## Problem
The dev environment was getting 403 permission errors when uploading artist images because the function was trying to write to the production bucket.

## Test plan
- [ ] Merge and let CI/CD deploy to dev
- [ ] Test artist image upload in dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)