### PR TITLE
feat: add unit testing infrastructure with Vitest (#24)

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -50,6 +50,20 @@ jobs:
       - name: Build functions
         run: npx nx run functions:build
 
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm install --frozen-lockfile
+      - name: Run unit tests
+        run: npx nx run-many --target=test --all --parallel=3
+
   storybook:
     name: Storybook Build
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,8 +74,10 @@
 | Authentication | Complete | `apps/maple-spruce/src/components/auth/` |
 | Navigation (responsive) | Complete | `apps/maple-spruce/src/components/layout/` |
 | Storybook | Complete | `apps/maple-spruce/.storybook/` |
-| Component stories | In progress | `apps/maple-spruce/src/components/**/*.stories.tsx` |
+| Component stories | Complete | `apps/maple-spruce/src/components/**/*.stories.tsx` |
 | Chromatic CI | Complete | `.github/workflows/chromatic.yml` |
+| Unit testing (Vitest) | Complete | `libs/ts/validation/`, `libs/ts/domain/` |
+| Unit tests in CI | Complete | `.github/workflows/build-check.yml` |
 
 ### Phase 1 Features
 
@@ -132,7 +134,7 @@ Square foundation is complete. Ready for Product Management integration.
 |------|--------|-------|
 | Deploy Functions to Firebase | Complete | #22 |
 | CI/CD for Functions | Complete | #23 |
-| Testing infrastructure | In progress | #24 |
+| Testing infrastructure | Complete | #24 |
 
 #### CI/CD Details (#23)
 
@@ -159,7 +161,7 @@ Functions follow Mountain Sol's auto-generated package.json pattern:
 - `getProducts`, `getProduct`, `createProduct`, `updateProduct`, `deleteProduct`
 - `uploadArtistImage`, `uploadProductImage`, `healthCheck`, `squareWebhook`
 
-#### Storybook & Testing Infrastructure (#24) - In Progress
+#### Storybook & Testing Infrastructure (#24) - Complete
 
 | Task | Status | Notes |
 |------|--------|-------|
@@ -171,6 +173,10 @@ Functions follow Mountain Sol's auto-generated package.json pattern:
 | Chromatic workflow | ✅ | `.github/workflows/chromatic.yml` |
 | Storybook build in CI | ✅ | Added to `.github/workflows/build-check.yml` |
 | Remaining component stories | ✅ | All 15 components have stories with proper fixtures |
+| Vitest workspace config | ✅ | `vitest.workspace.ts` |
+| Validation unit tests | ✅ | 7 test files, 139 tests |
+| Domain unit tests | ✅ | `product.spec.ts`, 25 tests |
+| Unit tests in CI | ✅ | Added to `.github/workflows/build-check.yml` |
 | Vercel deployment | ⏳ | Pending: `storybook.maple-and-spruce.com` |
 | Chromatic project token | ⏳ | Pending: Add `CHROMATIC_PROJECT_TOKEN` to GitHub secrets |
 

--- a/docs/plans/TESTING-INFRASTRUCTURE-PLAN.md
+++ b/docs/plans/TESTING-INFRASTRUCTURE-PLAN.md
@@ -1,0 +1,258 @@
+# Testing Infrastructure Implementation Plan
+
+> **Issue**: #24 - Add testing infrastructure
+> **Status**: Implemented
+> **Date**: 2026-01-19
+
+---
+
+## Executive Summary
+
+This plan establishes unit testing for Maple & Spruce using:
+- **Vitest** for unit tests (already installed)
+- **CI/CD integration** via GitHub Actions
+
+### Scope
+
+| In Scope | Out of Scope (Deferred) |
+|----------|------------------------|
+| Vitest unit tests for validation suites | E2E tests (Playwright) |
+| Vitest unit tests for domain helpers | Repository integration tests |
+| CI job to run tests on PRs | Firebase emulator tests |
+| 80% coverage requirement | Square service tests |
+
+### Testing Strategy
+
+| Layer | Tool | Purpose |
+|-------|------|---------|
+| Unit tests | Vitest | Validation suites, domain logic, utilities |
+| Component tests | Storybook + Chromatic | UI components in isolation (already complete) |
+| E2E tests | Playwright | Full user flows (deferred) |
+
+---
+
+## Current State
+
+### What Exists
+
+| Component | Status | Location |
+|-----------|--------|----------|
+| Vitest | Installed | `package.json` (v4.0.17) |
+| Storybook | Complete | All 15 components have stories |
+| Chromatic | Configured | Visual regression in CI |
+
+### What's Missing
+
+- No Vitest workspace configuration
+- No unit tests for validation suites
+- No unit tests for domain logic
+- No test job in CI workflow
+
+---
+
+## Implementation Plan
+
+### Phase 1: Vitest Configuration
+
+**Goal**: Set up Vitest workspace and library configs.
+
+#### 1.1 Workspace Configuration
+
+Create workspace-level Vitest config:
+
+```
+/vitest.workspace.ts          # Workspace config (points to lib configs)
+```
+
+#### 1.2 Library Test Configurations
+
+Add Vitest config and test target to each library:
+
+| Library | Config File |
+|---------|-------------|
+| `libs/ts/validation/` | `vitest.config.ts` |
+| `libs/ts/domain/` | `vitest.config.ts` |
+
+---
+
+### Phase 2: Validation Suite Tests
+
+**Goal**: 80%+ coverage on all validation suites (pure functions, no mocking needed).
+
+#### Files to Create
+
+```
+libs/ts/validation/src/lib/
+├── artist.validation.spec.ts          # NEW
+├── product.validation.spec.ts         # NEW
+├── category.validation.spec.ts        # NEW
+├── sale.validation.spec.ts            # NEW
+├── payout.validation.spec.ts          # NEW
+├── inventory-movement.validation.spec.ts  # NEW
+└── sync-conflict.validation.spec.ts   # NEW
+```
+
+#### Test Cases Per Suite
+
+Each validation suite should test:
+
+1. **Happy path** - Valid data passes validation
+2. **Required fields** - Missing required fields fail
+3. **Format validation** - Invalid formats fail (email, phone, etc.)
+4. **Boundary conditions** - Min/max values, edge cases
+5. **Single-field mode** - The `field` parameter for on-blur validation
+
+#### Example: Artist Validation Tests
+
+```typescript
+describe('artistValidation', () => {
+  describe('valid data', () => {
+    it('passes with all required fields', () => { ... });
+  });
+
+  describe('name field', () => {
+    it('fails when name is missing', () => { ... });
+    it('fails when name is too short', () => { ... });
+  });
+
+  describe('email field', () => {
+    it('fails when email is missing', () => { ... });
+    it('fails when email format is invalid', () => { ... });
+  });
+
+  describe('phone field', () => {
+    it('passes when phone is empty (optional)', () => { ... });
+    it('fails when phone format is invalid', () => { ... });
+  });
+
+  describe('defaultCommissionRate field', () => {
+    it('fails when commission rate is missing', () => { ... });
+    it('fails when commission rate is negative', () => { ... });
+    it('fails when commission rate exceeds 1', () => { ... });
+  });
+
+  describe('single-field validation', () => {
+    it('only validates specified field', () => { ... });
+  });
+});
+```
+
+---
+
+### Phase 3: Domain Helper Tests
+
+**Goal**: Test any utility functions in domain types.
+
+#### Files to Create
+
+```
+libs/ts/domain/src/lib/
+├── product.spec.ts                    # NEW (test generateSku)
+```
+
+#### Known Functions to Test
+
+| Function | Location | Test Cases |
+|----------|----------|------------|
+| `generateSku()` | `product.ts` | Returns valid format, uniqueness |
+
+---
+
+### Phase 4: CI Integration
+
+**Goal**: Run unit tests automatically on every PR, require 80% coverage.
+
+#### 4.1 Add Test Job to build-check.yml
+
+```yaml
+unit-tests:
+  name: Unit Tests
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        cache: 'npm'
+    - run: npm install --frozen-lockfile
+    - name: Run unit tests with coverage
+      run: npx nx run-many --target=test --all --coverage
+```
+
+#### 4.2 Add Test Scripts to package.json
+
+```json
+{
+  "scripts": {
+    "test": "nx run-many --target=test --all",
+    "test:coverage": "nx run-many --target=test --all --coverage"
+  }
+}
+```
+
+---
+
+## File Changes Summary
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `vitest.workspace.ts` | Workspace Vitest configuration |
+| `libs/ts/validation/vitest.config.ts` | Validation lib test config |
+| `libs/ts/validation/src/lib/*.spec.ts` | Validation suite tests (7 files) |
+| `libs/ts/domain/vitest.config.ts` | Domain lib test config |
+| `libs/ts/domain/src/lib/product.spec.ts` | Domain helper tests |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `.github/workflows/build-check.yml` | Add unit-tests job |
+| `package.json` | Add test scripts |
+| `libs/ts/validation/project.json` | Add test target |
+| `libs/ts/domain/project.json` | Add test target |
+
+---
+
+## Success Criteria
+
+- [ ] `npx nx run-many --target=test --all` passes
+- [ ] All 7 validation suites have tests
+- [ ] `generateSku()` has tests
+- [ ] 80%+ coverage on tested libraries
+- [ ] CI runs unit tests on every PR
+
+---
+
+## Deferred Items
+
+These items are explicitly out of scope for this implementation:
+
+| Item | Reason | Future Consideration |
+|------|--------|---------------------|
+| E2E tests (Playwright) | Features still evolving, Storybook covers components | Add when preparing for production launch |
+| Repository tests | Requires Firebase mocking complexity | Add when repository logic becomes more complex |
+| Square service tests | Working code, mocking Square SDK is complex | Add if bugs emerge |
+| Firebase emulator tests | Setup complexity | Consider for integration testing phase |
+
+---
+
+## References
+
+- [GitHub Issue #24](https://github.com/david-shortman/maple-and-spruce/issues/24)
+- [Vitest Documentation](https://vitest.dev/)
+- [Nx + Vitest Guide](https://nx.dev/recipes/testing/vitest)
+- [Vest Validation](https://vestjs.dev/)
+
+---
+
+## Approval
+
+- [ ] Plan reviewed
+- [ ] Ready to implement
+
+---
+
+*Created: 2026-01-19*

--- a/docs/sessions/SESSION.md
+++ b/docs/sessions/SESSION.md
@@ -7,9 +7,19 @@
 ## Current Status
 
 **Date**: 2026-01-19
-**Status**: ✅ Storybook implementation complete
+**Status**: ✅ Testing infrastructure complete
 
 ### Completed Today
+- **Unit Testing Infrastructure (#24):**
+  - Set up Vitest workspace configuration (`vitest.workspace.ts`)
+  - Configured validation library for testing (`libs/ts/validation/vitest.config.ts`)
+  - Configured domain library for testing (`libs/ts/domain/vitest.config.ts`)
+  - Wrote 7 validation suite tests (139 tests total)
+  - Wrote domain helper tests for `generateSku`, `isCacheStale`, `formatPrice`, `toCents` (25 tests)
+  - Added unit test job to CI workflow (`.github/workflows/build-check.yml`)
+  - Added `test` and `test:coverage` scripts to `package.json`
+  - Created implementation plan at `docs/plans/TESTING-INFRASTRUCTURE-PLAN.md`
+
 - **Storybook 10 implementation:**
   - Installed and configured `@storybook/nextjs` with Nx integration
   - Created mock data fixtures for artists, products, categories
@@ -76,6 +86,19 @@
 |---------|---------------------------|
 | Production | `prod` ✅ |
 | Development | `dev` ✅ |
+
+### Test Commands
+```bash
+# Run all tests
+npm test
+
+# Run with coverage
+npm run test:coverage
+
+# Run specific library
+npx nx run validation:test
+npx nx run domain:test
+```
 
 ### Storybook Commands
 ```bash

--- a/libs/ts/domain/project.json
+++ b/libs/ts/domain/project.json
@@ -7,6 +7,13 @@
   "targets": {
     "lint": {
       "executor": "@nx/eslint:lint"
+    },
+    "test": {
+      "executor": "@nx/vite:test",
+      "outputs": ["{options.reportsDirectory}"],
+      "options": {
+        "reportsDirectory": "../../../coverage/libs/ts/domain"
+      }
     }
   }
 }

--- a/libs/ts/domain/src/lib/product.spec.ts
+++ b/libs/ts/domain/src/lib/product.spec.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  generateSku,
+  isCacheStale,
+  getEffectiveCommissionRate,
+  formatPrice,
+  toCents,
+  CACHE_STALE_THRESHOLD_MS,
+} from './product';
+import type { Product } from './product';
+
+describe('generateSku', () => {
+  it('returns a string starting with prd_', () => {
+    const sku = generateSku();
+    expect(sku).toMatch(/^prd_/);
+  });
+
+  it('returns a string of correct length (prd_ + 8 chars)', () => {
+    const sku = generateSku();
+    expect(sku.length).toBe(12); // 'prd_' (4) + 8 random chars
+  });
+
+  it('generates unique SKUs on successive calls', () => {
+    const skus = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      skus.add(generateSku());
+    }
+    // All 100 should be unique
+    expect(skus.size).toBe(100);
+  });
+
+  it('only contains alphanumeric characters after prefix', () => {
+    const sku = generateSku();
+    const randomPart = sku.slice(4); // Remove 'prd_'
+    expect(randomPart).toMatch(/^[a-z0-9]+$/);
+  });
+});
+
+describe('isCacheStale', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns false when cache was just synced', () => {
+    const now = new Date();
+    vi.setSystemTime(now);
+
+    const product: Pick<Product, 'squareCache'> = {
+      squareCache: {
+        name: 'Test',
+        priceCents: 1000,
+        quantity: 5,
+        sku: 'prd_test123',
+        syncedAt: now,
+      },
+    };
+
+    expect(isCacheStale(product)).toBe(false);
+  });
+
+  it('returns false when cache is within threshold', () => {
+    const now = new Date();
+    vi.setSystemTime(now);
+
+    // Cache synced 4 minutes ago (threshold is 5 minutes)
+    const syncedAt = new Date(now.getTime() - 4 * 60 * 1000);
+
+    const product: Pick<Product, 'squareCache'> = {
+      squareCache: {
+        name: 'Test',
+        priceCents: 1000,
+        quantity: 5,
+        sku: 'prd_test123',
+        syncedAt,
+      },
+    };
+
+    expect(isCacheStale(product)).toBe(false);
+  });
+
+  it('returns true when cache exceeds threshold', () => {
+    const now = new Date();
+    vi.setSystemTime(now);
+
+    // Cache synced 6 minutes ago (threshold is 5 minutes)
+    const syncedAt = new Date(now.getTime() - 6 * 60 * 1000);
+
+    const product: Pick<Product, 'squareCache'> = {
+      squareCache: {
+        name: 'Test',
+        priceCents: 1000,
+        quantity: 5,
+        sku: 'prd_test123',
+        syncedAt,
+      },
+    };
+
+    expect(isCacheStale(product)).toBe(true);
+  });
+
+  it('returns true at exactly the threshold boundary', () => {
+    const now = new Date();
+    vi.setSystemTime(now);
+
+    // Cache synced exactly at threshold + 1ms
+    const syncedAt = new Date(now.getTime() - CACHE_STALE_THRESHOLD_MS - 1);
+
+    const product: Pick<Product, 'squareCache'> = {
+      squareCache: {
+        name: 'Test',
+        priceCents: 1000,
+        quantity: 5,
+        sku: 'prd_test123',
+        syncedAt,
+      },
+    };
+
+    expect(isCacheStale(product)).toBe(true);
+  });
+});
+
+describe('getEffectiveCommissionRate', () => {
+  it('returns custom rate when set', () => {
+    const product = { customCommissionRate: 0.25 };
+    const artistDefaultRate = 0.3;
+
+    expect(getEffectiveCommissionRate(product, artistDefaultRate)).toBe(0.25);
+  });
+
+  it('returns artist default rate when custom rate is undefined', () => {
+    const product = { customCommissionRate: undefined };
+    const artistDefaultRate = 0.3;
+
+    expect(getEffectiveCommissionRate(product, artistDefaultRate)).toBe(0.3);
+  });
+
+  it('returns custom rate of 0 when explicitly set to 0', () => {
+    const product = { customCommissionRate: 0 };
+    const artistDefaultRate = 0.3;
+
+    expect(getEffectiveCommissionRate(product, artistDefaultRate)).toBe(0);
+  });
+
+  it('returns custom rate of 1 when explicitly set to 1', () => {
+    const product = { customCommissionRate: 1 };
+    const artistDefaultRate = 0.3;
+
+    expect(getEffectiveCommissionRate(product, artistDefaultRate)).toBe(1);
+  });
+});
+
+describe('formatPrice', () => {
+  it('formats cents to dollars with 2 decimal places', () => {
+    expect(formatPrice(2500)).toBe('$25.00');
+  });
+
+  it('handles 0 cents', () => {
+    expect(formatPrice(0)).toBe('$0.00');
+  });
+
+  it('handles single digit cents', () => {
+    expect(formatPrice(5)).toBe('$0.05');
+  });
+
+  it('handles prices under $1', () => {
+    expect(formatPrice(99)).toBe('$0.99');
+  });
+
+  it('handles large prices', () => {
+    expect(formatPrice(10000000)).toBe('$100000.00');
+  });
+
+  it('formats prices with cents correctly', () => {
+    expect(formatPrice(1234)).toBe('$12.34');
+    expect(formatPrice(1)).toBe('$0.01');
+    expect(formatPrice(10)).toBe('$0.10');
+  });
+});
+
+describe('toCents', () => {
+  it('converts whole dollars to cents', () => {
+    expect(toCents(25)).toBe(2500);
+  });
+
+  it('converts dollars with cents', () => {
+    expect(toCents(25.99)).toBe(2599);
+  });
+
+  it('handles 0 dollars', () => {
+    expect(toCents(0)).toBe(0);
+  });
+
+  it('rounds fractional cents correctly', () => {
+    // $12.345 should round to 1235 cents
+    expect(toCents(12.345)).toBe(1235);
+    // $12.344 should round to 1234 cents
+    expect(toCents(12.344)).toBe(1234);
+  });
+
+  it('handles floating point precision issues', () => {
+    // 0.1 + 0.2 = 0.30000000000000004 in JS
+    // toCents should handle this gracefully
+    expect(toCents(0.1 + 0.2)).toBe(30);
+  });
+
+  it('handles large dollar amounts', () => {
+    expect(toCents(100000)).toBe(10000000);
+  });
+});
+
+describe('CACHE_STALE_THRESHOLD_MS', () => {
+  it('is set to 5 minutes', () => {
+    expect(CACHE_STALE_THRESHOLD_MS).toBe(5 * 60 * 1000);
+  });
+});

--- a/libs/ts/domain/vitest.config.ts
+++ b/libs/ts/domain/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  root: __dirname,
+  test: {
+    name: 'domain',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov'],
+      reportsDirectory: '../../../coverage/libs/ts/domain',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.spec.ts', 'src/index.ts'],
+      thresholds: {
+        branches: 80,
+        functions: 80,
+        lines: 80,
+        statements: 80,
+      },
+    },
+  },
+});

--- a/libs/ts/validation/project.json
+++ b/libs/ts/validation/project.json
@@ -10,6 +10,10 @@
     },
     "test": {
       "executor": "@nx/vite:test",
+      "defaultConfiguration": "default",
+      "configurations": {
+        "default": {}
+      },
       "outputs": ["{options.reportsDirectory}"],
       "options": {
         "reportsDirectory": "../../../coverage/libs/ts/validation"

--- a/libs/ts/validation/src/lib/artist.validation.spec.ts
+++ b/libs/ts/validation/src/lib/artist.validation.spec.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect } from 'vitest';
+import { artistValidation } from './artist.validation';
+import type { CreateArtistInput } from '@maple/ts/domain';
+
+describe('artistValidation', () => {
+  const validArtist: CreateArtistInput = {
+    name: 'Jane Doe',
+    email: 'jane@example.com',
+    phone: '555-123-4567',
+    defaultCommissionRate: 0.3,
+    status: 'active',
+  };
+
+  describe('valid data', () => {
+    it('passes with all required fields', () => {
+      const result = artistValidation(validArtist);
+      expect(result.isValid()).toBe(true);
+    });
+
+    it('passes without optional phone', () => {
+      const result = artistValidation({
+        ...validArtist,
+        phone: undefined,
+      });
+      expect(result.isValid()).toBe(true);
+    });
+  });
+
+  describe('name field', () => {
+    it('fails when name is missing', () => {
+      const result = artistValidation({
+        ...validArtist,
+        name: '',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('name')).toContain('Name is required');
+    });
+
+    it('fails when name is too short', () => {
+      const result = artistValidation({
+        ...validArtist,
+        name: 'A',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('name')).toContain(
+        'Name must be at least 2 characters'
+      );
+    });
+
+    it('passes with 2-character name', () => {
+      const result = artistValidation({
+        ...validArtist,
+        name: 'Jo',
+      });
+      expect(result.hasErrors('name')).toBe(false);
+    });
+  });
+
+  describe('email field', () => {
+    it('fails when email is missing', () => {
+      const result = artistValidation({
+        ...validArtist,
+        email: '',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('email')).toContain('Email is required');
+    });
+
+    it('fails when email format is invalid', () => {
+      const result = artistValidation({
+        ...validArtist,
+        email: 'not-an-email',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('email')).toContain('Email must be valid');
+    });
+
+    it('fails for email without domain', () => {
+      const result = artistValidation({
+        ...validArtist,
+        email: 'user@',
+      });
+      expect(result.isValid()).toBe(false);
+    });
+
+    it('passes with valid email formats', () => {
+      const validEmails = [
+        'user@example.com',
+        'user.name@example.com',
+        'user+tag@example.co.uk',
+      ];
+      validEmails.forEach((email) => {
+        const result = artistValidation({ ...validArtist, email });
+        expect(result.hasErrors('email')).toBe(false);
+      });
+    });
+  });
+
+  describe('phone field', () => {
+    it('passes when phone is empty (optional)', () => {
+      const result = artistValidation({
+        ...validArtist,
+        phone: '',
+      });
+      expect(result.hasErrors('phone')).toBe(false);
+    });
+
+    it('passes when phone is undefined (optional)', () => {
+      const result = artistValidation({
+        ...validArtist,
+        phone: undefined,
+      });
+      expect(result.hasErrors('phone')).toBe(false);
+    });
+
+    it('fails when phone format is invalid', () => {
+      const result = artistValidation({
+        ...validArtist,
+        phone: 'not-a-phone!',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('phone')).toContain(
+        'Phone must be valid if provided'
+      );
+    });
+
+    it('passes with various valid phone formats', () => {
+      const validPhones = [
+        '555-123-4567',
+        '(555) 123-4567',
+        '+1 555 123 4567',
+        '5551234567',
+      ];
+      validPhones.forEach((phone) => {
+        const result = artistValidation({ ...validArtist, phone });
+        expect(result.hasErrors('phone')).toBe(false);
+      });
+    });
+  });
+
+  describe('defaultCommissionRate field', () => {
+    it('fails when commission rate is missing', () => {
+      const result = artistValidation({
+        ...validArtist,
+        defaultCommissionRate: undefined,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('defaultCommissionRate')).toContain(
+        'Commission rate is required'
+      );
+    });
+
+    it('fails when commission rate is negative', () => {
+      const result = artistValidation({
+        ...validArtist,
+        defaultCommissionRate: -0.1,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('defaultCommissionRate')).toContain(
+        'Commission rate must be between 0 and 1'
+      );
+    });
+
+    it('fails when commission rate exceeds 1', () => {
+      const result = artistValidation({
+        ...validArtist,
+        defaultCommissionRate: 1.5,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('defaultCommissionRate')).toContain(
+        'Commission rate must be between 0 and 1'
+      );
+    });
+
+    it('passes with boundary values 0 and 1', () => {
+      [0, 1].forEach((rate) => {
+        const result = artistValidation({
+          ...validArtist,
+          defaultCommissionRate: rate,
+        });
+        expect(result.hasErrors('defaultCommissionRate')).toBe(false);
+      });
+    });
+
+    it('passes with typical commission rate', () => {
+      const result = artistValidation({
+        ...validArtist,
+        defaultCommissionRate: 0.3,
+      });
+      expect(result.hasErrors('defaultCommissionRate')).toBe(false);
+    });
+  });
+
+  describe('status field', () => {
+    it('fails when status is missing', () => {
+      const result = artistValidation({
+        ...validArtist,
+        status: '' as 'active',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('status')).toContain('Status is required');
+    });
+
+    it('fails when status is invalid', () => {
+      const result = artistValidation({
+        ...validArtist,
+        status: 'invalid' as 'active',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('status')).toContain(
+        'Status must be active or inactive'
+      );
+    });
+
+    it('passes with active status', () => {
+      const result = artistValidation({
+        ...validArtist,
+        status: 'active',
+      });
+      expect(result.hasErrors('status')).toBe(false);
+    });
+
+    it('passes with inactive status', () => {
+      const result = artistValidation({
+        ...validArtist,
+        status: 'inactive',
+      });
+      expect(result.hasErrors('status')).toBe(false);
+    });
+  });
+
+  describe('single-field validation', () => {
+    it('only validates specified field', () => {
+      const invalidData = {
+        name: '', // invalid
+        email: 'invalid', // invalid
+        defaultCommissionRate: 2, // invalid
+        status: '' as 'active', // invalid
+      };
+
+      // When validating only 'name', other errors should not appear
+      const result = artistValidation(invalidData, 'name');
+      expect(result.hasErrors('name')).toBe(true);
+      expect(result.hasErrors('email')).toBe(false);
+      expect(result.hasErrors('defaultCommissionRate')).toBe(false);
+      expect(result.hasErrors('status')).toBe(false);
+    });
+
+  });
+});

--- a/libs/ts/validation/src/lib/category.validation.spec.ts
+++ b/libs/ts/validation/src/lib/category.validation.spec.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import { categoryValidation } from './category.validation';
+import type { CreateCategoryInput } from '@maple/ts/domain';
+
+describe('categoryValidation', () => {
+  const validCategory: CreateCategoryInput = {
+    name: 'Pottery',
+    description: 'Handmade ceramic items',
+    order: 0,
+  };
+
+  describe('valid data', () => {
+    it('passes with all required fields', () => {
+      const result = categoryValidation(validCategory);
+      expect(result.isValid()).toBe(true);
+    });
+
+    it('passes without optional description', () => {
+      const result = categoryValidation({
+        name: 'Pottery',
+        order: 0,
+      });
+      expect(result.isValid()).toBe(true);
+    });
+  });
+
+  describe('name field', () => {
+    it('fails when name is missing', () => {
+      const result = categoryValidation({
+        ...validCategory,
+        name: '',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('name')).toContain('Name is required');
+    });
+
+    it('fails when name is too short', () => {
+      const result = categoryValidation({
+        ...validCategory,
+        name: 'A',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('name')).toContain(
+        'Name must be at least 2 characters'
+      );
+    });
+
+    it('fails when name exceeds 50 characters', () => {
+      const result = categoryValidation({
+        ...validCategory,
+        name: 'A'.repeat(51),
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('name')).toContain(
+        'Name must be at most 50 characters'
+      );
+    });
+
+    it('passes with 2-character name', () => {
+      const result = categoryValidation({
+        ...validCategory,
+        name: 'AB',
+      });
+      expect(result.hasErrors('name')).toBe(false);
+    });
+
+    it('passes with 50-character name', () => {
+      const result = categoryValidation({
+        ...validCategory,
+        name: 'A'.repeat(50),
+      });
+      expect(result.hasErrors('name')).toBe(false);
+    });
+  });
+
+  describe('description field', () => {
+    it('passes when description is empty (optional)', () => {
+      const result = categoryValidation({
+        ...validCategory,
+        description: '',
+      });
+      expect(result.hasErrors('description')).toBe(false);
+    });
+
+    it('passes when description is undefined (optional)', () => {
+      const result = categoryValidation({
+        ...validCategory,
+        description: undefined,
+      });
+      expect(result.hasErrors('description')).toBe(false);
+    });
+
+    it('fails when description exceeds 200 characters', () => {
+      const result = categoryValidation({
+        ...validCategory,
+        description: 'A'.repeat(201),
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('description')).toContain(
+        'Description must be at most 200 characters'
+      );
+    });
+
+    it('passes with 200-character description', () => {
+      const result = categoryValidation({
+        ...validCategory,
+        description: 'A'.repeat(200),
+      });
+      expect(result.hasErrors('description')).toBe(false);
+    });
+  });
+
+  describe('order field', () => {
+    it('fails when order is missing', () => {
+      const result = categoryValidation({
+        ...validCategory,
+        order: undefined as unknown as number,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('order')).toContain('Display order is required');
+    });
+
+    it('fails when order is negative', () => {
+      const result = categoryValidation({
+        ...validCategory,
+        order: -1,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('order')).toContain(
+        'Display order must be a non-negative number'
+      );
+    });
+
+    it('passes with 0 order', () => {
+      const result = categoryValidation({
+        ...validCategory,
+        order: 0,
+      });
+      expect(result.hasErrors('order')).toBe(false);
+    });
+
+    it('passes with positive order', () => {
+      const result = categoryValidation({
+        ...validCategory,
+        order: 10,
+      });
+      expect(result.hasErrors('order')).toBe(false);
+    });
+  });
+
+  describe('single-field validation', () => {
+    it('only validates specified field', () => {
+      const invalidData = {
+        name: '', // invalid
+        description: 'A'.repeat(201), // invalid
+        order: -1, // invalid
+      };
+
+      const result = categoryValidation(invalidData, 'name');
+      expect(result.hasErrors('name')).toBe(true);
+      expect(result.hasErrors('description')).toBe(false);
+      expect(result.hasErrors('order')).toBe(false);
+    });
+
+  });
+});

--- a/libs/ts/validation/src/lib/inventory-movement.validation.spec.ts
+++ b/libs/ts/validation/src/lib/inventory-movement.validation.spec.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect } from 'vitest';
+import { inventoryMovementValidation } from './inventory-movement.validation';
+import type { CreateInventoryMovementInput } from '@maple/ts/domain';
+
+describe('inventoryMovementValidation', () => {
+  const validMovement: CreateInventoryMovementInput = {
+    productId: 'prod-123',
+    type: 'restock',
+    quantityChange: 10,
+    quantityBefore: 5,
+    quantityAfter: 15,
+    source: 'manual',
+  };
+
+  describe('valid data', () => {
+    it('passes with all required fields', () => {
+      const result = inventoryMovementValidation(validMovement);
+      expect(result.isValid()).toBe(true);
+    });
+
+    it('passes with all valid movement types', () => {
+      const types: CreateInventoryMovementInput['type'][] = [
+        'sale',
+        'return',
+        'restock',
+        'adjustment',
+        'damaged',
+        'initial',
+      ];
+      types.forEach((type) => {
+        const movement =
+          type === 'sale'
+            ? { ...validMovement, type, saleId: 'sale-123' }
+            : { ...validMovement, type };
+        const result = inventoryMovementValidation(movement);
+        expect(result.hasErrors('type')).toBe(false);
+      });
+    });
+
+    it('passes with all valid sources', () => {
+      const sources: CreateInventoryMovementInput['source'][] = [
+        'manual',
+        'etsy',
+        'square',
+        'system',
+      ];
+      sources.forEach((source) => {
+        const result = inventoryMovementValidation({ ...validMovement, source });
+        expect(result.hasErrors('source')).toBe(false);
+      });
+    });
+  });
+
+  describe('productId field', () => {
+    it('fails when productId is missing', () => {
+      const result = inventoryMovementValidation({
+        ...validMovement,
+        productId: '',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('productId')).toContain('Product is required');
+    });
+  });
+
+  describe('type field', () => {
+    it('fails when type is missing', () => {
+      const result = inventoryMovementValidation({
+        ...validMovement,
+        type: '' as 'restock',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('type')).toContain('Movement type is required');
+    });
+
+    it('fails when type is invalid', () => {
+      const result = inventoryMovementValidation({
+        ...validMovement,
+        type: 'invalid' as 'restock',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('type')).toContain('Movement type must be valid');
+    });
+  });
+
+  describe('quantityChange field', () => {
+    it('fails when quantityChange is missing', () => {
+      const result = inventoryMovementValidation({
+        ...validMovement,
+        quantityChange: undefined as unknown as number,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('quantityChange')).toContain(
+        'Quantity change is required'
+      );
+    });
+
+    it('fails when quantityChange is 0', () => {
+      const result = inventoryMovementValidation({
+        ...validMovement,
+        quantityChange: 0,
+        quantityAfter: validMovement.quantityBefore, // Adjust to match
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('quantityChange')).toContain(
+        'Quantity change cannot be zero'
+      );
+    });
+
+    it('fails when quantityChange is not a whole number', () => {
+      const result = inventoryMovementValidation({
+        ...validMovement,
+        quantityChange: 2.5,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('quantityChange')).toContain(
+        'Quantity change must be a whole number'
+      );
+    });
+
+    it('passes with negative quantityChange (for sales/reductions)', () => {
+      const result = inventoryMovementValidation({
+        ...validMovement,
+        type: 'sale',
+        saleId: 'sale-123',
+        quantityChange: -2,
+        quantityBefore: 10,
+        quantityAfter: 8,
+      });
+      expect(result.hasErrors('quantityChange')).toBe(false);
+    });
+
+    it('passes with positive quantityChange (for restocks)', () => {
+      const result = inventoryMovementValidation({
+        ...validMovement,
+        quantityChange: 5,
+        quantityBefore: 10,
+        quantityAfter: 15,
+      });
+      expect(result.hasErrors('quantityChange')).toBe(false);
+    });
+  });
+
+  describe('quantityBefore field', () => {
+    it('fails when quantityBefore is missing', () => {
+      const result = inventoryMovementValidation({
+        ...validMovement,
+        quantityBefore: undefined as unknown as number,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('quantityBefore')).toContain(
+        'Quantity before is required'
+      );
+    });
+
+    it('fails when quantityBefore is negative', () => {
+      const result = inventoryMovementValidation({
+        ...validMovement,
+        quantityBefore: -1,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('quantityBefore')).toContain(
+        'Quantity before must be non-negative'
+      );
+    });
+
+    it('passes with 0 quantityBefore', () => {
+      const result = inventoryMovementValidation({
+        ...validMovement,
+        quantityBefore: 0,
+        quantityChange: 10,
+        quantityAfter: 10,
+      });
+      expect(result.hasErrors('quantityBefore')).toBe(false);
+    });
+  });
+
+  describe('quantityAfter field', () => {
+    it('fails when quantityAfter is missing', () => {
+      const result = inventoryMovementValidation({
+        ...validMovement,
+        quantityAfter: undefined as unknown as number,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('quantityAfter')).toContain(
+        'Quantity after is required'
+      );
+    });
+
+    it('fails when quantityAfter is negative', () => {
+      const result = inventoryMovementValidation({
+        ...validMovement,
+        quantityAfter: -1,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('quantityAfter')).toContain(
+        'Quantity after must be non-negative'
+      );
+    });
+
+    it('passes with 0 quantityAfter', () => {
+      const result = inventoryMovementValidation({
+        ...validMovement,
+        type: 'sale',
+        saleId: 'sale-123',
+        quantityBefore: 5,
+        quantityChange: -5,
+        quantityAfter: 0,
+      });
+      expect(result.hasErrors('quantityAfter')).toBe(false);
+    });
+  });
+
+  describe('source field', () => {
+    it('fails when source is missing', () => {
+      const result = inventoryMovementValidation({
+        ...validMovement,
+        source: '' as 'manual',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('source')).toContain('Source is required');
+    });
+
+    it('fails when source is invalid', () => {
+      const result = inventoryMovementValidation({
+        ...validMovement,
+        source: 'invalid' as 'manual',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('source')).toContain('Source must be valid');
+    });
+  });
+
+  describe('cross-field validation', () => {
+    it('fails when quantityAfter does not equal before + change', () => {
+      const result = inventoryMovementValidation({
+        ...validMovement,
+        quantityBefore: 10,
+        quantityChange: 5,
+        quantityAfter: 20, // Should be 15
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('quantityAfter')).toContain(
+        'Quantity after must equal before + change'
+      );
+    });
+
+    it('passes when quantityAfter equals before + change', () => {
+      const result = inventoryMovementValidation({
+        ...validMovement,
+        quantityBefore: 10,
+        quantityChange: 5,
+        quantityAfter: 15,
+      });
+      expect(result.hasErrors('quantityAfter')).toBe(false);
+    });
+
+    it('works correctly with negative changes', () => {
+      const result = inventoryMovementValidation({
+        type: 'sale',
+        productId: 'prod-123',
+        saleId: 'sale-123',
+        quantityBefore: 10,
+        quantityChange: -3,
+        quantityAfter: 7,
+        source: 'square',
+      });
+      expect(result.isValid()).toBe(true);
+    });
+  });
+
+  describe('saleId validation', () => {
+    it('fails when type is sale but saleId is missing', () => {
+      const result = inventoryMovementValidation({
+        ...validMovement,
+        type: 'sale',
+        saleId: undefined,
+        quantityChange: -1,
+        quantityAfter: validMovement.quantityBefore - 1,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('saleId')).toContain(
+        'Sale movements should have a sale ID'
+      );
+    });
+
+    it('passes when type is sale and saleId is provided', () => {
+      const result = inventoryMovementValidation({
+        ...validMovement,
+        type: 'sale',
+        saleId: 'sale-123',
+        quantityChange: -1,
+        quantityAfter: validMovement.quantityBefore - 1,
+      });
+      expect(result.hasErrors('saleId')).toBe(false);
+    });
+
+    it('passes when type is not sale and saleId is missing', () => {
+      const result = inventoryMovementValidation({
+        ...validMovement,
+        type: 'restock',
+        saleId: undefined,
+      });
+      expect(result.hasErrors('saleId')).toBe(false);
+    });
+  });
+
+  describe('single-field validation', () => {
+    it('only validates specified field', () => {
+      const invalidData = {
+        productId: '', // invalid
+        type: '' as 'restock', // invalid
+        quantityChange: 0, // invalid
+        quantityBefore: -1, // invalid
+        quantityAfter: -1, // invalid
+        source: '' as 'manual', // invalid
+      };
+
+      const result = inventoryMovementValidation(invalidData, 'productId');
+      expect(result.hasErrors('productId')).toBe(true);
+      expect(result.hasErrors('type')).toBe(false);
+      expect(result.hasErrors('quantityChange')).toBe(false);
+    });
+  });
+});

--- a/libs/ts/validation/src/lib/payout.validation.spec.ts
+++ b/libs/ts/validation/src/lib/payout.validation.spec.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { payoutValidation } from './payout.validation';
+import type { GeneratePayoutInput } from '@maple/ts/domain';
+
+describe('payoutValidation', () => {
+  const now = new Date('2026-01-15T12:00:00Z');
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const validPayout: GeneratePayoutInput = {
+    artistId: 'artist-123',
+    periodStart: new Date('2026-01-01T00:00:00Z'),
+    periodEnd: new Date('2026-01-14T23:59:59Z'),
+  };
+
+  describe('valid data', () => {
+    it('passes with all required fields', () => {
+      const result = payoutValidation(validPayout);
+      expect(result.isValid()).toBe(true);
+    });
+  });
+
+  describe('artistId field', () => {
+    it('fails when artistId is missing', () => {
+      const result = payoutValidation({
+        ...validPayout,
+        artistId: '',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('artistId')).toContain('Artist is required');
+    });
+  });
+
+  describe('periodStart field', () => {
+    it('fails when periodStart is missing', () => {
+      const result = payoutValidation({
+        ...validPayout,
+        periodStart: undefined as unknown as Date,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('periodStart')).toContain(
+        'Period start date is required'
+      );
+    });
+  });
+
+  describe('periodEnd field', () => {
+    it('fails when periodEnd is missing', () => {
+      const result = payoutValidation({
+        ...validPayout,
+        periodEnd: undefined as unknown as Date,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('periodEnd')).toContain(
+        'Period end date is required'
+      );
+    });
+  });
+
+  describe('cross-field validation', () => {
+    it('fails when end date is before start date', () => {
+      const result = payoutValidation({
+        ...validPayout,
+        periodStart: new Date('2026-01-10T00:00:00Z'),
+        periodEnd: new Date('2026-01-05T00:00:00Z'),
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('periodEnd')).toContain(
+        'End date must be after start date'
+      );
+    });
+
+    it('fails when end date equals start date', () => {
+      const sameDate = new Date('2026-01-10T00:00:00Z');
+      const result = payoutValidation({
+        ...validPayout,
+        periodStart: sameDate,
+        periodEnd: sameDate,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('periodEnd')).toContain(
+        'End date must be after start date'
+      );
+    });
+
+    it('fails when end date is in the future', () => {
+      const result = payoutValidation({
+        ...validPayout,
+        periodEnd: new Date('2026-01-20T00:00:00Z'), // 5 days after "now"
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('periodEnd')).toContain(
+        'End date cannot be in the future'
+      );
+    });
+
+    it('passes when end date is today (not in future)', () => {
+      const result = payoutValidation({
+        ...validPayout,
+        periodEnd: now,
+      });
+      expect(result.hasErrors('periodEnd')).toBe(false);
+    });
+
+    it('passes with valid date range', () => {
+      const result = payoutValidation({
+        ...validPayout,
+        periodStart: new Date('2026-01-01T00:00:00Z'),
+        periodEnd: new Date('2026-01-10T00:00:00Z'),
+      });
+      expect(result.isValid()).toBe(true);
+    });
+  });
+
+  describe('single-field validation', () => {
+    it('only validates specified field', () => {
+      const invalidData = {
+        artistId: '', // invalid
+        periodStart: undefined as unknown as Date, // invalid
+        periodEnd: undefined as unknown as Date, // invalid
+      };
+
+      const result = payoutValidation(invalidData, 'artistId');
+      expect(result.hasErrors('artistId')).toBe(true);
+      expect(result.hasErrors('periodStart')).toBe(false);
+      expect(result.hasErrors('periodEnd')).toBe(false);
+    });
+  });
+});

--- a/libs/ts/validation/src/lib/product.validation.spec.ts
+++ b/libs/ts/validation/src/lib/product.validation.spec.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect } from 'vitest';
+import { productValidation } from './product.validation';
+import type { CreateProductInput } from '@maple/ts/domain';
+
+describe('productValidation', () => {
+  const validProduct: CreateProductInput = {
+    artistId: 'artist-123',
+    status: 'active',
+    name: 'Handmade Pottery Bowl',
+    priceCents: 2500,
+    quantity: 5,
+  };
+
+  describe('valid data', () => {
+    it('passes with all required fields', () => {
+      const result = productValidation(validProduct);
+      expect(result.isValid()).toBe(true);
+    });
+
+    it('passes with optional fields', () => {
+      const result = productValidation({
+        ...validProduct,
+        categoryId: 'cat-123',
+        customCommissionRate: 0.25,
+        description: 'A beautiful handmade bowl',
+      });
+      expect(result.isValid()).toBe(true);
+    });
+  });
+
+  describe('artistId field', () => {
+    it('fails when artistId is missing', () => {
+      const result = productValidation({
+        ...validProduct,
+        artistId: '',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('artistId')).toContain('Artist is required');
+    });
+  });
+
+  describe('status field', () => {
+    it('fails when status is missing', () => {
+      const result = productValidation({
+        ...validProduct,
+        status: '' as 'active',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('status')).toContain('Status is required');
+    });
+
+    it('fails when status is invalid', () => {
+      const result = productValidation({
+        ...validProduct,
+        status: 'invalid' as 'active',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('status')).toContain(
+        'Status must be active, draft, or discontinued'
+      );
+    });
+
+    it('passes with all valid statuses', () => {
+      const validStatuses: ('active' | 'draft' | 'discontinued')[] = [
+        'active',
+        'draft',
+        'discontinued',
+      ];
+      validStatuses.forEach((status) => {
+        const result = productValidation({ ...validProduct, status });
+        expect(result.hasErrors('status')).toBe(false);
+      });
+    });
+  });
+
+  describe('customCommissionRate field', () => {
+    it('passes when commission rate is undefined (optional)', () => {
+      const result = productValidation({
+        ...validProduct,
+        customCommissionRate: undefined,
+      });
+      expect(result.hasErrors('customCommissionRate')).toBe(false);
+    });
+
+    it('fails when commission rate is negative', () => {
+      const result = productValidation({
+        ...validProduct,
+        customCommissionRate: -0.1,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('customCommissionRate')).toContain(
+        'Commission rate must be between 0 and 1'
+      );
+    });
+
+    it('fails when commission rate exceeds 1', () => {
+      const result = productValidation({
+        ...validProduct,
+        customCommissionRate: 1.5,
+      });
+      expect(result.isValid()).toBe(false);
+    });
+
+    it('passes with boundary values 0 and 1', () => {
+      [0, 1].forEach((rate) => {
+        const result = productValidation({
+          ...validProduct,
+          customCommissionRate: rate,
+        });
+        expect(result.hasErrors('customCommissionRate')).toBe(false);
+      });
+    });
+  });
+
+  describe('name field', () => {
+    it('fails when name is missing', () => {
+      const result = productValidation({
+        ...validProduct,
+        name: '',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('name')).toContain('Name is required');
+    });
+
+    it('fails when name is too short', () => {
+      const result = productValidation({
+        ...validProduct,
+        name: 'A',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('name')).toContain(
+        'Name must be at least 2 characters'
+      );
+    });
+
+    it('passes with 2-character name', () => {
+      const result = productValidation({
+        ...validProduct,
+        name: 'AB',
+      });
+      expect(result.hasErrors('name')).toBe(false);
+    });
+  });
+
+  describe('priceCents field', () => {
+    it('fails when price is missing', () => {
+      const result = productValidation({
+        ...validProduct,
+        priceCents: undefined as unknown as number,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('priceCents')).toContain('Price is required');
+    });
+
+    it('fails when price is 0', () => {
+      const result = productValidation({
+        ...validProduct,
+        priceCents: 0,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('priceCents')).toContain(
+        'Price must be greater than 0'
+      );
+    });
+
+    it('fails when price is negative', () => {
+      const result = productValidation({
+        ...validProduct,
+        priceCents: -100,
+      });
+      expect(result.isValid()).toBe(false);
+    });
+
+    it('fails when price exceeds $100,000', () => {
+      const result = productValidation({
+        ...validProduct,
+        priceCents: 10000001, // $100,000.01
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('priceCents')).toContain(
+        'Price cannot exceed $100,000'
+      );
+    });
+
+    it('passes with maximum allowed price ($100,000)', () => {
+      const result = productValidation({
+        ...validProduct,
+        priceCents: 10000000, // $100,000.00
+      });
+      expect(result.hasErrors('priceCents')).toBe(false);
+    });
+
+    it('passes with minimum valid price (1 cent)', () => {
+      const result = productValidation({
+        ...validProduct,
+        priceCents: 1,
+      });
+      expect(result.hasErrors('priceCents')).toBe(false);
+    });
+  });
+
+  describe('quantity field', () => {
+    it('fails when quantity is missing', () => {
+      const result = productValidation({
+        ...validProduct,
+        quantity: undefined as unknown as number,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('quantity')).toContain('Quantity is required');
+    });
+
+    it('fails when quantity is negative', () => {
+      const result = productValidation({
+        ...validProduct,
+        quantity: -1,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('quantity')).toContain(
+        'Quantity must be 0 or greater'
+      );
+    });
+
+    it('fails when quantity is not a whole number', () => {
+      const result = productValidation({
+        ...validProduct,
+        quantity: 2.5,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('quantity')).toContain(
+        'Quantity must be a whole number'
+      );
+    });
+
+    it('passes with 0 quantity', () => {
+      const result = productValidation({
+        ...validProduct,
+        quantity: 0,
+      });
+      expect(result.hasErrors('quantity')).toBe(false);
+    });
+
+    it('passes with positive whole number', () => {
+      const result = productValidation({
+        ...validProduct,
+        quantity: 100,
+      });
+      expect(result.hasErrors('quantity')).toBe(false);
+    });
+  });
+
+  describe('single-field validation', () => {
+    it('only validates specified field', () => {
+      const invalidData = {
+        artistId: '', // invalid
+        status: '' as 'active', // invalid
+        name: '', // invalid
+        priceCents: 0, // invalid
+        quantity: -1, // invalid
+      };
+
+      const result = productValidation(invalidData, 'name');
+      expect(result.hasErrors('name')).toBe(true);
+      expect(result.hasErrors('artistId')).toBe(false);
+      expect(result.hasErrors('priceCents')).toBe(false);
+    });
+
+  });
+});

--- a/libs/ts/validation/src/lib/sale.validation.spec.ts
+++ b/libs/ts/validation/src/lib/sale.validation.spec.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect } from 'vitest';
+import { saleValidation } from './sale.validation';
+import type { CreateSaleInput } from '@maple/ts/domain';
+
+describe('saleValidation', () => {
+  const validSale: CreateSaleInput = {
+    productId: 'prod-123',
+    artistId: 'artist-123',
+    salePrice: 25.0,
+    quantitySold: 1,
+    commission: 7.5,
+    artistEarnings: 17.5,
+    commissionRateApplied: 0.3,
+    source: 'square',
+    soldAt: new Date(),
+  };
+
+  describe('valid data', () => {
+    it('passes with all required fields', () => {
+      const result = saleValidation(validSale);
+      expect(result.isValid()).toBe(true);
+    });
+
+    it('passes with all valid sources', () => {
+      const sources: ('etsy' | 'square' | 'manual')[] = [
+        'etsy',
+        'square',
+        'manual',
+      ];
+      sources.forEach((source) => {
+        const result = saleValidation({ ...validSale, source });
+        expect(result.hasErrors('source')).toBe(false);
+      });
+    });
+  });
+
+  describe('productId field', () => {
+    it('fails when productId is missing', () => {
+      const result = saleValidation({
+        ...validSale,
+        productId: '',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('productId')).toContain('Product is required');
+    });
+  });
+
+  describe('artistId field', () => {
+    it('fails when artistId is missing', () => {
+      const result = saleValidation({
+        ...validSale,
+        artistId: '',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('artistId')).toContain('Artist is required');
+    });
+  });
+
+  describe('salePrice field', () => {
+    it('fails when salePrice is missing', () => {
+      const result = saleValidation({
+        ...validSale,
+        salePrice: undefined as unknown as number,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('salePrice')).toContain('Sale price is required');
+    });
+
+    it('fails when salePrice is 0', () => {
+      const result = saleValidation({
+        ...validSale,
+        salePrice: 0,
+        commission: 0,
+        artistEarnings: 0,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('salePrice')).toContain(
+        'Sale price must be greater than 0'
+      );
+    });
+
+    it('fails when salePrice is negative', () => {
+      const result = saleValidation({
+        ...validSale,
+        salePrice: -10,
+      });
+      expect(result.isValid()).toBe(false);
+    });
+  });
+
+  describe('quantitySold field', () => {
+    it('fails when quantitySold is missing', () => {
+      const result = saleValidation({
+        ...validSale,
+        quantitySold: undefined as unknown as number,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('quantitySold')).toContain(
+        'Quantity sold is required'
+      );
+    });
+
+    it('fails when quantitySold is 0', () => {
+      const result = saleValidation({
+        ...validSale,
+        quantitySold: 0,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('quantitySold')).toContain(
+        'Quantity sold must be at least 1'
+      );
+    });
+
+    it('fails when quantitySold is not a whole number', () => {
+      const result = saleValidation({
+        ...validSale,
+        quantitySold: 1.5,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('quantitySold')).toContain(
+        'Quantity sold must be a whole number'
+      );
+    });
+
+    it('passes with quantity of 1', () => {
+      const result = saleValidation({
+        ...validSale,
+        quantitySold: 1,
+      });
+      expect(result.hasErrors('quantitySold')).toBe(false);
+    });
+
+    it('passes with larger quantities', () => {
+      const result = saleValidation({
+        ...validSale,
+        quantitySold: 10,
+      });
+      expect(result.hasErrors('quantitySold')).toBe(false);
+    });
+  });
+
+  describe('commission field', () => {
+    it('fails when commission is missing', () => {
+      const result = saleValidation({
+        ...validSale,
+        commission: undefined as unknown as number,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('commission')).toContain('Commission is required');
+    });
+
+    it('fails when commission is negative', () => {
+      const result = saleValidation({
+        ...validSale,
+        commission: -5,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('commission')).toContain(
+        'Commission must be non-negative'
+      );
+    });
+
+    it('passes with 0 commission', () => {
+      const result = saleValidation({
+        ...validSale,
+        commission: 0,
+        artistEarnings: 25.0,
+        commissionRateApplied: 0,
+      });
+      expect(result.hasErrors('commission')).toBe(false);
+    });
+  });
+
+  describe('artistEarnings field', () => {
+    it('fails when artistEarnings is missing', () => {
+      const result = saleValidation({
+        ...validSale,
+        artistEarnings: undefined as unknown as number,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('artistEarnings')).toContain(
+        'Artist earnings is required'
+      );
+    });
+
+    it('fails when artistEarnings is negative', () => {
+      const result = saleValidation({
+        ...validSale,
+        artistEarnings: -10,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('artistEarnings')).toContain(
+        'Artist earnings must be non-negative'
+      );
+    });
+  });
+
+  describe('commissionRateApplied field', () => {
+    it('fails when commissionRateApplied is missing', () => {
+      const result = saleValidation({
+        ...validSale,
+        commissionRateApplied: undefined as unknown as number,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('commissionRateApplied')).toContain(
+        'Commission rate is required'
+      );
+    });
+
+    it('fails when commissionRateApplied is negative', () => {
+      const result = saleValidation({
+        ...validSale,
+        commissionRateApplied: -0.1,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('commissionRateApplied')).toContain(
+        'Commission rate must be between 0 and 1'
+      );
+    });
+
+    it('fails when commissionRateApplied exceeds 1', () => {
+      const result = saleValidation({
+        ...validSale,
+        commissionRateApplied: 1.5,
+      });
+      expect(result.isValid()).toBe(false);
+    });
+
+    it('passes with boundary values 0 and 1', () => {
+      [0, 1].forEach((rate) => {
+        const result = saleValidation({
+          ...validSale,
+          commissionRateApplied: rate,
+          commission: validSale.salePrice * rate,
+          artistEarnings: validSale.salePrice * (1 - rate),
+        });
+        expect(result.hasErrors('commissionRateApplied')).toBe(false);
+      });
+    });
+  });
+
+  describe('source field', () => {
+    it('fails when source is missing', () => {
+      const result = saleValidation({
+        ...validSale,
+        source: '' as 'square',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('source')).toContain('Sale source is required');
+    });
+
+    it('fails when source is invalid', () => {
+      const result = saleValidation({
+        ...validSale,
+        source: 'invalid' as 'square',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('source')).toContain(
+        'Sale source must be etsy, square, or manual'
+      );
+    });
+  });
+
+  describe('soldAt field', () => {
+    it('fails when soldAt is missing', () => {
+      const result = saleValidation({
+        ...validSale,
+        soldAt: undefined as unknown as Date,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('soldAt')).toContain('Sale date is required');
+    });
+  });
+
+  describe('cross-field validation', () => {
+    it('fails when commission + earnings does not equal sale price', () => {
+      const result = saleValidation({
+        ...validSale,
+        salePrice: 25.0,
+        commission: 5.0,
+        artistEarnings: 15.0, // 5 + 15 = 20, not 25
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('commission')).toContain(
+        'Commission + earnings must equal sale price'
+      );
+    });
+
+    it('passes when commission + earnings equals sale price', () => {
+      const result = saleValidation({
+        salePrice: 100.0,
+        commission: 30.0,
+        artistEarnings: 70.0,
+        productId: 'prod-123',
+        artistId: 'artist-123',
+        quantitySold: 1,
+        commissionRateApplied: 0.3,
+        source: 'square',
+        soldAt: new Date(),
+      });
+      expect(result.hasErrors('commission')).toBe(false);
+    });
+  });
+
+  describe('single-field validation', () => {
+    it('only validates specified field', () => {
+      const invalidData = {
+        productId: '', // invalid
+        artistId: '', // invalid
+        salePrice: 0, // invalid
+        quantitySold: 0, // invalid
+        commission: -1, // invalid
+        artistEarnings: -1, // invalid
+        commissionRateApplied: 2, // invalid
+        source: '' as 'square', // invalid
+        soldAt: new Date(),
+      };
+
+      const result = saleValidation(invalidData, 'productId');
+      expect(result.hasErrors('productId')).toBe(true);
+      expect(result.hasErrors('artistId')).toBe(false);
+      expect(result.hasErrors('salePrice')).toBe(false);
+    });
+  });
+});

--- a/libs/ts/validation/src/lib/sync-conflict.validation.spec.ts
+++ b/libs/ts/validation/src/lib/sync-conflict.validation.spec.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { syncConflictResolutionValidation } from './sync-conflict.validation';
+import type { ResolveSyncConflictInput } from '@maple/ts/domain';
+
+describe('syncConflictResolutionValidation', () => {
+  const validResolution: ResolveSyncConflictInput = {
+    conflictId: 'conflict-123',
+    resolution: 'use_local',
+  };
+
+  describe('valid data', () => {
+    it('passes with all required fields', () => {
+      const result = syncConflictResolutionValidation(validResolution);
+      expect(result.isValid()).toBe(true);
+    });
+
+    it('passes with all valid resolution types', () => {
+      const resolutions: ResolveSyncConflictInput['resolution'][] = [
+        'use_local',
+        'use_external',
+        'ignored',
+      ];
+      resolutions.forEach((resolution) => {
+        const result = syncConflictResolutionValidation({
+          ...validResolution,
+          resolution,
+        });
+        expect(result.hasErrors('resolution')).toBe(false);
+      });
+    });
+
+    it('passes for manual resolution with notes', () => {
+      const result = syncConflictResolutionValidation({
+        conflictId: 'conflict-123',
+        resolution: 'manual',
+        notes: 'Merged changes manually by keeping local price and external description',
+      });
+      expect(result.isValid()).toBe(true);
+    });
+  });
+
+  describe('conflictId field', () => {
+    it('fails when conflictId is missing', () => {
+      const result = syncConflictResolutionValidation({
+        ...validResolution,
+        conflictId: '',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('conflictId')).toContain(
+        'Conflict ID is required'
+      );
+    });
+  });
+
+  describe('resolution field', () => {
+    it('fails when resolution is missing', () => {
+      const result = syncConflictResolutionValidation({
+        ...validResolution,
+        resolution: '' as 'use_local',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('resolution')).toContain('Resolution is required');
+    });
+
+    it('fails when resolution is invalid', () => {
+      const result = syncConflictResolutionValidation({
+        ...validResolution,
+        resolution: 'invalid' as 'use_local',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('resolution')).toContain(
+        'Resolution must be valid'
+      );
+    });
+  });
+
+  describe('notes field (conditional validation)', () => {
+    it('fails when resolution is manual but notes are missing', () => {
+      const result = syncConflictResolutionValidation({
+        conflictId: 'conflict-123',
+        resolution: 'manual',
+        notes: undefined,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('notes')).toContain(
+        'Manual resolutions should include notes'
+      );
+    });
+
+    it('fails when resolution is manual but notes are empty', () => {
+      const result = syncConflictResolutionValidation({
+        conflictId: 'conflict-123',
+        resolution: 'manual',
+        notes: '',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('notes')).toContain(
+        'Manual resolutions should include notes'
+      );
+    });
+
+    it('passes when resolution is manual and notes are provided', () => {
+      const result = syncConflictResolutionValidation({
+        conflictId: 'conflict-123',
+        resolution: 'manual',
+        notes: 'Manually resolved by using local data',
+      });
+      expect(result.hasErrors('notes')).toBe(false);
+    });
+
+    it('passes when resolution is not manual and notes are missing', () => {
+      const result = syncConflictResolutionValidation({
+        conflictId: 'conflict-123',
+        resolution: 'use_local',
+        notes: undefined,
+      });
+      expect(result.hasErrors('notes')).toBe(false);
+    });
+
+    it('passes when resolution is not manual and notes are provided anyway', () => {
+      const result = syncConflictResolutionValidation({
+        conflictId: 'conflict-123',
+        resolution: 'use_external',
+        notes: 'Optional notes for non-manual resolution',
+      });
+      expect(result.hasErrors('notes')).toBe(false);
+    });
+  });
+
+  describe('single-field validation', () => {
+    it('only validates specified field', () => {
+      const invalidData = {
+        conflictId: '', // invalid
+        resolution: '' as 'use_local', // invalid
+      };
+
+      const result = syncConflictResolutionValidation(invalidData, 'conflictId');
+      expect(result.hasErrors('conflictId')).toBe(true);
+      expect(result.hasErrors('resolution')).toBe(false);
+    });
+
+  });
+});

--- a/libs/ts/validation/vitest.config.ts
+++ b/libs/ts/validation/vitest.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  root: __dirname,
+  test: {
+    name: 'validation',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov'],
+      reportsDirectory: '../../../coverage/libs/ts/validation',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.spec.ts', 'src/index.ts'],
+      thresholds: {
+        branches: 80,
+        functions: 80,
+        lines: 80,
+        statements: 80,
+      },
+    },
+  },
+  resolve: {
+    alias: {
+      '@maple/ts/domain': resolve(__dirname, '../domain/src/index.ts'),
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "@maple/source",
   "version": "0.0.0",
   "license": "MIT",
-  "scripts": {},
+  "scripts": {
+    "test": "nx run-many --target=test --all",
+    "test:coverage": "nx run-many --target=test --all --coverage"
+  },
   "private": true,
   "devDependencies": {
     "@eslint/js": "^9.8.0",

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,6 @@
+import { defineWorkspace } from 'vitest/config';
+
+export default defineWorkspace([
+  'libs/ts/validation/vitest.config.ts',
+  'libs/ts/domain/vitest.config.ts',
+]);


### PR DESCRIPTION
## Summary
- Set up Vitest workspace configuration for monorepo testing
- Add comprehensive unit tests for all 7 validation suites (139 tests)
- Add domain helper tests for `generateSku`, `isCacheStale`, `formatPrice`, `toCents` (25 tests)
- Add unit test job to CI workflow (`build-check.yml`)
- Add `test` and `test:coverage` scripts to package.json

## Test Coverage
| Library | Test Files | Tests |
|---------|------------|-------|
| validation | 7 | 139 |
| domain | 1 | 25 |
| **Total** | **8** | **164** |

## Test plan
- [x] All tests pass locally (`npm test`)
- [x] CI workflow includes unit-tests job
- [x] Coverage thresholds set to 80%

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)