### PR TITLE
feat: enable image upload during product creation

### DIFF
--- a/apps/maple-spruce/src/app/inventory/page.tsx
+++ b/apps/maple-spruce/src/app/inventory/page.tsx
@@ -3,12 +3,7 @@
 import { useState, useCallback, useMemo } from 'react';
 import { Box, Typography, Button } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
-import type {
-  Product,
-  CreateProductInput,
-  Artist,
-  Category,
-} from '@maple/ts/domain';
+import type { Product, CreateProductInput, Artist, Category } from '@maple/ts/domain';
 import { DeleteConfirmDialog } from '@maple/react/ui';
 import {
   ProductDataTable,
@@ -121,14 +116,14 @@ export default function InventoryPage() {
   }, []);
 
   const handleSubmitForm = useCallback(
-    async (data: CreateProductInput) => {
+    async (data: CreateProductInput): Promise<Product | void> => {
       setIsSubmitting(true);
 
       try {
         if (editingProduct) {
-          await updateProduct({ id: editingProduct.id, ...data });
+          return await updateProduct({ id: editingProduct.id, ...data });
         } else {
-          await createProduct(data);
+          return await createProduct(data);
         }
         // Form handles closing on success
       } finally {

--- a/apps/maple-spruce/src/components/inventory/ProductForm.tsx
+++ b/apps/maple-spruce/src/components/inventory/ProductForm.tsx
@@ -30,7 +30,8 @@ import { ImageUpload, type ImageUploadState } from '@maple/react/ui';
 interface ProductFormProps {
   open: boolean;
   onClose: () => void;
-  onSubmit: (data: CreateProductInput) => Promise<void>;
+  /** Returns the created/updated product so we can upload images after creation */
+  onSubmit: (data: CreateProductInput) => Promise<Product | void>;
   product?: Product;
   artists: Artist[];
   categories: Category[];

--- a/apps/maple-spruce/src/components/inventory/ProductFormSignals.stories.tsx
+++ b/apps/maple-spruce/src/components/inventory/ProductFormSignals.stories.tsx
@@ -297,3 +297,57 @@ export const CommissionRateInput: Story = {
     await expect(commissionInput).toHaveValue(35);
   },
 };
+
+// ============================================================
+// IMAGE UPLOAD ON CREATE STORIES
+// ============================================================
+
+/**
+ * Create mode shows image upload component (not the old "add after creation" alert)
+ *
+ * This verifies the UX improvement where users can select an image
+ * during product creation, not just when editing.
+ */
+export const CreateModeShowsImageUpload: Story = {
+  args: {
+    open: true,
+    isSubmitting: false,
+  },
+  play: async () => {
+    const canvas = await waitForDialog();
+
+    // The ImageUpload component should be present with its drop zone
+    // Look for the upload area text (not the old "can be added after creation" alert)
+    const uploadArea = canvas.getByText(/drag.*drop|click to upload/i);
+    await expect(uploadArea).toBeInTheDocument();
+
+    // The old info alert should NOT be present
+    const alerts = canvas.queryAllByRole('alert');
+    const addAfterCreationAlert = alerts.find((alert) =>
+      alert.textContent?.includes('after creation')
+    );
+    await expect(addAfterCreationAlert).toBeUndefined();
+  },
+};
+
+/**
+ * Edit mode also shows image upload (existing behavior preserved)
+ */
+export const EditModeShowsImageUpload: Story = {
+  args: {
+    open: true,
+    product: mockProduct,
+    isSubmitting: false,
+  },
+  play: async () => {
+    const canvas = await waitForDialog();
+
+    // Should show the existing image from the product
+    const existingImage = canvas.getByRole('img');
+    await expect(existingImage).toBeInTheDocument();
+    await expect(existingImage).toHaveAttribute(
+      'src',
+      expect.stringContaining('picsum')
+    );
+  },
+};


### PR DESCRIPTION
## Summary
- Enable image upload during product creation (not just edit)
- Add progress indicators: "Creating product..." → "Uploading image..."
- Keep modal open throughout the entire create + upload flow

## Changes
- `ProductFormSignals.tsx`: Enable ImageUpload for create mode, add `submissionPhase` signal for progress feedback
- `ProductForm.tsx`: Update type signature for consistency
- `inventory/page.tsx`: Return created product from submit handler
- `ProductFormSignals.stories.tsx`: Add stories verifying image upload is available on create

## Test plan
- [x] TypeScript compiles (`nx run maple-spruce:typecheck`)
- [x] Unit tests pass (164 tests)
- [x] Storybook builds successfully
- [x] App builds successfully
- [x] Manual testing: create product with image works locally

🤖 Generated with [Claude Code](https://claude.ai/code)