### PR TITLE
fix: remove status and createdAt from PublicArtist type

### DIFF
--- a/libs/ts/domain/src/lib/artist.ts
+++ b/libs/ts/domain/src/lib/artist.ts
@@ -44,26 +44,23 @@ export type UpdateArtistInput = Partial<
 
 /**
  * Public-facing artist information for website display.
- * Excludes sensitive data like email, commission rates, and internal notes.
+ * Excludes sensitive data like email, commission rates, internal notes,
+ * status (only active artists are returned), and timestamps.
  */
 export interface PublicArtist {
   id: string;
   name: string;
   photoUrl?: string;
-  /** Only 'active' artists are returned publicly, but included for type safety */
-  status: ArtistStatus;
-  createdAt: Date;
 }
 
 /**
  * Convert a full Artist to PublicArtist by stripping sensitive fields.
+ * Note: Only call this for active artists - filtering should happen at query level.
  */
 export function toPublicArtist(artist: Artist): PublicArtist {
   return {
     id: artist.id,
     name: artist.name,
     photoUrl: artist.photoUrl,
-    status: artist.status,
-    createdAt: artist.createdAt,
   };
 }


### PR DESCRIPTION
## Summary

Public API consumers don't need:
- `status` - only active artists are returned anyway (filtered at query level)
- `createdAt` - internal timestamp, not relevant to public display

Keep the public interface minimal: just `id`, `name`, and `photoUrl`.

## Changes
- `libs/ts/domain/src/lib/artist.ts` - Simplified `PublicArtist` interface and `toPublicArtist()` function

🤖 Generated with [Claude Code](https://claude.com/claude-code)