### PR TITLE
fix: resolve Firestore settings already initialized error

### DIFF
--- a/libs/firebase/database/src/lib/utilities/database.config.ts
+++ b/libs/firebase/database/src/lib/utilities/database.config.ts
@@ -40,8 +40,14 @@ export function getDb(): FirebaseFirestore.Firestore {
     ensureAdminInitialized();
     dbInstance = admin.firestore();
 
+    // Apply settings only once, and only if no operations have been performed yet.
+    // Wrap in try-catch because settings() throws if called after any Firestore operation.
     if (!settingsApplied) {
-      dbInstance.settings({ ignoreUndefinedProperties: true, preferRest: true });
+      try {
+        dbInstance.settings({ ignoreUndefinedProperties: true, preferRest: true });
+      } catch {
+        // Settings already applied or Firestore already in use - ignore
+      }
       settingsApplied = true;
     }
   }


### PR DESCRIPTION
## Summary
- Fixed the "Firestore has already been initialized" error that occurred on first function run after PR #100

## Changes
- `auth.utility.ts`: Changed to use centralized `getDb()` from `@maple/firebase/database` instead of directly calling `getFirestore()`, ensuring all Firestore access goes through a single initialization path
- `database.config.ts`: Added try-catch around `settings()` call as a defensive measure
- `auth.utility.spec.ts`: Updated tests to mock the new `@maple/firebase/database` dependency

## Root Cause
The `auth.utility.ts` was calling `getFirestore()` directly, which created a Firestore instance without our preferred settings. When `getDb()` was later called, it tried to apply settings to an already-initialized Firestore instance, causing the error.

## Test plan
- [x] Unit tests pass (`npm test`)
- [ ] Deploy and verify no errors on first function invocation
- [ ] Verify subsequent function calls still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)