### PR TITLE
fix: replace invalid npm install --frozen-lockfile with npm ci

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-      - run: npm install --frozen-lockfile
+      - run: npm ci --loglevel http
       - name: Run npm audit
         run: npm audit --audit-level=high
 
@@ -32,7 +32,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-      - run: npm install --frozen-lockfile
+      - run: npm ci --loglevel http
       - name: TypeScript typecheck
         run: npx nx run maple-spruce:typecheck
 
@@ -47,7 +47,14 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-      - run: npm install --frozen-lockfile
+      - run: npm ci --loglevel http
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
       - name: Build web app
         run: npx nx run maple-spruce:build
       - name: Build functions
@@ -67,7 +74,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-      - run: npm install --frozen-lockfile
+      - run: npm ci --loglevel http
       - name: Run unit tests with coverage
         run: npx vitest run --coverage
       - name: Report coverage
@@ -87,7 +94,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-      - run: npm install --frozen-lockfile
+      - run: npm ci --loglevel http
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
       - name: Build Storybook

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -26,7 +26,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --loglevel http
 
       - name: Build Storybook
         run: npx nx run maple-spruce:build-storybook

--- a/.github/workflows/firebase-functions-dev.yml
+++ b/.github/workflows/firebase-functions-dev.yml
@@ -37,7 +37,7 @@ jobs:
         run: echo "key=${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}" >> $GITHUB_OUTPUT
 
       - name: Install dependencies
-        run: npm install --frozen-lockfile
+        run: npm ci --loglevel http
 
       - name: Get affected functions
         id: get_affected
@@ -197,8 +197,16 @@ jobs:
       - name: Verify download
         run: ls -la dist/apps/functions
 
-      - name: Install dependencies
-        run: npm install --frozen-lockfile
+      - name: Restore node_modules cache
+        id: restore-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: ${{ needs.prepare_and_build.outputs.cache_key }}
+
+      - name: Install dependencies (fallback)
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: npm ci --loglevel http
 
       - name: Deploy functions group to Dev
         if: matrix.functions != ''

--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -40,7 +40,7 @@ jobs:
         run: echo "key=${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}" >> $GITHUB_OUTPUT
 
       - name: Install dependencies
-        run: npm install --frozen-lockfile
+        run: npm ci --loglevel http
 
       - name: Get affected functions
         id: get_affected
@@ -200,8 +200,16 @@ jobs:
       - name: Verify download
         run: ls -la dist/apps/functions
 
-      - name: Install dependencies
-        run: npm install --frozen-lockfile
+      - name: Restore node_modules cache
+        id: restore-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: ${{ needs.prepare_and_build.outputs.cache_key }}
+
+      - name: Install dependencies (fallback)
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: npm ci --loglevel http
 
       - name: Deploy functions group
         if: matrix.functions != ''


### PR DESCRIPTION
## Summary
- `npm install --frozen-lockfile` is a **Yarn flag** silently ignored by npm — installs were non-deterministic
- Replaced with `npm ci` (npm's actual lockfile-enforcing command) across all 4 workflows
- Added `--loglevel http` so registry requests produce visible output (prevents silent hangs on cache miss, which caused the Phase 3c runs to appear frozen)
- Added Next.js `.next/cache` caching to `build-check.yml` per [official Next.js CI docs](https://nextjs.org/docs/pages/guides/ci-build-caching)
- Firebase deploy jobs now restore `node_modules` from the build job's cache instead of doing a full cold install with no cache

## Changes
- `chromatic.yml`: `npm ci` → `npm ci --loglevel http`
- `build-check.yml`: `npm install --frozen-lockfile` → `npm ci --loglevel http` (×5 jobs), added `.next/cache` caching
- `firebase-functions-merge.yml`: `npm install --frozen-lockfile` → `npm ci --loglevel http`, deploy job restores `node_modules` cache from build job
- `firebase-functions-dev.yml`: same as merge workflow

## Testing
- [ ] CI passes on this PR (build-check workflow validates itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)