### PR TITLE
fix: use firebase binary name in CI deploy workflows

### DIFF
--- a/.github/workflows/firebase-functions-dev.yml
+++ b/.github/workflows/firebase-functions-dev.yml
@@ -216,7 +216,7 @@ jobs:
 
       - name: Deploy functions group to Dev
         if: matrix.functions != ''
-        run: pnpm exec firebase-tools deploy --only ${{ matrix.functions }} --project maple-and-spruce-dev --force --token "$(gcloud auth print-access-token)"
+        run: pnpm exec firebase deploy --only ${{ matrix.functions }} --project maple-and-spruce-dev --force --token "$(gcloud auth print-access-token)"
 
       - name: Skip empty function group
         if: matrix.functions == ''

--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -219,7 +219,7 @@ jobs:
 
       - name: Deploy functions group
         if: matrix.functions != ''
-        run: pnpm exec firebase-tools deploy --only ${{ matrix.functions }} --project maple-and-spruce --force --token "$(gcloud auth print-access-token)"
+        run: pnpm exec firebase deploy --only ${{ matrix.functions }} --project maple-and-spruce --force --token "$(gcloud auth print-access-token)"
 
       - name: Skip empty function group
         if: matrix.functions == ''


### PR DESCRIPTION
## Summary

- Fix `pnpm exec firebase-tools` → `pnpm exec firebase` in both deploy workflows
- `firebase-tools` is the npm package name, but the CLI binary it installs is `firebase`
- With npm's `npx`, both worked because npx resolves package names. `pnpm exec` only resolves binary names.

## Test plan

- [ ] Firebase functions deploy to dev succeeds on push to feature/fix branch
- [ ] Firebase functions deploy on merge to main succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)