### PR TITLE
fix: include VTIMEZONE in empty ICS feeds

### DIFF
--- a/libs/ts/calendar/src/lib/generate-ics-feed.spec.ts
+++ b/libs/ts/calendar/src/lib/generate-ics-feed.spec.ts
@@ -136,6 +136,14 @@ describe('generateIcsFeed', () => {
     expect(ics).not.toContain('BEGIN:VEVENT');
   });
 
+  it('includes VTIMEZONE even with no events', () => {
+    const ics = generateIcsFeed([], 'Empty Calendar');
+
+    expect(ics).toContain('BEGIN:VTIMEZONE');
+    expect(ics).toContain('TZID:America/New_York');
+    expect(ics).toContain('END:VTIMEZONE');
+  });
+
   it('includes prodId with Maple & Spruce', () => {
     const ics = generateIcsFeed([], 'Test');
 

--- a/libs/ts/calendar/src/lib/generate-ics-feed.ts
+++ b/libs/ts/calendar/src/lib/generate-ics-feed.ts
@@ -85,14 +85,16 @@ export function generateIcsFeed(
 
   // ical-generator does not emit VTIMEZONE blocks, which strict parsers
   // (e.g. Open Web Calendar / recurring-ical-events) require to resolve
-  // TZID references. Inject the VTIMEZONE component after the calendar header.
+  // TZID references. Always inject VTIMEZONE — even empty feeds declare
+  // TIMEZONE-ID which parsers try to resolve.
   const icsString = calendar.toString();
   const vtimezone = getVtimezoneComponent(TIMEZONE);
   if (vtimezone) {
-    return icsString.replace(
-      'BEGIN:VEVENT',
-      `${vtimezone}\r\nBEGIN:VEVENT`
-    );
+    // Insert before first VEVENT if events exist, otherwise before END:VCALENDAR
+    const insertBefore = icsString.includes('BEGIN:VEVENT')
+      ? 'BEGIN:VEVENT'
+      : 'END:VCALENDAR';
+    return icsString.replace(insertBefore, `${vtimezone}\r\n${insertBefore}`);
   }
   return icsString;
 }


### PR DESCRIPTION
## Summary
- Empty ICS feeds (e.g. hours feed with no events) still declare `TIMEZONE-ID` in the header, which causes Open Web Calendar's parser to fail with `ZoneInfoNotFoundError`
- Fixed VTIMEZONE injection to insert before `END:VCALENDAR` when no events exist

## Test plan
- [ ] `npm test` passes (13 calendar tests including new empty-feed VTIMEZONE test)
- [ ] After deploy, verify hours feed no longer causes errors in Open Web Calendar embed


🤖 Generated with [Claude Code](https://claude.com/claude-code)