### PR TITLE
feat: configurable calendar embed with admin UI

### DIFF
--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -116,6 +116,13 @@ export { calendarAdhocProxy } from '@maple/firebase/maple-functions/calendar-adh
 // Calendar triggers (Firestore)
 export { onClassWrite } from '@maple/firebase/maple-functions/on-class-write';
 
+// Calendar embed config
+export { getCalendarEmbedConfig } from '@maple/firebase/maple-functions/get-calendar-embed-config';
+export { updateCalendarEmbedConfig } from '@maple/firebase/maple-functions/update-calendar-embed-config';
+export { addCalendarEmbedSource } from '@maple/firebase/maple-functions/add-calendar-embed-source';
+export { removeCalendarEmbedSource } from '@maple/firebase/maple-functions/remove-calendar-embed-source';
+export { calendarEmbed } from '@maple/firebase/maple-functions/calendar-embed';
+
 // Registration functions
 export { getRegistrations } from '@maple/firebase/maple-functions/get-registrations';
 export { getRegistration } from '@maple/firebase/maple-functions/get-registration';

--- a/apps/maple-spruce/src/app/calendar-embed/page.tsx
+++ b/apps/maple-spruce/src/app/calendar-embed/page.tsx
@@ -1,0 +1,489 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  Card,
+  CardContent,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Switch,
+  IconButton,
+  Chip,
+  TextField,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Alert,
+  CircularProgress,
+  Skeleton,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import LockIcon from '@mui/icons-material/Lock';
+import SaveIcon from '@mui/icons-material/Save';
+import type {
+  CalendarEmbedSource,
+  CreateCalendarEmbedSourceInput,
+  UpdateCalendarEmbedSettingsInput,
+} from '@maple/ts/domain';
+import { DeleteConfirmDialog } from '@maple/react/ui';
+import { AppShell } from '../../components/layout';
+import { useCalendarEmbedConfig } from '@maple/react/data';
+
+function AddSourceDialog({
+  open,
+  onClose,
+  onSubmit,
+  isSubmitting,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (input: CreateCalendarEmbedSourceInput) => Promise<void>;
+  isSubmitting: boolean;
+}) {
+  const [label, setLabel] = useState('');
+  const [url, setUrl] = useState('');
+  const [color, setColor] = useState('5C8A97');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    if (!label.trim() || !url.trim()) {
+      setError('Label and URL are required');
+      return;
+    }
+    setError(null);
+    try {
+      await onSubmit({ label: label.trim(), url: url.trim(), color, enabled: true });
+      setLabel('');
+      setUrl('');
+      setColor('5C8A97');
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add source');
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Add Calendar Source</DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          {error && <Alert severity="error">{error}</Alert>}
+          <TextField
+            label="Label"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="e.g. Katie's Ad-Hoc Events"
+            required
+            fullWidth
+            autoFocus
+          />
+          <TextField
+            label="ICS Feed URL"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://calendar.google.com/calendar/ical/.../basic.ics"
+            required
+            fullWidth
+          />
+          <TextField
+            label="Color (hex without #)"
+            value={color}
+            onChange={(e) => setColor(e.target.value.replace('#', ''))}
+            placeholder="5C8A97"
+            fullWidth
+            InputProps={{
+              startAdornment: (
+                <Box
+                  sx={{
+                    width: 20,
+                    height: 20,
+                    borderRadius: '4px',
+                    backgroundColor: `#${color}`,
+                    mr: 1,
+                    flexShrink: 0,
+                  }}
+                />
+              ),
+            }}
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={isSubmitting}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? 'Adding...' : 'Add Source'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default function CalendarEmbedPage() {
+  const { configState, updateSettings, addSource, removeSource } =
+    useCalendarEmbedConfig();
+
+  // Add source dialog
+  const [isAddOpen, setIsAddOpen] = useState(false);
+  const [isAddSubmitting, setIsAddSubmitting] = useState(false);
+
+  // Delete source dialog
+  const [sourceToDelete, setSourceToDelete] =
+    useState<CalendarEmbedSource | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  // Settings form
+  const [isSavingSettings, setIsSavingSettings] = useState(false);
+  const [settingsSuccess, setSettingsSuccess] = useState(false);
+
+  const handleAddSource = useCallback(
+    async (input: CreateCalendarEmbedSourceInput) => {
+      setIsAddSubmitting(true);
+      try {
+        await addSource(input);
+      } finally {
+        setIsAddSubmitting(false);
+      }
+    },
+    [addSource]
+  );
+
+  const handleToggleSource = useCallback(
+    async (source: CalendarEmbedSource) => {
+      // Use updateSettings to toggle - we update the full config
+      // Actually we need updateSource - but we only have updateSettings and addSource/removeSource
+      // For now, updateSettings doesn't handle individual source updates
+      // We'll need to re-save the full sources array via updateSettings
+      if (configState.status !== 'success') return;
+      const updatedSources = configState.data.sources.map((s) =>
+        s.id === source.id ? { ...s, enabled: !s.enabled } : s
+      );
+      await updateSettings({ sources: updatedSources } as UpdateCalendarEmbedSettingsInput);
+    },
+    [configState, updateSettings]
+  );
+
+  const handleDeleteSource = useCallback(async () => {
+    if (!sourceToDelete) return;
+    setIsDeleting(true);
+    try {
+      await removeSource(sourceToDelete.id);
+      setSourceToDelete(null);
+    } catch (error) {
+      console.error('Failed to remove source:', error);
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [sourceToDelete, removeSource]);
+
+  const handleSaveSettings = useCallback(
+    async (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      if (configState.status !== 'success') return;
+      setIsSavingSettings(true);
+      setSettingsSuccess(false);
+
+      const form = e.currentTarget;
+      const formData = new FormData(form);
+
+      const input: UpdateCalendarEmbedSettingsInput = {
+        owcBaseUrl: formData.get('owcBaseUrl') as string,
+        title: formData.get('title') as string,
+        defaultTab: formData.get('defaultTab') as string,
+        skin: formData.get('skin') as string,
+        startOfWeek: formData.get('startOfWeek') as string,
+        timezone: formData.get('timezone') as string,
+        cssUrl: formData.get('cssUrl') as string,
+      };
+
+      try {
+        await updateSettings(input);
+        setSettingsSuccess(true);
+        setTimeout(() => setSettingsSuccess(false), 3000);
+      } catch (error) {
+        console.error('Failed to save settings:', error);
+      } finally {
+        setIsSavingSettings(false);
+      }
+    },
+    [configState, updateSettings]
+  );
+
+  if (configState.status === 'loading' || configState.status === 'idle') {
+    return (
+      <AppShell>
+        <Typography variant="h4" component="h1" sx={{ mb: 3 }}>
+          Calendar Embed
+        </Typography>
+        <Skeleton variant="rounded" height={200} />
+      </AppShell>
+    );
+  }
+
+  if (configState.status === 'error') {
+    return (
+      <AppShell>
+        <Typography variant="h4" component="h1" sx={{ mb: 3 }}>
+          Calendar Embed
+        </Typography>
+        <Alert severity="error">{configState.error}</Alert>
+      </AppShell>
+    );
+  }
+
+  const config = configState.data;
+
+  return (
+    <AppShell>
+      <Typography variant="h4" component="h1" sx={{ mb: 3 }}>
+        Calendar Embed
+      </Typography>
+
+      {/* Calendar Sources */}
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mb: 2,
+        }}
+      >
+        <Typography variant="h6">Calendar Sources</Typography>
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={() => setIsAddOpen(true)}
+          size="small"
+        >
+          Add Source
+        </Button>
+      </Box>
+
+      <TableContainer component={Card} sx={{ mb: 4 }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Color</TableCell>
+              <TableCell>Label</TableCell>
+              <TableCell>URL</TableCell>
+              <TableCell>Type</TableCell>
+              <TableCell align="center">Enabled</TableCell>
+              <TableCell align="right">Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {config.sources.map((source) => (
+              <TableRow key={source.id}>
+                <TableCell>
+                  <Box
+                    sx={{
+                      width: 20,
+                      height: 20,
+                      borderRadius: '4px',
+                      backgroundColor: `#${source.color}`,
+                    }}
+                  />
+                </TableCell>
+                <TableCell>{source.label}</TableCell>
+                <TableCell>
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      maxWidth: 300,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      fontFamily: 'monospace',
+                      fontSize: '0.75rem',
+                    }}
+                  >
+                    {source.url}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  {source.isSystem ? (
+                    <Chip label="System" size="small" variant="outlined" />
+                  ) : (
+                    <Chip label="Custom" size="small" color="info" />
+                  )}
+                </TableCell>
+                <TableCell align="center">
+                  <Switch
+                    checked={source.enabled}
+                    onChange={() => handleToggleSource(source)}
+                    size="small"
+                  />
+                </TableCell>
+                <TableCell align="right">
+                  {source.isSystem ? (
+                    <IconButton size="small" disabled>
+                      <LockIcon fontSize="small" />
+                    </IconButton>
+                  ) : (
+                    <IconButton
+                      size="small"
+                      color="error"
+                      onClick={() => setSourceToDelete(source)}
+                    >
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      {/* Display Settings */}
+      <Typography variant="h6" sx={{ mb: 2 }}>
+        Display Settings
+      </Typography>
+
+      <Card>
+        <CardContent>
+          <form onSubmit={handleSaveSettings}>
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+                gap: 2,
+              }}
+            >
+              <TextField
+                name="owcBaseUrl"
+                label="Open Web Calendar URL"
+                defaultValue={config.owcBaseUrl}
+                fullWidth
+                size="small"
+              />
+              <TextField
+                name="title"
+                label="Calendar Title"
+                defaultValue={config.title}
+                fullWidth
+                size="small"
+              />
+              <FormControl size="small" fullWidth>
+                <InputLabel>Default View</InputLabel>
+                <Select
+                  name="defaultTab"
+                  label="Default View"
+                  defaultValue={config.defaultTab}
+                >
+                  <MenuItem value="month">Month</MenuItem>
+                  <MenuItem value="week">Week</MenuItem>
+                  <MenuItem value="day">Day</MenuItem>
+                  <MenuItem value="agenda">Agenda</MenuItem>
+                </Select>
+              </FormControl>
+              <FormControl size="small" fullWidth>
+                <InputLabel>Skin</InputLabel>
+                <Select
+                  name="skin"
+                  label="Skin"
+                  defaultValue={config.skin}
+                >
+                  <MenuItem value="material">Material</MenuItem>
+                  <MenuItem value="flat">Flat</MenuItem>
+                  <MenuItem value="terrace">Terrace</MenuItem>
+                  <MenuItem value="contrast-black">Contrast Black</MenuItem>
+                  <MenuItem value="contrast-white">Contrast White</MenuItem>
+                </Select>
+              </FormControl>
+              <FormControl size="small" fullWidth>
+                <InputLabel>Start of Week</InputLabel>
+                <Select
+                  name="startOfWeek"
+                  label="Start of Week"
+                  defaultValue={config.startOfWeek}
+                >
+                  <MenuItem value="su">Sunday</MenuItem>
+                  <MenuItem value="mo">Monday</MenuItem>
+                </Select>
+              </FormControl>
+              <TextField
+                name="timezone"
+                label="Timezone"
+                defaultValue={config.timezone}
+                fullWidth
+                size="small"
+              />
+              <TextField
+                name="cssUrl"
+                label="Custom CSS URL (optional)"
+                defaultValue={config.cssUrl}
+                fullWidth
+                size="small"
+                sx={{ gridColumn: { sm: '1 / -1' } }}
+              />
+            </Box>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 2,
+                mt: 2,
+              }}
+            >
+              <Button
+                type="submit"
+                variant="contained"
+                startIcon={
+                  isSavingSettings ? (
+                    <CircularProgress size={16} />
+                  ) : (
+                    <SaveIcon />
+                  )
+                }
+                disabled={isSavingSettings}
+              >
+                {isSavingSettings ? 'Saving...' : 'Save Settings'}
+              </Button>
+              {settingsSuccess && (
+                <Alert severity="success" sx={{ py: 0 }}>
+                  Settings saved
+                </Alert>
+              )}
+            </Box>
+          </form>
+        </CardContent>
+      </Card>
+
+      {/* Dialogs */}
+      <AddSourceDialog
+        open={isAddOpen}
+        onClose={() => setIsAddOpen(false)}
+        onSubmit={handleAddSource}
+        isSubmitting={isAddSubmitting}
+      />
+
+      <DeleteConfirmDialog
+        open={!!sourceToDelete}
+        onClose={() => setSourceToDelete(null)}
+        onConfirm={handleDeleteSource}
+        isDeleting={isDeleting}
+        title="Remove Calendar Source?"
+        itemName={sourceToDelete?.label ?? ''}
+      />
+    </AppShell>
+  );
+}

--- a/apps/maple-spruce/src/components/layout/AppShellWrapper.tsx
+++ b/apps/maple-spruce/src/components/layout/AppShellWrapper.tsx
@@ -9,6 +9,7 @@ import SyncProblemIcon from '@mui/icons-material/SyncProblem';
 import SchoolIcon from '@mui/icons-material/School';
 import EventIcon from '@mui/icons-material/Event';
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
+import TuneIcon from '@mui/icons-material/Tune';
 import LocalOfferIcon from '@mui/icons-material/LocalOffer';
 import HowToRegIcon from '@mui/icons-material/HowToReg';
 import { AppShell, type NavItem } from '@maple/react/layout';
@@ -53,6 +54,11 @@ export function AppShellWrapper({
         label: 'Calendar Events',
         href: '/events',
         icon: <CalendarMonthIcon />,
+      },
+      {
+        label: 'Calendar Embed',
+        href: '/calendar-embed',
+        icon: <TuneIcon />,
       },
       {
         label: 'Sync',

--- a/docs/reference/deployed-functions.md
+++ b/docs/reference/deployed-functions.md
@@ -40,6 +40,10 @@
 ## Calendar Triggers (Phase 4.5)
 - `onClassWrite` — Firestore trigger: auto-generates CalendarEvents from published classes
 
+## Calendar Embed Config
+- `getCalendarEmbedConfig`, `updateCalendarEmbedConfig`, `addCalendarEmbedSource`, `removeCalendarEmbedSource`
+- `calendarEmbed` — HTTP: `/calendar/embed` (redirects to OWC with configured sources)
+
 ## Auth
 - `checkAdminStatus` — Authenticated users can check if they have admin access
 

--- a/firebase.json
+++ b/firebase.json
@@ -33,7 +33,8 @@
       { "source": "/calendar/events.ics", "function": "calendarEventsFeed" },
       { "source": "/calendar/hours.ics", "function": "calendarHoursFeed" },
       { "source": "/calendar/all.ics", "function": "calendarAllFeed" },
-      { "source": "/calendar/adhoc.ics", "function": "calendarAdhocProxy" }
+      { "source": "/calendar/adhoc.ics", "function": "calendarAdhocProxy" },
+      { "source": "/calendar/embed", "function": "calendarEmbed" }
     ]
   },
   "emulators": {

--- a/libs/firebase/database/src/index.ts
+++ b/libs/firebase/database/src/index.ts
@@ -27,3 +27,4 @@ export {
   CalendarEventRepository,
   type CalendarEventFilters,
 } from './lib/calendar-event.repository';
+export { CalendarEmbedConfigRepository } from './lib/calendar-embed-config.repository';

--- a/libs/firebase/database/src/lib/calendar-embed-config.repository.ts
+++ b/libs/firebase/database/src/lib/calendar-embed-config.repository.ts
@@ -1,0 +1,187 @@
+/**
+ * Calendar Embed Config Repository
+ *
+ * Singleton document at config/calendarEmbed. Seeds defaults on first read.
+ */
+import { db, toDate } from './utilities/database.config';
+import type {
+  CalendarEmbedConfig,
+  CalendarEmbedSource,
+  UpdateCalendarEmbedSettingsInput,
+  CreateCalendarEmbedSourceInput,
+  UpdateCalendarEmbedSourceInput,
+} from '@maple/ts/domain';
+
+const COLLECTION = 'config';
+const DOC_ID = 'calendarEmbed';
+
+function generateId(): string {
+  return db.collection('_').doc().id;
+}
+
+const DEFAULT_SYSTEM_SOURCES: CalendarEmbedSource[] = [
+  {
+    id: 'system-classes',
+    label: 'Classes & Workshops',
+    url: '/calendar/classes.ics',
+    color: '6B7B5E',
+    isSystem: true,
+    enabled: true,
+  },
+  {
+    id: 'system-music',
+    label: 'Music Lessons',
+    url: '/calendar/music.ics',
+    color: '4A3728',
+    isSystem: true,
+    enabled: true,
+  },
+  {
+    id: 'system-events',
+    label: 'Events & Jams',
+    url: '/calendar/events.ics',
+    color: 'C17817',
+    isSystem: true,
+    enabled: true,
+  },
+  {
+    id: 'system-hours',
+    label: 'Store Hours',
+    url: '/calendar/hours.ics',
+    color: '7A7A6E',
+    isSystem: true,
+    enabled: true,
+  },
+];
+
+function buildDefaultConfig(): Omit<CalendarEmbedConfig, 'updatedAt'> {
+  return {
+    owcBaseUrl: 'https://open-web-calendar-thz2.vercel.app',
+    defaultTab: 'month',
+    tabs: ['month', 'week', 'agenda'],
+    skin: 'material',
+    startOfWeek: 'su',
+    timezone: 'America/New_York',
+    title: 'Maple & Spruce Calendar',
+    cssUrl: '',
+    sources: DEFAULT_SYSTEM_SOURCES,
+  };
+}
+
+function docToConfig(
+  doc: FirebaseFirestore.DocumentSnapshot
+): CalendarEmbedConfig | undefined {
+  if (!doc.exists) return undefined;
+  const data = doc.data()!;
+  return {
+    owcBaseUrl: data.owcBaseUrl,
+    defaultTab: data.defaultTab,
+    tabs: data.tabs,
+    skin: data.skin,
+    startOfWeek: data.startOfWeek,
+    timezone: data.timezone,
+    title: data.title,
+    cssUrl: data.cssUrl ?? '',
+    sources: data.sources ?? [],
+    updatedAt: toDate(data.updatedAt),
+  };
+}
+
+export const CalendarEmbedConfigRepository = {
+  async get(): Promise<CalendarEmbedConfig> {
+    const docRef = db.collection(COLLECTION).doc(DOC_ID);
+    const doc = await docRef.get();
+
+    if (doc.exists) {
+      return docToConfig(doc)!;
+    }
+
+    // Seed on first read
+    const now = new Date();
+    const defaults = buildDefaultConfig();
+    const data = { ...defaults, updatedAt: now };
+    await docRef.set(data);
+    return { ...data, updatedAt: now };
+  },
+
+  async update(
+    input: UpdateCalendarEmbedSettingsInput
+  ): Promise<CalendarEmbedConfig> {
+    const docRef = db.collection(COLLECTION).doc(DOC_ID);
+    // Ensure doc exists
+    await this.get();
+
+    const { ...updates } = input;
+    await docRef.update({ ...updates, updatedAt: new Date() });
+
+    const updated = await docRef.get();
+    return docToConfig(updated)!;
+  },
+
+  async addSource(
+    input: CreateCalendarEmbedSourceInput
+  ): Promise<CalendarEmbedConfig> {
+    const config = await this.get();
+    const newSource: CalendarEmbedSource = {
+      ...input,
+      id: generateId(),
+      isSystem: false,
+    };
+
+    const sources = [...config.sources, newSource];
+    const docRef = db.collection(COLLECTION).doc(DOC_ID);
+    await docRef.update({ sources, updatedAt: new Date() });
+
+    const updated = await docRef.get();
+    return docToConfig(updated)!;
+  },
+
+  async updateSource(
+    input: UpdateCalendarEmbedSourceInput
+  ): Promise<CalendarEmbedConfig> {
+    const config = await this.get();
+    const sourceIndex = config.sources.findIndex((s) => s.id === input.id);
+    if (sourceIndex === -1) {
+      throw new Error(`Source ${input.id} not found`);
+    }
+
+    const existing = config.sources[sourceIndex];
+    const { id, ...updates } = input;
+
+    // System sources: only allow color and enabled changes
+    const updatedSource = existing.isSystem
+      ? {
+          ...existing,
+          ...(updates.color !== undefined && { color: updates.color }),
+          ...(updates.enabled !== undefined && { enabled: updates.enabled }),
+        }
+      : { ...existing, ...updates };
+
+    const sources = [...config.sources];
+    sources[sourceIndex] = updatedSource;
+
+    const docRef = db.collection(COLLECTION).doc(DOC_ID);
+    await docRef.update({ sources, updatedAt: new Date() });
+
+    const updated = await docRef.get();
+    return docToConfig(updated)!;
+  },
+
+  async removeSource(sourceId: string): Promise<CalendarEmbedConfig> {
+    const config = await this.get();
+    const source = config.sources.find((s) => s.id === sourceId);
+    if (!source) {
+      throw new Error(`Source ${sourceId} not found`);
+    }
+    if (source.isSystem) {
+      throw new Error('Cannot remove system calendar source');
+    }
+
+    const sources = config.sources.filter((s) => s.id !== sourceId);
+    const docRef = db.collection(COLLECTION).doc(DOC_ID);
+    await docRef.update({ sources, updatedAt: new Date() });
+
+    const updated = await docRef.get();
+    return docToConfig(updated)!;
+  },
+};

--- a/libs/firebase/maple-functions/add-calendar-embed-source/project.json
+++ b/libs/firebase/maple-functions/add-calendar-embed-source/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-add-calendar-embed-source",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/add-calendar-embed-source/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/add-calendar-embed-source/src/index.ts
+++ b/libs/firebase/maple-functions/add-calendar-embed-source/src/index.ts
@@ -1,0 +1,1 @@
+export { addCalendarEmbedSource } from './lib/add-calendar-embed-source';

--- a/libs/firebase/maple-functions/add-calendar-embed-source/src/lib/add-calendar-embed-source.ts
+++ b/libs/firebase/maple-functions/add-calendar-embed-source/src/lib/add-calendar-embed-source.ts
@@ -1,0 +1,17 @@
+import { createAdminFunction } from '@maple/firebase/functions';
+import { CalendarEmbedConfigRepository } from '@maple/firebase/database';
+import type {
+  AddCalendarEmbedSourceRequest,
+  AddCalendarEmbedSourceResponse,
+} from '@maple/ts/firebase/api-types';
+
+export const addCalendarEmbedSource = createAdminFunction<
+  AddCalendarEmbedSourceRequest,
+  AddCalendarEmbedSourceResponse
+>(async (data) => {
+  if (!data.label || !data.url) {
+    throw new Error('Label and URL are required');
+  }
+  const config = await CalendarEmbedConfigRepository.addSource(data);
+  return { config };
+});

--- a/libs/firebase/maple-functions/add-calendar-embed-source/tsconfig.json
+++ b/libs/firebase/maple-functions/add-calendar-embed-source/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/add-calendar-embed-source/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/add-calendar-embed-source/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/calendar-embed/project.json
+++ b/libs/firebase/maple-functions/calendar-embed/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-calendar-embed",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/calendar-embed/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/calendar-embed/src/index.ts
+++ b/libs/firebase/maple-functions/calendar-embed/src/index.ts
@@ -1,0 +1,1 @@
+export { calendarEmbed } from './lib/calendar-embed';

--- a/libs/firebase/maple-functions/calendar-embed/src/lib/calendar-embed.ts
+++ b/libs/firebase/maple-functions/calendar-embed/src/lib/calendar-embed.ts
@@ -1,0 +1,77 @@
+/**
+ * Calendar Embed HTTP Endpoint
+ *
+ * Public endpoint that reads the calendar embed configuration from Firestore
+ * and redirects to the Open Web Calendar instance with the appropriate parameters.
+ * This provides a stable URL for embedding in Webflow.
+ */
+import { onRequest } from 'firebase-functions/v2/https';
+import { CalendarEmbedConfigRepository } from '@maple/firebase/database';
+
+/**
+ * Resolve a source URL that may be a path (e.g. "/calendar/classes.ics")
+ * to a full URL using the request's host as the base for system feeds.
+ */
+function resolveSourceUrl(url: string, hostingBaseUrl: string): string {
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    return url;
+  }
+  return `${hostingBaseUrl}${url}`;
+}
+
+/**
+ * Determine the Firebase Hosting base URL from the request.
+ * In production: https://maple-and-spruce-api.web.app
+ * In dev: uses the request host or falls back to cloud function URL pattern.
+ */
+function getHostingBaseUrl(req: { hostname: string; protocol: string }): string {
+  // If the request comes through Firebase Hosting, use that host
+  if (req.hostname.includes('maple-and-spruce')) {
+    return `${req.protocol}://${req.hostname}`;
+  }
+  // Fallback: construct from the known hosting site
+  if (req.hostname.includes('-dev')) {
+    return 'https://maple-and-spruce-dev.web.app';
+  }
+  return 'https://maple-and-spruce-api.web.app';
+}
+
+export const calendarEmbed = onRequest(
+  { region: 'us-east4', cors: true },
+  async (request, response) => {
+    try {
+      const config = await CalendarEmbedConfigRepository.get();
+      const hostingBaseUrl = getHostingBaseUrl(request);
+
+      // Build OWC URL with enabled sources
+      const enabledSources = config.sources.filter((s) => s.enabled);
+      const params = new URLSearchParams();
+
+      for (const source of enabledSources) {
+        params.append('url', resolveSourceUrl(source.url, hostingBaseUrl));
+      }
+
+      params.set('tab', config.defaultTab);
+      for (const tab of config.tabs) {
+        params.append('tabs', tab);
+      }
+      params.set('skin', config.skin);
+      params.set('start_of_week', config.startOfWeek);
+      if (config.timezone) {
+        params.set('timezone', config.timezone);
+      }
+      if (config.title) {
+        params.set('title', config.title);
+      }
+      if (config.cssUrl) {
+        params.set('css_url', config.cssUrl);
+      }
+
+      const owcUrl = `${config.owcBaseUrl}/calendar.html?${params.toString()}`;
+      response.redirect(302, owcUrl);
+    } catch (error) {
+      console.error('Error generating calendar embed redirect:', error);
+      response.status(500).json({ error: 'Failed to load calendar configuration' });
+    }
+  }
+);

--- a/libs/firebase/maple-functions/calendar-embed/tsconfig.json
+++ b/libs/firebase/maple-functions/calendar-embed/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/calendar-embed/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/calendar-embed/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/get-calendar-embed-config/project.json
+++ b/libs/firebase/maple-functions/get-calendar-embed-config/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-get-calendar-embed-config",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/get-calendar-embed-config/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/get-calendar-embed-config/src/index.ts
+++ b/libs/firebase/maple-functions/get-calendar-embed-config/src/index.ts
@@ -1,0 +1,1 @@
+export { getCalendarEmbedConfig } from './lib/get-calendar-embed-config';

--- a/libs/firebase/maple-functions/get-calendar-embed-config/src/lib/get-calendar-embed-config.ts
+++ b/libs/firebase/maple-functions/get-calendar-embed-config/src/lib/get-calendar-embed-config.ts
@@ -1,0 +1,14 @@
+import { createAdminFunction } from '@maple/firebase/functions';
+import { CalendarEmbedConfigRepository } from '@maple/firebase/database';
+import type {
+  GetCalendarEmbedConfigRequest,
+  GetCalendarEmbedConfigResponse,
+} from '@maple/ts/firebase/api-types';
+
+export const getCalendarEmbedConfig = createAdminFunction<
+  GetCalendarEmbedConfigRequest,
+  GetCalendarEmbedConfigResponse
+>(async () => {
+  const config = await CalendarEmbedConfigRepository.get();
+  return { config };
+});

--- a/libs/firebase/maple-functions/get-calendar-embed-config/tsconfig.json
+++ b/libs/firebase/maple-functions/get-calendar-embed-config/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/get-calendar-embed-config/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/get-calendar-embed-config/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/remove-calendar-embed-source/project.json
+++ b/libs/firebase/maple-functions/remove-calendar-embed-source/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-remove-calendar-embed-source",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/remove-calendar-embed-source/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/remove-calendar-embed-source/src/index.ts
+++ b/libs/firebase/maple-functions/remove-calendar-embed-source/src/index.ts
@@ -1,0 +1,1 @@
+export { removeCalendarEmbedSource } from './lib/remove-calendar-embed-source';

--- a/libs/firebase/maple-functions/remove-calendar-embed-source/src/lib/remove-calendar-embed-source.ts
+++ b/libs/firebase/maple-functions/remove-calendar-embed-source/src/lib/remove-calendar-embed-source.ts
@@ -1,0 +1,17 @@
+import { createAdminFunction } from '@maple/firebase/functions';
+import { CalendarEmbedConfigRepository } from '@maple/firebase/database';
+import type {
+  RemoveCalendarEmbedSourceRequest,
+  RemoveCalendarEmbedSourceResponse,
+} from '@maple/ts/firebase/api-types';
+
+export const removeCalendarEmbedSource = createAdminFunction<
+  RemoveCalendarEmbedSourceRequest,
+  RemoveCalendarEmbedSourceResponse
+>(async (data) => {
+  if (!data.sourceId) {
+    throw new Error('Source ID is required');
+  }
+  const config = await CalendarEmbedConfigRepository.removeSource(data.sourceId);
+  return { config };
+});

--- a/libs/firebase/maple-functions/remove-calendar-embed-source/tsconfig.json
+++ b/libs/firebase/maple-functions/remove-calendar-embed-source/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/remove-calendar-embed-source/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/remove-calendar-embed-source/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/update-calendar-embed-config/project.json
+++ b/libs/firebase/maple-functions/update-calendar-embed-config/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-update-calendar-embed-config",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/update-calendar-embed-config/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/update-calendar-embed-config/src/index.ts
+++ b/libs/firebase/maple-functions/update-calendar-embed-config/src/index.ts
@@ -1,0 +1,1 @@
+export { updateCalendarEmbedConfig } from './lib/update-calendar-embed-config';

--- a/libs/firebase/maple-functions/update-calendar-embed-config/src/lib/update-calendar-embed-config.ts
+++ b/libs/firebase/maple-functions/update-calendar-embed-config/src/lib/update-calendar-embed-config.ts
@@ -1,0 +1,14 @@
+import { createAdminFunction } from '@maple/firebase/functions';
+import { CalendarEmbedConfigRepository } from '@maple/firebase/database';
+import type {
+  UpdateCalendarEmbedConfigRequest,
+  UpdateCalendarEmbedConfigResponse,
+} from '@maple/ts/firebase/api-types';
+
+export const updateCalendarEmbedConfig = createAdminFunction<
+  UpdateCalendarEmbedConfigRequest,
+  UpdateCalendarEmbedConfigResponse
+>(async (data) => {
+  const config = await CalendarEmbedConfigRepository.update(data);
+  return { config };
+});

--- a/libs/firebase/maple-functions/update-calendar-embed-config/tsconfig.json
+++ b/libs/firebase/maple-functions/update-calendar-embed-config/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/update-calendar-embed-config/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/update-calendar-embed-config/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/react/data/src/index.ts
+++ b/libs/react/data/src/index.ts
@@ -14,6 +14,7 @@ export {
   useCalendarEvents,
   type UseCalendarEventsFilters,
 } from './lib/useCalendarEvents';
+export { useCalendarEmbedConfig } from './lib/useCalendarEmbedConfig';
 
 // Phase 3c: Registration & Discounts
 export {

--- a/libs/react/data/src/lib/useCalendarEmbedConfig.ts
+++ b/libs/react/data/src/lib/useCalendarEmbedConfig.ts
@@ -1,0 +1,111 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { httpsCallable } from 'firebase/functions';
+import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
+import type {
+  CalendarEmbedConfig,
+  UpdateCalendarEmbedSettingsInput,
+  CreateCalendarEmbedSourceInput,
+  RequestState,
+} from '@maple/ts/domain';
+import type {
+  GetCalendarEmbedConfigRequest,
+  GetCalendarEmbedConfigResponse,
+  UpdateCalendarEmbedConfigRequest,
+  UpdateCalendarEmbedConfigResponse,
+  AddCalendarEmbedSourceRequest,
+  AddCalendarEmbedSourceResponse,
+  RemoveCalendarEmbedSourceRequest,
+  RemoveCalendarEmbedSourceResponse,
+} from '@maple/ts/firebase/api-types';
+
+export function useCalendarEmbedConfig() {
+  const [configState, setConfigState] = useState<
+    RequestState<CalendarEmbedConfig>
+  >({ status: 'idle' });
+
+  const fetchConfig = useCallback(async () => {
+    setConfigState({ status: 'loading' });
+    try {
+      const functions = getMapleFunctions();
+      const getConfig = httpsCallable<
+        GetCalendarEmbedConfigRequest,
+        GetCalendarEmbedConfigResponse
+      >(functions, 'getCalendarEmbedConfig');
+
+      const result = await getConfig({});
+      setConfigState({ status: 'success', data: result.data.config });
+    } catch (error) {
+      console.error('Failed to fetch calendar embed config:', error);
+      setConfigState({
+        status: 'error',
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to fetch calendar embed config',
+      });
+    }
+  }, []);
+
+  const updateSettings = useCallback(
+    async (
+      input: UpdateCalendarEmbedSettingsInput
+    ): Promise<CalendarEmbedConfig> => {
+      const functions = getMapleFunctions();
+      const update = httpsCallable<
+        UpdateCalendarEmbedConfigRequest,
+        UpdateCalendarEmbedConfigResponse
+      >(functions, 'updateCalendarEmbedConfig');
+
+      const result = await update(input);
+      setConfigState({ status: 'success', data: result.data.config });
+      return result.data.config;
+    },
+    []
+  );
+
+  const addSource = useCallback(
+    async (
+      input: CreateCalendarEmbedSourceInput
+    ): Promise<CalendarEmbedConfig> => {
+      const functions = getMapleFunctions();
+      const add = httpsCallable<
+        AddCalendarEmbedSourceRequest,
+        AddCalendarEmbedSourceResponse
+      >(functions, 'addCalendarEmbedSource');
+
+      const result = await add(input);
+      setConfigState({ status: 'success', data: result.data.config });
+      return result.data.config;
+    },
+    []
+  );
+
+  const removeSource = useCallback(
+    async (sourceId: string): Promise<CalendarEmbedConfig> => {
+      const functions = getMapleFunctions();
+      const remove = httpsCallable<
+        RemoveCalendarEmbedSourceRequest,
+        RemoveCalendarEmbedSourceResponse
+      >(functions, 'removeCalendarEmbedSource');
+
+      const result = await remove({ sourceId });
+      setConfigState({ status: 'success', data: result.data.config });
+      return result.data.config;
+    },
+    []
+  );
+
+  useEffect(() => {
+    fetchConfig();
+  }, [fetchConfig]);
+
+  return {
+    configState,
+    fetchConfig,
+    updateSettings,
+    addSource,
+    removeSource,
+  };
+}

--- a/libs/ts/domain/src/index.ts
+++ b/libs/ts/domain/src/index.ts
@@ -19,6 +19,7 @@ export * from './lib/discount';
 
 // Phase 4.5: Calendar
 export * from './lib/calendar-event';
+export * from './lib/calendar-embed-config';
 
 // State management
 export * from './lib/request-state';

--- a/libs/ts/domain/src/lib/calendar-embed-config.ts
+++ b/libs/ts/domain/src/lib/calendar-embed-config.ts
@@ -1,0 +1,75 @@
+/**
+ * Calendar Embed Configuration
+ *
+ * Singleton config document controlling which ICS feeds appear in the
+ * public calendar embed and how it's displayed. Stored at config/calendarEmbed
+ * in Firestore. The calendarEmbed HTTP function reads this at request time
+ * and redirects to Open Web Calendar with the appropriate parameters.
+ */
+
+/**
+ * A single calendar source (ICS feed) in the embed.
+ */
+export interface CalendarEmbedSource {
+  /** Unique identifier */
+  id: string;
+  /** Human-readable label (e.g., "Classes & Workshops") */
+  label: string;
+  /** ICS feed URL — path (e.g. "/calendar/classes.ics") or full URL */
+  url: string;
+  /** Hex color without # for admin UI display */
+  color: string;
+  /** System sources cannot be removed */
+  isSystem: boolean;
+  /** Whether this source is included in the embed */
+  enabled: boolean;
+}
+
+/**
+ * Full embed configuration
+ */
+export interface CalendarEmbedConfig {
+  /** Open Web Calendar base URL */
+  owcBaseUrl: string;
+  /** Default view: "month" | "week" | "day" | "agenda" */
+  defaultTab: string;
+  /** Available view tabs */
+  tabs: string[];
+  /** OWC skin name */
+  skin: string;
+  /** Start of week: "mo" | "su" */
+  startOfWeek: string;
+  /** IANA timezone */
+  timezone: string;
+  /** Calendar title */
+  title: string;
+  /** Optional custom CSS URL for OWC styling */
+  cssUrl: string;
+  /** All calendar sources */
+  sources: CalendarEmbedSource[];
+  updatedAt: Date;
+}
+
+/**
+ * Input for updating embed config (settings and/or sources)
+ */
+export type UpdateCalendarEmbedSettingsInput = Partial<
+  Omit<CalendarEmbedConfig, 'updatedAt'>
+>;
+
+/**
+ * Input for adding a custom calendar source
+ */
+export type CreateCalendarEmbedSourceInput = Omit<
+  CalendarEmbedSource,
+  'id' | 'isSystem'
+>;
+
+/**
+ * Input for updating a source (id required, isSystem not changeable)
+ */
+export type UpdateCalendarEmbedSourceInput = Partial<
+  Omit<CalendarEmbedSource, 'id' | 'isSystem'>
+> & {
+  id: string;
+};

--- a/libs/ts/firebase/api-types/src/lib/calendar-embed-config.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/calendar-embed-config.types.ts
@@ -1,0 +1,54 @@
+/**
+ * Calendar Embed Config API request/response types
+ */
+import type {
+  CalendarEmbedConfig,
+  CreateCalendarEmbedSourceInput,
+  UpdateCalendarEmbedSettingsInput,
+} from '@maple/ts/domain';
+
+// ============================================================================
+// Get Calendar Embed Config
+// ============================================================================
+
+export interface GetCalendarEmbedConfigRequest {
+  // no params needed
+}
+
+export interface GetCalendarEmbedConfigResponse {
+  config: CalendarEmbedConfig;
+}
+
+// ============================================================================
+// Update Calendar Embed Settings
+// ============================================================================
+
+export interface UpdateCalendarEmbedConfigRequest
+  extends UpdateCalendarEmbedSettingsInput {}
+
+export interface UpdateCalendarEmbedConfigResponse {
+  config: CalendarEmbedConfig;
+}
+
+// ============================================================================
+// Add Calendar Embed Source
+// ============================================================================
+
+export interface AddCalendarEmbedSourceRequest
+  extends CreateCalendarEmbedSourceInput {}
+
+export interface AddCalendarEmbedSourceResponse {
+  config: CalendarEmbedConfig;
+}
+
+// ============================================================================
+// Remove Calendar Embed Source
+// ============================================================================
+
+export interface RemoveCalendarEmbedSourceRequest {
+  sourceId: string;
+}
+
+export interface RemoveCalendarEmbedSourceResponse {
+  config: CalendarEmbedConfig;
+}

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -228,3 +228,15 @@ export type {
   CreateRegistrationRequest,
   CreateRegistrationResponse,
 } from './registration.types';
+
+// Calendar Embed Config types
+export type {
+  GetCalendarEmbedConfigRequest,
+  GetCalendarEmbedConfigResponse,
+  UpdateCalendarEmbedConfigRequest,
+  UpdateCalendarEmbedConfigResponse,
+  AddCalendarEmbedSourceRequest,
+  AddCalendarEmbedSourceResponse,
+  RemoveCalendarEmbedSourceRequest,
+  RemoveCalendarEmbedSourceResponse,
+} from './calendar-embed-config.types';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -225,6 +225,21 @@
       "@maple/react/discounts": ["libs/react/discounts/src/index.ts"],
       "@maple/react/registrations": ["libs/react/registrations/src/index.ts"],
       "@maple/react/events": ["libs/react/events/src/index.ts"],
+      "@maple/firebase/maple-functions/get-calendar-embed-config": [
+        "libs/firebase/maple-functions/get-calendar-embed-config/src/index.ts"
+      ],
+      "@maple/firebase/maple-functions/update-calendar-embed-config": [
+        "libs/firebase/maple-functions/update-calendar-embed-config/src/index.ts"
+      ],
+      "@maple/firebase/maple-functions/add-calendar-embed-source": [
+        "libs/firebase/maple-functions/add-calendar-embed-source/src/index.ts"
+      ],
+      "@maple/firebase/maple-functions/remove-calendar-embed-source": [
+        "libs/firebase/maple-functions/remove-calendar-embed-source/src/index.ts"
+      ],
+      "@maple/firebase/maple-functions/calendar-embed": [
+        "libs/firebase/maple-functions/calendar-embed/src/index.ts"
+      ],
       "@/*": ["apps/maple-spruce/src/*"]
     }
   }


### PR DESCRIPTION
## Summary
- Admin-managed calendar embed configuration stored in Firestore (`config/calendarEmbed`)
- Katie can add/remove custom ICS sources (e.g. her Google Calendar) from the admin UI — no code changes needed
- System feeds (classes, events, hours, music) always present, can be toggled on/off
- Stable embed URL: `/calendar/embed` — reads config from Firestore and 302 redirects to OWC
- Webflow iframe points to this URL and never needs updating
- Admin page at `/calendar-embed` with sources table and display settings (OWC URL, skin, timezone, etc.)

### New Cloud Functions
- `getCalendarEmbedConfig` — admin callable
- `updateCalendarEmbedConfig` — admin callable
- `addCalendarEmbedSource` — admin callable
- `removeCalendarEmbedSource` — admin callable
- `calendarEmbed` — HTTP, public: `/calendar/embed`

## Test plan
- [ ] `npm test` — all 8 projects pass
- [ ] Functions build succeeds
- [ ] After deploy, visit `/calendar/embed` — should 302 redirect to OWC with system feeds
- [ ] Admin UI: navigate to Calendar Embed page, verify sources table shows 4 system sources
- [ ] Add a custom ICS source, verify it appears in the embed
- [ ] Toggle a source off, verify it's excluded from the redirect
- [ ] Update display settings (skin, timezone), verify changes reflected in embed URL


🤖 Generated with [Claude Code](https://claude.com/claude-code)