### PR TITLE
feat: add quick links tiles to admin dashboard

### DIFF
--- a/apps/maple-spruce/src/app/page.tsx
+++ b/apps/maple-spruce/src/app/page.tsx
@@ -14,14 +14,37 @@ import {
   Stack,
 } from '@mui/material';
 import Grid from '@mui/material/Grid2';
+import AccountBalanceIcon from '@mui/icons-material/AccountBalance';
+import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
+import CampaignIcon from '@mui/icons-material/Campaign';
 import EventIcon from '@mui/icons-material/Event';
+import FolderSharedIcon from '@mui/icons-material/FolderShared';
 import HowToRegIcon from '@mui/icons-material/HowToReg';
 import InventoryIcon from '@mui/icons-material/Inventory';
+import LanguageIcon from '@mui/icons-material/Language';
+import ListAltIcon from '@mui/icons-material/ListAlt';
+import PhoneIcon from '@mui/icons-material/Phone';
+import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
+import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
+import StorefrontIcon from '@mui/icons-material/Storefront';
 import SyncProblemIcon from '@mui/icons-material/SyncProblem';
 import { formatClassPrice } from '@maple/ts/domain';
 import { useSyncConflictSummary } from '@maple/react/data';
 import { AppShell } from '../components/layout';
 import { useClasses, useRegistrations, useProducts } from '../hooks';
+
+const quickLinks = [
+  { label: 'Wave', href: 'https://my.waveapps.com', icon: AccountBalanceIcon, color: '#1c6dd0' },
+  { label: 'Tally', href: 'https://tally.so', icon: ListAltIcon, color: '#6c5ce7' },
+  { label: 'MailerLite', href: 'https://app.mailerlite.com', icon: CampaignIcon, color: '#09c269' },
+  { label: 'Google Drive', href: 'https://drive.google.com', icon: FolderSharedIcon, color: '#f4b400' },
+  { label: 'Square', href: 'https://squareup.com/dashboard', icon: ShoppingCartIcon, color: '#006aff' },
+  { label: 'Facebook Ads', href: 'https://adsmanager.facebook.com', icon: CampaignIcon, color: '#1877f2' },
+  { label: 'Webflow', href: 'https://webflow.com/dashboard', icon: LanguageIcon, color: '#4353ff' },
+  { label: 'Firebase', href: 'https://console.firebase.google.com', icon: AdminPanelSettingsIcon, color: '#f5820d' },
+  { label: 'Vercel', href: 'https://vercel.com/dashboard', icon: RocketLaunchIcon, color: '#000000' },
+  { label: 'Google Voice', href: 'https://voice.google.com', icon: PhoneIcon, color: '#34a853' },
+];
 
 /** Format a date as "Mon, Mar 23" */
 function formatShortDate(date: Date): string {
@@ -369,6 +392,45 @@ export default function DashboardPage() {
             </Card>
           </Grid>
         )}
+
+        {/* Quick Links */}
+        <Grid size={12}>
+          <Typography variant="h6" gutterBottom sx={{ mt: 1 }}>
+            <StorefrontIcon
+              fontSize="small"
+              sx={{ verticalAlign: 'middle', mr: 0.5 }}
+            />
+            Quick Links
+          </Typography>
+          <Grid container spacing={1.5}>
+            {quickLinks.map((link) => {
+              const Icon = link.icon;
+              return (
+                <Grid key={link.label} size={{ xs: 6, sm: 4, md: 3, lg: 2.4 }}>
+                  <Card variant="outlined">
+                    <CardActionArea
+                      href={link.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      sx={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        py: 2,
+                        px: 1,
+                      }}
+                    >
+                      <Icon sx={{ fontSize: 36, color: link.color, mb: 0.5 }} />
+                      <Typography variant="body2" noWrap>
+                        {link.label}
+                      </Typography>
+                    </CardActionArea>
+                  </Card>
+                </Grid>
+              );
+            })}
+          </Grid>
+        </Grid>
       </Grid>
     </AppShell>
   );


### PR DESCRIPTION
## Summary
- Adds a responsive grid of service quick link tiles to the bottom of the admin dashboard
- 10 services: Wave, Tally, MailerLite, Google Drive, Square, Facebook Ads, Webflow, Firebase, Vercel, Google Voice
- Each tile has a colored MUI icon and opens in a new tab

## Test plan
- [ ] Verify tiles render correctly on the dashboard
- [ ] Confirm responsive layout (2 cols mobile, 3 sm, 4 md, 5 lg)
- [ ] Verify all links open correct URLs in new tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)