### PR TITLE
fix: scope path-to-regexp override to unblock function deploys

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
       "yauzl": ">=3.2.1",
       "yaml": ">=2.8.3",
       "node-forge": ">=1.4.0",
-      "path-to-regexp": ">=8.4.0",
+      "path-to-regexp@>=2": ">=8.4.0",
       "serialize-javascript": ">=7.0.5",
       "brace-expansion@^5": ">=5.0.5",
       "brace-expansion@^2": ">=2.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ overrides:
   yauzl: '>=3.2.1'
   yaml: '>=2.8.3'
   node-forge: '>=1.4.0'
-  path-to-regexp: '>=8.4.0'
+  path-to-regexp@>=2: '>=8.4.0'
   serialize-javascript: '>=7.0.5'
   brace-expansion@^5: '>=5.0.5'
   brace-expansion@^2: '>=2.0.3'
@@ -7201,6 +7201,9 @@ packages:
     resolution: {integrity: sha512-rZkHeBn9Zzq52sd9IUIV3a5mfwBY+o2HePMh0wkGBM4z4qjvy2GwVxQ6nNXSfw6MmVP6gf1QIlWjiOavhM3x5g==}
     engines: {node: '>=v0.10.0'}
 
+  isarray@0.0.1:
+    resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
+
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
@@ -8487,6 +8490,12 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  path-to-regexp@0.1.13:
+    resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
+
+  path-to-regexp@1.9.0:
+    resolution: {integrity: sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==}
 
   path-to-regexp@8.4.0:
     resolution: {integrity: sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==}
@@ -17987,7 +17996,7 @@ snapshots:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 8.4.0
+      path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
       qs: 6.14.2
       range-parser: 1.2.1
@@ -19238,6 +19247,8 @@ snapshots:
       deep-is: 0.1.4
       ip-regex: 4.3.0
       is-url: 1.2.4
+
+  isarray@0.0.1: {}
 
   isarray@1.0.0: {}
 
@@ -20925,6 +20936,12 @@ snapshots:
       minipass: 7.1.3
     optional: true
 
+  path-to-regexp@0.1.13: {}
+
+  path-to-regexp@1.9.0:
+    dependencies:
+      isarray: 0.0.1
+
   path-to-regexp@8.4.0: {}
 
   path-type@4.0.0: {}
@@ -22475,7 +22492,7 @@ snapshots:
       morgan: 1.10.1
       on-finished: 2.4.1
       on-headers: 1.1.0
-      path-to-regexp: 8.4.0
+      path-to-regexp: 1.9.0
       router: 2.2.0
       update-notifier-cjs: 5.1.7(encoding@0.1.13)
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Fix the `path-to-regexp` pnpm override that was silently preventing all new Cloud Functions from deploying
- Scope override from `path-to-regexp: >=8.4.0` (breaks Express 4) to `path-to-regexp@>=2: >=8.4.0` (leaves Express 4's 0.x intact)

## Problem
The blanket override introduced in PR 181 forced Express 4's `path-to-regexp@0.1.x` dependency to `8.4.0`, which has an incompatible API. This caused `TypeError: pathRegexp is not a function` during Firebase function discovery. Deploy jobs reported success but no new functions were actually registered — the Etsy OAuth functions from PR 182 never deployed.

## Fix
Matches the pattern from the integration-tests worktree: `path-to-regexp@>=2: >=8.4.0` only overrides versions 2.0+ while letting Express 4 keep `0.1.13`.

## Test plan
- [x] `pnpm why path-to-regexp` shows Express 4 at `0.1.13`, Firebase tools at `8.4.0`
- [x] `pnpm audit --audit-level=high` shows 0 high vulnerabilities
- [ ] After merge: verify Etsy functions appear in `firebase functions:list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)