### PR TITLE
fix: wrap settings pages in AppShell for sidebar navigation

### DIFF
--- a/apps/maple-spruce/src/app/settings/etsy-callback/page.tsx
+++ b/apps/maple-spruce/src/app/settings/etsy-callback/page.tsx
@@ -11,6 +11,7 @@ import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import { useEtsyConnection } from '@maple/react/data';
+import { AppShell } from '../../../components/layout';
 
 export default function EtsyCallbackPage(): React.ReactNode {
   const searchParams = useSearchParams();
@@ -30,6 +31,7 @@ export default function EtsyCallbackPage(): React.ReactNode {
 
   if (!code || !state) {
     return (
+      <AppShell>
       <Card>
         <CardContent>
           <Alert severity="error">
@@ -41,11 +43,12 @@ export default function EtsyCallbackPage(): React.ReactNode {
           </Button>
         </CardContent>
       </Card>
+      </AppShell>
     );
   }
 
   return (
-    <>
+    <AppShell>
       <Typography variant="h4" gutterBottom>
         Connecting Etsy
       </Typography>
@@ -99,6 +102,6 @@ export default function EtsyCallbackPage(): React.ReactNode {
           </Stack>
         </CardContent>
       </Card>
-    </>
+    </AppShell>
   );
 }

--- a/apps/maple-spruce/src/app/settings/page.tsx
+++ b/apps/maple-spruce/src/app/settings/page.tsx
@@ -11,6 +11,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Alert from '@mui/material/Alert';
 import StorefrontIcon from '@mui/icons-material/Storefront';
 import { useEtsyConnection } from '@maple/react/data';
+import { AppShell } from '../../components/layout';
 
 export default function SettingsPage(): React.ReactNode {
   const { connectionState, authUrlState, generateAuthUrl } =
@@ -29,7 +30,7 @@ export default function SettingsPage(): React.ReactNode {
     connectionState.status === 'success' && connectionState.data.tokenValid;
 
   return (
-    <>
+    <AppShell>
       <Typography variant="h4" gutterBottom>
         Settings
       </Typography>
@@ -112,6 +113,6 @@ export default function SettingsPage(): React.ReactNode {
           </Stack>
         </CardContent>
       </Card>
-    </>
+    </AppShell>
   );
 }


### PR DESCRIPTION
## Summary
- Add missing `<AppShell>` wrapper to settings page and Etsy callback page
- Both pages now show the sidebar navigation like every other admin page

See #185 for the broader refactor to move AppShell into layout.tsx.

## Test plan
- [ ] Settings page renders with sidebar
- [ ] Etsy callback page renders with sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)