### PR TITLE
fix: improve registration confirmation page

### DIFF
--- a/apps/maple-spruce/src/app/register/[classId]/confirm/page.tsx
+++ b/apps/maple-spruce/src/app/register/[classId]/confirm/page.tsx
@@ -7,12 +7,22 @@ import {
   Container,
   Paper,
   Button,
+  Divider,
 } from '@mui/material';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 
 export default function RegistrationConfirmPage() {
   const searchParams = useSearchParams();
   const confirmationNumber = searchParams.get('confirmation') ?? '';
+  const customerName = searchParams.get('name') ?? '';
+  const className = searchParams.get('className') ?? '';
+  const amountCents = Number(searchParams.get('amount') ?? '0');
+  const quantity = Number(searchParams.get('qty') ?? '1');
+
+  const amountFormatted =
+    amountCents > 0
+      ? `$${(amountCents / 100).toFixed(2)}`
+      : 'Free';
 
   return (
     <Box
@@ -33,13 +43,28 @@ export default function RegistrationConfirmPage() {
           />
 
           <Typography variant="h4" component="h1" gutterBottom>
-            Registration Confirmed!
+            You&apos;re Registered!
           </Typography>
 
-          <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
-            You're all set. A confirmation email has been sent to your email
-            address.
-          </Typography>
+          {customerName && (
+            <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
+              Thanks, {customerName}! Your spot is reserved.
+            </Typography>
+          )}
+
+          {className && (
+            <Box sx={{ mb: 3 }}>
+              <Typography variant="h6" gutterBottom>
+                {className}
+              </Typography>
+              <Typography variant="body1" color="text.secondary">
+                {quantity > 1 ? `${quantity} spots` : '1 spot'} &middot;{' '}
+                {amountFormatted}
+              </Typography>
+            </Box>
+          )}
+
+          <Divider sx={{ my: 2 }} />
 
           {confirmationNumber && (
             <Box
@@ -50,44 +75,34 @@ export default function RegistrationConfirmPage() {
                 mb: 3,
               }}
             >
-              <Typography variant="subtitle2" color="text.secondary">
+              <Typography variant="body2" color="text.secondary">
                 Confirmation Number
               </Typography>
               <Typography
-                variant="h5"
+                variant="body1"
                 fontFamily="monospace"
                 fontWeight={600}
               >
                 {confirmationNumber}
               </Typography>
-              <Typography
-                variant="caption"
-                color="text.secondary"
-                display="block"
-                sx={{ mt: 0.5 }}
-              >
-                Please save this number for your records
-              </Typography>
             </Box>
           )}
 
           <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-            If you have any questions, please contact us at{' '}
+            Questions? Contact us at{' '}
             <Typography
-              component="span"
+              component="a"
+              href="mailto:katie@mapleandsprucefolkarts.com"
               variant="body2"
               color="primary"
               fontWeight={500}
+              sx={{ textDecoration: 'none' }}
             >
-              info@mapleandspruce.com
+              katie@mapleandsprucefolkarts.com
             </Typography>
           </Typography>
 
-          <Button
-            variant="contained"
-            href="/register"
-            size="large"
-          >
+          <Button variant="contained" href="/register" size="large">
             Browse More Classes
           </Button>
         </Paper>

--- a/apps/maple-spruce/src/app/register/[classId]/page.tsx
+++ b/apps/maple-spruce/src/app/register/[classId]/page.tsx
@@ -135,12 +135,22 @@ export default function RegisterClassPage() {
   );
 
   const handleSuccess = useCallback(
-    (confirmationNumber: string) => {
-      router.push(
-        `/register/${classId}/confirm?confirmation=${encodeURIComponent(confirmationNumber)}`
-      );
+    (details: {
+      confirmationNumber: string;
+      customerName: string;
+      pricePaidCents: number;
+      quantity: number;
+    }) => {
+      const params = new URLSearchParams({
+        confirmation: details.confirmationNumber,
+        name: details.customerName,
+        amount: String(details.pricePaidCents),
+        qty: String(details.quantity),
+        className: publicClass?.name ?? '',
+      });
+      router.push(`/register/${classId}/confirm?${params.toString()}`);
     },
-    [router, classId]
+    [router, classId, publicClass?.name]
   );
 
   const squareApplicationId =

--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
@@ -36,7 +36,12 @@ interface RegistrationCheckoutFormProps {
     notes?: string;
     paymentNonce: string;
   }) => Promise<CreateRegistrationResponse>;
-  onSuccess: (confirmationNumber: string) => void;
+  onSuccess: (details: {
+    confirmationNumber: string;
+    customerName: string;
+    pricePaidCents: number;
+    quantity: number;
+  }) => void;
 }
 
 export function RegistrationCheckoutForm({
@@ -145,7 +150,12 @@ export function RegistrationCheckoutForm({
         paymentNonce: nonce,
       });
 
-      onSuccess(result.confirmationNumber);
+      onSuccess({
+        confirmationNumber: result.confirmationNumber,
+        customerName: customerName.trim(),
+        pricePaidCents: result.registration.pricePaidCents,
+        quantity,
+      });
     } catch (error) {
       setSubmitError(
         error instanceof Error


### PR DESCRIPTION
## Summary
- Show class name, spots reserved, and amount paid on the confirmation page instead of just the confirmation number
- De-emphasize the confirmation code (still visible, but not the hero element)
- Remove the false "confirmation email sent" message (emails aren't wired up yet)
- Update contact email to katie@mapleandsprucefolkarts.com with a clickable mailto link

## Changes
- **RegistrationCheckoutForm.tsx** — `onSuccess` callback now passes `{ confirmationNumber, customerName, pricePaidCents, quantity }` instead of just a string
- **register/[classId]/page.tsx** — `handleSuccess` builds query params with class name, amount, quantity, customer name
- **register/[classId]/confirm/page.tsx** — Rewritten to show friendly details: "You're Registered!", class name, spots + price, and a smaller confirmation number section

## Test plan
- [ ] Register for a class in DEV, verify confirmation page shows class name, price, and customer name
- [ ] Verify confirmation number still displays
- [ ] Verify mailto link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)