### PR TITLE
feat: add date/time display fields and CMS collection updates (#208)

### DIFF
--- a/libs/firebase/webflow/src/lib/class.service.spec.ts
+++ b/libs/firebase/webflow/src/lib/class.service.spec.ts
@@ -60,6 +60,16 @@ describe('mapClassToFieldData', () => {
     expect(result.capacity).toBe(10);
   });
 
+  it('formats date and time display correctly', () => {
+    const result = mapClassToFieldData(mockClass, { isDev: false });
+    // Date should be formatted as a readable date string
+    expect(result['date-display']).toContain('2026');
+    expect(result['date-display']).toContain('May');
+    expect(result['date-display']).toContain('15');
+    // Time should be formatted as readable time
+    expect(result['time-display']).toMatch(/\d{1,2}:\d{2}\s*(AM|PM)/);
+  });
+
   it('formats price display correctly', () => {
     expect(mapClassToFieldData(mockClass, { isDev: false })['price-display']).toBe('$45');
 

--- a/libs/firebase/webflow/src/lib/class.service.ts
+++ b/libs/firebase/webflow/src/lib/class.service.ts
@@ -112,6 +112,23 @@ export function mapClassToFieldData(
     ? 'Class Full'
     : `${spotsRemaining} spot${spotsRemaining === 1 ? '' : 's'} remaining`;
 
+  // Format date and time display values
+  const dateObj = classEntity.dateTime instanceof Date
+    ? classEntity.dateTime
+    : new Date(classEntity.dateTime);
+
+  const dateDisplay = dateObj.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+  const timeDisplay = dateObj.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+
   const fieldData: ClassWebflowFieldData = {
     'firebase-id': classEntity.id,
     name: classEntity.name,
@@ -127,6 +144,8 @@ export function mapClassToFieldData(
     'price-display': priceDisplay,
     'duration-display': durationDisplay,
     'spots-display': spotsDisplay,
+    'date-display': dateDisplay,
+    'time-display': timeDisplay,
     'skill-level':
       classEntity.skillLevel === 'all-levels'
         ? 'All Levels'


### PR DESCRIPTION
## Summary
- Add `date-display` (e.g. "Saturday, May 15, 2026") and `time-display` (e.g. "2:00 PM") pre-formatted fields to the class Webflow sync
- Added corresponding CMS fields to Webflow Classes collection

## Changes
- `libs/firebase/webflow/src/lib/class.service.ts` — generate `date-display` and `time-display` from class dateTime
- `libs/firebase/webflow/src/lib/class.service.spec.ts` — test for date/time formatting

## Webflow Designer follow-up (#209)
After merge, rebind on the class detail template:
- Date value → `Date Display` field
- Time value → `Time Display` field
- Hide Location, What to Bring, Materials, Minimum Age cards when empty (conditional visibility)

Closes #208

## Test plan
- [x] 49 webflow library tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)