### PR TITLE
feat: Image2Pages Webflow widget for printable pattern tiling

### DIFF
--- a/apps/webflow-components/project.json
+++ b/apps/webflow-components/project.json
@@ -1,0 +1,21 @@
+{
+  "name": "webflow-components",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/webflow-components/src",
+  "projectType": "application",
+  "tags": [
+    "scope:webflow",
+    "type:app"
+  ],
+  "targets": {
+    "test": {
+      "executor": "@nx/vite:test",
+      "outputs": [
+        "{options.reportsDirectory}"
+      ],
+      "options": {
+        "reportsDirectory": "{projectRoot}/../../coverage/apps/webflow-components"
+      }
+    }
+  }
+}

--- a/apps/webflow-components/src/Image2PagesWidget.tsx
+++ b/apps/webflow-components/src/Image2PagesWidget.tsx
@@ -1,0 +1,479 @@
+/**
+ * Image2Pages Widget — tile a large image across multiple printable pages.
+ *
+ * Designed for embedding in Webflow via Code Components. Lets a customer
+ * upload a stained-glass pattern (or any image), pick how big they want it
+ * printed, preview the page tiling, and download a multi-page PDF that
+ * they can print and assemble. Everything runs in the browser; no upload
+ * leaves the visitor's machine.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  ThemeProvider,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from '@mui/material';
+import FileDownloadOutlinedIcon from '@mui/icons-material/FileDownloadOutlined';
+import OpenInNewOutlinedIcon from '@mui/icons-material/OpenInNewOutlined';
+import { theme, brandColors, surfaces, borders, text as textTokens } from '@maple/react/theme';
+import {
+  buildPdf,
+  computeLayout,
+  loadImage,
+  PAGE_SIZE_LABELS,
+  type Layout,
+  type PageSizeKey,
+  type Sizing,
+} from './lib/image2pages-tile';
+
+const PAGE_COUNT_OPTIONS = [1, 2, 4, 6, 8, 9, 12, 16];
+type SizingMode = 'pages' | 'width' | 'height';
+
+interface Image2PagesWidgetProps {
+  /** Optional heading shown above the controls. */
+  heading?: string;
+  /** Optional intro text shown below the heading. */
+  intro?: string;
+}
+
+export function Image2PagesWidget({
+  heading = 'Pattern Page Tiler',
+  intro = 'Upload a stained-glass pattern (or any image) and download a printable PDF tiled across as many pages as you need.',
+}: Image2PagesWidgetProps) {
+  const [file, setFile] = useState<File | null>(null);
+  const [image, setImage] = useState<HTMLImageElement | null>(null);
+  const [sizingMode, setSizingMode] = useState<SizingMode>('pages');
+  const [pageCount, setPageCount] = useState(8);
+  const [targetWidthIn, setTargetWidthIn] = useState(24);
+  const [targetHeightIn, setTargetHeightIn] = useState(24);
+  const [pageSize, setPageSize] = useState<PageSizeKey>('letter');
+  const [marginIn, setMarginIn] = useState(0.25);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pdfUrl, setPdfUrl] = useState<string | null>(null);
+  const objectUrlRef = useRef<string | null>(null);
+
+  // Revoke any blob URLs we created when unmounting.
+  useEffect(() => {
+    return () => {
+      if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+    };
+  }, []);
+
+  // Decode the file whenever it changes; clear any stale PDF.
+  useEffect(() => {
+    let cancelled = false;
+    let createdUrl: string | null = null;
+    setError(null);
+    setPdfUrl((u) => {
+      if (u) URL.revokeObjectURL(u);
+      return null;
+    });
+    if (!file) {
+      setImage(null);
+      return;
+    }
+    (async () => {
+      try {
+        const img = await loadImage(file);
+        createdUrl = img.src;
+        if (!cancelled) setImage(img);
+      } catch (e) {
+        if (!cancelled) setError((e as Error).message);
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (createdUrl) URL.revokeObjectURL(createdUrl);
+    };
+  }, [file]);
+
+  const sizing = useMemo<Sizing>(() => {
+    if (sizingMode === 'width') return { kind: 'width', inches: targetWidthIn };
+    if (sizingMode === 'height') return { kind: 'height', inches: targetHeightIn };
+    return { kind: 'pages', pageCount };
+  }, [sizingMode, pageCount, targetWidthIn, targetHeightIn]);
+
+  const layout = useMemo<Layout | null>(() => {
+    if (!image) return null;
+    try {
+      const l = computeLayout(image.width, image.height, sizing, pageSize, marginIn);
+      setError(null);
+      return l;
+    } catch (e) {
+      setError((e as Error).message);
+      return null;
+    }
+  }, [image, sizing, pageSize, marginIn]);
+
+  const handleGenerate = useCallback(async () => {
+    if (!image || !layout || !file) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const bytes = await buildPdf(image, layout);
+      const ab = bytes.slice().buffer;
+      const blob = new Blob([ab], { type: 'application/pdf' });
+      const url = URL.createObjectURL(blob);
+      if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+      objectUrlRef.current = url;
+      setPdfUrl(url);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }, [image, layout, file]);
+
+  const handleDownload = useCallback(() => {
+    if (!pdfUrl || !file || !layout) return;
+    const base = file.name.replace(/\.[^.]+$/, '');
+    const totalPages = layout.grid.cols * layout.grid.rows;
+    const a = document.createElement('a');
+    a.href = pdfUrl;
+    a.download = `${base} (${totalPages} pages).pdf`;
+    a.click();
+  }, [pdfUrl, file, layout]);
+
+  const handleOpen = useCallback(() => {
+    if (!pdfUrl) return;
+    const w = window.open(pdfUrl, '_blank');
+    if (w) w.focus();
+  }, [pdfUrl]);
+
+  const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFile(e.target.files?.[0] ?? null);
+  };
+
+  const onDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const f = e.dataTransfer.files?.[0];
+    if (f) setFile(f);
+  };
+
+  return (
+    <ThemeProvider theme={theme}>
+      <Box
+        sx={{
+          width: '100%',
+          fontFamily: 'system-ui, -apple-system, sans-serif',
+          color: textTokens.primary,
+        }}
+      >
+        <Box sx={{ mb: 3 }}>
+          <Typography variant="h5" sx={{ color: textTokens.primary, fontWeight: 600, mb: 0.5 }}>
+            {heading}
+          </Typography>
+          {intro && (
+            <Typography variant="body2" sx={{ color: textTokens.secondary }}>
+              {intro}
+            </Typography>
+          )}
+        </Box>
+
+        <Stack
+          spacing={2}
+          sx={{
+            backgroundColor: surfaces.paper,
+            border: `1px solid ${borders.subtle}`,
+            borderRadius: 2,
+            p: { xs: 2, sm: 3 },
+          }}
+        >
+          {/* File drop / picker */}
+          <Box
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={onDrop}
+            sx={{
+              position: 'relative',
+              border: `1.5px dashed ${file ? brandColors.sageGreen : borders.strong}`,
+              backgroundColor: file ? 'rgba(107, 123, 94, 0.06)' : 'transparent',
+              borderRadius: 2,
+              p: 3,
+              textAlign: 'center',
+              transition: 'border-color 0.15s, background-color 0.15s',
+            }}
+          >
+            <input
+              id="image2pages-file"
+              type="file"
+              accept="image/*"
+              onChange={onFileChange}
+              style={{
+                position: 'absolute',
+                inset: 0,
+                opacity: 0,
+                cursor: 'pointer',
+              }}
+            />
+            <Box sx={{ pointerEvents: 'none' }}>
+              <Typography variant="body1" sx={{ color: textTokens.primary, fontWeight: 500 }}>
+                {file ? file.name : 'Drop an image here or click to choose'}
+              </Typography>
+              {image && (
+                <Typography variant="caption" sx={{ color: textTokens.secondary }}>
+                  {image.width} × {image.height}px
+                </Typography>
+              )}
+            </Box>
+          </Box>
+
+          {/* Sizing mode toggle */}
+          <Box>
+            <Typography
+              variant="caption"
+              sx={{ display: 'block', mb: 0.75, color: textTokens.secondary }}
+            >
+              Sizing mode
+            </Typography>
+            <ToggleButtonGroup
+              size="small"
+              exclusive
+              value={sizingMode}
+              onChange={(_, v) => v && setSizingMode(v as SizingMode)}
+              sx={{
+                '& .MuiToggleButton-root': {
+                  textTransform: 'none',
+                  borderColor: borders.default,
+                  color: textTokens.secondary,
+                },
+                '& .Mui-selected': {
+                  backgroundColor: `${brandColors.sageGreen} !important`,
+                  color: `${surfaces.paper} !important`,
+                  borderColor: `${brandColors.sageGreen} !important`,
+                },
+              }}
+            >
+              <ToggleButton value="pages">By page count</ToggleButton>
+              <ToggleButton value="width">By width</ToggleButton>
+              <ToggleButton value="height">By height</ToggleButton>
+            </ToggleButtonGroup>
+          </Box>
+
+          {/* Numeric / select controls */}
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+            {sizingMode === 'pages' && (
+              <TextField
+                select
+                size="small"
+                label="Pages"
+                value={pageCount}
+                onChange={(e) => setPageCount(parseInt(e.target.value, 10))}
+                sx={{ minWidth: 140 }}
+              >
+                {PAGE_COUNT_OPTIONS.map((n) => (
+                  <MenuItem key={n} value={n}>
+                    {n}
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
+            {sizingMode === 'width' && (
+              <TextField
+                size="small"
+                label="Printed width (in)"
+                type="number"
+                inputProps={{ min: 0.5, step: 0.5 }}
+                value={targetWidthIn}
+                onChange={(e) => setTargetWidthIn(parseFloat(e.target.value) || 0)}
+                sx={{ minWidth: 160 }}
+              />
+            )}
+            {sizingMode === 'height' && (
+              <TextField
+                size="small"
+                label="Printed height (in)"
+                type="number"
+                inputProps={{ min: 0.5, step: 0.5 }}
+                value={targetHeightIn}
+                onChange={(e) => setTargetHeightIn(parseFloat(e.target.value) || 0)}
+                sx={{ minWidth: 160 }}
+              />
+            )}
+            <Select
+              size="small"
+              value={pageSize}
+              onChange={(e) => setPageSize(e.target.value as PageSizeKey)}
+              sx={{ minWidth: 200 }}
+            >
+              {(Object.keys(PAGE_SIZE_LABELS) as PageSizeKey[]).map((k) => (
+                <MenuItem key={k} value={k}>
+                  {PAGE_SIZE_LABELS[k]}
+                </MenuItem>
+              ))}
+            </Select>
+            <TextField
+              size="small"
+              label="Margin (in)"
+              type="number"
+              inputProps={{ min: 0, step: 0.05 }}
+              value={marginIn}
+              onChange={(e) => setMarginIn(Math.max(0, parseFloat(e.target.value) || 0))}
+              sx={{ minWidth: 130 }}
+            />
+          </Stack>
+
+          {/* Action row */}
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
+            <Button
+              variant="contained"
+              color="secondary"
+              disabled={!image || !layout || busy}
+              onClick={handleGenerate}
+            >
+              {busy ? 'Generating…' : 'Generate PDF'}
+            </Button>
+            <Button
+              variant="outlined"
+              color="primary"
+              startIcon={<FileDownloadOutlinedIcon />}
+              disabled={!pdfUrl}
+              onClick={handleDownload}
+            >
+              Download
+            </Button>
+            <Button
+              variant="outlined"
+              color="primary"
+              startIcon={<OpenInNewOutlinedIcon />}
+              disabled={!pdfUrl}
+              onClick={handleOpen}
+            >
+              Open / Print
+            </Button>
+          </Stack>
+
+          {error && <Alert severity="error">{error}</Alert>}
+        </Stack>
+
+        {image && layout && (
+          <Box
+            sx={{
+              mt: 3,
+              backgroundColor: surfaces.paper,
+              border: `1px solid ${borders.subtle}`,
+              borderRadius: 2,
+              p: { xs: 2, sm: 3 },
+            }}
+          >
+            <PreviewCanvas image={image} layout={layout} />
+            <Stack
+              direction={{ xs: 'column', sm: 'row' }}
+              spacing={{ xs: 0.5, sm: 3 }}
+              sx={{ mt: 1.5, color: textTokens.secondary, fontSize: 13 }}
+            >
+              <Box>
+                <Typography component="span" sx={{ fontWeight: 600, color: textTokens.primary }}>
+                  Pages:
+                </Typography>{' '}
+                {layout.grid.cols * layout.grid.rows} ({layout.grid.cols} × {layout.grid.rows}{' '}
+                {layout.grid.orient})
+              </Box>
+              <Box>
+                <Typography component="span" sx={{ fontWeight: 600, color: textTokens.primary }}>
+                  Printed size:
+                </Typography>{' '}
+                {(layout.grid.printedW / 72).toFixed(2)}″ × {(layout.grid.printedH / 72).toFixed(2)}
+                ″
+              </Box>
+            </Stack>
+          </Box>
+        )}
+
+        {pdfUrl && (
+          <Box sx={{ mt: 3 }}>
+            <Typography
+              variant="subtitle2"
+              sx={{ mb: 1, color: textTokens.secondary, fontWeight: 600 }}
+            >
+              PDF preview
+            </Typography>
+            <Box
+              component="iframe"
+              src={pdfUrl}
+              title="Image2Pages PDF preview"
+              sx={{
+                width: '100%',
+                height: 560,
+                border: `1px solid ${borders.subtle}`,
+                borderRadius: 2,
+                backgroundColor: surfaces.paper,
+              }}
+            />
+          </Box>
+        )}
+      </Box>
+    </ThemeProvider>
+  );
+}
+
+/**
+ * Renders the source image at a manageable display size, with dashed
+ * lines marking where each page boundary will fall on the printed image.
+ */
+function PreviewCanvas({ image, layout }: { image: HTMLImageElement; layout: Layout }) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const maxDisplay = 720;
+    const displayScale = Math.min(1, maxDisplay / image.width);
+    const dispW = Math.round(image.width * displayScale);
+    const dispH = Math.round(image.height * displayScale);
+
+    canvas.width = dispW;
+    canvas.height = dispH;
+    ctx.clearRect(0, 0, dispW, dispH);
+    ctx.drawImage(image, 0, 0, dispW, dispH);
+
+    const { grid, offsetX, offsetY } = layout;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([6, 4]);
+    ctx.strokeStyle = brandColors.darkBrown;
+
+    for (let c = 1; c < grid.cols; c++) {
+      const xPts = c * grid.pw - offsetX;
+      if (xPts <= 0 || xPts >= grid.printedW) continue;
+      const xDisp = (xPts / grid.printedW) * dispW;
+      ctx.beginPath();
+      ctx.moveTo(xDisp + 0.5, 0);
+      ctx.lineTo(xDisp + 0.5, dispH);
+      ctx.stroke();
+    }
+    for (let r = 1; r < grid.rows; r++) {
+      const yPts = r * grid.ph - offsetY;
+      if (yPts <= 0 || yPts >= grid.printedH) continue;
+      const yDisp = (yPts / grid.printedH) * dispH;
+      ctx.beginPath();
+      ctx.moveTo(0, yDisp + 0.5);
+      ctx.lineTo(dispW, yDisp + 0.5);
+      ctx.stroke();
+    }
+  }, [image, layout]);
+
+  return (
+    <Box
+      component="canvas"
+      ref={canvasRef}
+      sx={{
+        display: 'block',
+        maxWidth: '100%',
+        height: 'auto',
+        backgroundColor: surfaces.paper,
+        borderRadius: 1,
+      }}
+    />
+  );
+}

--- a/apps/webflow-components/src/image2pages.webflow.tsx
+++ b/apps/webflow-components/src/image2pages.webflow.tsx
@@ -1,0 +1,29 @@
+/**
+ * Webflow Code Component: Image2Pages
+ *
+ * Wraps the Image2PagesWidget for use in the Webflow Designer. Heading
+ * and intro text are configurable from the Designer panel so the same
+ * component can be reused across pages with different framing copy.
+ */
+import { declareComponent } from '@webflow/react';
+import { props } from '@webflow/data-types';
+import { emotionShadowDomDecorator } from '@webflow/emotion-utils';
+import { Image2PagesWidget } from './Image2PagesWidget';
+
+export default declareComponent(Image2PagesWidget, {
+  name: 'Image to Pages',
+  description:
+    'Lets visitors upload an image (e.g. a stained glass pattern) and download a multi-page PDF tiled across as many pages as needed for printing at scale. Runs entirely in the browser.',
+  decorators: [emotionShadowDomDecorator],
+  props: {
+    heading: props.Text({
+      name: 'Heading',
+      defaultValue: 'Pattern Page Tiler',
+    }),
+    intro: props.Text({
+      name: 'Intro text',
+      defaultValue:
+        'Upload a stained-glass pattern (or any image) and download a printable PDF tiled across as many pages as you need.',
+    }),
+  },
+});

--- a/apps/webflow-components/src/lib/image2pages-tile.spec.ts
+++ b/apps/webflow-components/src/lib/image2pages-tile.spec.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import {
+  bestGrid,
+  computeLayout,
+  gridFromTargetSize,
+  MAX_PAGES,
+  PAGE_SIZES,
+} from './image2pages-tile';
+
+const [LETTER_W, LETTER_H] = PAGE_SIZES.letter;
+const LETTER_PRINT_W = LETTER_W - 2 * 36; // 0.5in margin
+const LETTER_PRINT_H = LETTER_H - 2 * 36;
+
+describe('bestGrid', () => {
+  it('returns a 1x1 grid for a single page', () => {
+    const g = bestGrid(1, 800, 600, LETTER_PRINT_W, LETTER_PRINT_H);
+    expect(g.cols).toBe(1);
+    expect(g.rows).toBe(1);
+  });
+
+  it('picks landscape orientation for a wide image on a single page', () => {
+    const g = bestGrid(1, 1600, 400, LETTER_PRINT_W, LETTER_PRINT_H);
+    expect(g.orient).toBe('landscape');
+  });
+
+  it('picks portrait orientation for a tall image on a single page', () => {
+    const g = bestGrid(1, 400, 1600, LETTER_PRINT_W, LETTER_PRINT_H);
+    expect(g.orient).toBe('portrait');
+  });
+
+  it('maximizes printed area when given multiple page-count factor pairs', () => {
+    // 4 pages: factor pairs are (1,4),(2,2),(4,1) -- pick whichever maximizes area
+    const g = bestGrid(4, 1000, 1000, LETTER_PRINT_W, LETTER_PRINT_H);
+    expect(g.cols * g.rows).toBe(4);
+    // For a square image, 2x2 should give a larger printed area than 1x4 or 4x1
+    expect(g.cols).toBe(2);
+    expect(g.rows).toBe(2);
+  });
+
+  it('preserves the source aspect ratio in the printed dimensions', () => {
+    const g = bestGrid(2, 2000, 1000, LETTER_PRINT_W, LETTER_PRINT_H);
+    const aspect = g.printedW / g.printedH;
+    expect(aspect).toBeCloseTo(2, 5);
+  });
+});
+
+describe('gridFromTargetSize', () => {
+  it('throws if the target dimension is non-positive', () => {
+    expect(() =>
+      gridFromTargetSize({ kind: 'width', inches: 0 }, 800, 600, LETTER_PRINT_W, LETTER_PRINT_H),
+    ).toThrow();
+    expect(() =>
+      gridFromTargetSize({ kind: 'height', inches: -3 }, 800, 600, LETTER_PRINT_W, LETTER_PRINT_H),
+    ).toThrow();
+  });
+
+  it('uses a single page when the target fits within one printable area', () => {
+    // 4in wide on letter (7.5in printable) -- fits in 1 page
+    const g = gridFromTargetSize(
+      { kind: 'width', inches: 4 },
+      800,
+      600,
+      LETTER_PRINT_W,
+      LETTER_PRINT_H,
+    );
+    expect(g.cols * g.rows).toBe(1);
+  });
+
+  it('scales the image so the printed width matches the requested target', () => {
+    const g = gridFromTargetSize(
+      { kind: 'width', inches: 20 },
+      800,
+      600,
+      LETTER_PRINT_W,
+      LETTER_PRINT_H,
+    );
+    expect(g.printedW).toBeCloseTo(20 * 72, 5);
+    expect(g.printedH).toBeCloseTo(15 * 72, 5);
+  });
+
+  it('scales the image so the printed height matches the requested target', () => {
+    const g = gridFromTargetSize(
+      { kind: 'height', inches: 30 },
+      800,
+      600,
+      LETTER_PRINT_W,
+      LETTER_PRINT_H,
+    );
+    expect(g.printedH).toBeCloseTo(30 * 72, 5);
+    expect(g.printedW).toBeCloseTo(40 * 72, 5);
+  });
+
+  it('uses just enough columns and rows to cover the printed area', () => {
+    // 20in wide image on letter (7.5in printable width portrait, 10in landscape)
+    // Landscape 10in/page width -> ceil(20/10) = 2 cols
+    // 15in tall image -> ceil(15/7.5) = 2 rows landscape
+    const g = gridFromTargetSize(
+      { kind: 'width', inches: 20 },
+      800,
+      600,
+      LETTER_PRINT_W,
+      LETTER_PRINT_H,
+    );
+    expect(g.cols * g.rows).toBeGreaterThanOrEqual(4);
+    // Sanity: enough pages to cover the printed area
+    expect(g.cols * g.pw).toBeGreaterThanOrEqual(g.printedW - 1e-6);
+    expect(g.rows * g.ph).toBeGreaterThanOrEqual(g.printedH - 1e-6);
+  });
+
+  it('throws when the requested size would exceed the page-count safety cap', () => {
+    expect(() =>
+      gridFromTargetSize(
+        { kind: 'width', inches: 1000 },
+        800,
+        600,
+        LETTER_PRINT_W,
+        LETTER_PRINT_H,
+      ),
+    ).toThrow(new RegExp(String(MAX_PAGES)));
+  });
+});
+
+describe('computeLayout', () => {
+  it('throws if margins are larger than the page', () => {
+    expect(() => computeLayout(800, 600, { kind: 'pages', pageCount: 1 }, 'letter', 10)).toThrow();
+  });
+
+  it('centers the printed image within the total tiled area', () => {
+    const layout = computeLayout(800, 600, { kind: 'pages', pageCount: 1 }, 'letter', 0.5);
+    // offsetX/offsetY each = (totalDim - printedDim) / 2 -- both >= 0 and <= total
+    expect(layout.offsetX).toBeGreaterThanOrEqual(0);
+    expect(layout.offsetY).toBeGreaterThanOrEqual(0);
+    expect(layout.offsetX * 2 + layout.grid.printedW).toBeCloseTo(layout.totalW, 5);
+    expect(layout.offsetY * 2 + layout.grid.printedH).toBeCloseTo(layout.totalH, 5);
+  });
+
+  it('uses page dimensions corresponding to the chosen orientation', () => {
+    const wide = computeLayout(2000, 500, { kind: 'pages', pageCount: 1 }, 'letter', 0.5);
+    expect(wide.pageW).toBe(LETTER_H); // landscape -> page width is the long edge
+    expect(wide.pageH).toBe(LETTER_W);
+
+    const tall = computeLayout(500, 2000, { kind: 'pages', pageCount: 1 }, 'letter', 0.5);
+    expect(tall.pageW).toBe(LETTER_W);
+    expect(tall.pageH).toBe(LETTER_H);
+  });
+
+  it('produces consistent pxPerPt = imgW / printedW', () => {
+    const layout = computeLayout(1600, 1200, { kind: 'pages', pageCount: 4 }, 'letter', 0.5);
+    expect(layout.pxPerPt).toBeCloseTo(1600 / layout.grid.printedW, 5);
+  });
+
+  it('honors a width-based sizing request end-to-end', () => {
+    const layout = computeLayout(1000, 500, { kind: 'width', inches: 10 }, 'letter', 0.5);
+    expect(layout.grid.printedW).toBeCloseTo(10 * 72, 5);
+    expect(layout.grid.printedH).toBeCloseTo(5 * 72, 5);
+  });
+});

--- a/apps/webflow-components/src/lib/image2pages-tile.ts
+++ b/apps/webflow-components/src/lib/image2pages-tile.ts
@@ -161,6 +161,7 @@ export function computeLayout(
   return { grid, pageW, pageH, marginPts, totalW, totalH, offsetX, offsetY, pxPerPt };
 }
 
+/* c8 ignore start -- DOM/Canvas-bound, exercised in the browser only */
 /**
  * Build a tiled PDF from a decoded image and computed layout. Each tile is
  * extracted via a 2D canvas, encoded as PNG, and embedded into the PDF page.
@@ -242,3 +243,4 @@ export async function loadImage(file: File): Promise<HTMLImageElement> {
   await img.decode();
   return img;
 }
+/* c8 ignore stop */

--- a/apps/webflow-components/src/lib/image2pages-tile.ts
+++ b/apps/webflow-components/src/lib/image2pages-tile.ts
@@ -1,0 +1,244 @@
+/**
+ * Tiling logic for the Image2Pages widget.
+ *
+ * Pure-browser implementation: takes a decoded image plus a sizing
+ * description and produces a multi-page PDF that tiles the image across
+ * one or more printable pages. No server side, no native deps.
+ */
+import { PDFDocument } from 'pdf-lib';
+
+export type PageSizeKey = 'letter' | 'legal' | 'tabloid' | 'a4' | 'a3';
+
+export const PAGE_SIZES: Record<PageSizeKey, [number, number]> = {
+  letter: [612, 792],
+  legal: [612, 1008],
+  tabloid: [792, 1224],
+  a4: [595.28, 841.89],
+  a3: [841.89, 1190.55],
+};
+
+export const PAGE_SIZE_LABELS: Record<PageSizeKey, string> = {
+  letter: 'US Letter (8.5×11)',
+  legal: 'US Legal (8.5×14)',
+  tabloid: 'Tabloid (11×17)',
+  a4: 'A4',
+  a3: 'A3',
+};
+
+export interface Grid {
+  cols: number;
+  rows: number;
+  orient: 'portrait' | 'landscape';
+  pw: number;
+  ph: number;
+  scale: number;
+  printedW: number;
+  printedH: number;
+}
+
+export interface Layout {
+  grid: Grid;
+  pageW: number;
+  pageH: number;
+  marginPts: number;
+  totalW: number;
+  totalH: number;
+  offsetX: number;
+  offsetY: number;
+  pxPerPt: number;
+}
+
+export type Sizing =
+  | { kind: 'pages'; pageCount: number }
+  | { kind: 'width'; inches: number }
+  | { kind: 'height'; inches: number };
+
+export const MAX_PAGES = 400;
+
+/**
+ * Given a fixed page count, find the grid + orientation that fits the image
+ * with the largest possible printed area.
+ */
+export function bestGrid(
+  pageCount: number,
+  imgW: number,
+  imgH: number,
+  pageW: number,
+  pageH: number,
+): Grid {
+  const pairs: Array<[number, number]> = [];
+  for (let c = 1; c <= pageCount; c++) {
+    if (pageCount % c === 0) pairs.push([c, pageCount / c]);
+  }
+  let best: Grid | null = null;
+  for (const [cols, rows] of pairs) {
+    for (const orient of ['portrait', 'landscape'] as const) {
+      const pw = orient === 'portrait' ? pageW : pageH;
+      const ph = orient === 'portrait' ? pageH : pageW;
+      const totalW = cols * pw;
+      const totalH = rows * ph;
+      const scale = Math.min(totalW / imgW, totalH / imgH);
+      const printedW = imgW * scale;
+      const printedH = imgH * scale;
+      if (!best || printedW * printedH > best.printedW * best.printedH) {
+        best = { cols, rows, orient, pw, ph, scale, printedW, printedH };
+      }
+    }
+  }
+  return best!;
+}
+
+/**
+ * Given a target printed dimension (width or height in inches), find the
+ * smallest grid + page orientation that can accommodate the image at exactly
+ * that scale.
+ */
+export function gridFromTargetSize(
+  sizing: { kind: 'width' | 'height'; inches: number },
+  imgW: number,
+  imgH: number,
+  printW: number,
+  printH: number,
+): Grid {
+  if (!Number.isFinite(sizing.inches) || sizing.inches <= 0) {
+    throw new Error(`Target ${sizing.kind} must be greater than 0`);
+  }
+  const targetPts = sizing.inches * 72;
+  const scale = sizing.kind === 'width' ? targetPts / imgW : targetPts / imgH;
+  const printedW = imgW * scale;
+  const printedH = imgH * scale;
+
+  let best: Grid | null = null;
+  for (const orient of ['portrait', 'landscape'] as const) {
+    const pw = orient === 'portrait' ? printW : printH;
+    const ph = orient === 'portrait' ? printH : printW;
+    const cols = Math.max(1, Math.ceil(printedW / pw - 1e-9));
+    const rows = Math.max(1, Math.ceil(printedH / ph - 1e-9));
+    const total = cols * rows;
+    const wasted = cols * pw - printedW + (rows * ph - printedH);
+    if (
+      !best ||
+      total < best.cols * best.rows ||
+      (total === best.cols * best.rows &&
+        wasted < best.cols * best.pw - best.printedW + (best.rows * best.ph - best.printedH))
+    ) {
+      best = { cols, rows, orient, pw, ph, scale, printedW, printedH };
+    }
+  }
+  if (best!.cols * best!.rows > MAX_PAGES) {
+    throw new Error(
+      `That would require ${best!.cols * best!.rows} pages (max ${MAX_PAGES}). Try a smaller target size or a larger page size.`,
+    );
+  }
+  return best!;
+}
+
+export function computeLayout(
+  imgW: number,
+  imgH: number,
+  sizing: Sizing,
+  pageSize: PageSizeKey,
+  marginIn: number,
+): Layout {
+  const [PAGE_W, PAGE_H] = PAGE_SIZES[pageSize];
+  const marginPts = marginIn * 72;
+  const printW = PAGE_W - 2 * marginPts;
+  const printH = PAGE_H - 2 * marginPts;
+  if (printW <= 0 || printH <= 0) throw new Error('Margin too large for page');
+
+  const grid =
+    sizing.kind === 'pages'
+      ? bestGrid(sizing.pageCount, imgW, imgH, printW, printH)
+      : gridFromTargetSize(sizing, imgW, imgH, printW, printH);
+
+  const pageW = grid.orient === 'portrait' ? PAGE_W : PAGE_H;
+  const pageH = grid.orient === 'portrait' ? PAGE_H : PAGE_W;
+  const totalW = grid.cols * grid.pw;
+  const totalH = grid.rows * grid.ph;
+  const offsetX = (totalW - grid.printedW) / 2;
+  const offsetY = (totalH - grid.printedH) / 2;
+  const pxPerPt = imgW / grid.printedW;
+  return { grid, pageW, pageH, marginPts, totalW, totalH, offsetX, offsetY, pxPerPt };
+}
+
+/**
+ * Build a tiled PDF from a decoded image and computed layout. Each tile is
+ * extracted via a 2D canvas, encoded as PNG, and embedded into the PDF page.
+ */
+export async function buildPdf(
+  image: HTMLImageElement | ImageBitmap,
+  layout: Layout,
+): Promise<Uint8Array> {
+  const { grid, pageW, pageH, marginPts, offsetX, offsetY, pxPerPt } = layout;
+  const imgW = image.width;
+  const imgH = image.height;
+
+  const pdfDoc = await PDFDocument.create();
+
+  const tileCanvas = document.createElement('canvas');
+  const tileCtx = tileCanvas.getContext('2d');
+  if (!tileCtx) throw new Error('Could not get 2d context');
+
+  for (let r = 0; r < grid.rows; r++) {
+    for (let c = 0; c < grid.cols; c++) {
+      const tileX0 = c * grid.pw;
+      const tileY0 = r * grid.ph;
+      const tileX1 = tileX0 + grid.pw;
+      const tileY1 = tileY0 + grid.ph;
+
+      const ix0 = Math.max(tileX0, offsetX);
+      const iy0 = Math.max(tileY0, offsetY);
+      const ix1 = Math.min(tileX1, offsetX + grid.printedW);
+      const iy1 = Math.min(tileY1, offsetY + grid.printedH);
+
+      const page = pdfDoc.addPage([pageW, pageH]);
+
+      if (ix1 > ix0 && iy1 > iy0) {
+        const sx = Math.max(0, Math.round((ix0 - offsetX) * pxPerPt));
+        const sy = Math.max(0, Math.round((iy0 - offsetY) * pxPerPt));
+        let sw = Math.round((ix1 - ix0) * pxPerPt);
+        let sh = Math.round((iy1 - iy0) * pxPerPt);
+        sw = Math.min(sw, imgW - sx);
+        sh = Math.min(sh, imgH - sy);
+
+        tileCanvas.width = sw;
+        tileCanvas.height = sh;
+        tileCtx.clearRect(0, 0, sw, sh);
+        tileCtx.drawImage(image, sx, sy, sw, sh, 0, 0, sw, sh);
+
+        const blob: Blob = await new Promise((resolve, reject) =>
+          tileCanvas.toBlob(
+            (b) => (b ? resolve(b) : reject(new Error('toBlob failed'))),
+            'image/png',
+          ),
+        );
+        const buf = new Uint8Array(await blob.arrayBuffer());
+        const embedded = await pdfDoc.embedPng(buf);
+
+        const drawWidth = ix1 - ix0;
+        const drawHeight = iy1 - iy0;
+        const drawX = marginPts + (ix0 - tileX0);
+        const topFromPageTop = marginPts + (iy0 - tileY0);
+        const drawY = pageH - topFromPageTop - drawHeight;
+
+        page.drawImage(embedded, {
+          x: drawX,
+          y: drawY,
+          width: drawWidth,
+          height: drawHeight,
+        });
+      }
+    }
+  }
+
+  return pdfDoc.save();
+}
+
+export async function loadImage(file: File): Promise<HTMLImageElement> {
+  const url = URL.createObjectURL(file);
+  const img = new Image();
+  img.decoding = 'async';
+  img.src = url;
+  await img.decode();
+  return img;
+}

--- a/apps/webflow-components/vitest.config.ts
+++ b/apps/webflow-components/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  root: __dirname,
+  test: {
+    name: 'webflow-components',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov', 'json-summary', 'json'],
+      reportsDirectory: '../../coverage/apps/webflow-components',
+      include: ['src/lib/**/*.ts'],
+      exclude: ['src/**/*.spec.ts'],
+    },
+  },
+});

--- a/docs/reference/implementation-status.md
+++ b/docs/reference/implementation-status.md
@@ -152,8 +152,8 @@ Phased rollout of customer-facing interactions on the Webflow site.
 | Unit tests for tiling logic | **Complete** | `apps/webflow-components/src/lib/image2pages-tile.spec.ts` (16 tests) |
 | Image2Pages React widget | **Complete** | `apps/webflow-components/src/Image2PagesWidget.tsx` |
 | Webflow component declaration | **Complete** | `apps/webflow-components/src/image2pages.webflow.tsx` |
-| Published to workspace | Not Started | Awaiting `webflow components publish` |
-| Embedded on a Webflow page | Not Started | Pattern Scaling tool page |
+| Published to workspace | **Complete** | `webflow library share` published to Katie's Workspace |
+| Embedded on a Webflow page | **Complete** | New "Pattern Scaling Tool" page (`/untitled` slug, draft) with maple-nav + Image to Pages + Footer |
 
 ### Customer Self-Service (Backend only, PR pending)
 

--- a/docs/reference/implementation-status.md
+++ b/docs/reference/implementation-status.md
@@ -144,6 +144,17 @@ Phased rollout of customer-facing interactions on the Webflow site.
 | Test page | **Complete** | `mapleandsprucefolkarts.com/test-class-enrollment` |
 | CMS-bound class pages | Not Started | Needs #139-145, #202 |
 
+### Image2Pages Widget (PR pending)
+
+| Feature | Status | Location |
+|---------|--------|----------|
+| Image tiling library (pure browser) | **Complete** | `apps/webflow-components/src/lib/image2pages-tile.ts` |
+| Unit tests for tiling logic | **Complete** | `apps/webflow-components/src/lib/image2pages-tile.spec.ts` (16 tests) |
+| Image2Pages React widget | **Complete** | `apps/webflow-components/src/Image2PagesWidget.tsx` |
+| Webflow component declaration | **Complete** | `apps/webflow-components/src/image2pages.webflow.tsx` |
+| Published to workspace | Not Started | Awaiting `webflow components publish` |
+| Embedded on a Webflow page | Not Started | Pattern Scaling tool page |
+
 ### Customer Self-Service (Backend only, PR pending)
 
 | Feature | Status | Location |

--- a/docs/sessions/SESSION.md
+++ b/docs/sessions/SESSION.md
@@ -6,84 +6,77 @@
 
 ## Current Status
 
-**Date**: 2026-04-05
-**Status**: Integration test coverage expanded, Webflow CMS pipeline polishing
+**Date**: 2026-04-09
+**Status**: Class registration launch prep — wave 1 code complete, manual ops remaining. Image2Pages widget shipped on `feat/image2pages-widget`.
 
-### Current Focus: Integration Test Coverage (#167)
+### Image2Pages Webflow Widget (in flight)
 
-PR #218 adds 84 new integration tests across 8 domain-specific nx projects:
-- Split monolithic test project for `nx affected` efficiency
-- Shared utils extracted to `libs/firebase/integration-test-utils`
-- First Firestore trigger test (`onClassWrite` → calendar event sync)
-- 120 total tests passing against Firebase emulators
+Branch: `feat/image2pages-widget`
 
-Follow-up issues created for remaining coverage:
-- #219 — ICS calendar feed endpoints (HTTP pattern)
-- #220 — Registration admin + remaining maple-core endpoints
-- #221 — Square payment/catalog functions (needs Square sandbox)
-- #206 — syncClassToWebflow trigger (already existed)
+- New Webflow Code Component at `apps/webflow-components/src/Image2PagesWidget.tsx` + `image2pages.webflow.tsx`
+- Pure-browser tiling library at `apps/webflow-components/src/lib/image2pages-tile.ts` (Canvas + pdf-lib, no server)
+- Three sizing modes: by page count, target width (in), target height (in)
+- Live preview canvas with dashed dark-brown page-boundary overlay; brand-themed via `@maple/react/theme`
+- Tests: `apps/webflow-components/src/lib/image2pages-tile.spec.ts` (16 unit tests for `bestGrid` / `gridFromTargetSize` / `computeLayout`)
+- Nx scaffolding added: `apps/webflow-components/project.json` + `vitest.config.ts` (test target only — no build target; webflow-cli still drives bundling via `webflow.json`)
+- Ported from standalone prototype: github.com/david-shortman/image2pages-web
 
-### Previous Focus: Class Registration on Webflow (CMS Pipeline Done)
+### Registration Launch: Meta Ads Readiness
 
-Full CMS pipeline built and working:
-- Classes sync from Firebase → Webflow CMS via `syncClassToWebflow` trigger
-- Listing page at `/upcoming-classes` with CMS Collection List card grid
-- Detail template page at `/classes/[slug]` with class info + registration component
-- Registration component reads `firebase-id` from CMS and enables checkout
+Goal: enable paid Meta ads driving traffic to Webflow class registration pages.
 
-**Live test:** `mapleandsprucefolkarts.com/classes/trigger-test-class`
+### What's Done
 
-### Open PRs
+**Wave 1 code (all merged):**
+- PR #213 — Class roster admin page (#211)
+- PR #214 — Email templates for confirmation + cancellation (#197)
+- PR #216 — syncRegistrationCount Cloud Function (#143)
+- PR #217 — Integration tests for syncClassToWebflow (#206)
+- PR #218 — Integration test foundation with 8 domain-specific projects (#167)
+- PR #226 — Square receipt URL in registrations + emails (#192) — auto-merge pending
 
-| PR | Branch | Status | Description |
-|----|--------|--------|-------------|
-| #204 | `feature/141-sync-class-to-webflow` | Open | Full CMS pipeline + Webflow pages |
-| (needs PR) | `feature/190-registration-lookup` | Pushed, no PR | Backend for customer self-service lookup + cancel |
+**Registration flow verified:**
+- Registration widget placed on Webflow CMS class detail page
+- Props bound to CMS fields (firebase-id → classId)
+- Tested working end-to-end with dev Square configuration
 
-### Completed This Session (2026-04-04 — 2026-04-05)
+**Analysis completed:**
+- #205 sync fields already implemented — remaining work is Webflow Designer binding
+- #202 component already placed — just needed manual prop configuration (done)
 
-**CMS Pipeline (PR #204):**
-- ClassService for Webflow CMS sync (mirrors ArtistService pattern)
-- syncClassToWebflow Firestore trigger (published → sync, unpublished → remove)
-- Display-formatted fields: price-display, duration-display, spots-display
-- Classes CMS collection created in Webflow (19 fields including firebase-id)
-- Upcoming Classes listing page with CMS Collection List
-- Class detail template page with registration component
-- Card styling, link decoration, responsive breakpoints
-- WEBFLOW_CLASSES_COLLECTION_ID configured in .env.dev/.env.prod
-- 48 webflow library tests passing
+### Remaining Work (Manual Ops)
 
-**Registration Widget Updates:**
-- Removed redundant class info card (CMS page already shows it)
-- Fixed onSuccess handler signature
+| Task | Issue | Owner | Notes |
+|------|-------|-------|-------|
+| AWS account + SES setup | #223 | David | **Start first** — production access takes 24-48h |
+| Firebase email extension | #195 | David | After SES; then run `tools/seed-email-templates.ts` |
+| GA4 + GTM | #116 | David | Google/Webflow console work |
+| Meta Pixel | #224 | David | After GTM; needed for ad optimization |
+| Privacy + cancellation policy pages | #225 | David/Katie | Webflow content pages |
+| Canonical domain + sitemap | #120 | David | DNS + Webflow settings |
+| Switch widget to prod Square credentials | — | David | Webflow Designer, last step |
+| Upcoming Classes page enhancements | #210 | In progress | Agent working on Webflow MCP |
 
-**Issues Closed:** #139, #140, #141, #142, #144, #145, #146
+### Issues Created This Session
 
-### Remaining Work
-
-**Immediate polish (#205):**
-- Add `time-display` formatted field to sync
-- Bind remaining CMS fields on detail page (description, what-to-bring, etc.)
-- Create real test class with all fields populated
-- Hide empty detail cards with Webflow conditional visibility
-
-**Next priorities:**
-- #143 — Sync registration count changes to Webflow CMS (spots remaining updates)
-- #202 — Document registration component CMS binding (done manually)
-- #205 — Fix missing class data display
-- #163 — Payment & Registration Testing (integration tests, PR #187)
-- Self-service features (#189-192, #199)
-- Email infrastructure (#195-197)
+| Issue | Title |
+|-------|-------|
+| #215 | Admin email template management with preview |
+| #222 | Configure required status checks for PR merging |
+| #223 | Create AWS account + SES for Maple & Spruce |
+| #224 | Install Meta Pixel via GTM |
+| #225 | Privacy policy + cancellation policy pages |
 
 ### Key Decisions Made
 
-- **Webflow Code Components** for React integration — Shadow DOM, designer-configurable props
-- **CMS-powered class browsing** with React component only for registration/payment
-- **Pre-formatted display fields** in sync (price-display, duration-display, spots-display) to avoid client-side formatting
-- **Registration component shows form only** — class details handled by CMS page layout
+- **Handlebars templates** for emails (matches existing `createRegistration` code pattern, easier to update than inline HTML)
+- **Agent Teams** enabled for parallel development (experimental feature)
+- **Per-domain integration test apps** structure from #218 (artist, class, instructor, etc.)
+- **vitest.config.ts** excludes integration test apps from unit test runner
 
 ### Blockers
-- None currently
+- SES production access approval (24-48h) blocks email testing
+- No blockers for registration flow itself — working on dev
 
 ---
 

--- a/docs/sessions/SESSION.md
+++ b/docs/sessions/SESSION.md
@@ -19,6 +19,9 @@ Branch: `feat/image2pages-widget`
 - Live preview canvas with dashed dark-brown page-boundary overlay; brand-themed via `@maple/react/theme`
 - Tests: `apps/webflow-components/src/lib/image2pages-tile.spec.ts` (16 unit tests for `bestGrid` / `gridFromTargetSize` / `computeLayout`)
 - Nx scaffolding added: `apps/webflow-components/project.json` + `vitest.config.ts` (test target only — no build target; webflow-cli still drives bundling via `webflow.json`)
+- Published to workspace via `webflow library share` (env var aliasing: `WEBFLOW_TOKEN` → `WEBFLOW_WORKSPACE_API_TOKEN`)
+- Embedded on new "Pattern Scaling Tool" page (page id `69d7921b12449f27596c57e9`, draft) with maple-nav + Image to Pages + Footer
+- PR: [#231](https://github.com/Maple-and-Spruce/maple-and-spruce/pull/231)
 - Ported from standalone prototype: github.com/david-shortman/image2pages-web
 
 ### Registration Launch: Meta Ads Readiness

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "firebase-functions": "^7.2.2",
     "ical-generator": "^10.1.0",
     "next": "16.1.7",
+    "pdf-lib": "^1.17.1",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "square": "^43.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       next:
         specifier: 16.1.7
         version: 16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.97.3)
+      pdf-lib:
+        specifier: ^1.17.1
+        version: 1.17.1
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -3438,6 +3441,12 @@ packages:
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    resolution: {integrity: sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==}
+
+  '@pdf-lib/upng@1.0.1':
+    resolution: {integrity: sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==}
 
   '@peculiar/asn1-cms@2.6.1':
     resolution: {integrity: sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==}
@@ -9289,6 +9298,9 @@ packages:
   pbkdf2@3.1.5:
     resolution: {integrity: sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==}
     engines: {node: '>= 0.10'}
+
+  pdf-lib@1.17.1:
+    resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -15617,6 +15629,14 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
     optional: true
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    dependencies:
+      pako: 1.0.11
+
+  '@pdf-lib/upng@1.0.1':
+    dependencies:
+      pako: 1.0.11
 
   '@peculiar/asn1-cms@2.6.1':
     dependencies:
@@ -22541,6 +22561,13 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.12
       to-buffer: 1.2.2
+
+  pdf-lib@1.17.1:
+    dependencies:
+      '@pdf-lib/standard-fonts': 1.0.0
+      '@pdf-lib/upng': 1.0.1
+      pako: 1.0.11
+      tslib: 1.14.1
 
   pend@1.2.0: {}
 


### PR DESCRIPTION
## Summary

Adds a new Webflow Code Component that lets visitors upload an image (e.g. a stained glass pattern) and download a multi-page PDF tiled across as many pages as needed for printing at scale. Ports the standalone prototype at github.com/david-shortman/image2pages-web into the monorepo.

- New widget at `apps/webflow-components/src/Image2PagesWidget.tsx` + `image2pages.webflow.tsx`, following the `RegistrationWidget` pattern (`declareComponent` + `emotionShadowDomDecorator` + MUI ThemeProvider from `@maple/react/theme`)
- Pure-browser tiling library at `apps/webflow-components/src/lib/image2pages-tile.ts` — Canvas + `pdf-lib`, no server, no native deps
- Three sizing modes: by page count, target width (in), target height (in); auto-picks the grid + page orientation that maximizes printed area; 400-page safety cap
- Live preview canvas with dashed dark-brown overlay showing where each page boundary will fall
- 16 unit tests for the pure tiling functions (`bestGrid`, `gridFromTargetSize`, `computeLayout`)
- Adds minimal `project.json` + `vitest.config.ts` so `nx test webflow-components` works (no build target — `webflow-cli` still drives bundling via `webflow.json`)

## Test plan

- [x] `npx tsc --noEmit -p apps/webflow-components/tsconfig.json` clean
- [x] `nx test webflow-components` — 16/16 passing
- [ ] Publish to Webflow workspace via `webflow components publish`
- [ ] Smoke-test the widget in the Webflow Designer (renders inside shadow DOM, file picker works, PDF downloads)
- [ ] Embed on a new "Pattern Scaling" page

🤖 Generated with [Claude Code](https://claude.com/claude-code)