### PR TITLE
feat: fire Meta Pixel and GTM events on registration completion (#234)

### DIFF
--- a/apps/webflow-components/src/RegistrationWidget.tsx
+++ b/apps/webflow-components/src/RegistrationWidget.tsx
@@ -139,11 +139,40 @@ export function RegistrationWidget({
       quantity: number;
     }) => {
       if (state.status !== 'ready') return;
+
+      const className = state.publicClass.name;
+      const value = details.pricePaidCents / 100;
+
+      // Meta Pixel: CompleteRegistration event
+      const win = typeof window !== 'undefined' ? (window as unknown as Record<string, unknown>) : null;
+      if (win?.fbq) {
+        (win.fbq as (...args: unknown[]) => void)(
+          'track', 'CompleteRegistration', {
+            value,
+            currency: 'USD',
+            content_name: className,
+          }
+        );
+      }
+
+      // GTM dataLayer: for GA4 and other tags
+      if (win) {
+        const dataLayer = (win.dataLayer || []) as Record<string, unknown>[];
+        dataLayer.push({
+          event: 'complete_registration',
+          registration_value: value,
+          registration_currency: 'USD',
+          class_name: className,
+          confirmation_number: details.confirmationNumber,
+        });
+        win.dataLayer = dataLayer;
+      }
+
       setState({
         status: 'confirmed',
         confirmationNumber: details.confirmationNumber,
         customerName: details.customerName,
-        className: state.publicClass.name,
+        className,
         pricePaidCents: details.pricePaidCents,
         quantity: details.quantity,
       });


### PR DESCRIPTION
## Summary
- Fire `fbq('track', 'CompleteRegistration')` on successful class registration for Meta ad optimization
- Push `complete_registration` event to GTM dataLayer for GA4 conversion tracking
- Both fire in `handleSuccess` after payment is confirmed

## Details
- Meta Pixel ID: `1625932185289127`
- GTM Container: `GTM-P5NDCZSX`
- Event data includes: value (dollars), currency (USD), class name, confirmation number

## After merge
The Webflow Code Component needs to be republished:
```bash
npx webflow library share --manifest apps/webflow-components/webflow.json --skip-update-check
```

## Test plan
- [ ] TypeScript compiles clean
- [ ] Register for a class on dev
- [ ] Verify Meta Pixel Helper shows CompleteRegistration event
- [ ] Verify GA4 Real-time shows complete_registration event

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)