### PR TITLE
fix: pass env prop to SquareCardForm for SDK environment selection

### DIFF
--- a/apps/webflow-components/src/RegistrationWidget.tsx
+++ b/apps/webflow-components/src/RegistrationWidget.tsx
@@ -220,6 +220,7 @@ export function RegistrationWidget({
                   publicClass={state.publicClass}
                   squareApplicationId={squareAppId}
                   squareLocationId={squareLocationId}
+                  env={env}
                   onCalculateCost={handleCalculateCost}
                   onSubmit={handleSubmit}
                   onSuccess={handleSuccess}

--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
@@ -21,6 +21,8 @@ interface RegistrationCheckoutFormProps {
   publicClass: PublicClass;
   squareApplicationId: string;
   squareLocationId: string;
+  /** Square environment — passed through to SquareCardForm */
+  env?: string;
   onCalculateCost: (
     classId: string,
     quantity: number,
@@ -48,6 +50,7 @@ export function RegistrationCheckoutForm({
   publicClass,
   squareApplicationId,
   squareLocationId,
+  env,
   onCalculateCost,
   onSubmit,
   onSuccess,
@@ -283,6 +286,7 @@ export function RegistrationCheckoutForm({
         <SquareCardForm
           applicationId={squareApplicationId}
           locationId={squareLocationId}
+          env={env}
           onReady={() => setIsCardReady(true)}
           onTokenizeRef={(fn) => {
             tokenizeRef.current = fn;

--- a/libs/react/registrations/src/lib/SquareCardForm.tsx
+++ b/libs/react/registrations/src/lib/SquareCardForm.tsx
@@ -37,6 +37,8 @@ declare global {
 interface SquareCardFormProps {
   applicationId: string;
   locationId: string;
+  /** Square environment — 'prod' loads production SDK, anything else loads sandbox */
+  env?: string;
   /** Called when the form is ready to tokenize */
   onReady?: () => void;
   /** Ref function to expose tokenize to parent */
@@ -87,6 +89,7 @@ function findShadowHost(el: HTMLElement): Element | null {
 export function SquareCardForm({
   applicationId,
   locationId,
+  env,
   onReady,
   onTokenizeRef,
   afterCardContent,
@@ -120,8 +123,7 @@ export function SquareCardForm({
     if (initializedRef.current) return;
     initializedRef.current = true;
 
-    const isSandbox =
-      applicationId.startsWith('sandbox-');
+    const isSandbox = env ? env !== 'prod' : applicationId.startsWith('sandbox-');
     const scriptUrl = isSandbox
       ? 'https://sandbox.web.squarecdn.com/v1/square.js'
       : 'https://web.squarecdn.com/v1/square.js';


### PR DESCRIPTION
## Summary
Passes the `env` prop (`dev`/`prod`) from the Webflow component through
RegistrationCheckoutForm → SquareCardForm so the Square SDK URL is
determined by the explicit environment setting rather than app ID prefix.

## After merge
Republish Webflow component:
```bash
npx webflow library share --manifest apps/webflow-components/webflow.json --skip-update-check
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)