### PR TITLE
fix: omit sandbox Square receipt URL from confirmation email (#242)

### DIFF
--- a/libs/firebase/maple-functions/create-registration/src/lib/create-registration.ts
+++ b/libs/firebase/maple-functions/create-registration/src/lib/create-registration.ts
@@ -215,7 +215,9 @@ export const createRegistration = Functions.endpoint
               confirmationNumber,
               amountPaid: `$${(finalCostCents / 100).toFixed(2)}`,
               quantity: data.quantity,
-              receiptUrl: squareReceiptUrl,
+              receiptUrl: squareReceiptUrl?.includes('squareupsandbox.com')
+                ? undefined
+                : squareReceiptUrl,
               materialsIncluded: classEntity.materialsIncluded,
               whatToBring: classEntity.whatToBring,
             },


### PR DESCRIPTION
## Summary
- Square sandbox receipt URLs (`squareupsandbox.com`) don't resolve to real receipt pages, causing broken links in confirmation emails during dev/testing
- Filter out sandbox URLs so the `{{#if receiptUrl}}` Handlebars conditional in the email template correctly hides the link
- Production receipt URLs (`squareup.com`) are unaffected and continue to render normally

## Changes
- `libs/firebase/maple-functions/create-registration/src/lib/create-registration.ts`: pass `undefined` instead of the sandbox URL when building the email template data

## Test plan
- [ ] Register for a class in sandbox — confirmation email should NOT show "View Payment Receipt" link
- [ ] Verify production receipt URLs still appear in emails (no `squareupsandbox.com` in the URL)

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)