### PR TITLE
fix: add phone number input masking to registration form (#241)

### DIFF
--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
@@ -17,6 +17,18 @@ import type {
   CreateRegistrationResponse,
 } from '@maple/ts/firebase/api-types';
 
+/**
+ * Formats a string of digits into US phone format: (XXX) XXX-XXXX.
+ * Strips all non-digit characters first, then applies the mask progressively.
+ */
+export function formatPhoneNumber(value: string): string {
+  const digits = value.replace(/\D/g, '').slice(0, 10);
+  if (digits.length === 0) return '';
+  if (digits.length <= 3) return `(${digits}`;
+  if (digits.length <= 6) return `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
+  return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
+}
+
 interface RegistrationCheckoutFormProps {
   publicClass: PublicClass;
   squareApplicationId: string;
@@ -214,8 +226,11 @@ export function RegistrationCheckoutForm({
             label="Phone Number (optional)"
             type="tel"
             value={customerPhone}
-            onChange={(e) => setCustomerPhone(e.target.value)}
+            onChange={(e) =>
+              setCustomerPhone(formatPhoneNumber(e.target.value))
+            }
             fullWidth
+            placeholder="(304) 555-1234"
           />
           <TextField
             label="Number of Spots"

--- a/libs/react/registrations/src/lib/formatPhoneNumber.spec.ts
+++ b/libs/react/registrations/src/lib/formatPhoneNumber.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { formatPhoneNumber } from './RegistrationCheckoutForm';
 
 describe('formatPhoneNumber', () => {

--- a/libs/react/registrations/src/lib/formatPhoneNumber.spec.ts
+++ b/libs/react/registrations/src/lib/formatPhoneNumber.spec.ts
@@ -1,0 +1,43 @@
+import { formatPhoneNumber } from './RegistrationCheckoutForm';
+
+describe('formatPhoneNumber', () => {
+  it('returns empty string for empty input', () => {
+    expect(formatPhoneNumber('')).toBe('');
+  });
+
+  it('returns empty string for non-digit input', () => {
+    expect(formatPhoneNumber('abc')).toBe('');
+  });
+
+  it('wraps first digit in opening paren', () => {
+    expect(formatPhoneNumber('3')).toBe('(3');
+  });
+
+  it('formats partial area code', () => {
+    expect(formatPhoneNumber('30')).toBe('(30');
+    expect(formatPhoneNumber('304')).toBe('(304');
+  });
+
+  it('adds closing paren and space after area code', () => {
+    expect(formatPhoneNumber('3045')).toBe('(304) 5');
+  });
+
+  it('formats 6 digits with exchange', () => {
+    expect(formatPhoneNumber('304555')).toBe('(304) 555');
+  });
+
+  it('adds dash before last 4 digits', () => {
+    expect(formatPhoneNumber('3045551')).toBe('(304) 555-1');
+    expect(formatPhoneNumber('3045551234')).toBe('(304) 555-1234');
+  });
+
+  it('strips non-digit characters before formatting', () => {
+    expect(formatPhoneNumber('(304) 555-1234')).toBe('(304) 555-1234');
+    expect(formatPhoneNumber('304-555-1234')).toBe('(304) 555-1234');
+    expect(formatPhoneNumber('304.555.1234')).toBe('(304) 555-1234');
+  });
+
+  it('truncates to 10 digits', () => {
+    expect(formatPhoneNumber('30455512345678')).toBe('(304) 555-1234');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds progressive phone number formatting to the registration checkout form phone field
- As the user types, input is formatted as `(XXX) XXX-XXXX` using a lightweight `formatPhoneNumber` helper (no new dependency)
- Adds placeholder text showing the expected format
- Includes unit tests for the formatter function (9 test cases)

## Changes
- `libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx` -- added exported `formatPhoneNumber` function and wired it to the phone TextField onChange
- `libs/react/registrations/src/lib/formatPhoneNumber.spec.ts` -- unit tests covering empty input, partial digits, full 10-digit formatting, non-digit stripping, and truncation

## Testing
- [x] Unit tests pass (9/9)
- [x] TypeScript compiles cleanly
- [ ] Manual test in registration widget

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)