### PR TITLE
fix: require instructorId for published classes (#238)

### DIFF
--- a/libs/ts/validation/src/lib/class.validation.spec.ts
+++ b/libs/ts/validation/src/lib/class.validation.spec.ts
@@ -393,6 +393,59 @@ describe('classValidation', () => {
     });
   });
 
+  describe('instructorId field', () => {
+    it('fails when published class has no instructorId', () => {
+      const result = classValidation({
+        ...validClass,
+        status: 'published',
+        instructorId: undefined,
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('instructorId')).toContain(
+        'Instructor is required for published classes'
+      );
+    });
+
+    it('fails when published class has empty instructorId', () => {
+      const result = classValidation({
+        ...validClass,
+        status: 'published',
+        instructorId: '',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('instructorId')).toContain(
+        'Instructor is required for published classes'
+      );
+    });
+
+    it('passes when published class has instructorId', () => {
+      const result = classValidation({
+        ...validClass,
+        status: 'published',
+        instructorId: 'instructor-123',
+      });
+      expect(result.hasErrors('instructorId')).toBe(false);
+    });
+
+    it('passes when draft class has no instructorId', () => {
+      const result = classValidation({
+        ...validClass,
+        status: 'draft',
+        instructorId: undefined,
+      });
+      expect(result.hasErrors('instructorId')).toBe(false);
+    });
+
+    it('passes when cancelled class has no instructorId', () => {
+      const result = classValidation({
+        ...validClass,
+        status: 'cancelled',
+        instructorId: undefined,
+      });
+      expect(result.hasErrors('instructorId')).toBe(false);
+    });
+  });
+
   describe('minimumAge field', () => {
     it('passes when minimumAge is undefined (optional)', () => {
       const result = classValidation({

--- a/libs/ts/validation/src/lib/class.validation.ts
+++ b/libs/ts/validation/src/lib/class.validation.ts
@@ -150,6 +150,13 @@ export const classValidation = create(
       }
     });
 
+    // Instructor validation (required when published)
+    test('instructorId', 'Instructor is required for published classes', () => {
+      if (data.status === 'published') {
+        enforce(data.instructorId).isNotBlank();
+      }
+    });
+
     // Minimum age validation (optional)
     test('minimumAge', 'Minimum age must be between 0 and 100', () => {
       if (data.minimumAge !== undefined && data.minimumAge !== null) {


### PR DESCRIPTION
## Summary
- Adds a Vest validation rule requiring `instructorId` to be non-empty when class status is `published`
- Draft, cancelled, and completed classes are unaffected — instructorId remains optional for those statuses
- Prevents publishing a class without an instructor, which caused blank instructor names on the Webflow class detail page

## Changes
- `libs/ts/validation/src/lib/class.validation.ts` — added `instructorId` validation rule conditional on `status === 'published'`
- `libs/ts/validation/src/lib/class.validation.spec.ts` — added 5 tests covering published (with/without instructor), draft, and cancelled statuses

## Testing
- [x] All 49 validation tests pass (44 existing + 5 new)
- [x] No changes to Cloud Functions needed — `create-class` and `update-class` already run `classValidation` and reject invalid input

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)