### PR TITLE
fix: add timeouts to prevent integration tests from hanging

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -174,6 +174,7 @@ jobs:
     name: Integration Tests
     needs: [install]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     if: github.repository == 'Maple-and-Spruce/maple-and-spruce'
     steps:
       - uses: actions/checkout@v4

--- a/apps/functions-integration-tests-artist/vitest.config.ts
+++ b/apps/functions-integration-tests-artist/vitest.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     include: ['src/**/*.spec.ts'],
     setupFiles: ['../../libs/firebase/integration-test-utils/src/lib/setup.ts'],
     testTimeout: 30000,
+    hookTimeout: 30000,
     fileParallelism: false,
     sequence: {
       concurrent: false,

--- a/apps/functions-integration-tests-calendar/vitest.config.ts
+++ b/apps/functions-integration-tests-calendar/vitest.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     include: ['src/**/*.spec.ts'],
     setupFiles: ['../../libs/firebase/integration-test-utils/src/lib/setup.ts'],
     testTimeout: 30000,
+    hookTimeout: 30000,
     fileParallelism: false,
     sequence: {
       concurrent: false,

--- a/apps/functions-integration-tests-category/vitest.config.ts
+++ b/apps/functions-integration-tests-category/vitest.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     include: ['src/**/*.spec.ts'],
     setupFiles: ['../../libs/firebase/integration-test-utils/src/lib/setup.ts'],
     testTimeout: 30000,
+    hookTimeout: 30000,
     fileParallelism: false,
     sequence: {
       concurrent: false,

--- a/apps/functions-integration-tests-class/vitest.config.ts
+++ b/apps/functions-integration-tests-class/vitest.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     include: ['src/**/*.spec.ts'],
     setupFiles: ['../../libs/firebase/integration-test-utils/src/lib/setup.ts'],
     testTimeout: 30000,
+    hookTimeout: 30000,
     fileParallelism: false,
     sequence: {
       concurrent: false,

--- a/apps/functions-integration-tests-discount/vitest.config.ts
+++ b/apps/functions-integration-tests-discount/vitest.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     include: ['src/**/*.spec.ts'],
     setupFiles: ['../../libs/firebase/integration-test-utils/src/lib/setup.ts'],
     testTimeout: 30000,
+    hookTimeout: 30000,
     fileParallelism: false,
     sequence: {
       concurrent: false,

--- a/apps/functions-integration-tests-instructor/vitest.config.ts
+++ b/apps/functions-integration-tests-instructor/vitest.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     include: ['src/**/*.spec.ts'],
     setupFiles: ['../../libs/firebase/integration-test-utils/src/lib/setup.ts'],
     testTimeout: 30000,
+    hookTimeout: 30000,
     fileParallelism: false,
     sequence: {
       concurrent: false,

--- a/apps/functions-integration-tests-registration/vitest.config.ts
+++ b/apps/functions-integration-tests-registration/vitest.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     include: ['src/**/*.spec.ts'],
     setupFiles: ['../../libs/firebase/integration-test-utils/src/lib/setup.ts'],
     testTimeout: 30000,
+    hookTimeout: 30000,
     fileParallelism: false,
     sequence: {
       concurrent: false,

--- a/apps/functions-integration-tests-utility/vitest.config.ts
+++ b/apps/functions-integration-tests-utility/vitest.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     include: ['src/**/*.spec.ts'],
     setupFiles: ['../../libs/firebase/integration-test-utils/src/lib/setup.ts'],
     testTimeout: 30000,
+    hookTimeout: 30000,
     fileParallelism: false,
     sequence: {
       concurrent: false,

--- a/libs/firebase/integration-test-utils/src/lib/setup.ts
+++ b/libs/firebase/integration-test-utils/src/lib/setup.ts
@@ -18,7 +18,7 @@ beforeAll(async () => {
 
   for (const check of checks) {
     try {
-      await fetch(check.url);
+      await fetch(check.url, { signal: AbortSignal.timeout(10000) });
     } catch {
       throw new Error(
         `${check.name} emulator is not running at ${check.url}. ` +

--- a/libs/firebase/integration-test-utils/src/lib/utils/http-client.ts
+++ b/libs/firebase/integration-test-utils/src/lib/utils/http-client.ts
@@ -34,6 +34,7 @@ export async function callFunction<
     method: 'POST',
     headers,
     body: JSON.stringify({ data: options.data ?? {} }),
+    signal: AbortSignal.timeout(15000),
   });
 
   const bodyText = await response.text();


### PR DESCRIPTION
## Summary
- Adds `timeout-minutes: 20` to the integration tests CI job (was defaulting to GitHub's 360-minute max)
- Adds `hookTimeout: 30000` to all 8 integration test vitest configs so `beforeAll`/`afterAll` hooks can't hang indefinitely
- Adds `AbortSignal.timeout(15000)` to the HTTP client `fetch` in `callFunction()` 
- Adds `AbortSignal.timeout(10000)` to emulator health check fetches in setup

## Test plan
- [ ] Integration tests still pass locally with emulators running
- [ ] CI integration test job completes (or fails with a timeout error instead of hanging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)