### PR TITLE
fix: extract formatPhoneNumber to own module to fix CI coverage

### DIFF
--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
@@ -16,18 +16,7 @@ import type {
   CalculateRegistrationCostResponse,
   CreateRegistrationResponse,
 } from '@maple/ts/firebase/api-types';
-
-/**
- * Formats a string of digits into US phone format: (XXX) XXX-XXXX.
- * Strips all non-digit characters first, then applies the mask progressively.
- */
-export function formatPhoneNumber(value: string): string {
-  const digits = value.replace(/\D/g, '').slice(0, 10);
-  if (digits.length === 0) return '';
-  if (digits.length <= 3) return `(${digits}`;
-  if (digits.length <= 6) return `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
-  return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
-}
+import { formatPhoneNumber } from './formatPhoneNumber';
 
 interface RegistrationCheckoutFormProps {
   publicClass: PublicClass;

--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
@@ -17,6 +17,18 @@ import type {
   CreateRegistrationResponse,
 } from '@maple/ts/firebase/api-types';
 
+/**
+ * Formats a string of digits into US phone format: (XXX) XXX-XXXX.
+ * Strips all non-digit characters first, then applies the mask progressively.
+ */
+export function formatPhoneNumber(value: string): string {
+  const digits = value.replace(/\D/g, '').slice(0, 10);
+  if (digits.length === 0) return '';
+  if (digits.length <= 3) return `(${digits}`;
+  if (digits.length <= 6) return `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
+  return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
+}
+
 interface RegistrationCheckoutFormProps {
   publicClass: PublicClass;
   squareApplicationId: string;
@@ -214,8 +226,11 @@ export function RegistrationCheckoutForm({
             label="Phone Number (optional)"
             type="tel"
             value={customerPhone}
-            onChange={(e) => setCustomerPhone(e.target.value)}
+            onChange={(e) =>
+              setCustomerPhone(formatPhoneNumber(e.target.value))
+            }
             fullWidth
+            placeholder="(304) 555-1234"
           />
           <TextField
             label="Number of Spots"

--- a/libs/react/registrations/src/lib/formatPhoneNumber.spec.ts
+++ b/libs/react/registrations/src/lib/formatPhoneNumber.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { formatPhoneNumber } from './RegistrationCheckoutForm';
 
 describe('formatPhoneNumber', () => {

--- a/libs/react/registrations/src/lib/formatPhoneNumber.spec.ts
+++ b/libs/react/registrations/src/lib/formatPhoneNumber.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatPhoneNumber } from './RegistrationCheckoutForm';
+import { formatPhoneNumber } from './formatPhoneNumber';
 
 describe('formatPhoneNumber', () => {
   it('returns empty string for empty input', () => {

--- a/libs/react/registrations/src/lib/formatPhoneNumber.spec.ts
+++ b/libs/react/registrations/src/lib/formatPhoneNumber.spec.ts
@@ -1,0 +1,43 @@
+import { formatPhoneNumber } from './RegistrationCheckoutForm';
+
+describe('formatPhoneNumber', () => {
+  it('returns empty string for empty input', () => {
+    expect(formatPhoneNumber('')).toBe('');
+  });
+
+  it('returns empty string for non-digit input', () => {
+    expect(formatPhoneNumber('abc')).toBe('');
+  });
+
+  it('wraps first digit in opening paren', () => {
+    expect(formatPhoneNumber('3')).toBe('(3');
+  });
+
+  it('formats partial area code', () => {
+    expect(formatPhoneNumber('30')).toBe('(30');
+    expect(formatPhoneNumber('304')).toBe('(304');
+  });
+
+  it('adds closing paren and space after area code', () => {
+    expect(formatPhoneNumber('3045')).toBe('(304) 5');
+  });
+
+  it('formats 6 digits with exchange', () => {
+    expect(formatPhoneNumber('304555')).toBe('(304) 555');
+  });
+
+  it('adds dash before last 4 digits', () => {
+    expect(formatPhoneNumber('3045551')).toBe('(304) 555-1');
+    expect(formatPhoneNumber('3045551234')).toBe('(304) 555-1234');
+  });
+
+  it('strips non-digit characters before formatting', () => {
+    expect(formatPhoneNumber('(304) 555-1234')).toBe('(304) 555-1234');
+    expect(formatPhoneNumber('304-555-1234')).toBe('(304) 555-1234');
+    expect(formatPhoneNumber('304.555.1234')).toBe('(304) 555-1234');
+  });
+
+  it('truncates to 10 digits', () => {
+    expect(formatPhoneNumber('30455512345678')).toBe('(304) 555-1234');
+  });
+});

--- a/libs/react/registrations/src/lib/formatPhoneNumber.ts
+++ b/libs/react/registrations/src/lib/formatPhoneNumber.ts
@@ -1,0 +1,11 @@
+/**
+ * Formats a string of digits into US phone format: (XXX) XXX-XXXX.
+ * Strips all non-digit characters first, then applies the mask progressively.
+ */
+export function formatPhoneNumber(value: string): string {
+  const digits = value.replace(/\D/g, '').slice(0, 10);
+  if (digits.length === 0) return '';
+  if (digits.length <= 3) return `(${digits}`;
+  if (digits.length <= 6) return `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
+  return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     exclude: [
       '**/node_modules/**',
       '**/dist/**',
+      '.claude/**',
       'apps/maple-spruce-e2e/**',
       'apps/functions-integration-tests/**',
       'apps/functions-integration-tests-*/**',


### PR DESCRIPTION
## Summary
- Extract `formatPhoneNumber` from `RegistrationCheckoutForm.tsx` into its own `formatPhoneNumber.ts` module
- Update the spec to import from the new module instead of the React component
- Exclude `.claude/**` from root vitest config to prevent worktree test pollution locally

## Root cause
The `formatPhoneNumber.spec.ts` imported from `RegistrationCheckoutForm.tsx`, which caused V8 to instrument the entire registrations lib — including `SquareCardForm.tsx` (1% coverage) and `CostSummary.tsx` (33% coverage). This dragged global coverage from 81% to 72%, below the 80% threshold.

## Test plan
- [x] `pnpm exec vitest run --coverage` passes all thresholds (81.69% stmts, 84.59% funcs, 81.71% lines)
- [x] All 47 test files pass
- [ ] CI "Unit Tests & Coverage" job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)