### PR TITLE
feat: sync instructor bio and image to Webflow CMS (#239)

### DIFF
--- a/libs/firebase/maple-functions/sync-class-to-webflow/src/lib/sync-class-to-webflow.ts
+++ b/libs/firebase/maple-functions/sync-class-to-webflow/src/lib/sync-class-to-webflow.ts
@@ -163,6 +163,8 @@ export const syncClassToWebflow = onDocumentWritten(
         publish: shouldPublish,
         isDev,
         instructorName: instructor?.name,
+        instructorBio: instructor?.bio,
+        instructorImage: instructor?.photoUrl,
         categoryName: category?.name,
         registrationCount,
       });

--- a/libs/firebase/webflow/src/lib/class.service.spec.ts
+++ b/libs/firebase/webflow/src/lib/class.service.spec.ts
@@ -140,6 +140,8 @@ describe('mapClassToFieldData', () => {
     const result = mapClassToFieldData(mockClass, {
       isDev: false,
       instructorName: 'Jane Doe',
+      instructorBio: 'Jane has been teaching pottery for 15 years.',
+      instructorImage: 'https://storage.example.com/instructors/jane.jpg',
       categoryName: 'Ceramics',
     });
 
@@ -150,10 +152,29 @@ describe('mapClassToFieldData', () => {
     expect(result['what-to-bring']).toBe('Apron, towel');
     expect(result['minimum-age']).toBe(12);
     expect(result['instructor-name']).toBe('Jane Doe');
+    expect(result['instructor-bio']).toBe(
+      'Jane has been teaching pottery for 15 years.'
+    );
+    expect(result['instructor-image']).toEqual({
+      url: 'https://storage.example.com/instructors/jane.jpg',
+      alt: 'Jane Doe profile photo',
+    });
     expect(result['category-name']).toBe('Ceramics');
     expect(result['class-image']).toEqual({
       url: 'https://storage.example.com/pottery.jpg',
       alt: 'Pottery 101 class image',
+    });
+  });
+
+  it('uses fallback alt text for instructor image when no name provided', () => {
+    const result = mapClassToFieldData(mockClass, {
+      isDev: false,
+      instructorImage: 'https://storage.example.com/instructors/jane.jpg',
+    });
+
+    expect(result['instructor-image']).toEqual({
+      url: 'https://storage.example.com/instructors/jane.jpg',
+      alt: 'Instructor profile photo',
     });
   });
 
@@ -181,6 +202,8 @@ describe('mapClassToFieldData', () => {
     expect(result['what-to-bring']).toBeUndefined();
     expect(result['minimum-age']).toBeUndefined();
     expect(result['instructor-name']).toBeUndefined();
+    expect(result['instructor-bio']).toBeUndefined();
+    expect(result['instructor-image']).toBeUndefined();
     expect(result['category-name']).toBeUndefined();
   });
 });

--- a/libs/firebase/webflow/src/lib/class.service.ts
+++ b/libs/firebase/webflow/src/lib/class.service.ts
@@ -38,6 +38,10 @@ export interface SyncClassInput {
   isDev?: boolean;
   /** Enriched instructor name (denormalized) */
   instructorName?: string;
+  /** Enriched instructor bio (denormalized) */
+  instructorBio?: string;
+  /** Enriched instructor profile image URL (denormalized) */
+  instructorImage?: string;
   /** Enriched category name (denormalized) */
   categoryName?: string;
   /** Current registration count for spots remaining calculation */
@@ -78,6 +82,8 @@ export interface ClassWebflowFieldData {
 export interface MapClassOptions {
   isDev: boolean;
   instructorName?: string;
+  instructorBio?: string;
+  instructorImage?: string;
   categoryName?: string;
   registrationCount?: number;
 }
@@ -188,6 +194,19 @@ export function mapClassToFieldData(
     fieldData['instructor-name'] = options.instructorName;
   }
 
+  if (options.instructorBio) {
+    fieldData['instructor-bio'] = options.instructorBio;
+  }
+
+  if (options.instructorImage) {
+    fieldData['instructor-image'] = {
+      url: options.instructorImage,
+      alt: options.instructorName
+        ? `${options.instructorName} profile photo`
+        : 'Instructor profile photo',
+    };
+  }
+
   if (options.categoryName) {
     fieldData['category-name'] = options.categoryName;
   }
@@ -214,6 +233,8 @@ export class ClassService {
       publish = false,
       isDev = false,
       instructorName,
+      instructorBio,
+      instructorImage,
       categoryName,
       registrationCount,
     } = input;
@@ -226,6 +247,8 @@ export class ClassService {
     const fieldData = mapClassToFieldData(classEntity, {
       isDev,
       instructorName,
+      instructorBio,
+      instructorImage,
       categoryName,
       registrationCount,
     });


### PR DESCRIPTION
## Summary
- Adds `instructor-bio` (PlainText) and `instructor-image` (Image) fields to Webflow Classes CMS sync
- Data comes from the already-fetched Instructor entity — no additional Firestore reads
- CMS fields created on the Classes collection via Webflow API
- 49 webflow library tests passing

## Changes
- `libs/firebase/webflow/src/lib/class.service.ts` — map instructor bio + image
- `libs/firebase/maple-functions/sync-class-to-webflow/` — pass instructor data through
- `libs/firebase/webflow/src/lib/class.service.spec.ts` — updated tests

## After merge
Bind the new CMS fields in Webflow Designer:
- `instructor-bio` → "Meet Your Instructor" bio text
- `instructor-image` → instructor photo element

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)