### PR TITLE
fix: remove unused cert import in seed-email-templates

### DIFF
--- a/tools/seed-email-templates.ts
+++ b/tools/seed-email-templates.ts
@@ -9,7 +9,7 @@
  *   npx tsx tools/seed-email-templates.ts --prod    # seeds prod project
  */
 
-import { cert, initializeApp } from 'firebase-admin/app';
+import { initializeApp } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 
 const isProd = process.argv.includes('--prod');


### PR DESCRIPTION
## Summary
- Removes unused `cert` import from `firebase-admin/app` in `tools/seed-email-templates.ts`
- This was causing a compilation error when running the script with `ts-node`

## Test plan
- [x] Ran `ts-node tools/seed-email-templates.ts` successfully against dev
- [x] Ran `ts-node tools/seed-email-templates.ts --prod` successfully against prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)