### PR TITLE
fix: use Eastern timezone for date/time display in Webflow CMS sync

### DIFF
--- a/libs/firebase/webflow/src/lib/class.service.spec.ts
+++ b/libs/firebase/webflow/src/lib/class.service.spec.ts
@@ -60,14 +60,11 @@ describe('mapClassToFieldData', () => {
     expect(result.capacity).toBe(10);
   });
 
-  it('formats date and time display correctly', () => {
+  it('formats date and time display in Eastern time', () => {
+    // mockClass.dateTime is 2026-05-15T14:00:00.000Z = 10:00 AM Eastern (EDT)
     const result = mapClassToFieldData(mockClass, { isDev: false });
-    // Date should be formatted as a readable date string
-    expect(result['date-display']).toContain('2026');
-    expect(result['date-display']).toContain('May');
-    expect(result['date-display']).toContain('15');
-    // Time should be formatted as readable time
-    expect(result['time-display']).toMatch(/\d{1,2}:\d{2}\s*(AM|PM)/);
+    expect(result['date-display']).toBe('Friday, May 15, 2026');
+    expect(result['time-display']).toBe('10:00 AM');
   });
 
   it('formats price display correctly', () => {

--- a/libs/firebase/webflow/src/lib/class.service.ts
+++ b/libs/firebase/webflow/src/lib/class.service.ts
@@ -128,11 +128,13 @@ export function mapClassToFieldData(
     month: 'long',
     day: 'numeric',
     year: 'numeric',
+    timeZone: 'America/New_York',
   });
 
   const timeDisplay = dateObj.toLocaleTimeString('en-US', {
     hour: 'numeric',
     minute: '2-digit',
+    timeZone: 'America/New_York',
   });
 
   const fieldData: ClassWebflowFieldData = {


### PR DESCRIPTION
## Summary
Cloud Functions run in UTC, so `toLocaleTimeString()` without a timezone option displayed UTC times on the Webflow class pages (e.g., 8PM instead of 4PM EDT).

## Fix
Added `timeZone: 'America/New_York'` to both `date-display` and `time-display` formatting in `mapClassToFieldData()`.

## Test plan
- [x] Updated unit test asserts correct Eastern time for UTC input
- [x] All 81 webflow lib tests passing
- [ ] Re-sync a class and verify correct time on Webflow

Part of #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)