### PR TITLE
fix: revert security audit to pnpm audit

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -48,15 +48,29 @@ jobs:
 
   security:
     name: Security Audit
+    needs: [install]
     runs-on: ubuntu-latest
     if: github.repository == 'Maple-and-Spruce/maple-and-spruce'
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run OSV vulnerability scan
-        uses: google/osv-scanner-action/osv-scanner-action@v1
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          scan-args: --lockfile=pnpm-lock.yaml
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: ${{ needs.install.outputs.cache_key }}
+
+      - name: Run pnpm audit
+        run: pnpm audit --audit-level=high --ignore-registry-errors
 
   typecheck:
     name: TypeScript Check


### PR DESCRIPTION
## Summary

Reverts the OSV scanner change from #267. Restores `pnpm audit` with `--ignore-registry-errors` flag so CI doesn't fail while the npm registry audit endpoint is down ([pnpm/pnpm#11265](https://github.com/pnpm/pnpm/issues/11265)).

Once pnpm ships a fix for the 410, we can remove `--ignore-registry-errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)