### PR TITLE
fix: parallel coverage pipeline with nyc merge and 80% threshold

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -315,11 +315,11 @@ jobs:
           pnpm exec nyc merge coverage/to-merge coverage/merged/coverage-final.json
           pnpm exec nyc report -t coverage/merged --reporter=text
 
-      - name: Check coverage thresholds
+      - name: Check coverage thresholds (80%)
         run: |
           pnpm exec nyc check-coverage \
             --lines 80 \
             --functions 80 \
-            --statements 79 \
+            --statements 80 \
             --branches 50 \
             -t coverage/merged

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -315,11 +315,11 @@ jobs:
           pnpm exec nyc merge coverage/to-merge coverage/merged/coverage-final.json
           pnpm exec nyc report -t coverage/merged --reporter=text
 
-      - name: Check coverage thresholds (80%)
+      - name: Check coverage thresholds
         run: |
           pnpm exec nyc check-coverage \
             --lines 80 \
             --functions 80 \
-            --statements 80 \
+            --statements 79 \
             --branches 50 \
             -t coverage/merged

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -277,9 +277,6 @@ jobs:
     needs: [install, unit-tests, storybook]
     runs-on: ubuntu-latest
     if: github.repository == 'Maple-and-Spruce/maple-and-spruce'
-    permissions:
-      contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
@@ -310,23 +307,19 @@ jobs:
           name: coverage-storybook
           path: coverage/storybook
 
-      - name: Prepare coverage files for merge
+      - name: Prepare and merge coverage reports
         run: |
-          mkdir -p coverage/to-merge
+          mkdir -p coverage/to-merge coverage/merged
           cp coverage/unit/coverage-final.json coverage/to-merge/unit.json
           cp coverage/storybook/coverage-final.json coverage/to-merge/storybook.json
-
-      - name: Merge coverage reports
-        run: |
-          mkdir -p coverage/merged
           pnpm exec nyc merge coverage/to-merge coverage/merged/coverage-final.json
           pnpm exec nyc report -t coverage/merged --reporter=text
 
-      - name: Check coverage thresholds
+      - name: Check coverage thresholds (80%)
         run: |
           pnpm exec nyc check-coverage \
             --lines 80 \
             --functions 80 \
-            --statements 79 \
+            --statements 80 \
             --branches 50 \
             -t coverage/merged

--- a/libs/firebase/database/src/lib/utilities/database.config.spec.ts
+++ b/libs/firebase/database/src/lib/utilities/database.config.spec.ts
@@ -143,11 +143,13 @@ describe('database.config', () => {
     it('should return non-function properties directly', async () => {
       const { db } = await import('./database.config');
 
-      // Access a non-function property through the proxy
-      const type = db.type;
+      // Access a made-up property to exercise the proxy's non-function return path (line 119)
+      const val = (db as unknown as Record<string, unknown>)['nonExistentProp'];
 
-      // Should have triggered initialization
+      // Should have triggered initialization via the proxy
       expect(mocks.firestore).toHaveBeenCalledTimes(1);
+      // Non-existent property returns undefined
+      expect(val).toBeUndefined();
     });
   });
 

--- a/libs/firebase/database/src/lib/utilities/database.config.spec.ts
+++ b/libs/firebase/database/src/lib/utilities/database.config.spec.ts
@@ -139,5 +139,76 @@ describe('database.config', () => {
       // The proxy should delegate to the same instance
       // (We can't directly compare since proxy wraps it, but initialization count confirms sharing)
     });
+
+    it('should return non-function properties directly', async () => {
+      const { db } = await import('./database.config');
+
+      // Access a non-function property through the proxy
+      const type = db.type;
+
+      // Should have triggered initialization
+      expect(mocks.firestore).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('toDate', () => {
+    it('returns fallback for null', async () => {
+      const { toDate } = await import('./database.config');
+      const fallback = new Date('2025-01-01');
+      expect(toDate(null, fallback)).toBe(fallback);
+    });
+
+    it('returns fallback for undefined', async () => {
+      const { toDate } = await import('./database.config');
+      const fallback = new Date('2025-01-01');
+      expect(toDate(undefined, fallback)).toBe(fallback);
+    });
+
+    it('converts Firestore Timestamp (object with toDate method)', async () => {
+      const { toDate } = await import('./database.config');
+      const expected = new Date('2025-06-15T10:00:00Z');
+      const timestamp = { toDate: () => expected };
+      expect(toDate(timestamp)).toBe(expected);
+    });
+
+    it('returns Date instances as-is', async () => {
+      const { toDate } = await import('./database.config');
+      const date = new Date('2025-06-15T10:00:00Z');
+      expect(toDate(date)).toBe(date);
+    });
+
+    it('parses valid ISO string', async () => {
+      const { toDate } = await import('./database.config');
+      const result = toDate('2025-06-15T10:00:00Z');
+      expect(result.toISOString()).toBe('2025-06-15T10:00:00.000Z');
+    });
+
+    it('parses valid numeric timestamp', async () => {
+      const { toDate } = await import('./database.config');
+      const ts = new Date('2025-06-15T10:00:00Z').getTime();
+      const result = toDate(ts);
+      expect(result.toISOString()).toBe('2025-06-15T10:00:00.000Z');
+    });
+
+    it('returns fallback for invalid string', async () => {
+      const { toDate } = await import('./database.config');
+      const fallback = new Date('2025-01-01');
+      expect(toDate('not-a-date', fallback)).toBe(fallback);
+    });
+
+    it('returns fallback for unrecognized types (object without toDate)', async () => {
+      const { toDate } = await import('./database.config');
+      const fallback = new Date('2025-01-01');
+      expect(toDate({ foo: 'bar' }, fallback)).toBe(fallback);
+    });
+
+    it('uses default fallback (current date) when none provided', async () => {
+      const { toDate } = await import('./database.config');
+      const before = Date.now();
+      const result = toDate(null);
+      const after = Date.now();
+      expect(result.getTime()).toBeGreaterThanOrEqual(before);
+      expect(result.getTime()).toBeLessThanOrEqual(after);
+    });
   });
 });


### PR DESCRIPTION
## Summary
The Storybook migration PR (#269) didn't include the CI changes. This PR fixes:

1. **Unit Tests job**: uploads `coverage/unit/coverage-final.json` artifact
2. **Storybook job**: replaces removed `test-storybook` with `vitest run --config vitest.storybook.config.ts --coverage`, uploads storybook coverage artifact
3. **New Merged Coverage Check job**: downloads both artifacts, `nyc merge`, `nyc check-coverage` at 80% threshold

Both test jobs run in parallel. Coverage merge only runs after both complete.

## Verified locally
Merged unit + storybook coverage: 80.17% lines, 80.45% functions — passes 80% threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)