### PR TITLE
fix: coerce session dateTime strings to Date in domain helpers

### DIFF
--- a/libs/ts/domain/src/lib/class.spec.ts
+++ b/libs/ts/domain/src/lib/class.spec.ts
@@ -327,4 +327,69 @@ describe('Class domain helpers', () => {
       expect(result.timeDisplay).toBe('Varies');
     });
   });
+
+  describe('ISO string coercion (client-side JSON)', () => {
+    // Firebase callable functions serialize Date objects to ISO strings.
+    // All domain helpers must handle string dateTime values gracefully.
+
+    const isoClass = {
+      ...baseClass,
+      sessions: [{ dateTime: '2030-06-15T14:00:00.000Z' as unknown as Date }],
+    };
+
+    const isoMultiSession = {
+      ...baseClass,
+      sessions: [
+        { dateTime: '2030-06-29T14:00:00.000Z' as unknown as Date },
+        { dateTime: '2030-06-15T14:00:00.000Z' as unknown as Date },
+        { dateTime: '2030-06-22T14:00:00.000Z' as unknown as Date },
+      ],
+    };
+
+    it('getFirstSession handles ISO strings', () => {
+      const first = getFirstSession(isoClass);
+      expect(first.dateTime).toBe('2030-06-15T14:00:00.000Z');
+    });
+
+    it('getSortedSessions handles ISO strings', () => {
+      const sorted = getSortedSessions(isoMultiSession);
+      expect(sorted.map((s) => String(s.dateTime))).toEqual([
+        '2030-06-15T14:00:00.000Z',
+        '2030-06-22T14:00:00.000Z',
+        '2030-06-29T14:00:00.000Z',
+      ]);
+    });
+
+    it('getRegistrationCutoff handles ISO string sessions', () => {
+      const cutoff = getRegistrationCutoff(isoClass);
+      expect(cutoff).toEqual(new Date('2030-06-15T14:00:00.000Z'));
+    });
+
+    it('getRegistrationCutoff handles ISO string registrationClosesAt', () => {
+      const withOverride = {
+        ...isoClass,
+        registrationClosesAt: '2030-06-10T00:00:00.000Z' as unknown as Date,
+      };
+      expect(getRegistrationCutoff(withOverride)).toEqual(new Date('2030-06-10T00:00:00.000Z'));
+    });
+
+    it('getSessionEndTime handles ISO string', () => {
+      const session = { dateTime: '2030-06-15T14:00:00.000Z' as unknown as Date };
+      const result = getSessionEndTime(session, 120);
+      expect(result).toEqual(new Date('2030-06-15T16:00:00.000Z'));
+    });
+
+    it('formatSessions handles ISO strings', () => {
+      const result = formatSessions(
+        [
+          { dateTime: '2030-06-15T18:00:00.000Z' as unknown as Date },
+          { dateTime: '2030-06-22T18:00:00.000Z' as unknown as Date },
+        ],
+        'America/New_York'
+      );
+      expect(result.sharedTime).toBe(true);
+      expect(result.dateDisplay).toContain('Jun 15');
+      expect(result.dateDisplay).toContain('Jun 22');
+    });
+  });
 });

--- a/libs/ts/domain/src/lib/class.ts
+++ b/libs/ts/domain/src/lib/class.ts
@@ -149,9 +149,14 @@ export interface PublicClass {
 /**
  * Return class sessions sorted earliest-first without mutating the input.
  */
+/** Coerce a dateTime value that may be a string (from JSON serialization) to a Date. */
+function ensureDate(dt: Date | string): Date {
+  return dt instanceof Date ? dt : new Date(dt);
+}
+
 export function getSortedSessions(classEntity: Class): ClassSession[] {
   return [...classEntity.sessions].sort(
-    (a, b) => a.dateTime.getTime() - b.dateTime.getTime()
+    (a, b) => ensureDate(a.dateTime).getTime() - ensureDate(b.dateTime).getTime()
   );
 }
 
@@ -172,7 +177,7 @@ export function getFirstSession(classEntity: Class): ClassSession {
  * to the first session's start time.
  */
 export function getRegistrationCutoff(classEntity: Class): Date {
-  return classEntity.registrationClosesAt ?? getFirstSession(classEntity).dateTime;
+  return ensureDate(classEntity.registrationClosesAt ?? getFirstSession(classEntity).dateTime);
 }
 
 /**
@@ -259,7 +264,7 @@ export function getSessionEndTime(
   session: ClassSession,
   durationMinutes: number
 ): Date {
-  return new Date(session.dateTime.getTime() + durationMinutes * 60 * 1000);
+  return new Date(ensureDate(session.dateTime).getTime() + durationMinutes * 60 * 1000);
 }
 
 /**
@@ -297,18 +302,18 @@ export function formatSessions(
   }
 
   const sorted = [...sessions].sort(
-    (a, b) => a.dateTime.getTime() - b.dateTime.getTime()
+    (a, b) => ensureDate(a.dateTime).getTime() - ensureDate(b.dateTime).getTime()
   );
 
-  const timeOf = (d: Date): string =>
-    d.toLocaleTimeString('en-US', {
+  const timeOf = (d: Date | string): string =>
+    ensureDate(d).toLocaleTimeString('en-US', {
       hour: 'numeric',
       minute: '2-digit',
       timeZone,
     });
 
-  const dateOf = (d: Date): string =>
-    d.toLocaleDateString('en-US', {
+  const dateOf = (d: Date | string): string =>
+    ensureDate(d).toLocaleDateString('en-US', {
       month: 'short',
       day: 'numeric',
       timeZone,


### PR DESCRIPTION
## Summary
- Firebase callable functions serialize `Date` objects to ISO strings over JSON
- Client-side code calling `formatSessions()`, `getFirstSession()`, etc. crashes with `TypeError: e.toLocaleTimeString is not a function` because `dateTime` values arrive as strings, not `Date` instances
- Adds `ensureDate()` helper that normalizes `string | Date` to `Date` in all domain functions that operate on session dateTimes

## Test plan
- [x] `nx test domain` passes
- [ ] Load `/classes` page in admin app — no crash
- [ ] Class cards display date/time correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)