### PR TITLE
fix: auto-publish Webflow CMS deletions to live site

### DIFF
--- a/libs/firebase/integration-test-mock-server/src/index.ts
+++ b/libs/firebase/integration-test-mock-server/src/index.ts
@@ -7,5 +7,6 @@ export {
 export {
   registerWebflowRoutes,
   resetWebflowState,
+  getWebflowDeleteLog,
 } from './lib/routes/webflow.js';
 export { createMockServer } from './lib/create-mock-server.js';

--- a/libs/firebase/integration-test-mock-server/src/lib/routes/webflow.ts
+++ b/libs/firebase/integration-test-mock-server/src/lib/routes/webflow.ts
@@ -5,7 +5,8 @@
  * - GET /collections/:collectionId/items (list items)
  * - POST /collections/:collectionId/items (create item)
  * - PATCH /collections/:collectionId/items/:itemId (update item)
- * - DELETE /collections/:collectionId/items/:itemId (delete item)
+ * - DELETE /collections/:collectionId/items/:itemId (staged delete)
+ * - DELETE /collections/:collectionId/items/:itemId/live (live delete; auto-publishes)
  * - PUT /collections/:collectionId/items/publish (publish items)
  */
 import { MockServer } from '../mock-server.js';
@@ -14,6 +15,12 @@ let itemCounter = 0;
 
 /** In-memory CMS items store, keyed by collection → itemId */
 const collections = new Map<string, Map<string, Record<string, unknown>>>();
+
+/**
+ * Tracks which delete endpoint was used for each item ID.
+ * Integration tests can inspect this to verify prod vs. dev delete behavior.
+ */
+const deleteLog: Array<{ itemId: string; live: boolean }> = [];
 
 function getCollection(
   collectionId: string
@@ -106,12 +113,25 @@ export function registerWebflowRoutes(server: MockServer): void {
     return { status: 200, body: updated };
   });
 
-  // Delete collection item
+  // Delete collection item (live — auto-publishes the removal)
+  // Must be registered before the staged route so the `/live` suffix matches first.
+  server.delete('/collections/:collectionId/items/:itemId/live', (req) => {
+    const collectionId = req.params['collectionId'];
+    const itemId = req.params['itemId'];
+    const collection = getCollection(collectionId);
+    collection.delete(itemId);
+    deleteLog.push({ itemId, live: true });
+
+    return { status: 204, body: {} };
+  });
+
+  // Delete collection item (staged — requires a separate publish to go live)
   server.delete('/collections/:collectionId/items/:itemId', (req) => {
     const collectionId = req.params['collectionId'];
     const itemId = req.params['itemId'];
     const collection = getCollection(collectionId);
     collection.delete(itemId);
+    deleteLog.push({ itemId, live: false });
 
     return { status: 204, body: {} };
   });
@@ -144,4 +164,16 @@ export function registerWebflowRoutes(server: MockServer): void {
 export function resetWebflowState(): void {
   itemCounter = 0;
   collections.clear();
+  deleteLog.length = 0;
+}
+
+/**
+ * Get the delete-endpoint log.
+ * Each entry records whether the live (/live) or staged endpoint was hit.
+ */
+export function getWebflowDeleteLog(): ReadonlyArray<{
+  itemId: string;
+  live: boolean;
+}> {
+  return deleteLog;
 }

--- a/libs/firebase/maple-functions/sync-artist-to-webflow/src/lib/sync-artist-to-webflow.ts
+++ b/libs/firebase/maple-functions/sync-artist-to-webflow/src/lib/sync-artist-to-webflow.ts
@@ -91,12 +91,16 @@ export const syncArtistToWebflow = onDocumentWritten(
 
     const webflow = new Webflow(secrets, strings);
 
+    const isDev = FirebaseProject.isDev;
+    const publishRemoval = !isDev;
+
     try {
       // Case 1: Artist deleted
       if (!afterArtist) {
         console.log('Artist deleted, removing from Webflow');
         const removed = await webflow.artistService.removeArtist(
-          event.params.artistId
+          event.params.artistId,
+          publishRemoval
         );
         console.log(
           removed
@@ -112,7 +116,10 @@ export const syncArtistToWebflow = onDocumentWritten(
         afterArtist.status !== 'active'
       ) {
         console.log('Artist became inactive, removing from Webflow');
-        const removed = await webflow.artistService.removeArtist(afterArtist.id);
+        const removed = await webflow.artistService.removeArtist(
+          afterArtist.id,
+          publishRemoval
+        );
         console.log(
           removed
             ? 'Successfully removed from Webflow'
@@ -130,7 +137,6 @@ export const syncArtistToWebflow = onDocumentWritten(
       // Case 4: Artist is active - sync to Webflow
       // Auto-publish only in prod, and only if preventAutoPublish is not set
       // Dev items are never published - they stay as drafts with is-dev-environment=true
-      const isDev = FirebaseProject.isDev;
       const shouldPublish = !isDev && !afterArtist.preventAutoPublish;
       console.log('Syncing active artist to Webflow:', {
         name: afterArtist.name,

--- a/libs/firebase/maple-functions/sync-class-to-webflow/src/lib/sync-class-to-webflow.ts
+++ b/libs/firebase/maple-functions/sync-class-to-webflow/src/lib/sync-class-to-webflow.ts
@@ -143,12 +143,16 @@ export const syncClassToWebflow = onDocumentWritten(
 
     const webflow = new Webflow(secrets, strings);
 
+    const isDev = FirebaseProject.isDev;
+    const shouldPublish = !isDev;
+
     try {
       // Case 1: Class deleted
       if (!afterClass) {
         console.log('Class deleted, removing from Webflow');
         const removed = await webflow.classService.removeClass(
-          event.params.classId
+          event.params.classId,
+          shouldPublish
         );
         console.log(
           removed
@@ -164,7 +168,10 @@ export const syncClassToWebflow = onDocumentWritten(
         afterClass.status !== 'published'
       ) {
         console.log('Class unpublished, removing from Webflow');
-        const removed = await webflow.classService.removeClass(afterClass.id);
+        const removed = await webflow.classService.removeClass(
+          afterClass.id,
+          shouldPublish
+        );
         console.log(
           removed
             ? 'Successfully removed from Webflow'
@@ -180,8 +187,6 @@ export const syncClassToWebflow = onDocumentWritten(
       }
 
       // Case 4: Class is published — enrich and sync to Webflow
-      const isDev = FirebaseProject.isDev;
-      const shouldPublish = !isDev;
 
       // Fetch enrichment data in parallel
       const [instructor, category, registrationCount] = await Promise.all([

--- a/libs/firebase/maple-functions/sync-instructor-to-webflow/src/lib/sync-instructor-to-webflow.ts
+++ b/libs/firebase/maple-functions/sync-instructor-to-webflow/src/lib/sync-instructor-to-webflow.ts
@@ -91,12 +91,16 @@ export const syncInstructorToWebflow = onDocumentWritten(
 
     const webflow = new Webflow(secrets, strings);
 
+    const isDev = FirebaseProject.isDev;
+    const shouldPublish = !isDev;
+
     try {
       // Case 1: Instructor deleted
       if (!afterInstructor) {
         console.log('Instructor deleted, removing from Webflow');
         const removed = await webflow.instructorService.removeInstructor(
-          event.params.instructorId
+          event.params.instructorId,
+          shouldPublish
         );
         console.log(
           removed
@@ -112,7 +116,10 @@ export const syncInstructorToWebflow = onDocumentWritten(
         afterInstructor.status !== 'active'
       ) {
         console.log('Instructor became inactive, removing from Webflow');
-        const removed = await webflow.instructorService.removeInstructor(afterInstructor.id);
+        const removed = await webflow.instructorService.removeInstructor(
+          afterInstructor.id,
+          shouldPublish
+        );
         console.log(
           removed
             ? 'Successfully removed from Webflow'
@@ -130,8 +137,6 @@ export const syncInstructorToWebflow = onDocumentWritten(
       // Case 4: Instructor is active - sync to Webflow
       // Auto-publish only in prod
       // Dev items are never published - they stay as drafts with is-dev-environment=true
-      const isDev = FirebaseProject.isDev;
-      const shouldPublish = !isDev;
       console.log('Syncing active instructor to Webflow:', {
         name: afterInstructor.name,
         isDev,

--- a/libs/firebase/webflow/src/lib/artist.service.spec.ts
+++ b/libs/firebase/webflow/src/lib/artist.service.spec.ts
@@ -169,6 +169,7 @@ describe('ArtistService', () => {
         createItem: vi.fn(),
         updateItem: vi.fn(),
         deleteItem: vi.fn(),
+        deleteItemLive: vi.fn(),
         publishItem: vi.fn(),
       },
     },
@@ -340,6 +341,57 @@ describe('ArtistService', () => {
       );
     });
 
+    it('defaults to staged delete (deleteItem, not deleteItemLive)', async () => {
+      mockClient.collections.items.listItems.mockResolvedValue({
+        items: [
+          { id: 'wf-staged', fieldData: { 'firebase-id': 'artist-abc' } },
+        ],
+      });
+      mockClient.collections.items.deleteItem.mockResolvedValue({});
+
+      await service.removeArtist('artist-abc');
+
+      expect(mockClient.collections.items.deleteItem).toHaveBeenCalledTimes(1);
+      expect(
+        mockClient.collections.items.deleteItemLive
+      ).not.toHaveBeenCalled();
+    });
+
+    it('uses deleteItemLive when publish=true to auto-publish removal', async () => {
+      mockClient.collections.items.listItems.mockResolvedValue({
+        items: [{ id: 'wf-live', fieldData: { 'firebase-id': 'artist-abc' } }],
+      });
+      mockClient.collections.items.deleteItemLive.mockResolvedValue({});
+
+      const result = await service.removeArtist('artist-abc', true);
+
+      expect(result).toBe(true);
+      expect(mockClient.collections.items.deleteItemLive).toHaveBeenCalledWith(
+        COLLECTION_ID,
+        'wf-live'
+      );
+      expect(mockClient.collections.items.deleteItem).not.toHaveBeenCalled();
+    });
+
+    it('uses deleteItem when publish=false', async () => {
+      mockClient.collections.items.listItems.mockResolvedValue({
+        items: [
+          { id: 'wf-staged', fieldData: { 'firebase-id': 'artist-abc' } },
+        ],
+      });
+      mockClient.collections.items.deleteItem.mockResolvedValue({});
+
+      await service.removeArtist('artist-abc', false);
+
+      expect(mockClient.collections.items.deleteItem).toHaveBeenCalledWith(
+        COLLECTION_ID,
+        'wf-staged'
+      );
+      expect(
+        mockClient.collections.items.deleteItemLive
+      ).not.toHaveBeenCalled();
+    });
+
     it('returns false when artist not found in Webflow', async () => {
       mockClient.collections.items.listItems.mockResolvedValue({ items: [] });
 
@@ -347,6 +399,18 @@ describe('ArtistService', () => {
 
       expect(result).toBe(false);
       expect(mockClient.collections.items.deleteItem).not.toHaveBeenCalled();
+    });
+
+    it('does not call any delete when publish=true and item not found', async () => {
+      mockClient.collections.items.listItems.mockResolvedValue({ items: [] });
+
+      const result = await service.removeArtist('artist-missing', true);
+
+      expect(result).toBe(false);
+      expect(mockClient.collections.items.deleteItem).not.toHaveBeenCalled();
+      expect(
+        mockClient.collections.items.deleteItemLive
+      ).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/firebase/webflow/src/lib/artist.service.ts
+++ b/libs/firebase/webflow/src/lib/artist.service.ts
@@ -186,21 +186,31 @@ export class ArtistService {
 
   /**
    * Remove an artist from Webflow CMS.
+   * When publish=true, uses deleteItemLive so the deletion is reflected on
+   * the live site without a manual republish.
    *
    * @param firebaseId - Firebase artist ID
+   * @param publish - Whether to also publish the deletion to the live site
    * @returns True if deleted, false if not found
    */
-  async removeArtist(firebaseId: string): Promise<boolean> {
+  async removeArtist(firebaseId: string, publish = false): Promise<boolean> {
     const existingItem = await this.findByFirebaseId(firebaseId);
 
     if (!existingItem) {
       return false;
     }
 
-    await this.client.collections.items.deleteItem(
-      this.collectionId,
-      existingItem.id
-    );
+    if (publish) {
+      await this.client.collections.items.deleteItemLive(
+        this.collectionId,
+        existingItem.id
+      );
+    } else {
+      await this.client.collections.items.deleteItem(
+        this.collectionId,
+        existingItem.id
+      );
+    }
 
     return true;
   }

--- a/libs/firebase/webflow/src/lib/class.service.spec.ts
+++ b/libs/firebase/webflow/src/lib/class.service.spec.ts
@@ -227,6 +227,7 @@ describe('ClassService', () => {
         createItem: vi.fn(),
         updateItem: vi.fn(),
         deleteItem: vi.fn(),
+        deleteItemLive: vi.fn(),
         publishItem: vi.fn(),
       },
     },
@@ -441,6 +442,53 @@ describe('ClassService', () => {
       );
     });
 
+    it('defaults to staged delete (deleteItem, not deleteItemLive)', async () => {
+      mockClient.collections.items.listItems.mockResolvedValue({
+        items: [{ id: 'wf-staged', fieldData: { 'firebase-id': 'class-abc' } }],
+      });
+      mockClient.collections.items.deleteItem.mockResolvedValue({});
+
+      await service.removeClass('class-abc');
+
+      expect(mockClient.collections.items.deleteItem).toHaveBeenCalledTimes(1);
+      expect(
+        mockClient.collections.items.deleteItemLive
+      ).not.toHaveBeenCalled();
+    });
+
+    it('uses deleteItemLive when publish=true to auto-publish removal', async () => {
+      mockClient.collections.items.listItems.mockResolvedValue({
+        items: [{ id: 'wf-live', fieldData: { 'firebase-id': 'class-abc' } }],
+      });
+      mockClient.collections.items.deleteItemLive.mockResolvedValue({});
+
+      const result = await service.removeClass('class-abc', true);
+
+      expect(result).toBe(true);
+      expect(mockClient.collections.items.deleteItemLive).toHaveBeenCalledWith(
+        COLLECTION_ID,
+        'wf-live'
+      );
+      expect(mockClient.collections.items.deleteItem).not.toHaveBeenCalled();
+    });
+
+    it('uses deleteItem when publish=false', async () => {
+      mockClient.collections.items.listItems.mockResolvedValue({
+        items: [{ id: 'wf-staged', fieldData: { 'firebase-id': 'class-abc' } }],
+      });
+      mockClient.collections.items.deleteItem.mockResolvedValue({});
+
+      await service.removeClass('class-abc', false);
+
+      expect(mockClient.collections.items.deleteItem).toHaveBeenCalledWith(
+        COLLECTION_ID,
+        'wf-staged'
+      );
+      expect(
+        mockClient.collections.items.deleteItemLive
+      ).not.toHaveBeenCalled();
+    });
+
     it('returns false when class not found in Webflow', async () => {
       mockClient.collections.items.listItems.mockResolvedValue({ items: [] });
 
@@ -449,6 +497,18 @@ describe('ClassService', () => {
       expect(result).toBe(false);
       expect(
         mockClient.collections.items.deleteItem
+      ).not.toHaveBeenCalled();
+    });
+
+    it('does not call any delete when publish=true and item not found', async () => {
+      mockClient.collections.items.listItems.mockResolvedValue({ items: [] });
+
+      const result = await service.removeClass('class-missing', true);
+
+      expect(result).toBe(false);
+      expect(mockClient.collections.items.deleteItem).not.toHaveBeenCalled();
+      expect(
+        mockClient.collections.items.deleteItemLive
       ).not.toHaveBeenCalled();
     });
   });

--- a/libs/firebase/webflow/src/lib/class.service.ts
+++ b/libs/firebase/webflow/src/lib/class.service.ts
@@ -277,15 +277,24 @@ export class ClassService {
 
   /**
    * Remove a class from Webflow CMS.
+   * When publish=true, uses deleteItemLive so the deletion is reflected on
+   * the live site without a manual republish.
    */
-  async removeClass(firebaseId: string): Promise<boolean> {
+  async removeClass(firebaseId: string, publish = false): Promise<boolean> {
     const existingItem = await this.findByFirebaseId(firebaseId);
     if (!existingItem) return false;
 
-    await this.client.collections.items.deleteItem(
-      this.collectionId,
-      existingItem.id
-    );
+    if (publish) {
+      await this.client.collections.items.deleteItemLive(
+        this.collectionId,
+        existingItem.id
+      );
+    } else {
+      await this.client.collections.items.deleteItem(
+        this.collectionId,
+        existingItem.id
+      );
+    }
     return true;
   }
 

--- a/libs/firebase/webflow/src/lib/delete-publish.integration.spec.ts
+++ b/libs/firebase/webflow/src/lib/delete-publish.integration.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * Integration tests for the publish flag on the remove* methods.
+ *
+ * Exercises the real `webflow-api` SDK against an in-process mock HTTP
+ * server (no Firebase emulator required). Verifies end-to-end that:
+ *
+ * - publish=true → SDK hits DELETE /collections/:id/items/:itemId/live
+ * - publish=false (default) → SDK hits DELETE /collections/:id/items/:itemId
+ *
+ * The unit specs (class.service.spec.ts etc.) mock the SDK client, so
+ * this file is the only place the wire-level contract is verified.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import { WebflowClient } from 'webflow-api';
+import type { Artist, Class, Instructor } from '@maple/ts/domain';
+import {
+  MockServer,
+  registerWebflowRoutes,
+  resetWebflowState,
+  getWebflowDeleteLog,
+} from '@maple/firebase/integration-test-mock-server';
+import { ClassService } from './class.service';
+import { ArtistService } from './artist.service';
+import { InstructorService } from './instructor.service';
+
+const CLASSES_COLLECTION = 'col-classes';
+const ARTISTS_COLLECTION = 'col-artists';
+const INSTRUCTORS_COLLECTION = 'col-instructors';
+
+// Use a non-default port to avoid colliding with the shared 9999 used by
+// run-integration-tests.sh when both harnesses run on the same machine.
+const PORT = 19999;
+const BASE_URL = `http://localhost:${PORT}`;
+
+let server: MockServer;
+let client: WebflowClient;
+
+beforeAll(async () => {
+  server = new MockServer();
+  registerWebflowRoutes(server);
+  await server.start(PORT);
+
+  client = new WebflowClient({
+    accessToken: 'mock-token',
+    baseUrl: BASE_URL,
+  });
+});
+
+afterAll(async () => {
+  await server.stop();
+});
+
+beforeEach(() => {
+  resetWebflowState();
+  server.clearRequests();
+});
+
+/**
+ * Seed a CMS item via the SDK's createItem. Returns the Webflow item ID.
+ * Creates an item with the given firebase-id so the service's
+ * findByFirebaseId lookup resolves it.
+ */
+async function seedItem(
+  collectionId: string,
+  firebaseId: string
+): Promise<string> {
+  const response = await client.collections.items.createItem(collectionId, {
+    isArchived: false,
+    isDraft: false,
+    fieldData: {
+      name: `seed-${firebaseId}`,
+      slug: `seed-${firebaseId}`,
+      'firebase-id': firebaseId,
+    },
+  });
+  if (!response.id) throw new Error('Mock server did not return an item id');
+  return response.id;
+}
+
+describe('ClassService.removeClass — publish flag routing', () => {
+  const service = () => new ClassService(client, CLASSES_COLLECTION);
+
+  const mockClass: Class = {
+    id: 'class-pub-true',
+    name: 'Seed Class',
+  } as Class;
+
+  it('hits the /live delete endpoint when publish=true', async () => {
+    const itemId = await seedItem(CLASSES_COLLECTION, mockClass.id);
+
+    const removed = await service().removeClass(mockClass.id, true);
+
+    expect(removed).toBe(true);
+    const log = getWebflowDeleteLog();
+    expect(log).toEqual([{ itemId, live: true }]);
+  });
+
+  it('hits the staged delete endpoint when publish=false', async () => {
+    const itemId = await seedItem(CLASSES_COLLECTION, 'class-pub-false');
+
+    const removed = await service().removeClass('class-pub-false', false);
+
+    expect(removed).toBe(true);
+    const log = getWebflowDeleteLog();
+    expect(log).toEqual([{ itemId, live: false }]);
+  });
+
+  it('defaults to the staged delete endpoint when publish is omitted', async () => {
+    const itemId = await seedItem(CLASSES_COLLECTION, 'class-default');
+
+    await service().removeClass('class-default');
+
+    expect(getWebflowDeleteLog()).toEqual([{ itemId, live: false }]);
+  });
+});
+
+describe('ArtistService.removeArtist — publish flag routing', () => {
+  const service = () => new ArtistService(client, ARTISTS_COLLECTION);
+
+  const mockArtist: Artist = {
+    id: 'artist-pub-true',
+    name: 'Seed Artist',
+  } as Artist;
+
+  it('hits the /live delete endpoint when publish=true', async () => {
+    const itemId = await seedItem(ARTISTS_COLLECTION, mockArtist.id);
+
+    const removed = await service().removeArtist(mockArtist.id, true);
+
+    expect(removed).toBe(true);
+    expect(getWebflowDeleteLog()).toEqual([{ itemId, live: true }]);
+  });
+
+  it('hits the staged delete endpoint when publish=false', async () => {
+    const itemId = await seedItem(ARTISTS_COLLECTION, 'artist-pub-false');
+
+    const removed = await service().removeArtist('artist-pub-false', false);
+
+    expect(removed).toBe(true);
+    expect(getWebflowDeleteLog()).toEqual([{ itemId, live: false }]);
+  });
+});
+
+describe('InstructorService.removeInstructor — publish flag routing', () => {
+  const service = () => new InstructorService(client, INSTRUCTORS_COLLECTION);
+
+  const mockInstructor: Instructor = {
+    id: 'inst-pub-true',
+    name: 'Seed Instructor',
+  } as Instructor;
+
+  it('hits the /live delete endpoint when publish=true', async () => {
+    const itemId = await seedItem(INSTRUCTORS_COLLECTION, mockInstructor.id);
+
+    const removed = await service().removeInstructor(mockInstructor.id, true);
+
+    expect(removed).toBe(true);
+    expect(getWebflowDeleteLog()).toEqual([{ itemId, live: true }]);
+  });
+
+  it('hits the staged delete endpoint when publish=false', async () => {
+    const itemId = await seedItem(INSTRUCTORS_COLLECTION, 'inst-pub-false');
+
+    const removed = await service().removeInstructor('inst-pub-false', false);
+
+    expect(removed).toBe(true);
+    expect(getWebflowDeleteLog()).toEqual([{ itemId, live: false }]);
+  });
+});

--- a/libs/firebase/webflow/src/lib/instructor.service.spec.ts
+++ b/libs/firebase/webflow/src/lib/instructor.service.spec.ts
@@ -163,6 +163,7 @@ function createMockClient() {
         createItem: vi.fn(),
         updateItem: vi.fn(),
         deleteItem: vi.fn(),
+        deleteItemLive: vi.fn(),
         publishItem: vi.fn(),
       },
     },
@@ -190,6 +191,7 @@ describe('InstructorService', () => {
       createItem: ReturnType<typeof vi.fn>;
       updateItem: ReturnType<typeof vi.fn>;
       deleteItem: ReturnType<typeof vi.fn>;
+      deleteItemLive: ReturnType<typeof vi.fn>;
       publishItem: ReturnType<typeof vi.fn>;
     };
 
@@ -286,6 +288,53 @@ describe('InstructorService', () => {
       expect(items().deleteItem).toHaveBeenCalledWith(collectionId, 'wf-del');
     });
 
+    it('defaults to staged delete (deleteItem, not deleteItemLive)', async () => {
+      items().listItems.mockResolvedValue({
+        items: [
+          { id: 'wf-staged', fieldData: { 'firebase-id': 'inst-001' } },
+        ],
+      });
+      items().deleteItem.mockResolvedValue({});
+
+      await service.removeInstructor('inst-001');
+
+      expect(items().deleteItem).toHaveBeenCalledTimes(1);
+      expect(items().deleteItemLive).not.toHaveBeenCalled();
+    });
+
+    it('uses deleteItemLive when publish=true to auto-publish removal', async () => {
+      items().listItems.mockResolvedValue({
+        items: [{ id: 'wf-live', fieldData: { 'firebase-id': 'inst-001' } }],
+      });
+      items().deleteItemLive.mockResolvedValue({});
+
+      const result = await service.removeInstructor('inst-001', true);
+
+      expect(result).toBe(true);
+      expect(items().deleteItemLive).toHaveBeenCalledWith(
+        collectionId,
+        'wf-live'
+      );
+      expect(items().deleteItem).not.toHaveBeenCalled();
+    });
+
+    it('uses deleteItem when publish=false', async () => {
+      items().listItems.mockResolvedValue({
+        items: [
+          { id: 'wf-staged', fieldData: { 'firebase-id': 'inst-001' } },
+        ],
+      });
+      items().deleteItem.mockResolvedValue({});
+
+      await service.removeInstructor('inst-001', false);
+
+      expect(items().deleteItem).toHaveBeenCalledWith(
+        collectionId,
+        'wf-staged'
+      );
+      expect(items().deleteItemLive).not.toHaveBeenCalled();
+    });
+
     it('returns false when instructor not found in Webflow', async () => {
       items().listItems.mockResolvedValue({ items: [] });
 
@@ -293,6 +342,16 @@ describe('InstructorService', () => {
 
       expect(result).toBe(false);
       expect(items().deleteItem).not.toHaveBeenCalled();
+    });
+
+    it('does not call any delete when publish=true and item not found', async () => {
+      items().listItems.mockResolvedValue({ items: [] });
+
+      const result = await service.removeInstructor('nonexistent', true);
+
+      expect(result).toBe(false);
+      expect(items().deleteItem).not.toHaveBeenCalled();
+      expect(items().deleteItemLive).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/firebase/webflow/src/lib/instructor.service.ts
+++ b/libs/firebase/webflow/src/lib/instructor.service.ts
@@ -184,21 +184,34 @@ export class InstructorService {
 
   /**
    * Remove an instructor from Webflow CMS.
+   * When publish=true, uses deleteItemLive so the deletion is reflected on
+   * the live site without a manual republish.
    *
    * @param firebaseId - Firebase instructor ID
+   * @param publish - Whether to also publish the deletion to the live site
    * @returns True if deleted, false if not found
    */
-  async removeInstructor(firebaseId: string): Promise<boolean> {
+  async removeInstructor(
+    firebaseId: string,
+    publish = false
+  ): Promise<boolean> {
     const existingItem = await this.findByFirebaseId(firebaseId);
 
     if (!existingItem) {
       return false;
     }
 
-    await this.client.collections.items.deleteItem(
-      this.collectionId,
-      existingItem.id
-    );
+    if (publish) {
+      await this.client.collections.items.deleteItemLive(
+        this.collectionId,
+        existingItem.id
+      );
+    } else {
+      await this.client.collections.items.deleteItem(
+        this.collectionId,
+        existingItem.id
+      );
+    }
 
     return true;
   }

--- a/libs/firebase/webflow/vitest.config.ts
+++ b/libs/firebase/webflow/vitest.config.ts
@@ -1,7 +1,16 @@
 import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
 
 export default defineConfig({
   root: __dirname,
+  resolve: {
+    alias: {
+      '@maple/firebase/integration-test-mock-server': resolve(
+        __dirname,
+        '../../../libs/firebase/integration-test-mock-server/src/index.ts'
+      ),
+    },
+  },
   test: {
     name: 'webflow',
     globals: true,


### PR DESCRIPTION
## Summary

When a class, artist, or instructor is deleted (or moves to an inactive/unpublished status), the Firestore trigger correctly removes the item from the Webflow CMS — but the deletion wasn't reflected on the live site until someone manually republished. This bridges that gap so prod deletions go live automatically.

## Changes

- `ClassService.removeClass`, `ArtistService.removeArtist`, `InstructorService.removeInstructor` now accept a `publish` flag (default `false`). When true, they call `deleteItemLive` instead of `deleteItem` so the Webflow SDK deletes and publishes in a single API call.
- The three `sync-*-to-webflow` Firestore triggers pass `!isDev`, matching the existing create/update auto-publish behavior — prod publishes, dev stays draft.

## Testing

- [x] Webflow unit tests pass (90/90)
- [x] `webflow` lib builds cleanly
- [ ] Manual: delete a class in the prod admin portal and confirm it disappears from the live site without a manual republish

## Notes

No batch-delete flow exists today, so per-item publish is the right tool (1 publish per minute rate limit is not a concern). If batch operations land later, we'd likely want a single `sites.publish()` at the end instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)