### PR TITLE
chore: auto-publish webflow components on merge

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -138,6 +138,38 @@ jobs:
       - name: Build functions
         run: pnpm exec nx run functions:build
 
+  webflow-components-typecheck:
+    name: Webflow Components Typecheck
+    needs: [install]
+    runs-on: ubuntu-latest
+    if: github.repository == 'Maple-and-Spruce/maple-and-spruce'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: ${{ needs.install.outputs.cache_key }}
+
+      # Webflow's CLI `library bundle` command is broken upstream with
+      # current webpack / Module Federation transitive versions (fails
+      # with "no files found for remoteEntry chunk"). The actual
+      # `library share` command on merge has its own working pipeline.
+      # A typecheck is the best PR-time gate we have against shipping
+      # broken component code.
+      - name: Typecheck webflow components
+        run: pnpm exec tsc --noEmit -p apps/webflow-components/tsconfig.json
+
   unit-tests:
     name: Unit Tests & Coverage
     needs: [install]

--- a/.github/workflows/webflow-components-publish.yml
+++ b/.github/workflows/webflow-components-publish.yml
@@ -1,0 +1,37 @@
+name: Publish Webflow Components on merge
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/webflow-components/**'
+  workflow_dispatch: {}
+
+env:
+  NX_DAEMON: 'false'
+
+jobs:
+  publish:
+    name: Publish library to Webflow Workspace
+    runs-on: ubuntu-latest
+    if: github.repository == 'Maple-and-Spruce/maple-and-spruce'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Share webflow components library
+        env:
+          WEBFLOW_WORKSPACE_API_TOKEN: ${{ secrets.WEBFLOW_WORKSPACE_API_TOKEN }}
+        run: pnpm exec webflow library share --no-input --skip-update-check --manifest apps/webflow-components/webflow.json


### PR DESCRIPTION
## Summary
Adds CI/CD for `apps/webflow-components` so merges to `main` that touch the component code publish automatically to the Webflow Workspace (no more manual `webflow library share` from a laptop).

## Changes
- **`.github/workflows/webflow-components-publish.yml`** (new) — runs `webflow library share --no-input` on push to `main` when `apps/webflow-components/**` changes, with a `workflow_dispatch` escape hatch for manual re-runs. Auth via `WEBFLOW_WORKSPACE_API_TOKEN` secret.
- **`.github/workflows/build-check.yml`** — new `webflow-components-typecheck` job on PRs. Originally scoped to run `webflow library bundle`, but that command is currently broken upstream regardless of branch or fresh/stale install (fails with `[ Module Federation Manifest Plugin ]: no files found for remoteEntry chunk` across `@webflow/webflow-cli@1.13.0`/`1.13.1` and webpack `5.105.x`/`5.106.x`). The actual `library share` command on merge has its own working bundling pipeline and is unaffected. Typechecking the component source is the best PR-time gate we can offer until Webflow ships a fix.

## ⚠ Action required before merge
Add `WEBFLOW_WORKSPACE_API_TOKEN` to repo Secrets (Settings → Secrets and variables → Actions). Mint a workspace API token at webflow.com → Workspace Settings → Integrations → API access. Without the secret, the publish step will fail on first run.

## Testing
- [x] Verified `tsc --noEmit -p apps/webflow-components/tsconfig.json` passes locally
- [x] Confirmed `webflow library share` works from local main (with existing auth)
- [x] Confirmed `webflow library bundle` fails on main even without any PR changes — documented reasoning in workflow comment so future-us doesn't re-attempt the same broken approach
- [ ] First workflow run will be the integration test — worth watching once the secret is added

🤖 Generated with [Claude Code](https://claude.com/claude-code)