### PR TITLE
feat: music lesson student admin UI (#278)

### DIFF
--- a/apps/maple-spruce/.storybook/fixtures/index.ts
+++ b/apps/maple-spruce/.storybook/fixtures/index.ts
@@ -11,3 +11,4 @@ export * from './instructors';
 export * from './classes';
 export * from './discounts';
 export * from './registrations';
+export * from './students';

--- a/apps/maple-spruce/.storybook/fixtures/students.ts
+++ b/apps/maple-spruce/.storybook/fixtures/students.ts
@@ -1,0 +1,91 @@
+import type { Student } from '@maple/ts/domain';
+
+/**
+ * Mock music lesson student data for Storybook stories.
+ */
+
+export const mockStudent: Student = {
+  id: 'student-001',
+  name: 'Olive Thompson',
+  instrument: 'violin',
+  isAdultStudent: false,
+  primaryTeacherId: 'instructor-001',
+  registeredLessonLength: '30-min-initial',
+  isHopeScholarship: false,
+  primaryContactName: 'Rita Thompson',
+  primaryContactEmail: 'rita@example.com',
+  primaryContactPhone: '304-555-1234',
+  status: 'active',
+  notes: 'Loves Twinkle variations.',
+  createdAt: new Date('2026-01-10T10:00:00Z'),
+  updatedAt: new Date('2026-03-01T14:00:00Z'),
+};
+
+export const mockStudentHope: Student = {
+  id: 'student-002',
+  name: 'Felix Rivera',
+  instrument: 'piano',
+  isAdultStudent: false,
+  primaryTeacherId: 'instructor-002',
+  registeredLessonLength: '45-min',
+  isHopeScholarship: true,
+  primaryContactName: 'Dana Rivera',
+  primaryContactEmail: 'dana@example.com',
+  primaryContactPhone: '304-555-5678',
+  status: 'active',
+  notes: 'Billed through Hope/EMA portal per lesson.',
+  createdAt: new Date('2026-02-05T10:00:00Z'),
+  updatedAt: new Date('2026-02-05T10:00:00Z'),
+};
+
+export const mockStudentAdult: Student = {
+  id: 'student-003',
+  name: 'Maya Chen',
+  instrument: 'guitar',
+  isAdultStudent: true,
+  primaryTeacherId: 'instructor-003',
+  registeredLessonLength: '60-min',
+  isHopeScholarship: false,
+  primaryContactName: 'Maya Chen',
+  primaryContactEmail: 'maya@example.com',
+  status: 'active',
+  createdAt: new Date('2026-03-12T09:00:00Z'),
+  updatedAt: new Date('2026-03-12T09:00:00Z'),
+};
+
+export const mockStudentInactive: Student = {
+  id: 'student-004',
+  name: 'Jonas Park',
+  instrument: 'cello',
+  isAdultStudent: false,
+  primaryTeacherId: 'instructor-001',
+  isHopeScholarship: false,
+  primaryContactName: 'Soo Park',
+  primaryContactEmail: 'soo@example.com',
+  status: 'inactive',
+  notes: 'On hiatus — family moved out of state.',
+  createdAt: new Date('2025-09-01T10:00:00Z'),
+  updatedAt: new Date('2026-01-15T10:00:00Z'),
+};
+
+export const mockStudentMinimal: Student = {
+  id: 'student-005',
+  name: 'Iris Park',
+  instrument: 'voice',
+  isAdultStudent: false,
+  primaryTeacherId: 'instructor-001',
+  isHopeScholarship: false,
+  primaryContactName: 'Lee Park',
+  primaryContactEmail: 'lee@example.com',
+  status: 'active',
+  createdAt: new Date('2026-04-01T10:00:00Z'),
+  updatedAt: new Date('2026-04-01T10:00:00Z'),
+};
+
+export const mockStudents: Student[] = [
+  mockStudent,
+  mockStudentHope,
+  mockStudentAdult,
+  mockStudentInactive,
+  mockStudentMinimal,
+];

--- a/apps/maple-spruce/src/app/students/page.tsx
+++ b/apps/maple-spruce/src/app/students/page.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { Alert, Box, Button, Typography } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import type { CreateStudentInput, Student } from '@maple/ts/domain';
+import { DeleteConfirmDialog } from '@maple/react/ui';
+import { StudentForm, StudentList } from '@maple/react/students';
+import { AppShell } from '../../components/layout';
+import { useInstructors, useStudents } from '../../hooks';
+
+export default function StudentsPage() {
+  const {
+    studentsState,
+    createStudent,
+    updateStudent,
+    deleteStudent: deleteStudentApi,
+  } = useStudents();
+  const { instructorsState } = useInstructors();
+
+  const instructors =
+    instructorsState.status === 'success' ? instructorsState.data : [];
+
+  // Form dialog state
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editingStudent, setEditingStudent] = useState<Student | undefined>();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Delete dialog state
+  const [studentToDelete, setStudentToDelete] = useState<Student | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleOpenForm = useCallback((student?: Student) => {
+    setEditingStudent(student);
+    setIsFormOpen(true);
+  }, []);
+
+  const handleCloseForm = useCallback(() => {
+    setIsFormOpen(false);
+    setEditingStudent(undefined);
+  }, []);
+
+  const handleSubmitForm = useCallback(
+    async (data: CreateStudentInput) => {
+      setIsSubmitting(true);
+
+      try {
+        if (editingStudent) {
+          await updateStudent({ id: editingStudent.id, ...data });
+        } else {
+          await createStudent(data);
+        }
+        handleCloseForm();
+      } catch (error) {
+        console.error('Failed to save student:', error);
+        throw error;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [editingStudent, handleCloseForm, createStudent, updateStudent]
+  );
+
+  const handleOpenDelete = useCallback((student: Student) => {
+    setStudentToDelete(student);
+  }, []);
+
+  const handleCloseDelete = useCallback(() => {
+    setStudentToDelete(null);
+  }, []);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!studentToDelete) return;
+
+    setIsDeleting(true);
+
+    try {
+      await deleteStudentApi(studentToDelete.id);
+      handleCloseDelete();
+    } catch (error) {
+      console.error('Failed to delete student:', error);
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [studentToDelete, handleCloseDelete, deleteStudentApi]);
+
+  return (
+    <AppShell>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mb: 3,
+        }}
+      >
+        <Typography variant="h4" component="h1">
+          Students
+        </Typography>
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={() => handleOpenForm()}
+          disabled={instructors.length === 0}
+        >
+          Add Student
+        </Button>
+      </Box>
+
+      {instructors.length === 0 && instructorsState.status === 'success' && (
+        <Alert severity="info" sx={{ mb: 3 }}>
+          Add at least one instructor before creating student records — every
+          student needs a primary teacher.
+        </Alert>
+      )}
+
+      <StudentList
+        studentsState={studentsState}
+        instructors={instructors}
+        onEdit={handleOpenForm}
+        onDelete={handleOpenDelete}
+      />
+
+      <StudentForm
+        open={isFormOpen}
+        onClose={handleCloseForm}
+        onSubmit={handleSubmitForm}
+        student={editingStudent}
+        instructors={instructors}
+        isSubmitting={isSubmitting}
+      />
+
+      <DeleteConfirmDialog
+        open={!!studentToDelete}
+        onClose={handleCloseDelete}
+        onConfirm={handleConfirmDelete}
+        isDeleting={isDeleting}
+        title="Delete Student?"
+        itemName={studentToDelete?.name ?? ''}
+        warningContent={
+          <Alert severity="warning">
+            Prefer setting the student to &quot;inactive&quot; to preserve
+            lesson and invoice history. Deleting cannot be undone.
+          </Alert>
+        }
+      />
+    </AppShell>
+  );
+}

--- a/apps/maple-spruce/src/components/layout/AppShellWrapper.tsx
+++ b/apps/maple-spruce/src/components/layout/AppShellWrapper.tsx
@@ -7,6 +7,7 @@ import PeopleIcon from '@mui/icons-material/People';
 import CategoryIcon from '@mui/icons-material/Category';
 import SyncProblemIcon from '@mui/icons-material/SyncProblem';
 import SchoolIcon from '@mui/icons-material/School';
+import MusicNoteIcon from '@mui/icons-material/MusicNote';
 import EventIcon from '@mui/icons-material/Event';
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import TuneIcon from '@mui/icons-material/Tune';
@@ -80,6 +81,16 @@ export function AppShellWrapper({
             label: 'Registrations',
             href: '/registrations',
             icon: <HowToRegIcon />,
+          },
+        ],
+      },
+      {
+        label: 'Music Lessons',
+        items: [
+          {
+            label: 'Students',
+            href: '/students',
+            icon: <MusicNoteIcon />,
           },
         ],
       },

--- a/apps/maple-spruce/src/hooks/index.ts
+++ b/apps/maple-spruce/src/hooks/index.ts
@@ -4,6 +4,7 @@ export {
   useCategories,
   useProducts,
   useInstructors,
+  useStudents,
   useClasses,
   useClassCategories,
   useDiscounts,

--- a/docs/reference/implementation-status.md
+++ b/docs/reference/implementation-status.md
@@ -167,7 +167,7 @@ Phased rollout of customer-facing interactions on the Webflow site.
 
 ## Phase 4: Music Lessons - Epic #10
 
-### Student Records (#278, backend in progress)
+### Student Records (#278, Complete)
 
 | Feature | Status | Location |
 |---------|--------|----------|
@@ -177,9 +177,10 @@ Phased rollout of customer-facing interactions on the Webflow site.
 | Student API types | **Complete** | `libs/ts/firebase/api-types/src/lib/student.types.ts` |
 | Student CRUD Cloud Functions (5) | **Complete** | `libs/firebase/maple-functions/{create,get,get-list,update,delete}-student/` |
 | Student unit + integration tests | **Complete** | `libs/ts/{domain,validation}/src/lib/student*.spec.ts`, `apps/functions-integration-tests-student/` |
-| useStudents hook | Not Started | #278 |
-| Student list/form/detail components | Not Started | #278 |
-| Admin /students page + nav | Not Started | #278 |
+| useStudents hook | **Complete** | `libs/react/data/src/lib/useStudents.ts` |
+| StudentList + StudentForm (Preact signals, Vest) | **Complete** | `libs/react/students/src/lib/` |
+| Storybook interaction tests (24) | **Complete** | `libs/react/students/src/lib/*.stories.tsx` |
+| Admin /students page + Music Lessons nav group | **Complete** | `apps/maple-spruce/src/app/students/page.tsx`, `AppShellWrapper.tsx` |
 
 ## Phase 4.5: Calendar System (Complete)
 

--- a/libs/react/data/src/index.ts
+++ b/libs/react/data/src/index.ts
@@ -9,6 +9,9 @@ export { useInstructors } from './lib/useInstructors';
 export { useClasses, type UseClassesFilters } from './lib/useClasses';
 export { useClassCategories } from './lib/useClassCategories';
 
+// Phase 4: Music Lessons
+export { useStudents } from './lib/useStudents';
+
 // Phase 4.5: Calendar
 export {
   useCalendarEvents,

--- a/libs/react/data/src/lib/useStudents.ts
+++ b/libs/react/data/src/lib/useStudents.ts
@@ -1,0 +1,133 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { httpsCallable } from 'firebase/functions';
+import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
+import type {
+  Student,
+  CreateStudentInput,
+  UpdateStudentInput,
+  RequestState,
+} from '@maple/ts/domain';
+import type {
+  GetStudentsRequest,
+  GetStudentsResponse,
+  CreateStudentRequest,
+  CreateStudentResponse,
+  UpdateStudentRequest,
+  UpdateStudentResponse,
+  DeleteStudentRequest,
+  DeleteStudentResponse,
+} from '@maple/ts/firebase/api-types';
+
+/**
+ * Hook for managing music lesson student CRUD operations.
+ *
+ * Provides state + API calls for the admin student management page.
+ * Mirrors useInstructors's shape.
+ */
+export function useStudents() {
+  const [studentsState, setStudentsState] = useState<RequestState<Student[]>>({
+    status: 'idle',
+  });
+
+  const fetchStudents = useCallback(async () => {
+    setStudentsState({ status: 'loading' });
+
+    try {
+      const functions = getMapleFunctions();
+      const getStudents = httpsCallable<
+        GetStudentsRequest,
+        GetStudentsResponse
+      >(functions, 'getStudents');
+
+      const result = await getStudents({});
+      setStudentsState({
+        status: 'success',
+        data: result.data.students,
+      });
+    } catch (error) {
+      console.error('Failed to fetch students:', error);
+      setStudentsState({
+        status: 'error',
+        error:
+          error instanceof Error ? error.message : 'Failed to fetch students',
+      });
+    }
+  }, []);
+
+  const createStudent = useCallback(
+    async (input: CreateStudentInput): Promise<Student> => {
+      const functions = getMapleFunctions();
+      const create = httpsCallable<
+        CreateStudentRequest,
+        CreateStudentResponse
+      >(functions, 'createStudent');
+
+      const result = await create(input);
+
+      setStudentsState((prev) => {
+        if (prev.status !== 'success') return prev;
+        const newData = [...prev.data, result.data.student].sort((a, b) =>
+          a.name.localeCompare(b.name)
+        );
+        return { ...prev, data: newData };
+      });
+
+      return result.data.student;
+    },
+    []
+  );
+
+  const updateStudent = useCallback(
+    async (input: UpdateStudentInput): Promise<Student> => {
+      const functions = getMapleFunctions();
+      const update = httpsCallable<
+        UpdateStudentRequest,
+        UpdateStudentResponse
+      >(functions, 'updateStudent');
+
+      const result = await update(input);
+
+      setStudentsState((prev) => {
+        if (prev.status !== 'success') return prev;
+        const newData = prev.data
+          .map((s) =>
+            s.id === result.data.student.id ? result.data.student : s
+          )
+          .sort((a, b) => a.name.localeCompare(b.name));
+        return { ...prev, data: newData };
+      });
+
+      return result.data.student;
+    },
+    []
+  );
+
+  const deleteStudent = useCallback(async (id: string): Promise<void> => {
+    const functions = getMapleFunctions();
+    const del = httpsCallable<DeleteStudentRequest, DeleteStudentResponse>(
+      functions,
+      'deleteStudent'
+    );
+
+    await del({ id });
+
+    setStudentsState((prev) => {
+      if (prev.status !== 'success') return prev;
+      return { ...prev, data: prev.data.filter((s) => s.id !== id) };
+    });
+  }, []);
+
+  useEffect(() => {
+    fetchStudents();
+  }, [fetchStudents]);
+
+  return {
+    studentsState,
+    fetchStudents,
+    createStudent,
+    updateStudent,
+    deleteStudent,
+  };
+}

--- a/libs/react/students/project.json
+++ b/libs/react/students/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "react-students",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/react/students/src",
+  "projectType": "library",
+  "tags": ["scope:react", "type:feature"],
+  "targets": {}
+}

--- a/libs/react/students/src/index.ts
+++ b/libs/react/students/src/index.ts
@@ -1,0 +1,6 @@
+export { StudentList } from './lib/StudentList';
+export { StudentForm } from './lib/StudentForm';
+export {
+  INSTRUMENT_LABELS,
+  LESSON_LENGTH_LABELS,
+} from './lib/labels';

--- a/libs/react/students/src/lib/StudentForm.stories.tsx
+++ b/libs/react/students/src/lib/StudentForm.stories.tsx
@@ -1,0 +1,267 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn, expect, userEvent, waitFor, within } from 'storybook/test';
+import { StudentForm } from './StudentForm';
+import {
+  mockStudent,
+  mockStudentHope,
+  mockStudentAdult,
+  mockInstructor,
+  mockInstructor2,
+  mockInstructorPercentage,
+} from '../../../../../apps/maple-spruce/.storybook/fixtures';
+
+const instructors = [mockInstructor, mockInstructor2, mockInstructorPercentage];
+
+const meta = {
+  component: StudentForm,
+  title: 'Students/StudentForm',
+  parameters: { layout: 'centered', a11y: { disable: true } },
+  args: {
+    onClose: fn(),
+    onSubmit: fn(),
+    instructors,
+  },
+} satisfies Meta<typeof StudentForm>;
+
+/** Dialog renders in a portal; query against document.body. */
+const getDialogCanvas = () => within(document.body);
+
+/** Wait for dialog content to be fully rendered. */
+const waitForDialog = async () => {
+  const canvas = getDialogCanvas();
+  await waitFor(
+    () => {
+      expect(canvas.getByRole('dialog')).toBeInTheDocument();
+      expect(canvas.getByLabelText(/student name/i)).toBeInTheDocument();
+    },
+    { timeout: 3000 }
+  );
+  return canvas;
+};
+
+export default meta;
+type Story = StoryObj<typeof StudentForm>;
+
+// ============================================================
+// VISUAL STATES
+// ============================================================
+
+export const Closed: Story = {
+  args: { open: false, isSubmitting: false },
+};
+
+export const CreateNew: Story = {
+  args: { open: true, isSubmitting: false },
+};
+
+export const EditExisting: Story = {
+  args: { open: true, student: mockStudent, isSubmitting: false },
+};
+
+export const EditHopeScholarship: Story = {
+  args: { open: true, student: mockStudentHope, isSubmitting: false },
+};
+
+export const EditAdultStudent: Story = {
+  args: { open: true, student: mockStudentAdult, isSubmitting: false },
+};
+
+export const Submitting: Story = {
+  args: { open: true, student: mockStudent, isSubmitting: true },
+};
+
+// ============================================================
+// INTERACTION TESTS
+// ============================================================
+
+export const ValidationErrorsOnEmptySubmit: Story = {
+  args: { open: true, isSubmitting: false },
+  play: async ({ args }) => {
+    const canvas = await waitForDialog();
+
+    // Submit without filling required fields
+    await userEvent.click(canvas.getByRole('button', { name: /^add$/i }));
+
+    await waitFor(() => {
+      expect(canvas.getByLabelText(/student name/i)).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      );
+    });
+
+    // Primary contact fields should also be flagged
+    expect(canvas.getByLabelText(/primary contact name/i)).toHaveAttribute(
+      'aria-invalid',
+      'true'
+    );
+    expect(canvas.getByLabelText(/primary contact email/i)).toHaveAttribute(
+      'aria-invalid',
+      'true'
+    );
+
+    await expect(args.onSubmit).not.toHaveBeenCalled();
+  },
+};
+
+export const SuccessfulSubmission: Story = {
+  args: {
+    open: true,
+    isSubmitting: false,
+    onSubmit: fn().mockResolvedValue(undefined),
+  },
+  play: async ({ args }) => {
+    const canvas = await waitForDialog();
+
+    await userEvent.type(
+      canvas.getByLabelText(/student name/i),
+      'Iris Park'
+    );
+    await userEvent.type(
+      canvas.getByLabelText(/primary contact name/i),
+      'Lee Park'
+    );
+    await userEvent.type(
+      canvas.getByLabelText(/primary contact email/i),
+      'lee@example.com'
+    );
+
+    // Instrument already defaults to piano; pick the primary teacher
+    const teacherSelect = canvas.getByLabelText(/primary teacher/i);
+    await userEvent.click(teacherSelect);
+    const teacherOption = await waitFor(() =>
+      canvas.getByRole('option', { name: mockInstructor.name })
+    );
+    await userEvent.click(teacherOption);
+
+    await userEvent.click(canvas.getByRole('button', { name: /^add$/i }));
+
+    await waitFor(() => {
+      expect(args.onSubmit).toHaveBeenCalledTimes(1);
+      expect(args.onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Iris Park',
+          instrument: 'piano',
+          primaryTeacherId: mockInstructor.id,
+          primaryContactName: 'Lee Park',
+          primaryContactEmail: 'lee@example.com',
+          isAdultStudent: false,
+          isHopeScholarship: false,
+          status: 'active',
+        })
+      );
+    });
+  },
+};
+
+export const CancelButtonClosesDialog: Story = {
+  args: { open: true, isSubmitting: false },
+  play: async ({ args }) => {
+    const canvas = await waitForDialog();
+
+    await userEvent.click(canvas.getByRole('button', { name: /cancel/i }));
+    await expect(args.onClose).toHaveBeenCalledTimes(1);
+  },
+};
+
+export const EditFormIsPrePopulated: Story = {
+  args: { open: true, student: mockStudent, isSubmitting: false },
+  play: async () => {
+    const canvas = await waitForDialog();
+
+    await waitFor(() => {
+      expect(canvas.getByLabelText(/student name/i)).toHaveValue(
+        mockStudent.name
+      );
+    });
+
+    expect(canvas.getByLabelText(/primary contact name/i)).toHaveValue(
+      mockStudent.primaryContactName
+    );
+    expect(canvas.getByLabelText(/primary contact email/i)).toHaveValue(
+      mockStudent.primaryContactEmail
+    );
+  },
+};
+
+export const AdultStudentTogglesContactSectionHeader: Story = {
+  args: { open: true, isSubmitting: false },
+  play: async () => {
+    const canvas = await waitForDialog();
+
+    // Defaults to minor — "Parent / guardian" section header visible
+    expect(canvas.getByText(/parent.*guardian/i)).toBeInTheDocument();
+
+    // Toggle adult switch
+    await userEvent.click(
+      canvas.getByRole('checkbox', { name: /adult student/i })
+    );
+
+    // Section header flips to "Contact"
+    await waitFor(() => {
+      // Use queryAllByText since "Secondary contact" also contains "contact"
+      const headers = canvas.queryAllByText(/^contact$/i);
+      expect(headers.length).toBeGreaterThan(0);
+    });
+  },
+};
+
+export const InvalidPrimaryContactEmailBlocksSubmit: Story = {
+  args: {
+    open: true,
+    isSubmitting: false,
+    onSubmit: fn().mockResolvedValue(undefined),
+  },
+  play: async ({ args }) => {
+    const canvas = await waitForDialog();
+
+    await userEvent.type(
+      canvas.getByLabelText(/student name/i),
+      'Test Student'
+    );
+    await userEvent.type(
+      canvas.getByLabelText(/primary contact name/i),
+      'Test Parent'
+    );
+    await userEvent.type(
+      canvas.getByLabelText(/primary contact email/i),
+      'not-an-email'
+    );
+
+    // Select teacher so that's not what blocks submit
+    const teacherSelect = canvas.getByLabelText(/primary teacher/i);
+    await userEvent.click(teacherSelect);
+    const teacherOption = await waitFor(() =>
+      canvas.getByRole('option', { name: mockInstructor.name })
+    );
+    await userEvent.click(teacherOption);
+
+    await userEvent.click(canvas.getByRole('button', { name: /^add$/i }));
+
+    await waitFor(() => {
+      expect(canvas.getByLabelText(/primary contact email/i)).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      );
+    });
+
+    await expect(args.onSubmit).not.toHaveBeenCalled();
+  },
+};
+
+export const HopeScholarshipToggles: Story = {
+  args: { open: true, isSubmitting: false },
+  play: async () => {
+    const canvas = await waitForDialog();
+
+    const hopeToggle = canvas.getByRole('checkbox', {
+      name: /hope scholarship/i,
+    });
+    expect(hopeToggle).not.toBeChecked();
+
+    await userEvent.click(hopeToggle);
+
+    await waitFor(() => {
+      expect(hopeToggle).toBeChecked();
+    });
+  },
+};

--- a/libs/react/students/src/lib/StudentForm.tsx
+++ b/libs/react/students/src/lib/StudentForm.tsx
@@ -1,0 +1,460 @@
+'use client';
+
+/**
+ * StudentForm - Music lesson student form using Preact Signals.
+ *
+ * Mirrors InstructorForm's signals idiom:
+ * - `useSignals()` runtime hook at the top
+ * - `useSignal()` per form field
+ * - `useComputed()` for derived state (validation, errors, field errors)
+ * - `batch()` when resetting multiple fields together
+ */
+
+import { useCallback, useEffect } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  FormControl,
+  FormControlLabel,
+  FormHelperText,
+  InputLabel,
+  MenuItem,
+  Select,
+  Switch,
+  Alert,
+  Divider,
+  Typography,
+} from '@mui/material';
+import type {
+  Instructor,
+  Instrument,
+  LessonLength,
+  Student,
+  StudentStatus,
+  CreateStudentInput,
+} from '@maple/ts/domain';
+import { INSTRUMENTS, LESSON_LENGTHS } from '@maple/ts/domain';
+import { studentValidation } from '@maple/ts/validation';
+import {
+  useSignal,
+  useComputed,
+  batch,
+  useSignals,
+} from '@maple/react/signals';
+import { INSTRUMENT_LABELS, LESSON_LENGTH_LABELS } from './labels';
+
+interface StudentFormProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (data: CreateStudentInput) => Promise<void>;
+  student?: Student;
+  instructors: Instructor[];
+  isSubmitting?: boolean;
+}
+
+export function StudentForm({
+  open,
+  onClose,
+  onSubmit,
+  student,
+  instructors,
+  isSubmitting = false,
+}: StudentFormProps) {
+  useSignals();
+
+  // ============================================================
+  // FORM FIELD SIGNALS
+  // ============================================================
+  const name = useSignal('');
+  const instrument = useSignal<Instrument>('piano');
+  const isAdultStudent = useSignal(false);
+  const primaryTeacherId = useSignal('');
+  const registeredLessonLength = useSignal<LessonLength | ''>('');
+  const isHopeScholarship = useSignal(false);
+  const primaryContactName = useSignal('');
+  const primaryContactEmail = useSignal('');
+  const primaryContactPhone = useSignal('');
+  const secondaryContactEmail = useSignal('');
+  const secondaryContactPhone = useSignal('');
+  const notes = useSignal('');
+  const status = useSignal<StudentStatus>('active');
+
+  // ============================================================
+  // UI STATE SIGNALS
+  // ============================================================
+  const showValidationErrors = useSignal(false);
+  const submitError = useSignal<string | null>(null);
+
+  const isEdit = !!student;
+
+  // ============================================================
+  // VALIDATION
+  // ============================================================
+  const validation = useComputed(() => {
+    return studentValidation({
+      name: name.value,
+      instrument: instrument.value,
+      isAdultStudent: isAdultStudent.value,
+      primaryTeacherId: primaryTeacherId.value,
+      registeredLessonLength: registeredLessonLength.value || undefined,
+      isHopeScholarship: isHopeScholarship.value,
+      primaryContactName: primaryContactName.value,
+      primaryContactEmail: primaryContactEmail.value,
+      primaryContactPhone: primaryContactPhone.value || undefined,
+      secondaryContactEmail: secondaryContactEmail.value || undefined,
+      secondaryContactPhone: secondaryContactPhone.value || undefined,
+      notes: notes.value || undefined,
+      status: status.value,
+    });
+  });
+
+  const errors = useComputed<Record<string, string[]>>(() => {
+    if (!showValidationErrors.value) return {};
+    return validation.value.getErrors();
+  });
+
+  const isValid = useComputed(() => validation.value.isValid());
+
+  const getFieldError = (field: string): string | null => {
+    const fieldErrors = errors.value[field];
+    return fieldErrors?.[0] ?? null;
+  };
+
+  // ============================================================
+  // EFFECTS
+  // ============================================================
+  useEffect(() => {
+    if (!open) return;
+
+    if (student) {
+      batch(() => {
+        name.value = student.name;
+        instrument.value = student.instrument;
+        isAdultStudent.value = student.isAdultStudent;
+        primaryTeacherId.value = student.primaryTeacherId;
+        registeredLessonLength.value = student.registeredLessonLength ?? '';
+        isHopeScholarship.value = student.isHopeScholarship;
+        primaryContactName.value = student.primaryContactName;
+        primaryContactEmail.value = student.primaryContactEmail;
+        primaryContactPhone.value = student.primaryContactPhone ?? '';
+        secondaryContactEmail.value = student.secondaryContactEmail ?? '';
+        secondaryContactPhone.value = student.secondaryContactPhone ?? '';
+        notes.value = student.notes ?? '';
+        status.value = student.status;
+        showValidationErrors.value = false;
+        submitError.value = null;
+      });
+    } else {
+      batch(() => {
+        name.value = '';
+        instrument.value = 'piano';
+        isAdultStudent.value = false;
+        primaryTeacherId.value = '';
+        registeredLessonLength.value = '';
+        isHopeScholarship.value = false;
+        primaryContactName.value = '';
+        primaryContactEmail.value = '';
+        primaryContactPhone.value = '';
+        secondaryContactEmail.value = '';
+        secondaryContactPhone.value = '';
+        notes.value = '';
+        status.value = 'active';
+        showValidationErrors.value = false;
+        submitError.value = null;
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, student]);
+
+  // ============================================================
+  // HANDLERS
+  // ============================================================
+  const handleSubmit = useCallback(async () => {
+    showValidationErrors.value = true;
+
+    if (!isValid.value) {
+      return;
+    }
+
+    // Signal writes are synchronous — guards against double-submit.
+    if (isSubmitting) return;
+
+    submitError.value = null;
+
+    try {
+      const input: CreateStudentInput = {
+        name: name.value,
+        instrument: instrument.value,
+        isAdultStudent: isAdultStudent.value,
+        primaryTeacherId: primaryTeacherId.value,
+        registeredLessonLength: registeredLessonLength.value || undefined,
+        isHopeScholarship: isHopeScholarship.value,
+        primaryContactName: primaryContactName.value,
+        primaryContactEmail: primaryContactEmail.value,
+        primaryContactPhone: primaryContactPhone.value || undefined,
+        secondaryContactEmail: secondaryContactEmail.value || undefined,
+        secondaryContactPhone: secondaryContactPhone.value || undefined,
+        notes: notes.value || undefined,
+        status: status.value,
+      };
+
+      await onSubmit(input);
+      onClose();
+    } catch (error: unknown) {
+      let message = 'Failed to save student';
+      if (error instanceof Error) {
+        message = error.message;
+      } else if (
+        typeof error === 'object' &&
+        error !== null &&
+        'message' in error
+      ) {
+        message = String((error as { message: unknown }).message);
+      }
+      submitError.value = message;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onSubmit, onClose, isSubmitting]);
+
+  // ============================================================
+  // RENDER
+  // ============================================================
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>{isEdit ? 'Edit Student' : 'Add Student'}</DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          {submitError.value && (
+            <Alert severity="error" onClose={() => (submitError.value = null)}>
+              {submitError.value}
+            </Alert>
+          )}
+
+          {/* Student name */}
+          <TextField
+            label="Student name"
+            value={name.value}
+            onChange={(e) => (name.value = e.target.value)}
+            error={!!getFieldError('name')}
+            helperText={getFieldError('name')}
+            required
+            fullWidth
+          />
+
+          {/* Instrument */}
+          <FormControl fullWidth error={!!getFieldError('instrument')}>
+            <InputLabel id="student-instrument-label">Instrument</InputLabel>
+            <Select
+              labelId="student-instrument-label"
+              label="Instrument"
+              value={instrument.value}
+              onChange={(e) =>
+                (instrument.value = e.target.value as Instrument)
+              }
+            >
+              {INSTRUMENTS.map((inst) => (
+                <MenuItem key={inst} value={inst}>
+                  {INSTRUMENT_LABELS[inst]}
+                </MenuItem>
+              ))}
+            </Select>
+            {getFieldError('instrument') && (
+              <FormHelperText>{getFieldError('instrument')}</FormHelperText>
+            )}
+          </FormControl>
+
+          {/* Primary teacher */}
+          <FormControl fullWidth error={!!getFieldError('primaryTeacherId')}>
+            <InputLabel id="student-teacher-label">Primary teacher</InputLabel>
+            <Select
+              labelId="student-teacher-label"
+              label="Primary teacher"
+              value={primaryTeacherId.value}
+              onChange={(e) => (primaryTeacherId.value = e.target.value)}
+            >
+              {instructors.length === 0 && (
+                <MenuItem value="" disabled>
+                  <em>No instructors available</em>
+                </MenuItem>
+              )}
+              {instructors.map((i) => (
+                <MenuItem key={i.id} value={i.id}>
+                  {i.name}
+                </MenuItem>
+              ))}
+            </Select>
+            <FormHelperText>
+              {getFieldError('primaryTeacherId') ??
+                'Individual lessons may record a substitute teacher.'}
+            </FormHelperText>
+          </FormControl>
+
+          {/* Registered lesson length (optional) */}
+          <FormControl
+            fullWidth
+            error={!!getFieldError('registeredLessonLength')}
+          >
+            <InputLabel id="student-lesson-length-label">
+              Registered lesson length
+            </InputLabel>
+            <Select
+              labelId="student-lesson-length-label"
+              label="Registered lesson length"
+              value={registeredLessonLength.value}
+              onChange={(e) =>
+                (registeredLessonLength.value = e.target.value as
+                  | LessonLength
+                  | '')
+              }
+            >
+              <MenuItem value="">
+                <em>Not set</em>
+              </MenuItem>
+              {LESSON_LENGTHS.map((len) => (
+                <MenuItem key={len} value={len}>
+                  {LESSON_LENGTH_LABELS[len]}
+                </MenuItem>
+              ))}
+            </Select>
+            <FormHelperText>
+              {getFieldError('registeredLessonLength') ??
+                'For tracking — not enforced on lessons or invoices.'}
+            </FormHelperText>
+          </FormControl>
+
+          {/* Flags */}
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={isAdultStudent.value}
+                  onChange={(e) => (isAdultStudent.value = e.target.checked)}
+                />
+              }
+              label="Adult student"
+            />
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={isHopeScholarship.value}
+                  onChange={(e) =>
+                    (isHopeScholarship.value = e.target.checked)
+                  }
+                />
+              }
+              label="Hope Scholarship (WV)"
+            />
+          </Box>
+
+          <Divider />
+
+          {/* Primary contact — section header reflects adult-student flag */}
+          <Typography variant="overline" color="text.secondary">
+            {isAdultStudent.value ? 'Contact' : 'Parent / guardian'}
+          </Typography>
+          <TextField
+            label="Primary contact name"
+            value={primaryContactName.value}
+            onChange={(e) => (primaryContactName.value = e.target.value)}
+            error={!!getFieldError('primaryContactName')}
+            helperText={getFieldError('primaryContactName')}
+            required
+            fullWidth
+          />
+          <TextField
+            label="Primary contact email"
+            type="email"
+            value={primaryContactEmail.value}
+            onChange={(e) => (primaryContactEmail.value = e.target.value)}
+            error={!!getFieldError('primaryContactEmail')}
+            helperText={getFieldError('primaryContactEmail')}
+            required
+            fullWidth
+          />
+          <TextField
+            label="Primary contact phone"
+            value={primaryContactPhone.value}
+            onChange={(e) => (primaryContactPhone.value = e.target.value)}
+            error={!!getFieldError('primaryContactPhone')}
+            helperText={getFieldError('primaryContactPhone') || 'Optional'}
+            fullWidth
+          />
+
+          <Divider />
+
+          {/* Secondary contact */}
+          <Typography variant="overline" color="text.secondary">
+            Secondary contact (optional)
+          </Typography>
+          <TextField
+            label="Secondary contact email"
+            type="email"
+            value={secondaryContactEmail.value}
+            onChange={(e) => (secondaryContactEmail.value = e.target.value)}
+            error={!!getFieldError('secondaryContactEmail')}
+            helperText={getFieldError('secondaryContactEmail')}
+            fullWidth
+          />
+          <TextField
+            label="Secondary contact phone"
+            value={secondaryContactPhone.value}
+            onChange={(e) => (secondaryContactPhone.value = e.target.value)}
+            error={!!getFieldError('secondaryContactPhone')}
+            helperText={getFieldError('secondaryContactPhone')}
+            fullWidth
+          />
+
+          <Divider />
+
+          {/* Status */}
+          <FormControl fullWidth error={!!getFieldError('status')}>
+            <InputLabel id="student-status-label">Status</InputLabel>
+            <Select
+              labelId="student-status-label"
+              label="Status"
+              value={status.value}
+              onChange={(e) =>
+                (status.value = e.target.value as StudentStatus)
+              }
+            >
+              <MenuItem value="active">Active</MenuItem>
+              <MenuItem value="inactive">Inactive</MenuItem>
+            </Select>
+            {getFieldError('status') && (
+              <FormHelperText>{getFieldError('status')}</FormHelperText>
+            )}
+          </FormControl>
+
+          {/* Notes */}
+          <TextField
+            label="Internal notes"
+            value={notes.value}
+            onChange={(e) => (notes.value = e.target.value)}
+            error={!!getFieldError('notes')}
+            helperText={getFieldError('notes') || 'Optional'}
+            multiline
+            rows={3}
+            fullWidth
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={isSubmitting}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? 'Saving...' : isEdit ? 'Update' : 'Add'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/libs/react/students/src/lib/StudentList.stories.tsx
+++ b/libs/react/students/src/lib/StudentList.stories.tsx
@@ -1,0 +1,168 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn, expect, userEvent, waitFor, within } from 'storybook/test';
+import { StudentList } from './StudentList';
+import {
+  mockStudent,
+  mockStudents,
+  mockStudentHope,
+  mockStudentInactive,
+  mockInstructor,
+  mockInstructor2,
+  mockInstructorPercentage,
+} from '../../../../../apps/maple-spruce/.storybook/fixtures';
+import type { RequestState, Student } from '@maple/ts/domain';
+
+const instructors = [mockInstructor, mockInstructor2, mockInstructorPercentage];
+
+const meta = {
+  component: StudentList,
+  title: 'Students/StudentList',
+  parameters: { layout: 'padded' },
+  args: {
+    onEdit: fn(),
+    onDelete: fn(),
+    instructors,
+  },
+} satisfies Meta<typeof StudentList>;
+
+export default meta;
+type Story = StoryObj<typeof StudentList>;
+
+// ============================================================
+// VISUAL STATES
+// ============================================================
+
+export const Idle: Story = {
+  args: {
+    studentsState: { status: 'idle' } as RequestState<Student[]>,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    studentsState: { status: 'loading' } as RequestState<Student[]>,
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    studentsState: {
+      status: 'error',
+      error: 'Failed to fetch students from the server.',
+    } as RequestState<Student[]>,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    studentsState: {
+      status: 'success',
+      data: [],
+    } as RequestState<Student[]>,
+  },
+};
+
+export const WithData: Story = {
+  args: {
+    studentsState: {
+      status: 'success',
+      data: mockStudents,
+    } as RequestState<Student[]>,
+  },
+};
+
+export const HopeStudentOnly: Story = {
+  args: {
+    studentsState: {
+      status: 'success',
+      data: [mockStudentHope],
+    } as RequestState<Student[]>,
+  },
+};
+
+export const InactiveStudent: Story = {
+  args: {
+    studentsState: {
+      status: 'success',
+      data: [mockStudentInactive],
+    } as RequestState<Student[]>,
+  },
+};
+
+// ============================================================
+// INTERACTION TESTS
+// ============================================================
+
+export const EditButtonCallsOnEdit: Story = {
+  args: {
+    studentsState: {
+      status: 'success',
+      data: [mockStudent],
+    } as RequestState<Student[]>,
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const editButton = canvas.getByRole('button', { name: /edit/i });
+    await userEvent.click(editButton);
+
+    await waitFor(() => {
+      expect(args.onEdit).toHaveBeenCalledTimes(1);
+      expect(args.onEdit).toHaveBeenCalledWith(mockStudent);
+    });
+  },
+};
+
+export const DeleteButtonCallsOnDelete: Story = {
+  args: {
+    studentsState: {
+      status: 'success',
+      data: [mockStudent],
+    } as RequestState<Student[]>,
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const deleteButton = canvas.getByRole('button', { name: /delete/i });
+    await userEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(args.onDelete).toHaveBeenCalledTimes(1);
+      expect(args.onDelete).toHaveBeenCalledWith(mockStudent);
+    });
+  },
+};
+
+export const HopeScholarshipChipRendered: Story = {
+  args: {
+    studentsState: {
+      status: 'success',
+      data: [mockStudentHope],
+    } as RequestState<Student[]>,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(() => {
+      expect(canvas.getByText(/Hope Scholarship/i)).toBeInTheDocument();
+    });
+  },
+};
+
+export const TeacherNameRenderedFromInstructors: Story = {
+  args: {
+    studentsState: {
+      status: 'success',
+      data: [mockStudent],
+    } as RequestState<Student[]>,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(() => {
+      expect(
+        canvas.getByText(new RegExp(`Teacher: ${mockInstructor.name}`))
+      ).toBeInTheDocument();
+    });
+  },
+};

--- a/libs/react/students/src/lib/StudentList.tsx
+++ b/libs/react/students/src/lib/StudentList.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  Chip,
+  IconButton,
+  Grid2 as Grid,
+  Skeleton,
+  Alert,
+} from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import StarsIcon from '@mui/icons-material/Stars';
+import type { Instructor, RequestState, Student } from '@maple/ts/domain';
+import { INSTRUMENT_LABELS, LESSON_LENGTH_LABELS } from './labels';
+
+interface StudentListProps {
+  studentsState: RequestState<Student[]>;
+  instructors: Instructor[];
+  onEdit: (student: Student) => void;
+  onDelete: (student: Student) => void;
+}
+
+const statusColors: Record<string, 'success' | 'default'> = {
+  active: 'success',
+  inactive: 'default',
+};
+
+function StudentCard({
+  student,
+  teacherName,
+  onEdit,
+  onDelete,
+}: {
+  student: Student;
+  teacherName: string;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <Card>
+      <CardContent>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+          }}
+        >
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Typography variant="h6" component="h3" noWrap>
+              {student.name}
+            </Typography>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ mb: 0.5 }}
+            >
+              {INSTRUMENT_LABELS[student.instrument]}
+              {student.registeredLessonLength &&
+                ` • ${LESSON_LENGTH_LABELS[student.registeredLessonLength]}`}
+            </Typography>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ mb: 0.5 }}
+            >
+              Teacher: {teacherName}
+            </Typography>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ mb: 1 }}
+              noWrap
+            >
+              {student.isAdultStudent ? 'Contact' : 'Parent/guardian'}:{' '}
+              {student.primaryContactName} · {student.primaryContactEmail}
+            </Typography>
+            <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+              <Chip
+                label={student.status}
+                size="small"
+                color={statusColors[student.status]}
+              />
+              {student.isHopeScholarship && (
+                <Chip
+                  label="Hope Scholarship"
+                  size="small"
+                  color="info"
+                  variant="outlined"
+                  icon={<StarsIcon />}
+                />
+              )}
+              {student.isAdultStudent && (
+                <Chip
+                  label="Adult"
+                  size="small"
+                  variant="outlined"
+                />
+              )}
+            </Box>
+          </Box>
+          <Box sx={{ display: 'flex', gap: 0.5 }}>
+            <IconButton onClick={onEdit} size="small" aria-label="Edit">
+              <EditIcon />
+            </IconButton>
+            <IconButton
+              onClick={onDelete}
+              size="small"
+              aria-label="Delete"
+              color="error"
+            >
+              <DeleteIcon />
+            </IconButton>
+          </Box>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <Grid container spacing={2}>
+      {[1, 2, 3].map((i) => (
+        <Grid size={{ xs: 12, sm: 6, md: 4 }} key={i}>
+          <Card>
+            <CardContent>
+              <Skeleton variant="text" width="60%" height={32} />
+              <Skeleton variant="text" width="80%" />
+              <Skeleton variant="text" width="50%" />
+              <Box sx={{ display: 'flex', gap: 1, mt: 1 }}>
+                <Skeleton variant="rounded" width={80} height={24} />
+              </Box>
+            </CardContent>
+          </Card>
+        </Grid>
+      ))}
+    </Grid>
+  );
+}
+
+export function StudentList({
+  studentsState,
+  instructors,
+  onEdit,
+  onDelete,
+}: StudentListProps) {
+  if (studentsState.status === 'loading') {
+    return <LoadingSkeleton />;
+  }
+
+  if (studentsState.status === 'error') {
+    return (
+      <Alert severity="error">
+        Failed to load students: {studentsState.error}
+      </Alert>
+    );
+  }
+
+  if (studentsState.status === 'idle') {
+    return null;
+  }
+
+  const students = studentsState.data;
+
+  if (students.length === 0) {
+    return (
+      <Box sx={{ textAlign: 'center', py: 8, color: 'text.secondary' }}>
+        <Typography variant="h6">No students yet</Typography>
+        <Typography>
+          Click &quot;Add Student&quot; to create the first record.
+        </Typography>
+      </Box>
+    );
+  }
+
+  const teacherNameById = new Map(
+    instructors.map((i) => [i.id, i.name])
+  );
+
+  return (
+    <Grid container spacing={2}>
+      {students.map((student) => (
+        <Grid size={{ xs: 12, sm: 6, md: 4 }} key={student.id}>
+          <StudentCard
+            student={student}
+            teacherName={
+              teacherNameById.get(student.primaryTeacherId) ?? 'Unassigned'
+            }
+            onEdit={() => onEdit(student)}
+            onDelete={() => onDelete(student)}
+          />
+        </Grid>
+      ))}
+    </Grid>
+  );
+}

--- a/libs/react/students/src/lib/labels.ts
+++ b/libs/react/students/src/lib/labels.ts
@@ -1,0 +1,24 @@
+import type { Instrument, LessonLength } from '@maple/ts/domain';
+
+export const INSTRUMENT_LABELS: Record<Instrument, string> = {
+  piano: 'Piano',
+  guitar: 'Guitar',
+  violin: 'Violin',
+  viola: 'Viola',
+  cello: 'Cello',
+  bass: 'Bass',
+  voice: 'Voice',
+  ukulele: 'Ukulele',
+  mandolin: 'Mandolin',
+  banjo: 'Banjo',
+  fiddle: 'Fiddle',
+  flute: 'Flute',
+  other: 'Other',
+};
+
+export const LESSON_LENGTH_LABELS: Record<LessonLength, string> = {
+  '30-min-initial': '30 min (initial)',
+  '30-min-full': '30 min (full)',
+  '45-min': '45 min',
+  '60-min': '60 min',
+};

--- a/libs/react/students/tsconfig.json
+++ b/libs/react/students/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "strict": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/react/students/tsconfig.lib.json
+++ b/libs/react/students/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts", "src/**/*.stories.tsx"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -252,6 +252,7 @@
         "libs/firebase/maple-functions/on-class-write/src/index.ts"
       ],
       "@maple/react/instructors": ["libs/react/instructors/src/index.ts"],
+      "@maple/react/students": ["libs/react/students/src/index.ts"],
       "@maple/react/classes": ["libs/react/classes/src/index.ts"],
       "@maple/react/discounts": ["libs/react/discounts/src/index.ts"],
       "@maple/react/registrations": ["libs/react/registrations/src/index.ts"],


### PR DESCRIPTION
## Summary

Closes #278. Ships the Katie-facing surface for the Student model landed in #288: a **student-first `/students` page**, dialog-based create/edit, list cards with Hope / Adult / status chips, and a new **"Music Lessons" nav group** in the admin shell.

## Stack

- **`libs/react/students`** — `StudentList`, `StudentForm`. StudentForm uses the Preact Signals idiom (`useSignals()` runtime hook, `useSignal`/`useComputed` per field, `batch` on reset) — matches the post-#287 pattern. Validation via the shared Vest `studentValidation` suite from #288 (no parallel frontend validation logic).
- **`useStudents` hook** in `@maple/react/data` — CRUD with optimistic local state, mirrors `useInstructors`.
- **Students page** in `apps/maple-spruce/src/app/students/page.tsx` — teacher dropdown fed by `useInstructors`; "Add Student" button is disabled with an inline hint when no instructors exist.
- **AppShellWrapper** — adds a "Music Lessons" nav group (will grow with #279 / #280 / #281).
- **Labels** — `INSTRUMENT_LABELS` and `LESSON_LENGTH_LABELS` for pretty display of the Student enums.
- **Storybook fixtures** — `mockStudent`, `mockStudentHope`, `mockStudentAdult`, `mockStudentInactive`, `mockStudentMinimal`.

## Testing

- [x] **24 Storybook interaction tests** pass via `vitest.storybook.config.ts` (Playwright/Chromium):
  - `StudentList`: edit/delete row buttons, Hope Scholarship chip rendering, teacher-name join from instructors prop
  - `StudentForm`: validation errors on empty submit, successful submission (with teacher dropdown selection), cancel, edit pre-populated, adult/minor section-header toggle, Hope Scholarship toggle, invalid email blocks submit
- [x] `tsc --noEmit` clean for `apps/maple-spruce` and `libs/react/students`
- [x] `nx lint` for `react-students` and `data` — net-same lint state as baseline (circular file chain between page.tsx and sibling stories is a pre-existing repo pattern on Instructor / Class / Registration; not introduced here)

## Notes

- Input labels stay static (\`Primary contact name/email/phone\`); the adult-vs-minor cue lives in the section header (`Parent / guardian` ↔ `Contact`) so the form layout stays stable across toggles.
- Not in this PR (future issues): lesson scheduling (#279), invoice initiation + delivery (#280/#281), Hope Scholarship behavioral rules (#282), teacher payouts (#283).

Closes #278
Part of #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)