### PR TITLE
refactor: migrate Vest suites to staticSuite and unify backend validation

### DIFF
--- a/.claude/rules/firebase-functions.md
+++ b/.claude/rules/firebase-functions.md
@@ -63,6 +63,57 @@ Functions.endpoint
   .handle<Req, Res>(async (data) => { ... });
 ```
 
+## Input Validation
+
+Cloud functions that mutate entities **MUST** validate input using the shared Vest suites from `@maple/ts/validation`. Suites are declared with `staticSuite` (never `create`) so they're pure functions — no retained state across invocations, safe to call from warm cloud function containers without `.reset()`.
+
+**Create pattern** — validate the full payload:
+
+```typescript
+import { createAdminFunction, throwValidationError } from '@maple/firebase/functions';
+import { classValidation } from '@maple/ts/validation';
+
+export const createClass = createAdminFunction<Req, Res>(async (data) => {
+  const result = classValidation(data);
+  if (result.hasErrors()) {
+    throwValidationError(result.getErrors());
+  }
+  // ...server-only validation (uniqueness, refs) and repository.create
+});
+```
+
+**Update (partial) pattern** — validate only the changed fields, using the existing record for cross-field context. Gate on `hasErrors()` (not `!isValid()`) because `only()` makes per-field `isValid()` unreliable:
+
+```typescript
+import {
+  createAdminFunction,
+  throwInvalidArgument,
+  throwNotFound,
+  throwValidationError,
+} from '@maple/firebase/functions';
+import { classValidation } from '@maple/ts/validation';
+
+export const updateClass = createAdminFunction<Req, Res>(async (data) => {
+  if (!data.id) throwInvalidArgument('Class ID is required');
+
+  const existing = await Repository.findById(data.id);
+  if (!existing) throwNotFound('Class', data.id);
+
+  const fields = Object.keys(data).filter((key) => key !== 'id');
+  if (fields.length > 0) {
+    const result = classValidation({ ...existing, ...data }, fields);
+    if (result.hasErrors()) {
+      throwValidationError(result.getErrors());
+    }
+  }
+  // ...repository.update
+});
+```
+
+**Error helpers** (`throwInvalidArgument`, `throwNotFound`, `throwValidationError`) live in `@maple/firebase/functions` (`errors.utility.ts`). They throw typed `HttpsError` codes — prefer them over bare `throw new Error(...)` so clients can discriminate failures.
+
+**Validation must run BEFORE any external writes** (Square, Webflow, payments). Invalid data must never reach external APIs and fail halfway through.
+
 ## Testing
 
 **Unit tests**: Use `vi.mock()` to mock repositories and external services. See ADR-017 for patterns.

--- a/apps/functions-integration-tests-discount/src/discount-functions.spec.ts
+++ b/apps/functions-integration-tests-discount/src/discount-functions.spec.ts
@@ -376,4 +376,160 @@ describe('Discount Functions', () => {
       expect(result.status).not.toBe(200);
     });
   });
+
+  describe('Update validation', () => {
+    let updateTargetId: string;
+    let collisionTargetCode: string;
+
+    beforeAll(async () => {
+      const [targetRes, collisionRes] = await Promise.all([
+        callFunction<CreatePercentDiscount, CreateDiscountResponse>({
+          functionName: 'createDiscount',
+          data: { ...PERCENT_DISCOUNT, code: 'UPD-TARGET' },
+          idToken: adminUser.idToken,
+        }),
+        callFunction<CreatePercentDiscount, CreateDiscountResponse>({
+          functionName: 'createDiscount',
+          data: { ...PERCENT_DISCOUNT, code: 'UPD-TAKEN' },
+          idToken: adminUser.idToken,
+        }),
+      ]);
+
+      updateTargetId = targetRes.data!.discount.id;
+      collisionTargetCode = collisionRes.data!.discount.code;
+    });
+
+    afterAll(async () => {
+      const res = await callFunction<GetDiscountsRequest, GetDiscountsResponse>(
+        {
+          functionName: 'getDiscounts',
+          idToken: adminUser.idToken,
+        }
+      );
+      const toDelete = (res.data?.discounts ?? []).filter((d) =>
+        ['UPD-TARGET', 'UPD-TAKEN', 'UPD-RENAMED'].includes(d.code)
+      );
+      await Promise.all(
+        toDelete.map((d) =>
+          callFunction<DeleteDiscountRequest>({
+            functionName: 'deleteDiscount',
+            data: { id: d.id },
+            idToken: adminUser.idToken,
+          })
+        )
+      );
+    });
+
+    it('should succeed when updating with valid partial payload', async () => {
+      const result = await callFunction<
+        UpdateDiscountRequest,
+        UpdateDiscountResponse
+      >({
+        functionName: 'updateDiscount',
+        data: {
+          id: updateTargetId,
+          description: 'Updated description via partial payload',
+        },
+        idToken: adminUser.idToken,
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.data?.discount.description).toBe(
+        'Updated description via partial payload'
+      );
+    });
+
+    it('should reject update with empty code', async () => {
+      const result = await callFunction<UpdateDiscountRequest>({
+        functionName: 'updateDiscount',
+        data: {
+          id: updateTargetId,
+          code: '',
+        },
+        idToken: adminUser.idToken,
+      });
+
+      expect(result.status).not.toBe(200);
+      const errorMessage =
+        typeof result.raw === 'object' &&
+        result.raw !== null &&
+        'error' in result.raw
+          ? ((result.raw as { error: { message?: string } }).error?.message ??
+            '')
+          : '';
+      expect(errorMessage).toMatch(/code/i);
+    });
+
+    it('should reject update with out-of-range percent', async () => {
+      const result = await callFunction<UpdateDiscountRequest>({
+        functionName: 'updateDiscount',
+        data: {
+          id: updateTargetId,
+          percent: -5,
+        },
+        idToken: adminUser.idToken,
+      });
+
+      expect(result.status).not.toBe(200);
+      const errorMessage =
+        typeof result.raw === 'object' &&
+        result.raw !== null &&
+        'error' in result.raw
+          ? ((result.raw as { error: { message?: string } }).error?.message ??
+            '')
+          : '';
+      expect(errorMessage).toMatch(/percent/i);
+    });
+
+    it('should reject update with invalid code characters', async () => {
+      const result = await callFunction<UpdateDiscountRequest>({
+        functionName: 'updateDiscount',
+        data: {
+          id: updateTargetId,
+          code: 'BAD CODE!',
+        },
+        idToken: adminUser.idToken,
+      });
+
+      expect(result.status).not.toBe(200);
+    });
+
+    it('should still reject code collision (DB-level uniqueness)', async () => {
+      const result = await callFunction<UpdateDiscountRequest>({
+        functionName: 'updateDiscount',
+        data: {
+          id: updateTargetId,
+          code: collisionTargetCode,
+        },
+        idToken: adminUser.idToken,
+      });
+
+      expect(result.status).not.toBe(200);
+      const errorMessage =
+        typeof result.raw === 'object' &&
+        result.raw !== null &&
+        'error' in result.raw
+          ? ((result.raw as { error: { message?: string } }).error?.message ??
+            '')
+          : '';
+      expect(errorMessage).toMatch(/already exists/i);
+    });
+
+    it('should allow renaming to a fresh code', async () => {
+      const result = await callFunction<
+        UpdateDiscountRequest,
+        UpdateDiscountResponse
+      >({
+        functionName: 'updateDiscount',
+        data: {
+          id: updateTargetId,
+          code: 'UPD-RENAMED',
+        },
+        idToken: adminUser.idToken,
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.data?.discount.code).toBe('UPD-RENAMED');
+    });
+  });
 });

--- a/apps/functions-integration-tests-registration/project.json
+++ b/apps/functions-integration-tests-registration/project.json
@@ -6,6 +6,7 @@
   "tags": ["type:e2e"],
   "implicitDependencies": [
     "firebase-maple-functions-calculate-registration-cost",
+    "firebase-maple-functions-update-registration",
     "firebase-integration-test-utils"
   ],
   "targets": {

--- a/apps/functions-integration-tests-registration/src/update-registration.spec.ts
+++ b/apps/functions-integration-tests-registration/src/update-registration.spec.ts
@@ -1,0 +1,228 @@
+/**
+ * Integration tests for updateRegistration Cloud Function.
+ *
+ * Seeds a registration directly into Firestore and exercises the admin
+ * update endpoint. Verifies that:
+ *  - Valid partial updates succeed and preserve unchanged fields.
+ *  - Invalid field values are rejected by the Vest `registrationValidation`
+ *    suite with an invalid-argument error.
+ *  - Non-existent registrations produce a not-found style error.
+ *  - Non-admin / unauthenticated callers are rejected before validation.
+ */
+import {
+  createTestUser,
+  clearAuthEmulator,
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  callFunction,
+} from '@maple/firebase/integration-test-utils';
+import type { TestUser } from '@maple/firebase/integration-test-utils';
+import {
+  ADMIN_USER,
+  NON_ADMIN_USER,
+} from '@maple/firebase/integration-test-utils';
+import type {
+  UpdateRegistrationRequest,
+  UpdateRegistrationResponse,
+} from '@maple/ts/firebase/api-types';
+
+const REGISTRATION_ID = 'test-reg-update-1';
+const CLASS_ID = 'test-reg-update-class';
+
+const BASE_REGISTRATION = {
+  classId: CLASS_ID,
+  customerEmail: 'original@test.com',
+  customerName: 'Original Customer',
+  customerPhone: '+1 304-555-0100',
+  quantity: 1,
+  pricePaidCents: 4770,
+  subtotalCents: 4500,
+  taxAmountCents: 270,
+  taxRatePercent: 6.0,
+  status: 'confirmed',
+  notes: 'Original notes',
+  confirmationNumber: 'MS-ABC123',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+describe('updateRegistration', () => {
+  let adminUser: TestUser;
+  let nonAdminUser: TestUser;
+
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+
+    adminUser = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
+    nonAdminUser = await createTestUser(
+      NON_ADMIN_USER.email,
+      NON_ADMIN_USER.password
+    );
+
+    await setFirestoreDoc('admins', adminUser.uid, {
+      userId: adminUser.uid,
+      email: adminUser.email,
+    });
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  beforeEach(async () => {
+    // Re-seed the registration before each test so mutations don't leak.
+    await setFirestoreDoc('registrations', REGISTRATION_ID, BASE_REGISTRATION);
+  });
+
+  describe('Auth guard', () => {
+    it('should reject unauthenticated requests', async () => {
+      const result = await callFunction<UpdateRegistrationRequest>({
+        functionName: 'updateRegistration',
+        data: { id: REGISTRATION_ID, status: 'no-show' },
+      });
+      expect(result.status).not.toBe(200);
+    });
+
+    it('should reject non-admin users', async () => {
+      const result = await callFunction<UpdateRegistrationRequest>({
+        functionName: 'updateRegistration',
+        data: { id: REGISTRATION_ID, status: 'no-show' },
+        idToken: nonAdminUser.idToken,
+      });
+      expect(result.status).not.toBe(200);
+    });
+  });
+
+  describe('Happy path', () => {
+    it('should update status alone without requiring other fields', async () => {
+      const result = await callFunction<
+        UpdateRegistrationRequest,
+        UpdateRegistrationResponse
+      >({
+        functionName: 'updateRegistration',
+        data: { id: REGISTRATION_ID, status: 'no-show' },
+        idToken: adminUser.idToken,
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.data?.registration.status).toBe('no-show');
+      expect(result.data?.registration.customerEmail).toBe(
+        BASE_REGISTRATION.customerEmail
+      );
+      expect(result.data?.registration.customerName).toBe(
+        BASE_REGISTRATION.customerName
+      );
+    });
+
+    it('should update notes alone', async () => {
+      const result = await callFunction<
+        UpdateRegistrationRequest,
+        UpdateRegistrationResponse
+      >({
+        functionName: 'updateRegistration',
+        data: {
+          id: REGISTRATION_ID,
+          notes: 'Customer requested a window seat.',
+        },
+        idToken: adminUser.idToken,
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.data?.registration.notes).toBe(
+        'Customer requested a window seat.'
+      );
+    });
+
+    it('should update customerName with valid value', async () => {
+      const result = await callFunction<
+        UpdateRegistrationRequest,
+        UpdateRegistrationResponse
+      >({
+        functionName: 'updateRegistration',
+        data: { id: REGISTRATION_ID, customerName: 'Updated Customer' },
+        idToken: adminUser.idToken,
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.data?.registration.customerName).toBe('Updated Customer');
+    });
+  });
+
+  describe('Validation (Vest suite)', () => {
+    it('should reject invalid customerEmail', async () => {
+      const result = await callFunction<UpdateRegistrationRequest>({
+        functionName: 'updateRegistration',
+        data: { id: REGISTRATION_ID, customerEmail: 'not-an-email' },
+        idToken: adminUser.idToken,
+      });
+      expect(result.status).not.toBe(200);
+    });
+
+    it('should reject customerName that is too short', async () => {
+      const result = await callFunction<UpdateRegistrationRequest>({
+        functionName: 'updateRegistration',
+        data: { id: REGISTRATION_ID, customerName: 'A' },
+        idToken: adminUser.idToken,
+      });
+      expect(result.status).not.toBe(200);
+    });
+
+    it('should reject quantity greater than 10', async () => {
+      const result = await callFunction<UpdateRegistrationRequest>({
+        functionName: 'updateRegistration',
+        data: { id: REGISTRATION_ID, quantity: 42 },
+        idToken: adminUser.idToken,
+      });
+      expect(result.status).not.toBe(200);
+    });
+
+    it('should reject quantity less than 1', async () => {
+      const result = await callFunction<UpdateRegistrationRequest>({
+        functionName: 'updateRegistration',
+        data: { id: REGISTRATION_ID, quantity: 0 },
+        idToken: adminUser.idToken,
+      });
+      expect(result.status).not.toBe(200);
+    });
+
+    it('should reject notes longer than 500 characters', async () => {
+      const result = await callFunction<UpdateRegistrationRequest>({
+        functionName: 'updateRegistration',
+        data: { id: REGISTRATION_ID, notes: 'x'.repeat(501) },
+        idToken: adminUser.idToken,
+      });
+      expect(result.status).not.toBe(200);
+    });
+
+    it('should reject invalid customerPhone', async () => {
+      const result = await callFunction<UpdateRegistrationRequest>({
+        functionName: 'updateRegistration',
+        data: { id: REGISTRATION_ID, customerPhone: 'abc' },
+        idToken: adminUser.idToken,
+      });
+      expect(result.status).not.toBe(200);
+    });
+  });
+
+  describe('Not found', () => {
+    it('should reject update for a non-existent registration', async () => {
+      const result = await callFunction<UpdateRegistrationRequest>({
+        functionName: 'updateRegistration',
+        data: { id: 'does-not-exist', status: 'no-show' },
+        idToken: adminUser.idToken,
+      });
+      expect(result.status).not.toBe(200);
+    });
+
+    it('should reject missing id', async () => {
+      const result = await callFunction<Partial<UpdateRegistrationRequest>>({
+        functionName: 'updateRegistration',
+        data: { status: 'no-show' },
+        idToken: adminUser.idToken,
+      });
+      expect(result.status).not.toBe(200);
+    });
+  });
+});

--- a/apps/functions-integration-tests-square/src/cancel-registration.spec.ts
+++ b/apps/functions-integration-tests-square/src/cancel-registration.spec.ts
@@ -1,0 +1,225 @@
+/**
+ * Integration tests for cancelRegistration Cloud Function.
+ *
+ * Uses the mock HTTP server for Square refund API calls. Seeds a
+ * registration directly into Firestore and exercises:
+ *  - Auth guard (non-admin rejected)
+ *  - Happy path cancel without refund
+ *  - Happy path cancel with refund (hits mock Square /v2/refunds)
+ *  - Domain guards: invalid argument (missing id), not-found,
+ *    failed-precondition (already cancelled / refunded),
+ *    failed-precondition when refund requested on refund-ineligible status.
+ */
+import {
+  createTestUser,
+  clearAuthEmulator,
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  callFunction,
+} from '@maple/firebase/integration-test-utils';
+import type { TestUser } from '@maple/firebase/integration-test-utils';
+import {
+  ADMIN_USER,
+  NON_ADMIN_USER,
+} from '@maple/firebase/integration-test-utils';
+import type {
+  CancelRegistrationRequest,
+  CancelRegistrationResponse,
+} from '@maple/ts/firebase/api-types';
+
+const CLASS_ID = 'test-cancel-class';
+
+function baseRegistration(overrides: Record<string, unknown> = {}) {
+  return {
+    classId: CLASS_ID,
+    customerEmail: 'cancel@test.com',
+    customerName: 'Cancel Customer',
+    quantity: 1,
+    pricePaidCents: 4770,
+    subtotalCents: 4500,
+    taxAmountCents: 270,
+    taxRatePercent: 6.0,
+    status: 'confirmed',
+    confirmationNumber: 'MS-CAN001',
+    squarePaymentId: 'mock-payment-1',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('cancelRegistration', () => {
+  let adminUser: TestUser;
+  let nonAdminUser: TestUser;
+
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+
+    adminUser = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
+    nonAdminUser = await createTestUser(
+      NON_ADMIN_USER.email,
+      NON_ADMIN_USER.password
+    );
+
+    await setFirestoreDoc('admins', adminUser.uid, {
+      userId: adminUser.uid,
+      email: adminUser.email,
+    });
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  describe('Auth guard', () => {
+    it('should reject unauthenticated requests', async () => {
+      await setFirestoreDoc(
+        'registrations',
+        'auth-test-1',
+        baseRegistration()
+      );
+      const result = await callFunction<CancelRegistrationRequest>({
+        functionName: 'cancelRegistration',
+        data: { id: 'auth-test-1' },
+      });
+      expect(result.status).not.toBe(200);
+    });
+
+    it('should reject non-admin users', async () => {
+      await setFirestoreDoc(
+        'registrations',
+        'auth-test-2',
+        baseRegistration()
+      );
+      const result = await callFunction<CancelRegistrationRequest>({
+        functionName: 'cancelRegistration',
+        data: { id: 'auth-test-2' },
+        idToken: nonAdminUser.idToken,
+      });
+      expect(result.status).not.toBe(200);
+    });
+  });
+
+  describe('Domain guards', () => {
+    it('should reject missing id (invalid-argument)', async () => {
+      const result = await callFunction<Partial<CancelRegistrationRequest>>({
+        functionName: 'cancelRegistration',
+        data: {},
+        idToken: adminUser.idToken,
+      });
+      expect(result.status).not.toBe(200);
+    });
+
+    it('should reject non-existent registration (not-found)', async () => {
+      const result = await callFunction<CancelRegistrationRequest>({
+        functionName: 'cancelRegistration',
+        data: { id: 'does-not-exist' },
+        idToken: adminUser.idToken,
+      });
+      expect(result.status).not.toBe(200);
+    });
+
+    it('should reject cancel on already-cancelled registration', async () => {
+      await setFirestoreDoc(
+        'registrations',
+        'already-cancelled',
+        baseRegistration({ status: 'cancelled' })
+      );
+      const result = await callFunction<CancelRegistrationRequest>({
+        functionName: 'cancelRegistration',
+        data: { id: 'already-cancelled' },
+        idToken: adminUser.idToken,
+      });
+      expect(result.status).not.toBe(200);
+    });
+
+    it('should reject cancel on already-refunded registration', async () => {
+      await setFirestoreDoc(
+        'registrations',
+        'already-refunded',
+        baseRegistration({ status: 'refunded' })
+      );
+      const result = await callFunction<CancelRegistrationRequest>({
+        functionName: 'cancelRegistration',
+        data: { id: 'already-refunded' },
+        idToken: adminUser.idToken,
+      });
+      expect(result.status).not.toBe(200);
+    });
+  });
+
+  describe('Happy path', () => {
+    it('should cancel a confirmed registration without refund', async () => {
+      await setFirestoreDoc(
+        'registrations',
+        'cancel-no-refund',
+        baseRegistration()
+      );
+
+      const result = await callFunction<
+        CancelRegistrationRequest,
+        CancelRegistrationResponse
+      >({
+        functionName: 'cancelRegistration',
+        data: { id: 'cancel-no-refund' },
+        idToken: adminUser.idToken,
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.data?.registration.status).toBe('cancelled');
+      expect(result.data?.refundId).toBeUndefined();
+    });
+
+    it('should cancel and refund a confirmed registration with payment', async () => {
+      await setFirestoreDoc(
+        'registrations',
+        'cancel-with-refund',
+        baseRegistration({ squarePaymentId: 'mock-payment-refund-1' })
+      );
+
+      const result = await callFunction<
+        CancelRegistrationRequest,
+        CancelRegistrationResponse
+      >({
+        functionName: 'cancelRegistration',
+        data: { id: 'cancel-with-refund', refund: true },
+        idToken: adminUser.idToken,
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.data?.registration.status).toBe('refunded');
+      expect(result.data?.refundId).toBeDefined();
+      expect(result.data?.refundId).toMatch(/^mock-refund-/);
+    });
+
+    it('should cancel without refund when refund=true but no squarePaymentId', async () => {
+      // Free registration — no payment to refund. The function still
+      // cancels successfully (refund branch is skipped).
+      await setFirestoreDoc(
+        'registrations',
+        'cancel-free',
+        baseRegistration({
+          squarePaymentId: undefined,
+          pricePaidCents: 0,
+          subtotalCents: 0,
+          taxAmountCents: 0,
+        })
+      );
+
+      const result = await callFunction<
+        CancelRegistrationRequest,
+        CancelRegistrationResponse
+      >({
+        functionName: 'cancelRegistration',
+        data: { id: 'cancel-free', refund: true },
+        idToken: adminUser.idToken,
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.data?.registration.status).toBe('cancelled');
+      expect(result.data?.refundId).toBeUndefined();
+    });
+  });
+});

--- a/docs/architecture/PATTERNS-AND-PRACTICES.md
+++ b/docs/architecture/PATTERNS-AND-PRACTICES.md
@@ -796,13 +796,16 @@ export default function Error({
 
 Use [Vest](https://vestjs.dev/) for declarative validation that can be shared between client and server.
 
+**Always use `staticSuite`, never `create`.** Suites declared with `staticSuite` are pure functions: each call returns an independent `SuiteResult` with no retained state. Suites declared with `create` are stateful — results from prior calls can leak into subsequent runs, which breaks reactive computeds in the client and bleeds state across requests in warm cloud function containers. Stateful suites force every callsite to manage `.reset()` defensively; stateless suites just work.
+
 ```typescript
 // libs/ts/validation/src/artist.validation.ts
-import { create, test, enforce, only } from 'vest';
+import { staticSuite, test, enforce, only } from 'vest';
 import type { CreateArtistInput } from '@maple/ts/domain';
 
-export const artistValidation = create((data: Partial<CreateArtistInput>, field?: string) => {
-    only(field); // Only validate specific field if provided
+export const artistValidation = staticSuite(
+  (data: Partial<CreateArtistInput>, field?: string | string[]) => {
+    only(field); // Scope to one field (string) or a list of fields (string[])
 
     test('name', 'Name is required', () => {
         enforce(data.name).isNotBlank();
@@ -825,7 +828,8 @@ export const artistValidation = create((data: Partial<CreateArtistInput>, field?
             enforce(data.defaultCommissionRate).isBetween(0, 1);
         }
     });
-});
+  }
+);
 ```
 
 ### Shared Validation Pattern (Client + Server)
@@ -888,32 +892,71 @@ function ClassForm({ onSubmit }) {
 }
 ```
 
-**Backend Cloud Function Pattern:**
+**Backend Cloud Function — Create Pattern:**
 
 ```typescript
 // create-class.ts
-import { createAdminFunction } from '@maple/firebase/functions';
+import {
+  createAdminFunction,
+  throwValidationError,
+} from '@maple/firebase/functions';
 import { classValidation } from '@maple/ts/validation';
 
 export const createClass = createAdminFunction<CreateClassRequest, CreateClassResponse>(
   async (data) => {
-    // Same validation suite as frontend
     const result = classValidation(data);
-    if (!result.isValid()) {
-      const errors = result.getErrors();
-      const errorMessages = Object.entries(errors)
-        .map(([field, msgs]) => `${field}: ${msgs.join(', ')}`)
-        .join('; ');
-      throw new Error(`Validation failed: ${errorMessages}`);
+    if (result.hasErrors()) {
+      throwValidationError(result.getErrors());
     }
 
-    // Additional server-only validations (e.g., uniqueness checks)
+    // Server-only validations (uniqueness, referential integrity, etc.)
     const existing = await Repository.findByEmail(data.email);
     if (existing) {
       throw new Error(`An item with email ${data.email} already exists`);
     }
 
     return await Repository.create(data);
+  }
+);
+```
+
+**Backend Cloud Function — Update (Partial) Pattern:**
+
+Partial updates validate only the fields the caller sent, using the existing record as context for cross-field rules. Always gate on `hasErrors()` — when `only()` scopes validation to a subset of fields, the top-level `isValid()` is unreliable because skipped fields report as invalid at the per-field level.
+
+```typescript
+// update-class.ts
+import {
+  createAdminFunction,
+  throwInvalidArgument,
+  throwNotFound,
+  throwValidationError,
+} from '@maple/firebase/functions';
+import { classValidation } from '@maple/ts/validation';
+
+export const updateClass = createAdminFunction<UpdateClassRequest, UpdateClassResponse>(
+  async (data) => {
+    if (!data.id) {
+      throwInvalidArgument('Class ID is required');
+    }
+
+    const existing = await Repository.findById(data.id);
+    if (!existing) {
+      throwNotFound('Class', data.id);
+    }
+
+    const fields = Object.keys(data).filter((key) => key !== 'id');
+    if (fields.length > 0) {
+      // Merge existing + data so cross-field rules (e.g. discount type-conditional)
+      // have context. Pass `fields` to only() so unrelated required checks don't
+      // fail a partial update.
+      const result = classValidation({ ...existing, ...data }, fields);
+      if (result.hasErrors()) {
+        throwValidationError(result.getErrors());
+      }
+    }
+
+    return await Repository.update(data);
   }
 );
 ```

--- a/docs/architecture/SOL-PATTERNS-REFERENCE.md
+++ b/docs/architecture/SOL-PATTERNS-REFERENCE.md
@@ -312,10 +312,13 @@ SOL uses [Vest](https://vestjs.dev/) for declarative validation with suite defin
 ### Pattern
 
 ```typescript
-import { create, test, enforce, only } from 'vest';
+import { staticSuite, test, enforce, only } from 'vest';
 
-export const artistValidation = create((data: Partial<Artist>, field?: string) => {
-    only(field); // Only validate specific field if provided
+// Always use staticSuite (never create) — each call returns a fresh,
+// independent result with no retained state. See PATTERNS-AND-PRACTICES.md.
+export const artistValidation = staticSuite(
+  (data: Partial<Artist>, field?: string | string[]) => {
+    only(field); // Scope to a single field or a list of fields
 
     test('name', 'Name is required', () => {
         enforce(data.name).isNotBlank();
@@ -332,7 +335,8 @@ export const artistValidation = create((data: Partial<Artist>, field?: string) =
     test('commissionRate', 'Commission rate must be between 0 and 1', () => {
         enforce(data.commissionRate).isBetween(0, 1);
     });
-});
+  }
+);
 
 // Usage in component
 const result = artistValidation(formData);

--- a/libs/firebase/maple-functions/cancel-registration/src/lib/cancel-registration.ts
+++ b/libs/firebase/maple-functions/cancel-registration/src/lib/cancel-registration.ts
@@ -4,7 +4,13 @@
  * Admin-only endpoint for cancelling a registration with optional Square refund.
  * Deployed to us-east4 via CI/CD pipeline.
  */
-import { Functions, Role } from '@maple/firebase/functions';
+import {
+  Functions,
+  Role,
+  throwFailedPrecondition,
+  throwInvalidArgument,
+  throwNotFound,
+} from '@maple/firebase/functions';
 import { RegistrationRepository } from '@maple/firebase/database';
 import {
   Square,
@@ -23,14 +29,19 @@ export const cancelRegistration = Functions.endpoint
   .requiringRole(Role.Admin)
   .handle<CancelRegistrationRequest, CancelRegistrationResponse>(
     async (data, _context, secrets, strings) => {
+      // The `registrationValidation` Vest suite covers registration form
+      // fields (classId, customerName/Email/Phone, quantity, notes). None
+      // of those are part of the cancel payload ({id, refund?}), so the
+      // suite is not applicable here — the entity was already validated
+      // when it was created. We keep narrow type/status guards instead.
       if (!data.id) {
-        throw new Error('Registration ID is required');
+        throwInvalidArgument('Registration ID is required');
       }
 
       // Look up the registration
       const registration = await RegistrationRepository.findById(data.id);
       if (!registration) {
-        throw new Error(`Registration not found: ${data.id}`);
+        throwNotFound('Registration', data.id);
       }
 
       // Check if already cancelled/refunded
@@ -38,7 +49,7 @@ export const cancelRegistration = Functions.endpoint
         registration.status === 'cancelled' ||
         registration.status === 'refunded'
       ) {
-        throw new Error(
+        throwFailedPrecondition(
           `Registration is already ${registration.status}`
         );
       }
@@ -48,7 +59,7 @@ export const cancelRegistration = Functions.endpoint
       // Process refund if requested and payment exists
       if (data.refund && registration.squarePaymentId) {
         if (!canRefundRegistration(registration)) {
-          throw new Error(
+          throwFailedPrecondition(
             `Cannot refund a registration with status '${registration.status}'`
           );
         }

--- a/libs/firebase/maple-functions/update-discount/src/lib/update-discount.ts
+++ b/libs/firebase/maple-functions/update-discount/src/lib/update-discount.ts
@@ -5,8 +5,14 @@
  * Admin-only endpoint.
  * Deployed to us-east4 via CI/CD pipeline.
  */
-import { createAdminFunction } from '@maple/firebase/functions';
+import {
+  createAdminFunction,
+  throwInvalidArgument,
+  throwNotFound,
+  throwValidationError,
+} from '@maple/firebase/functions';
 import { DiscountRepository } from '@maple/firebase/database';
+import { discountValidation } from '@maple/ts/validation';
 import type {
   UpdateDiscountRequest,
   UpdateDiscountResponse,
@@ -17,16 +23,22 @@ export const updateDiscount = createAdminFunction<
   UpdateDiscountResponse
 >(async (data) => {
   if (!data.id) {
-    throw new Error('Discount ID is required');
+    throwInvalidArgument('Discount ID is required');
   }
 
-  // Check if discount exists
   const existing = await DiscountRepository.findById(data.id);
   if (!existing) {
-    throw new Error(`Discount not found: ${data.id}`);
+    throwNotFound('Discount', data.id);
   }
 
-  // If code is changing, check for uniqueness
+  const fields = Object.keys(data).filter((key) => key !== 'id');
+  if (fields.length > 0) {
+    const result = discountValidation({ ...existing, ...data }, fields);
+    if (result.hasErrors()) {
+      throwValidationError(result.getErrors());
+    }
+  }
+
   if (data.code && data.code.toUpperCase() !== existing.code) {
     const codeExists = await DiscountRepository.findByCode(data.code);
     if (codeExists) {

--- a/libs/firebase/maple-functions/update-product/src/lib/update-product.ts
+++ b/libs/firebase/maple-functions/update-product/src/lib/update-product.ts
@@ -12,13 +12,19 @@
  * For quantity changes:
  * - Updates Square Inventory API, then updates Firestore cache
  */
-import { Functions, Role, throwNotFound } from '@maple/firebase/functions';
+import {
+  Functions,
+  Role,
+  throwNotFound,
+  throwValidationError,
+} from '@maple/firebase/functions';
 import { ProductRepository } from '@maple/firebase/database';
 import {
   Square,
   SQUARE_SECRET_NAMES,
   SQUARE_STRING_NAMES,
 } from '@maple/firebase/square';
+import { productValidation } from '@maple/ts/validation';
 import type {
   UpdateProductRequest,
   UpdateProductResponse,
@@ -30,25 +36,19 @@ export const updateProduct = Functions.endpoint
   .requiringRole(Role.Admin)
   .handle<UpdateProductRequest, UpdateProductResponse>(
     async (data, _context, secrets, strings) => {
-      // Check product exists
       const existing = await ProductRepository.findById(data.id);
       if (!existing) {
         throwNotFound('Product', data.id);
       }
 
-      // Validate Firestore-owned fields
-      if (
-        data.status &&
-        !['active', 'draft', 'discontinued'].includes(data.status)
-      ) {
-        throw new Error('Status must be active, draft, or discontinued');
-      }
-
-      if (
-        data.customCommissionRate !== undefined &&
-        (data.customCommissionRate < 0 || data.customCommissionRate > 1)
-      ) {
-        throw new Error('Commission rate must be between 0 and 1');
+      // Validation must run before any Square writes — invalid data must
+      // never reach Square and fail halfway through.
+      const fields = Object.keys(data).filter((key) => key !== 'id');
+      if (fields.length > 0) {
+        const result = productValidation({ ...existing, ...data }, fields);
+        if (result.hasErrors()) {
+          throwValidationError(result.getErrors());
+        }
       }
 
       // Check if any Square-owned fields are being updated

--- a/libs/firebase/maple-functions/update-registration/src/lib/update-registration.ts
+++ b/libs/firebase/maple-functions/update-registration/src/lib/update-registration.ts
@@ -5,8 +5,14 @@
  * Admin-only endpoint.
  * Deployed to us-east4 via CI/CD pipeline.
  */
-import { createAdminFunction } from '@maple/firebase/functions';
+import {
+  createAdminFunction,
+  throwInvalidArgument,
+  throwNotFound,
+  throwValidationError,
+} from '@maple/firebase/functions';
 import { RegistrationRepository } from '@maple/firebase/database';
+import { registrationValidation } from '@maple/ts/validation';
 import type {
   UpdateRegistrationRequest,
   UpdateRegistrationResponse,
@@ -17,13 +23,23 @@ export const updateRegistration = createAdminFunction<
   UpdateRegistrationResponse
 >(async (data) => {
   if (!data.id) {
-    throw new Error('Registration ID is required');
+    throwInvalidArgument('Registration ID is required');
   }
 
-  // Check if registration exists
   const existing = await RegistrationRepository.findById(data.id);
   if (!existing) {
-    throw new Error(`Registration not found: ${data.id}`);
+    throwNotFound('Registration', data.id);
+  }
+
+  const fields = Object.keys(data).filter((key) => key !== 'id');
+  if (fields.length > 0) {
+    const result = registrationValidation(
+      { ...existing, ...data },
+      fields
+    );
+    if (result.hasErrors()) {
+      throwValidationError(result.getErrors());
+    }
   }
 
   const registration = await RegistrationRepository.update(data);

--- a/libs/firebase/maple-functions/upload-artist-image/src/lib/upload-artist-image.ts
+++ b/libs/firebase/maple-functions/upload-artist-image/src/lib/upload-artist-image.ts
@@ -7,22 +7,17 @@
  * Images are stored in Firebase Storage and made publicly accessible.
  * The returned URL can be stored in the artist's photoUrl field.
  */
-import { createAdminFunction, FirebaseProject } from '@maple/firebase/functions';
+import {
+  createAdminFunction,
+  FirebaseProject,
+  throwValidationError,
+} from '@maple/firebase/functions';
+import { imageUploadValidation } from '@maple/ts/validation';
 import admin from 'firebase-admin';
 import type {
   UploadArtistImageRequest,
   UploadArtistImageResponse,
 } from '@maple/ts/firebase/api-types';
-
-/**
- * Allowed image MIME types for artist photos
- */
-const ALLOWED_IMAGE_TYPES = [
-  'image/jpeg',
-  'image/png',
-  'image/webp',
-  'image/gif',
-];
 
 export const uploadArtistImage = createAdminFunction<
   UploadArtistImageRequest,
@@ -30,16 +25,9 @@ export const uploadArtistImage = createAdminFunction<
 >(async (data) => {
   const { artistId, imageBase64, contentType } = data;
 
-  // Validate image data
-  if (!imageBase64) {
-    throw new Error('imageBase64 is required');
-  }
-
-  // Validate content type
-  if (!ALLOWED_IMAGE_TYPES.includes(contentType)) {
-    throw new Error(
-      `Invalid content type. Allowed: ${ALLOWED_IMAGE_TYPES.join(', ')}`
-    );
+  const validation = imageUploadValidation({ imageBase64, contentType });
+  if (validation.hasErrors()) {
+    throwValidationError(validation.getErrors());
   }
 
   // Get Firebase Storage bucket for current project

--- a/libs/firebase/maple-functions/upload-class-image/src/lib/upload-class-image.ts
+++ b/libs/firebase/maple-functions/upload-class-image/src/lib/upload-class-image.ts
@@ -10,22 +10,14 @@
 import {
   createAdminFunction,
   FirebaseProject,
+  throwValidationError,
 } from '@maple/firebase/functions';
+import { imageUploadValidation } from '@maple/ts/validation';
 import admin from 'firebase-admin';
 import type {
   UploadClassImageRequest,
   UploadClassImageResponse,
 } from '@maple/ts/firebase/api-types';
-
-/**
- * Allowed image MIME types for class photos
- */
-const ALLOWED_IMAGE_TYPES = [
-  'image/jpeg',
-  'image/png',
-  'image/webp',
-  'image/gif',
-];
 
 export const uploadClassImage = createAdminFunction<
   UploadClassImageRequest,
@@ -33,16 +25,9 @@ export const uploadClassImage = createAdminFunction<
 >(async (data) => {
   const { classId, imageBase64, contentType } = data;
 
-  // Validate image data
-  if (!imageBase64) {
-    throw new Error('imageBase64 is required');
-  }
-
-  // Validate content type
-  if (!ALLOWED_IMAGE_TYPES.includes(contentType)) {
-    throw new Error(
-      `Invalid content type. Allowed: ${ALLOWED_IMAGE_TYPES.join(', ')}`
-    );
+  const validation = imageUploadValidation({ imageBase64, contentType });
+  if (validation.hasErrors()) {
+    throwValidationError(validation.getErrors());
   }
 
   // Get Firebase Storage bucket for current project

--- a/libs/firebase/maple-functions/upload-instructor-image/src/lib/upload-instructor-image.ts
+++ b/libs/firebase/maple-functions/upload-instructor-image/src/lib/upload-instructor-image.ts
@@ -5,22 +5,17 @@
  * Images are stored in Firebase Storage and made publicly accessible.
  * The returned URL can be stored in the instructor's photoUrl field.
  */
-import { createAdminFunction, FirebaseProject } from '@maple/firebase/functions';
+import {
+  createAdminFunction,
+  FirebaseProject,
+  throwValidationError,
+} from '@maple/firebase/functions';
+import { imageUploadValidation } from '@maple/ts/validation';
 import admin from 'firebase-admin';
 import type {
   UploadInstructorImageRequest,
   UploadInstructorImageResponse,
 } from '@maple/ts/firebase/api-types';
-
-/**
- * Allowed image MIME types for instructor photos
- */
-const ALLOWED_IMAGE_TYPES = [
-  'image/jpeg',
-  'image/png',
-  'image/webp',
-  'image/gif',
-];
 
 export const uploadInstructorImage = createAdminFunction<
   UploadInstructorImageRequest,
@@ -28,16 +23,9 @@ export const uploadInstructorImage = createAdminFunction<
 >(async (data) => {
   const { instructorId, imageBase64, contentType } = data;
 
-  // Validate image data
-  if (!imageBase64) {
-    throw new Error('imageBase64 is required');
-  }
-
-  // Validate content type
-  if (!ALLOWED_IMAGE_TYPES.includes(contentType)) {
-    throw new Error(
-      `Invalid content type. Allowed: ${ALLOWED_IMAGE_TYPES.join(', ')}`
-    );
+  const validation = imageUploadValidation({ imageBase64, contentType });
+  if (validation.hasErrors()) {
+    throwValidationError(validation.getErrors());
   }
 
   // Get Firebase Storage bucket for current project

--- a/libs/firebase/maple-functions/upload-product-image/src/lib/upload-product-image.ts
+++ b/libs/firebase/maple-functions/upload-product-image/src/lib/upload-product-image.ts
@@ -12,32 +12,36 @@
  * 2. Upload image to Square via Catalog API
  * 3. Update Firestore cache with the new image URL
  */
-import { Functions, Role } from '@maple/firebase/functions';
+import {
+  Functions,
+  Role,
+  throwInvalidArgument,
+  throwNotFound,
+  throwValidationError,
+} from '@maple/firebase/functions';
 import { ProductRepository } from '@maple/firebase/database';
 import {
   Square,
   SQUARE_SECRET_NAMES,
   SQUARE_STRING_NAMES,
 } from '@maple/firebase/square';
+import { imageUploadValidation } from '@maple/ts/validation';
 import type {
   UploadProductImageRequest,
   UploadProductImageResponse,
 } from '@maple/ts/firebase/api-types';
 
 /**
- * Allowed image MIME types (matches Square's supported formats)
+ * Square's Catalog API rejects webp and caps images at 15MB, so we override
+ * the default allowlist + max size for product uploads.
  */
-const ALLOWED_IMAGE_TYPES = [
+const SQUARE_ALLOWED_IMAGE_TYPES = [
   'image/jpeg',
   'image/pjpeg',
   'image/png',
   'image/gif',
-];
-
-/**
- * Max file size: 15MB (Square's limit)
- */
-const MAX_IMAGE_SIZE_BYTES = 15 * 1024 * 1024;
+] as const;
+const SQUARE_MAX_IMAGE_BYTES = 15 * 1024 * 1024;
 
 export const uploadProductImage = Functions.endpoint
   .usingSecrets(...SQUARE_SECRET_NAMES)
@@ -47,36 +51,23 @@ export const uploadProductImage = Functions.endpoint
     async (data, _context, secrets, strings) => {
       const { productId, imageBase64, contentType, caption } = data;
 
-      // Validate required fields
       if (!productId) {
-        throw new Error('productId is required');
+        throwInvalidArgument('productId is required');
       }
 
-      if (!imageBase64) {
-        throw new Error('imageBase64 is required');
+      const validation = imageUploadValidation({
+        imageBase64,
+        contentType,
+        allowedMimeTypes: SQUARE_ALLOWED_IMAGE_TYPES,
+        maxSizeBytes: SQUARE_MAX_IMAGE_BYTES,
+      });
+      if (validation.hasErrors()) {
+        throwValidationError(validation.getErrors());
       }
 
-      if (!contentType) {
-        throw new Error('contentType is required');
-      }
-
-      // Validate content type
-      if (!ALLOWED_IMAGE_TYPES.includes(contentType)) {
-        throw new Error(
-          `Invalid content type. Allowed: ${ALLOWED_IMAGE_TYPES.join(', ')}`
-        );
-      }
-
-      // Validate base64 size (rough estimate)
-      const estimatedBytes = Math.ceil(imageBase64.length * 0.75);
-      if (estimatedBytes > MAX_IMAGE_SIZE_BYTES) {
-        throw new Error('Image too large. Maximum size is 15MB.');
-      }
-
-      // Find the product to get Square item ID
       const product = await ProductRepository.findById(productId);
       if (!product) {
-        throw new Error(`Product not found: ${productId}`);
+        throwNotFound('Product', productId);
       }
 
       if (!product.squareItemId) {

--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.spec.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.spec.tsx
@@ -1,7 +1,14 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useEffect } from 'react';
 import type { PublicClass } from '@maple/ts/domain';
@@ -63,6 +70,14 @@ const mockRegistrationResponse = {
 describe('RegistrationCheckoutForm submit flow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  // @testing-library/react v13+ auto-registers cleanup only when Vitest
+  // globals are enabled. This spec runs under both the project config
+  // (globals: true) and the repo-root config during CI coverage runs
+  // (globals: false). Explicit cleanup keeps tests isolated under either.
+  afterEach(() => {
+    cleanup();
   });
 
   it('blocks submit and surfaces validation errors when the form is empty', async () => {

--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.spec.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.spec.tsx
@@ -65,6 +65,92 @@ describe('RegistrationCheckoutForm submit flow', () => {
     vi.clearAllMocks();
   });
 
+  it('blocks submit and surfaces validation errors when the form is empty', async () => {
+    const user = userEvent.setup();
+
+    const onSubmit = vi.fn();
+    const onCalculateCost = vi.fn().mockResolvedValue(mockCostResponse);
+    const onSuccess = vi.fn();
+
+    render(
+      <RegistrationCheckoutForm
+        publicClass={mockPublicClass}
+        squareApplicationId="test-app"
+        squareLocationId="test-loc"
+        onCalculateCost={onCalculateCost}
+        onSubmit={onSubmit}
+        onSuccess={onSuccess}
+      />
+    );
+
+    const registerButton = await screen.findByRole('button', {
+      name: /Register & Pay/,
+    });
+    await waitFor(() => expect(registerButton).toBeEnabled());
+
+    // Submit without filling anything — the Vest suite should reject.
+    await user.click(registerButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/name is required/i)).toBeInTheDocument();
+      expect(screen.getByText(/email is required/i)).toBeInTheDocument();
+    });
+
+    // Backend must not be called.
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('blocks submit on an invalid email and lets it through once corrected', async () => {
+    const user = userEvent.setup();
+
+    const onSubmit = vi.fn().mockResolvedValue(mockRegistrationResponse);
+    const onCalculateCost = vi.fn().mockResolvedValue(mockCostResponse);
+    const onSuccess = vi.fn();
+
+    render(
+      <RegistrationCheckoutForm
+        publicClass={mockPublicClass}
+        squareApplicationId="test-app"
+        squareLocationId="test-loc"
+        onCalculateCost={onCalculateCost}
+        onSubmit={onSubmit}
+        onSuccess={onSuccess}
+      />
+    );
+
+    const registerButton = await screen.findByRole('button', {
+      name: /Register & Pay/,
+    });
+    await waitFor(() => expect(registerButton).toBeEnabled());
+
+    fireEvent.change(screen.getByLabelText(/Full Name/), {
+      target: { value: 'Jane Doe' },
+    });
+    fireEvent.change(screen.getByLabelText(/Email Address/), {
+      target: { value: 'not-an-email' },
+    });
+
+    await user.click(registerButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/email must be a valid email address/i)
+      ).toBeInTheDocument();
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    // Fix the email and resubmit — it should now pass.
+    fireEvent.change(screen.getByLabelText(/Email Address/), {
+      target: { value: 'jane@example.com' },
+    });
+
+    await user.click(registerButton);
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+  });
+
   it('disables the Register button immediately on click and ignores repeat clicks while the backend is cold-starting', async () => {
     const user = userEvent.setup();
 

--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.stories.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.stories.tsx
@@ -1,0 +1,117 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import type { PublicClass } from '@maple/ts/domain';
+import type { CalculateRegistrationCostResponse } from '@maple/ts/firebase/api-types';
+import { RegistrationCheckoutForm } from './RegistrationCheckoutForm';
+
+/**
+ * Visual-only stories for RegistrationCheckoutForm.
+ *
+ * Interaction coverage (empty submit shows errors, invalid email shows error,
+ * valid submit proceeds to tokenize) lives in RegistrationCheckoutForm.spec.tsx,
+ * which is able to `vi.mock('./SquareCardForm')` — Square's Web Payments SDK
+ * loads from a CDN at runtime and cannot be meaningfully exercised in
+ * Storybook without adding new module-mock infrastructure to main.ts.
+ *
+ * These stories cover the visual states the spec doesn't: an open class,
+ * a class with limited spots, and a fully-booked class.
+ */
+
+const mockPublicClass: PublicClass = {
+  id: 'class-001',
+  name: 'Introduction to Weaving',
+  description:
+    'Learn the fundamentals of weaving in this beginner-friendly workshop.',
+  shortDescription: 'Create your first woven wall hanging.',
+  instructorId: 'instructor-001',
+  instructorName: 'Sarah Weaver',
+  sessions: [{ dateTime: '2030-04-14T10:00:00.000Z' }],
+  durationMinutes: 180,
+  capacity: 8,
+  spotsRemaining: 5,
+  priceCents: 7500,
+  imageUrl: 'https://picsum.photos/seed/weaving/800/600',
+  categoryId: 'cat-fiber',
+  categoryName: 'Fiber Arts',
+  skillLevel: 'beginner',
+  location: 'Maple & Spruce Studio',
+};
+
+const mockCostResponse: CalculateRegistrationCostResponse = {
+  originalCostCents: 7500,
+  discountAmountCents: 0,
+  finalCostCents: 7500,
+  taxRatePercent: 6,
+  taxAmountCents: 450,
+  totalCents: 7950,
+};
+
+const meta = {
+  component: RegistrationCheckoutForm,
+  title: 'Registrations/RegistrationCheckoutForm',
+  parameters: {
+    layout: 'padded',
+    // Square loads external scripts which can flake a11y audits; the real
+    // risk here is covered by the in-app accessibility review, not Storybook.
+    a11y: { disable: true },
+  },
+  args: {
+    publicClass: mockPublicClass,
+    squareApplicationId: 'sandbox-sq0idb-placeholder',
+    squareLocationId: 'L_PLACEHOLDER',
+    env: 'sandbox',
+    onCalculateCost: fn(async () => mockCostResponse),
+    onSubmit: fn(),
+    onSuccess: fn(),
+  },
+} satisfies Meta<typeof RegistrationCheckoutForm>;
+
+export default meta;
+type Story = StoryObj<typeof RegistrationCheckoutForm>;
+
+/**
+ * Default checkout form for a class with plenty of spots.
+ */
+export const Default: Story = {};
+
+/**
+ * Class with only one spot remaining — quantity is capped at 1.
+ */
+export const OneSpotLeft: Story = {
+  args: {
+    publicClass: {
+      ...mockPublicClass,
+      spotsRemaining: 1,
+    },
+  },
+};
+
+/**
+ * Class that is fully booked — registration blocked with a warning banner.
+ */
+export const FullyBooked: Story = {
+  args: {
+    publicClass: {
+      ...mockPublicClass,
+      spotsRemaining: 0,
+    },
+  },
+};
+
+/**
+ * Cost calculation that includes a discount — exercises the discount-applied
+ * Alert and the cost summary breakdown.
+ */
+export const WithDiscountApplied: Story = {
+  args: {
+    onCalculateCost: fn(async () => ({
+      originalCostCents: 7500,
+      discountAmountCents: 1500,
+      finalCostCents: 6000,
+      taxRatePercent: 6,
+      taxAmountCents: 360,
+      totalCents: 6360,
+      discountDescription: 'SAVE20 — 20% off',
+    })),
+  },
+};

--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
@@ -22,6 +22,7 @@ import type {
   CalculateRegistrationCostResponse,
   CreateRegistrationResponse,
 } from '@maple/ts/firebase/api-types';
+import { registrationValidation } from '@maple/ts/validation';
 import { formatPhoneNumber } from './formatPhoneNumber';
 
 /**
@@ -127,6 +128,9 @@ export function RegistrationCheckoutForm({
   const submitError = useSignal<string | null>(null);
   const isCardReady = useSignal(false);
   const quantityWarning = useSignal<string | null>(null);
+  // Gate field errors until the user has attempted a submit once — mirrors
+  // the ClassForm/ArtistForm pattern so users aren't yelled at mid-typing.
+  const showValidationErrors = useSignal(false);
 
   // Derived state — guaranteed in sync with its inputs.
   const isFull = useComputed(() => publicClass.spotsRemaining <= 0);
@@ -139,6 +143,34 @@ export function RegistrationCheckoutForm({
   const isButtonDisabled = useComputed(
     () => isSubmitting.value || !isCardReady.value || isFull.value
   );
+
+  // ============================================================
+  // VALIDATION — Vest suite wired through computed signals.
+  // Note: discountCode is intentionally excluded — it's validated
+  // server-side by the lookup-discount function.
+  // ============================================================
+  const validation = useComputed(() =>
+    registrationValidation({
+      classId: publicClass.id,
+      customerName: customerName.value,
+      customerEmail: customerEmail.value,
+      customerPhone: customerPhone.value || undefined,
+      quantity: quantity.value,
+      notes: notes.value || undefined,
+    })
+  );
+
+  const errors = useComputed<Record<string, string[]>>(() => {
+    if (!showValidationErrors.value) return {};
+    return validation.value.getErrors();
+  });
+
+  const isValid = useComputed(() => validation.value.isValid());
+
+  const getFieldError = (field: string): string | null => {
+    const fieldErrors = errors.value[field];
+    return fieldErrors?.[0] ?? null;
+  };
 
   // Tokenize ref from SquareCardForm — a function handle, not state.
   const tokenizeRef = useRef<(() => Promise<string>) | null>(null);
@@ -200,21 +232,19 @@ export function RegistrationCheckoutForm({
     // second click that arrives before React re-renders still sees
     // isSubmitting.value === true and bails out.
     if (isSubmitting.value) return;
+
+    // Reveal field-level errors on the first submit attempt. Read
+    // validity *after* flipping the flag so the computed error map
+    // is populated in the same tick.
+    showValidationErrors.value = true;
+    if (!isValid.value) {
+      return;
+    }
+
     isSubmitting.value = true;
     submitError.value = null;
 
     try {
-      if (!customerName.value.trim()) {
-        submitError.value = 'Please enter your name';
-        return;
-      }
-      if (
-        !customerEmail.value.trim() ||
-        !customerEmail.value.includes('@')
-      ) {
-        submitError.value = 'Please enter a valid email address';
-        return;
-      }
       if (!tokenizeRef.current) {
         submitError.value = 'Payment form not ready. Please wait and try again.';
         return;
@@ -257,6 +287,8 @@ export function RegistrationCheckoutForm({
     onSuccess,
     isSubmitting,
     submitError,
+    showValidationErrors,
+    isValid,
   ]);
 
   return (
@@ -283,6 +315,8 @@ export function RegistrationCheckoutForm({
             label="Full Name"
             value={customerName.value}
             onChange={(e) => (customerName.value = e.target.value)}
+            error={!!getFieldError('customerName')}
+            helperText={getFieldError('customerName')}
             required
             fullWidth
           />
@@ -291,9 +325,13 @@ export function RegistrationCheckoutForm({
             type="email"
             value={customerEmail.value}
             onChange={(e) => (customerEmail.value = e.target.value)}
+            error={!!getFieldError('customerEmail')}
+            helperText={
+              getFieldError('customerEmail') ||
+              'Confirmation will be sent to this address'
+            }
             required
             fullWidth
-            helperText="Confirmation will be sent to this address"
           />
           <TextField
             label="Phone Number (optional)"
@@ -302,6 +340,8 @@ export function RegistrationCheckoutForm({
             onChange={(e) =>
               (customerPhone.value = formatPhoneNumber(e.target.value))
             }
+            error={!!getFieldError('customerPhone')}
+            helperText={getFieldError('customerPhone')}
             fullWidth
             placeholder="(304) 555-1234"
           />
@@ -313,10 +353,12 @@ export function RegistrationCheckoutForm({
             inputProps={{ min: 1, max: maxQuantity.value }}
             fullWidth
             disabled={isFull.value}
+            error={!!getFieldError('quantity')}
             helperText={
-              isFull.value
+              getFieldError('quantity') ||
+              (isFull.value
                 ? 'No spots available'
-                : `${publicClass.spotsRemaining} spot${publicClass.spotsRemaining === 1 ? '' : 's'} available`
+                : `${publicClass.spotsRemaining} spot${publicClass.spotsRemaining === 1 ? '' : 's'} available`)
             }
           />
           {quantityWarning.value && (
@@ -332,6 +374,8 @@ export function RegistrationCheckoutForm({
             rows={2}
             fullWidth
             placeholder="Dietary restrictions, accessibility needs, etc."
+            error={!!getFieldError('notes')}
+            helperText={getFieldError('notes')}
           />
         </Box>
       </Box>

--- a/libs/react/registrations/vitest.config.ts
+++ b/libs/react/registrations/vitest.config.ts
@@ -4,9 +4,11 @@ import path from 'node:path';
 export default defineConfig({
   root: __dirname,
   resolve: {
-    // Point @maple/react/signals at the real lib entry so vitest can
-    // resolve it without a full tsconfig-paths plugin. Tests can still
-    // mock specific exports via vi.mock.
+    // Resolve @maple/* workspace aliases via tsconfig paths (native Vite
+    // support). The explicit @maple/react/signals alias is kept so the
+    // local signals entry wins — the tsconfig path resolves to the same
+    // file but goes through a slower lookup.
+    tsconfigPaths: true,
     alias: {
       '@maple/react/signals': path.resolve(__dirname, '../signals/src/index.ts'),
     },

--- a/libs/ts/validation/src/lib/artist.validation.ts
+++ b/libs/ts/validation/src/lib/artist.validation.ts
@@ -4,7 +4,7 @@
  * Vest validation for artist forms.
  * @see https://vestjs.dev/
  */
-import { create, test, enforce, only } from 'vest';
+import { staticSuite, test, enforce, only } from 'vest';
 import type { CreateArtistInput } from '@maple/ts/domain';
 
 /**
@@ -25,8 +25,8 @@ import type { CreateArtistInput } from '@maple/ts/domain';
  * const result = artistValidation(formData, 'email');
  * const errors = result.getErrors('email');
  */
-export const artistValidation = create(
-  (data: Partial<CreateArtistInput>, field?: string) => {
+export const artistValidation = staticSuite(
+  (data: Partial<CreateArtistInput>, field?: string | string[]) => {
     only(field);
 
     test('name', 'Name is required', () => {

--- a/libs/ts/validation/src/lib/calendar-event.validation.ts
+++ b/libs/ts/validation/src/lib/calendar-event.validation.ts
@@ -4,7 +4,7 @@
  * Vest validation for calendar event forms.
  * @see https://vestjs.dev/
  */
-import { create, test, enforce, only } from 'vest';
+import { staticSuite, test, enforce, only } from 'vest';
 import type { CreateCalendarEventInput } from '@maple/ts/domain';
 import { CALENDAR_EVENT_TYPES } from '@maple/ts/domain';
 
@@ -14,8 +14,8 @@ import { CALENDAR_EVENT_TYPES } from '@maple/ts/domain';
  * @param data - Partial calendar event data to validate
  * @param field - Optional field to validate (for single-field validation)
  */
-export const calendarEventValidation = create(
-  (data: Partial<CreateCalendarEventInput>, field?: string) => {
+export const calendarEventValidation = staticSuite(
+  (data: Partial<CreateCalendarEventInput>, field?: string | string[]) => {
     only(field);
 
     // Title validation

--- a/libs/ts/validation/src/lib/category.validation.ts
+++ b/libs/ts/validation/src/lib/category.validation.ts
@@ -4,7 +4,7 @@
  * Vest validation for category forms.
  * @see https://vestjs.dev/
  */
-import { create, test, enforce, only } from 'vest';
+import { staticSuite, test, enforce, only } from 'vest';
 import type { CreateCategoryInput } from '@maple/ts/domain';
 
 /**
@@ -25,8 +25,8 @@ import type { CreateCategoryInput } from '@maple/ts/domain';
  * const result = categoryValidation(formData, 'name');
  * const errors = result.getErrors('name');
  */
-export const categoryValidation = create(
-  (data: Partial<CreateCategoryInput>, field?: string) => {
+export const categoryValidation = staticSuite(
+  (data: Partial<CreateCategoryInput>, field?: string | string[]) => {
     only(field);
 
     test('name', 'Name is required', () => {

--- a/libs/ts/validation/src/lib/class-category.validation.ts
+++ b/libs/ts/validation/src/lib/class-category.validation.ts
@@ -4,7 +4,7 @@
  * Vest validation for class category forms.
  * @see https://vestjs.dev/
  */
-import { create, test, enforce, only } from 'vest';
+import { staticSuite, test, enforce, only } from 'vest';
 import type { CreateClassCategoryInput } from '@maple/ts/domain';
 
 /**
@@ -20,8 +20,8 @@ import type { CreateClassCategoryInput } from '@maple/ts/domain';
  *   // Submit form
  * }
  */
-export const classCategoryValidation = create(
-  (data: Partial<CreateClassCategoryInput>, field?: string) => {
+export const classCategoryValidation = staticSuite(
+  (data: Partial<CreateClassCategoryInput>, field?: string | string[]) => {
     only(field);
 
     test('name', 'Name is required', () => {

--- a/libs/ts/validation/src/lib/class.validation.ts
+++ b/libs/ts/validation/src/lib/class.validation.ts
@@ -4,7 +4,7 @@
  * Vest validation for class/workshop forms.
  * @see https://vestjs.dev/
  */
-import { create, test, enforce, only } from 'vest';
+import { staticSuite, test, enforce, only } from 'vest';
 import type { CreateClassInput } from '@maple/ts/domain';
 
 /**
@@ -20,8 +20,8 @@ import type { CreateClassInput } from '@maple/ts/domain';
  *   // Submit form
  * }
  */
-export const classValidation = create(
-  (data: Partial<CreateClassInput>, field?: string) => {
+export const classValidation = staticSuite(
+  (data: Partial<CreateClassInput>, field?: string | string[]) => {
     only(field);
 
     // Name validation

--- a/libs/ts/validation/src/lib/discount.validation.spec.ts
+++ b/libs/ts/validation/src/lib/discount.validation.spec.ts
@@ -375,5 +375,30 @@ describe('discountValidation', () => {
       expect(result.hasErrors('type')).toBe(false);
       expect(result.hasErrors('description')).toBe(false);
     });
+
+    it('scopes validation to a list of fields (partial update)', () => {
+      // Simulates a partial update payload: only `code` and `percent` are
+      // being changed, with `type` merged in from the existing record so
+      // type-conditional tests still fire against the correct type.
+      const partialUpdate: DiscountValidationInput = {
+        type: 'percent',
+        code: 'BAD CODE!',
+        percent: 150,
+      };
+
+      const result = discountValidation(partialUpdate, ['code', 'percent']);
+      expect(result.hasErrors('code')).toBe(true);
+      expect(result.hasErrors('percent')).toBe(true);
+    });
+
+    it('passes when partial update contains only valid fields', () => {
+      const partialUpdate: DiscountValidationInput = {
+        type: 'percent',
+        description: 'Updated description',
+      };
+
+      const result = discountValidation(partialUpdate, ['description']);
+      expect(result.hasErrors()).toBe(false);
+    });
   });
 });

--- a/libs/ts/validation/src/lib/discount.validation.ts
+++ b/libs/ts/validation/src/lib/discount.validation.ts
@@ -6,7 +6,7 @@
  *
  * @see https://vestjs.dev/
  */
-import { create, test, enforce, only } from 'vest';
+import { staticSuite, test, enforce, only } from 'vest';
 import { DISCOUNT_TYPES, DISCOUNT_STATUSES } from '@maple/ts/domain';
 import type { DiscountType, DiscountStatus } from '@maple/ts/domain';
 
@@ -29,10 +29,13 @@ export interface DiscountValidationInput {
  * Validate discount form data
  *
  * @param data - Partial discount data to validate
- * @param field - Optional field to validate (for single-field validation)
+ * @param field - Optional field (or list of fields) to validate. Pass a single
+ *   field name for per-field form validation, or an array of field names to
+ *   scope validation to a partial-update payload (only those fields are
+ *   tested). Omit to validate all fields.
  */
-export const discountValidation = create(
-  (data: DiscountValidationInput, field?: string) => {
+export const discountValidation = staticSuite(
+  (data: DiscountValidationInput, field?: string | string[]) => {
     only(field);
 
     // Code validation

--- a/libs/ts/validation/src/lib/image-upload.validation.spec.ts
+++ b/libs/ts/validation/src/lib/image-upload.validation.spec.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import {
+  imageUploadValidation,
+  DEFAULT_IMAGE_MAX_BYTES,
+  type ImageUploadValidationInput,
+} from './image-upload.validation';
+
+/** Build a base64 payload whose decoded size is roughly `bytes`. */
+function base64OfSize(bytes: number): string {
+  // 4 base64 chars encode 3 bytes, so base64 length = ceil(bytes / 3) * 4.
+  const len = Math.ceil(bytes / 3) * 4;
+  return 'A'.repeat(len);
+}
+
+describe('imageUploadValidation', () => {
+  const validInput: ImageUploadValidationInput = {
+    imageBase64: base64OfSize(1024),
+    contentType: 'image/jpeg',
+  };
+
+  describe('valid data', () => {
+    it('passes with jpeg under the default size limit', () => {
+      const result = imageUploadValidation(validInput);
+      expect(result.hasErrors()).toBe(false);
+    });
+
+    it('passes for each default mime type', () => {
+      for (const contentType of [
+        'image/jpeg',
+        'image/png',
+        'image/webp',
+        'image/gif',
+      ]) {
+        const result = imageUploadValidation({ ...validInput, contentType });
+        expect(result.hasErrors('contentType')).toBe(false);
+      }
+    });
+  });
+
+  describe('imageBase64', () => {
+    it('fails when payload is missing', () => {
+      const result = imageUploadValidation({
+        ...validInput,
+        imageBase64: undefined,
+      });
+      expect(result.getErrors('imageBase64')).toContain('Image data is required');
+    });
+
+    it('fails when decoded size exceeds the default limit', () => {
+      const oversized = base64OfSize(DEFAULT_IMAGE_MAX_BYTES + 1024);
+      const result = imageUploadValidation({
+        ...validInput,
+        imageBase64: oversized,
+      });
+      expect(result.hasErrors('imageBase64')).toBe(true);
+      expect(result.getErrors('imageBase64').join(' ')).toMatch(/smaller than/i);
+    });
+
+    it('respects a custom maxSizeBytes override (Square 15MB case)', () => {
+      const twelveMB = base64OfSize(12 * 1024 * 1024);
+      // Default 10MB limit rejects:
+      expect(
+        imageUploadValidation({ ...validInput, imageBase64: twelveMB })
+          .hasErrors('imageBase64')
+      ).toBe(true);
+      // 15MB override accepts:
+      expect(
+        imageUploadValidation({
+          ...validInput,
+          imageBase64: twelveMB,
+          maxSizeBytes: 15 * 1024 * 1024,
+        }).hasErrors('imageBase64')
+      ).toBe(false);
+    });
+  });
+
+  describe('contentType', () => {
+    it('fails when contentType is missing', () => {
+      const result = imageUploadValidation({
+        ...validInput,
+        contentType: undefined,
+      });
+      expect(result.getErrors('contentType')).toContain(
+        'Content type is required'
+      );
+    });
+
+    it('rejects disallowed mime types under the default allowlist', () => {
+      const result = imageUploadValidation({
+        ...validInput,
+        contentType: 'application/pdf',
+      });
+      expect(result.hasErrors('contentType')).toBe(true);
+    });
+
+    it('rejects webp under a Square-style allowlist override', () => {
+      const result = imageUploadValidation({
+        ...validInput,
+        contentType: 'image/webp',
+        allowedMimeTypes: [
+          'image/jpeg',
+          'image/pjpeg',
+          'image/png',
+          'image/gif',
+        ],
+      });
+      expect(result.hasErrors('contentType')).toBe(true);
+    });
+
+    it('accepts pjpeg only when the override allows it', () => {
+      expect(
+        imageUploadValidation({ ...validInput, contentType: 'image/pjpeg' })
+          .hasErrors('contentType')
+      ).toBe(true);
+      expect(
+        imageUploadValidation({
+          ...validInput,
+          contentType: 'image/pjpeg',
+          allowedMimeTypes: [
+            'image/jpeg',
+            'image/pjpeg',
+            'image/png',
+            'image/gif',
+          ],
+        }).hasErrors('contentType')
+      ).toBe(false);
+    });
+  });
+
+  describe('staticSuite contract', () => {
+    it('returns a fresh result per call — no state leakage', () => {
+      // First call with invalid data sets errors
+      const bad = imageUploadValidation({ imageBase64: '', contentType: '' });
+      expect(bad.hasErrors()).toBe(true);
+
+      // Second call with fully valid data must not inherit errors
+      const good = imageUploadValidation(validInput);
+      expect(good.hasErrors()).toBe(false);
+    });
+  });
+
+  describe('single-field scoping', () => {
+    it('only runs tests for the scoped field', () => {
+      const result = imageUploadValidation(
+        { imageBase64: '', contentType: '' },
+        'imageBase64'
+      );
+      expect(result.hasErrors('imageBase64')).toBe(true);
+      expect(result.hasErrors('contentType')).toBe(false);
+    });
+  });
+});

--- a/libs/ts/validation/src/lib/image-upload.validation.ts
+++ b/libs/ts/validation/src/lib/image-upload.validation.ts
@@ -1,0 +1,77 @@
+/**
+ * Image upload validation suite
+ *
+ * Shared Vest suite for the `upload-*-image` cloud functions. Validates the
+ * base64 payload, the MIME type, and the decoded image size. Allowed MIME
+ * types and the max size are configurable per caller because downstream
+ * providers differ (e.g. Square's Catalog API rejects webp and caps at 15MB,
+ * Firebase Storage has neither constraint).
+ *
+ * Entity-id handling is left to callers because it differs per endpoint —
+ * product uploads require it (Square needs the item id), artist/class/
+ * instructor uploads accept a missing id and fall back to a `temp/` path.
+ */
+import { staticSuite, test, enforce, only } from 'vest';
+
+/** Default allowed MIME types (matches Firebase Storage uploads). */
+export const DEFAULT_IMAGE_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+] as const;
+
+/** Default max decoded image size: 10MB. */
+export const DEFAULT_IMAGE_MAX_BYTES = 10 * 1024 * 1024;
+
+export interface ImageUploadValidationInput {
+  /** Base64-encoded image payload. */
+  imageBase64?: string;
+  /** MIME type declared by the caller. */
+  contentType?: string;
+  /** Allowed MIME types for this upload. Defaults to DEFAULT_IMAGE_MIME_TYPES. */
+  allowedMimeTypes?: readonly string[];
+  /** Max decoded size in bytes. Defaults to DEFAULT_IMAGE_MAX_BYTES. */
+  maxSizeBytes?: number;
+}
+
+/** Estimate decoded byte length from a base64 string (~33% overhead). */
+function estimateDecodedBytes(base64: string): number {
+  return Math.ceil(base64.length * 0.75);
+}
+
+export const imageUploadValidation = staticSuite(
+  (data: ImageUploadValidationInput, field?: string | string[]) => {
+    only(field);
+
+    const allowed = data.allowedMimeTypes ?? DEFAULT_IMAGE_MIME_TYPES;
+    const maxBytes = data.maxSizeBytes ?? DEFAULT_IMAGE_MAX_BYTES;
+    const maxMB = Math.round(maxBytes / 1024 / 1024);
+
+    test('imageBase64', 'Image data is required', () => {
+      enforce(data.imageBase64).isNotBlank();
+    });
+
+    test('contentType', 'Content type is required', () => {
+      enforce(data.contentType).isNotBlank();
+    });
+
+    test(
+      'contentType',
+      `Content type must be one of: ${allowed.join(', ')}`,
+      () => {
+        if (data.contentType) {
+          enforce(data.contentType).inside(allowed);
+        }
+      }
+    );
+
+    test('imageBase64', `Image must be smaller than ${maxMB}MB`, () => {
+      if (data.imageBase64) {
+        enforce(estimateDecodedBytes(data.imageBase64)).lessThanOrEquals(
+          maxBytes
+        );
+      }
+    });
+  }
+);

--- a/libs/ts/validation/src/lib/index.ts
+++ b/libs/ts/validation/src/lib/index.ts
@@ -40,3 +40,11 @@ export {
 
 // Phase 4.5: Calendar
 export { calendarEventValidation } from './calendar-event.validation';
+
+// Shared helpers
+export {
+  imageUploadValidation,
+  DEFAULT_IMAGE_MIME_TYPES,
+  DEFAULT_IMAGE_MAX_BYTES,
+  type ImageUploadValidationInput,
+} from './image-upload.validation';

--- a/libs/ts/validation/src/lib/instructor.validation.ts
+++ b/libs/ts/validation/src/lib/instructor.validation.ts
@@ -4,7 +4,7 @@
  * Vest validation for instructor forms.
  * @see https://vestjs.dev/
  */
-import { create, test, enforce, only } from 'vest';
+import { staticSuite, test, enforce, only } from 'vest';
 import type { CreateInstructorInput } from '@maple/ts/domain';
 
 /**
@@ -20,8 +20,8 @@ import type { CreateInstructorInput } from '@maple/ts/domain';
  *   // Submit form
  * }
  */
-export const instructorValidation = create(
-  (data: Partial<CreateInstructorInput>, field?: string) => {
+export const instructorValidation = staticSuite(
+  (data: Partial<CreateInstructorInput>, field?: string | string[]) => {
     only(field);
 
     test('name', 'Name is required', () => {

--- a/libs/ts/validation/src/lib/inventory-movement.validation.ts
+++ b/libs/ts/validation/src/lib/inventory-movement.validation.ts
@@ -4,7 +4,7 @@
  * Vest validation for inventory adjustments.
  * @see https://vestjs.dev/
  */
-import { create, test, enforce, only } from 'vest';
+import { staticSuite, test, enforce, only } from 'vest';
 import type { CreateInventoryMovementInput } from '@maple/ts/domain';
 
 const VALID_MOVEMENT_TYPES = [
@@ -30,8 +30,8 @@ const VALID_SOURCES = ['manual', 'etsy', 'square', 'system'] as const;
  *   // Record movement
  * }
  */
-export const inventoryMovementValidation = create(
-  (data: Partial<CreateInventoryMovementInput>, field?: string) => {
+export const inventoryMovementValidation = staticSuite(
+  (data: Partial<CreateInventoryMovementInput>, field?: string | string[]) => {
     only(field);
 
     test('productId', 'Product is required', () => {

--- a/libs/ts/validation/src/lib/lesson.validation.ts
+++ b/libs/ts/validation/src/lib/lesson.validation.ts
@@ -3,7 +3,7 @@
  *
  * Vest validation for music lesson forms (single + series).
  */
-import { create, test, enforce, only } from 'vest';
+import { staticSuite, test, enforce, only } from 'vest';
 import type {
   CreateLessonInput,
   CreateLessonSeriesInput,
@@ -13,8 +13,8 @@ import { LESSON_STATUSES } from '@maple/ts/domain';
 /** Allowed lesson durations in minutes. Mirrors LessonLength tiers on Student. */
 const ALLOWED_DURATIONS = [30, 45, 60] as const;
 
-export const lessonValidation = create(
-  (data: Partial<CreateLessonInput>, field?: string) => {
+export const lessonValidation = staticSuite(
+  (data: Partial<CreateLessonInput>, field?: string | string[]) => {
     only(field);
 
     test('studentId', 'Student is required', () => {
@@ -70,8 +70,8 @@ export const lessonValidation = create(
   }
 );
 
-export const lessonSeriesValidation = create(
-  (data: Partial<CreateLessonSeriesInput>, field?: string) => {
+export const lessonSeriesValidation = staticSuite(
+  (data: Partial<CreateLessonSeriesInput>, field?: string | string[]) => {
     only(field);
 
     test('studentId', 'Student is required', () => {

--- a/libs/ts/validation/src/lib/payout.validation.ts
+++ b/libs/ts/validation/src/lib/payout.validation.ts
@@ -4,7 +4,7 @@
  * Vest validation for payout generation forms.
  * @see https://vestjs.dev/
  */
-import { create, test, enforce, only } from 'vest';
+import { staticSuite, test, enforce, only } from 'vest';
 import type { GeneratePayoutInput } from '@maple/ts/domain';
 
 /**
@@ -19,8 +19,8 @@ import type { GeneratePayoutInput } from '@maple/ts/domain';
  *   // Generate payout
  * }
  */
-export const payoutValidation = create(
-  (data: Partial<GeneratePayoutInput>, field?: string) => {
+export const payoutValidation = staticSuite(
+  (data: Partial<GeneratePayoutInput>, field?: string | string[]) => {
     only(field);
 
     test('artistId', 'Artist is required', () => {

--- a/libs/ts/validation/src/lib/product.validation.spec.ts
+++ b/libs/ts/validation/src/lib/product.validation.spec.ts
@@ -265,4 +265,66 @@ describe('productValidation', () => {
     });
 
   });
+
+  describe('partial-update validation (array of fields)', () => {
+    // When Vest's only() scopes validation to a subset of fields, the fields
+    // whose tests didn't run report valid:false at the per-field level, which
+    // makes the top-level isValid() unreliable. Callers gate on hasErrors()
+    // instead; these tests mirror that contract.
+
+    it('only validates the fields in the provided array', () => {
+      // A status-only update patch: name/priceCents/quantity are absent,
+      // which would normally fail the "required" tests. Passing only the
+      // fields that are present should scope validation to those fields.
+      const patch = { status: 'draft' as const };
+
+      const result = productValidation(patch, ['status']);
+      expect(result.hasErrors()).toBe(false);
+      expect(result.hasErrors('name')).toBe(false);
+      expect(result.hasErrors('priceCents')).toBe(false);
+      expect(result.hasErrors('quantity')).toBe(false);
+    });
+
+    it('catches invalid status in a partial update', () => {
+      const patch = { status: 'archived' as 'active' };
+
+      const result = productValidation(patch, ['status']);
+      expect(result.hasErrors()).toBe(true);
+      expect(result.getErrors('status')).toContain(
+        'Status must be active, draft, or discontinued'
+      );
+    });
+
+    it('catches out-of-range commission rate in a partial update', () => {
+      const patch = { customCommissionRate: 1.5 };
+
+      const result = productValidation(patch, ['customCommissionRate']);
+      expect(result.hasErrors()).toBe(true);
+      expect(result.getErrors('customCommissionRate')).toContain(
+        'Commission rate must be between 0 and 1'
+      );
+    });
+
+    it('allows a valid multi-field partial update (status + commission)', () => {
+      const patch = {
+        status: 'active' as const,
+        customCommissionRate: 0.3,
+      };
+
+      const result = productValidation(patch, [
+        'status',
+        'customCommissionRate',
+      ]);
+      expect(result.hasErrors()).toBe(false);
+    });
+
+    it('does not require name/price/quantity when not in the field list', () => {
+      // Simulates an artistId-only patch. Without array scoping this would
+      // fail "Name is required" / "Price is required" / "Quantity is required".
+      const patch = { artistId: 'artist-999' };
+
+      const result = productValidation(patch, ['artistId']);
+      expect(result.hasErrors()).toBe(false);
+    });
+  });
 });

--- a/libs/ts/validation/src/lib/product.validation.ts
+++ b/libs/ts/validation/src/lib/product.validation.ts
@@ -7,7 +7,7 @@
  *
  * @see https://vestjs.dev/
  */
-import { create, test, enforce, only } from 'vest';
+import { staticSuite, test, enforce, only } from 'vest';
 import type { CreateProductInput } from '@maple/ts/domain';
 
 /**
@@ -18,7 +18,10 @@ import type { CreateProductInput } from '@maple/ts/domain';
  * - Square-bound: name, description, priceCents, quantity
  *
  * @param data - Partial product data to validate
- * @param field - Optional field to validate (for single-field validation)
+ * @param field - Optional field(s) to validate (for single-field or
+ *                partial-update validation). Pass a string for a single
+ *                field, or an array of field names to validate only those
+ *                fields (useful for partial updates).
  *
  * @example
  * // Full validation
@@ -26,9 +29,13 @@ import type { CreateProductInput } from '@maple/ts/domain';
  * if (result.isValid()) {
  *   // Submit form
  * }
+ *
+ * @example
+ * // Partial update - only validate fields that were provided
+ * const result = productValidation(patch, Object.keys(patch));
  */
-export const productValidation = create(
-  (data: Partial<CreateProductInput>, field?: string) => {
+export const productValidation = staticSuite(
+  (data: Partial<CreateProductInput>, field?: string | string[]) => {
     only(field);
 
     // === Firestore-owned fields ===

--- a/libs/ts/validation/src/lib/registration.validation.ts
+++ b/libs/ts/validation/src/lib/registration.validation.ts
@@ -6,7 +6,7 @@
  *
  * @see https://vestjs.dev/
  */
-import { create, test, enforce, only } from 'vest';
+import { staticSuite, test, enforce, only } from 'vest';
 
 /**
  * Input shape for registration validation
@@ -26,8 +26,8 @@ export interface RegistrationValidationInput {
  * @param data - Partial registration data to validate
  * @param field - Optional field to validate (for single-field validation)
  */
-export const registrationValidation = create(
-  (data: RegistrationValidationInput, field?: string) => {
+export const registrationValidation = staticSuite(
+  (data: RegistrationValidationInput, field?: string | string[]) => {
     only(field);
 
     // Class ID validation

--- a/libs/ts/validation/src/lib/sale.validation.ts
+++ b/libs/ts/validation/src/lib/sale.validation.ts
@@ -4,7 +4,7 @@
  * Vest validation for sale recording forms.
  * @see https://vestjs.dev/
  */
-import { create, test, enforce, only } from 'vest';
+import { staticSuite, test, enforce, only } from 'vest';
 import type { CreateSaleInput } from '@maple/ts/domain';
 
 /**
@@ -19,8 +19,8 @@ import type { CreateSaleInput } from '@maple/ts/domain';
  *   // Record sale
  * }
  */
-export const saleValidation = create(
-  (data: Partial<CreateSaleInput>, field?: string) => {
+export const saleValidation = staticSuite(
+  (data: Partial<CreateSaleInput>, field?: string | string[]) => {
     only(field);
 
     test('productId', 'Product is required', () => {

--- a/libs/ts/validation/src/lib/student.validation.ts
+++ b/libs/ts/validation/src/lib/student.validation.ts
@@ -4,12 +4,12 @@
  * Vest validation for music lesson student forms.
  * @see https://vestjs.dev/
  */
-import { create, test, enforce, only } from 'vest';
+import { staticSuite, test, enforce, only } from 'vest';
 import type { CreateStudentInput } from '@maple/ts/domain';
 import { INSTRUMENTS, LESSON_LENGTHS } from '@maple/ts/domain';
 
-export const studentValidation = create(
-  (data: Partial<CreateStudentInput>, field?: string) => {
+export const studentValidation = staticSuite(
+  (data: Partial<CreateStudentInput>, field?: string | string[]) => {
     only(field);
 
     test('name', 'Student name is required', () => {

--- a/libs/ts/validation/src/lib/sync-conflict.validation.ts
+++ b/libs/ts/validation/src/lib/sync-conflict.validation.ts
@@ -4,7 +4,7 @@
  * Vest validation for sync conflict resolution.
  * @see https://vestjs.dev/
  */
-import { create, test, enforce, only } from 'vest';
+import { staticSuite, test, enforce, only } from 'vest';
 import type { ResolveSyncConflictInput } from '@maple/ts/domain';
 
 const VALID_RESOLUTIONS = [
@@ -26,8 +26,8 @@ const VALID_RESOLUTIONS = [
  *   // Resolve conflict
  * }
  */
-export const syncConflictResolutionValidation = create(
-  (data: Partial<ResolveSyncConflictInput>, field?: string) => {
+export const syncConflictResolutionValidation = staticSuite(
+  (data: Partial<ResolveSyncConflictInput>, field?: string | string[]) => {
     only(field);
 
     test('conflictId', 'Conflict ID is required', () => {


### PR DESCRIPTION
## Summary

Migrates all Vest validation suites from stateful `create()` to stateless `staticSuite()`, normalizes the backend partial-update pattern, adds a shared image-upload suite (with size-limit protection for 3 endpoints that lacked it), and wires `registrationValidation` into the public checkout form.

The core win is correctness: `staticSuite` returns a fresh `SuiteResult` per call, so reactive computeds on the frontend and warm cloud function containers on the backend no longer need defensive `.reset()` calls or per-field `getErrors()` workarounds.

## Changes

**Validation lib**
- All 17 suites flipped `create` → `staticSuite` (artist, calendar-event, category, class, class-category, discount, instructor, inventory-movement, lesson (×2), payout, product, registration, sale, student, sync-conflict — plus new image-upload)
- Widened `field?: string` → `field?: string | string[]` across all suites to enable scoped partial-update validation via `only()`
- New `imageUploadValidation` suite with overridable `allowedMimeTypes` and `maxSizeBytes` (defaults: 10MB, `{jpeg, png, webp, gif}`)

**Backend cloud functions**
- Canonical partial-update pattern applied to `update-discount`, `update-product`, `update-registration`:
  ```ts
  const fields = Object.keys(data).filter((key) => key !== 'id');
  const result = xValidation({ ...existing, ...data }, fields);
  if (result.hasErrors()) throwValidationError(result.getErrors());
  ```
- `imageUploadValidation` wired into `upload-artist-image`, `upload-class-image`, `upload-instructor-image`, `upload-product-image`. Product upload overrides to Square's constraints (15MB, no webp). **Artist/class/instructor uploads just gained the size-limit protection they lacked.**
- `cancel-registration` upgraded to typed `HttpsError` helpers (`throwInvalidArgument`, `throwNotFound`, `throwFailedPrecondition`). Suite intentionally not wired — its `{id, refund?}` payload doesn't map to registration form fields.
- Removed `VALIDATED_PRODUCT_FIELDS` const and per-field `getErrors()` workarounds — no longer needed with stateless suites

**Frontend**
- `RegistrationCheckoutForm` now uses `registrationValidation` instead of ad-hoc `includes('@')` email checks. Preact Signals + `useComputed` pattern matches `ClassForm`. Errors shown only after first submit attempt.
- New `RegistrationCheckoutForm.stories.tsx` (visual states) + spec additions for empty/invalid-email submit paths

**Docs**
- `.claude/rules/firebase-functions.md` — new "Input Validation" section codifying the create + partial-update patterns
- `docs/architecture/PATTERNS-AND-PRACTICES.md` — states the `staticSuite` rule explicitly with rationale, adds partial-update pattern
- `docs/architecture/SOL-PATTERNS-REFERENCE.md` — example updated to match

**Integration tests added**
- `apps/functions-integration-tests-registration/src/update-registration.spec.ts` (13 cases)
- `apps/functions-integration-tests-square/src/cancel-registration.spec.ts` (9 cases)
- `apps/functions-integration-tests-discount/src/discount-functions.spec.ts` — 6 new partial-update cases

## Testing

- [x] 396/396 validation unit tests pass (`nx run validation:vitest:test`)
- [x] 12/12 RegistrationCheckoutForm specs pass (`nx run react-registrations:vitest:test`)
- [x] All 4 function codebases build clean (`nx run-many --target=build --projects=functions,functions-calendar,functions-square,functions-sync`)
- [x] Lint clean across all updated projects
- [ ] Integration tests run locally (blocked by `firebase login --reauth` in this env; CI will execute)

## Follow-ups (not in this PR)

- Integration test project for `upload-*-image` endpoints (none currently exist)
- 4 consumer-less suites (`sale`, `payout`, `inventoryMovement`, `classCategory`) awaiting their endpoints
- 8 `delete-*` endpoints still lack input validation (very low risk — id-only payloads, admin-gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)