### PR TITLE
feat: Hope Scholarship handling (#282)

### DIFF
--- a/apps/maple-spruce/.storybook/fixtures/lessons.ts
+++ b/apps/maple-spruce/.storybook/fixtures/lessons.ts
@@ -67,10 +67,24 @@ export const mockLessonCancelled: Lesson = {
   updatedAt: NOW,
 };
 
+/** Past-dated lesson still in `scheduled` status — ready to be marked rendered. */
+export const mockLessonPastScheduled: Lesson = {
+  id: 'lesson-006',
+  studentId: 'student-001',
+  scheduledAt: new Date('2026-04-12T15:00:00Z'),
+  durationMinutes: 30,
+  teacherId: 'instructor-001',
+  seriesId: 'series-spring',
+  status: 'scheduled',
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
 export const mockLessons: Lesson[] = [
   mockLessonUpcomingSingle,
   mockLessonUpcomingSeries,
   mockLessonUpcomingSubstitute,
   mockLessonPastRendered,
   mockLessonCancelled,
+  mockLessonPastScheduled,
 ];

--- a/apps/maple-spruce/src/app/students/[id]/page.tsx
+++ b/apps/maple-spruce/src/app/students/[id]/page.tsx
@@ -23,6 +23,7 @@ import type {
 import { DeleteConfirmDialog } from '@maple/react/ui';
 import {
   EditLessonDialog,
+  HopeScholarshipBanner,
   LessonList,
   ScheduleLessonDialog,
 } from '@maple/react/lessons';
@@ -98,6 +99,15 @@ export default function StudentDetailPage() {
     try {
       await updateLesson({ id: cancelLesson.id, status: 'cancelled' });
       setCancelLesson(null);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleMarkRendered = async (lesson: Lesson) => {
+    setIsSubmitting(true);
+    try {
+      await updateLesson({ id: lesson.id, status: 'rendered' });
     } finally {
       setIsSubmitting(false);
     }
@@ -198,6 +208,12 @@ export default function StudentDetailPage() {
         </Button>
       </Box>
 
+      {student.isHopeScholarship && (
+        <HopeScholarshipBanner
+          registeredLessonLength={student.registeredLessonLength}
+        />
+      )}
+
       <Typography variant="h6" component="h2" sx={{ mb: 2 }}>
         Lessons
       </Typography>
@@ -207,6 +223,7 @@ export default function StudentDetailPage() {
         primaryTeacherId={student.primaryTeacherId}
         onEdit={(lesson) => setEditLesson(lesson)}
         onCancel={(lesson) => setCancelLesson(lesson)}
+        onMarkRendered={handleMarkRendered}
       />
 
       <ScheduleLessonDialog

--- a/apps/maple-spruce/src/app/students/page.tsx
+++ b/apps/maple-spruce/src/app/students/page.tsx
@@ -1,13 +1,22 @@
 'use client';
 
-import { useState, useCallback } from 'react';
-import { Alert, Box, Button, Typography } from '@mui/material';
+import { useMemo, useState, useCallback } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
-import type { CreateStudentInput, Student } from '@maple/ts/domain';
+import type { CreateStudentInput, RequestState, Student } from '@maple/ts/domain';
 import { DeleteConfirmDialog } from '@maple/react/ui';
 import { StudentForm, StudentList } from '@maple/react/students';
 import { AppShell } from '../../components/layout';
 import { useInstructors, useStudents } from '../../hooks';
+
+type HopeFilter = 'all' | 'hope' | 'private';
 
 export default function StudentsPage() {
   const {
@@ -29,6 +38,20 @@ export default function StudentsPage() {
   // Delete dialog state
   const [studentToDelete, setStudentToDelete] = useState<Student | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+
+  // Hope Scholarship filter — client-side since roster is small.
+  const [hopeFilter, setHopeFilter] = useState<HopeFilter>('all');
+
+  const filteredStudentsState = useMemo<RequestState<Student[]>>(() => {
+    if (studentsState.status !== 'success') return studentsState;
+    if (hopeFilter === 'all') return studentsState;
+    const predicate = (s: Student) =>
+      hopeFilter === 'hope' ? s.isHopeScholarship : !s.isHopeScholarship;
+    return {
+      ...studentsState,
+      data: studentsState.data.filter(predicate),
+    };
+  }, [studentsState, hopeFilter]);
 
   const handleOpenForm = useCallback((student?: Student) => {
     setEditingStudent(student);
@@ -114,8 +137,24 @@ export default function StudentsPage() {
         </Alert>
       )}
 
+      <Box sx={{ mb: 2 }}>
+        <ToggleButtonGroup
+          exclusive
+          value={hopeFilter}
+          onChange={(_, next) => {
+            if (next) setHopeFilter(next as HopeFilter);
+          }}
+          size="small"
+          aria-label="Filter students by Hope Scholarship"
+        >
+          <ToggleButton value="all">All students</ToggleButton>
+          <ToggleButton value="hope">Hope Scholarship only</ToggleButton>
+          <ToggleButton value="private">Private-pay only</ToggleButton>
+        </ToggleButtonGroup>
+      </Box>
+
       <StudentList
-        studentsState={studentsState}
+        studentsState={filteredStudentsState}
         instructors={instructors}
         onEdit={handleOpenForm}
         onDelete={handleOpenDelete}

--- a/docs/reference/implementation-status.md
+++ b/docs/reference/implementation-status.md
@@ -167,6 +167,20 @@ Phased rollout of customer-facing interactions on the Webflow site.
 
 ## Phase 4: Music Lessons - Epic #10
 
+### Hope Scholarship Handling (#282, Complete)
+
+| Feature | Status | Location |
+|---------|--------|----------|
+| Hope flag on Student (set/unset by Katie) | **Complete** | shipped in #278 |
+| Hope per-lesson rate constants + helpers | **Complete** | `libs/react/lessons/src/lib/hope-rates.ts` (+ 7 unit tests) |
+| `HopeRatesTable` (4-tier, highlight current) | **Complete** | `libs/react/lessons/src/lib/HopeRatesTable.tsx` |
+| `HopeScholarshipBanner` on student detail | **Complete** | `libs/react/lessons/src/lib/HopeScholarshipBanner.tsx` |
+| Mark-lesson-rendered action (past scheduled lessons) | **Complete** | `LessonList.tsx` + `/students/[id]/page.tsx` |
+| Hope filter on `/students` (All / Hope / Private) | **Complete** | `/students/page.tsx` |
+| Exclude Hope students from in-app invoice flow | **Deferred to #280** | invoice flow doesn't exist yet |
+| Rendered lessons feed teacher payouts | **Data ready** | `Lesson.status='rendered'` records exist; aggregation in #283 |
+| Storybook interaction tests | **Complete** | 18 new (rates table, banner, mark-rendered on LessonList) |
+
 ### Lesson Scheduling (#279, Complete)
 
 | Feature | Status | Location |

--- a/libs/react/lessons/src/index.ts
+++ b/libs/react/lessons/src/index.ts
@@ -1,7 +1,16 @@
 export { LessonList } from './lib/LessonList';
 export { ScheduleLessonDialog } from './lib/ScheduleLessonDialog';
 export { EditLessonDialog } from './lib/EditLessonDialog';
+export { HopeRatesTable } from './lib/HopeRatesTable';
+export { HopeScholarshipBanner } from './lib/HopeScholarshipBanner';
 export {
   generateWeeklyDates,
   type SeriesCadence,
 } from './lib/series-dates';
+export {
+  HOPE_PER_LESSON_RATE_CENTS,
+  HOPE_MONTHLY_EQUIVALENT_CENTS,
+  getHopePerLessonRateCents,
+  getHopeMonthlyEquivalentCents,
+  formatCents,
+} from './lib/hope-rates';

--- a/libs/react/lessons/src/lib/HopeRatesTable.stories.tsx
+++ b/libs/react/lessons/src/lib/HopeRatesTable.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within, waitFor } from 'storybook/test';
+import { HopeRatesTable } from './HopeRatesTable';
+
+const meta = {
+  component: HopeRatesTable,
+  title: 'Lessons/HopeRatesTable',
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof HopeRatesTable>;
+
+export default meta;
+type Story = StoryObj<typeof HopeRatesTable>;
+
+export const Default: Story = {};
+
+export const HighlightInitialTier: Story = {
+  args: { highlightTier: '30-min-initial' },
+};
+
+export const HighlightFullTier: Story = {
+  args: { highlightTier: '30-min-full' },
+};
+
+export const Highlight45: Story = {
+  args: { highlightTier: '45-min' },
+};
+
+export const Highlight60: Story = {
+  args: { highlightTier: '60-min' },
+};
+
+export const HeadingSuppressed: Story = {
+  args: { heading: null },
+};
+
+export const CustomHeading: Story = {
+  args: { heading: 'Current rates' },
+};
+
+// ============================================================
+// INTERACTION TESTS
+// ============================================================
+
+export const AllFourTiersRendered: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(() => {
+      expect(canvas.getByText(/30 min \(initial/i)).toBeInTheDocument();
+      expect(canvas.getByText(/30 min \(full/i)).toBeInTheDocument();
+      expect(canvas.getByText(/^45 min$/i)).toBeInTheDocument();
+      expect(canvas.getByText(/^60 min$/i)).toBeInTheDocument();
+    });
+  },
+};
+
+export const DollarAmountsFormattedWithCents: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(() => {
+      // Per-lesson amounts
+      expect(canvas.getByText('$32.50')).toBeInTheDocument();
+      expect(canvas.getByText('$41.25')).toBeInTheDocument();
+      expect(canvas.getByText('$58.75')).toBeInTheDocument();
+      expect(canvas.getByText('$75.00')).toBeInTheDocument();
+      // Monthly equivalents
+      expect(canvas.getByText('$130.00')).toBeInTheDocument();
+      expect(canvas.getByText('$165.00')).toBeInTheDocument();
+      expect(canvas.getByText('$235.00')).toBeInTheDocument();
+      expect(canvas.getByText('$300.00')).toBeInTheDocument();
+    });
+  },
+};
+
+export const HighlightedRowMatchesProp: Story = {
+  args: { highlightTier: '45-min' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(() => {
+      // The highlighted row should contain "45 min" and $58.75
+      const row = canvas.getByText('$58.75').closest('tr');
+      expect(row).not.toBeNull();
+      expect(row?.className).toMatch(/Mui-selected/);
+    });
+  },
+};

--- a/libs/react/lessons/src/lib/HopeRatesTable.tsx
+++ b/libs/react/lessons/src/lib/HopeRatesTable.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import {
+  Box,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import StarsIcon from '@mui/icons-material/Stars';
+import type { LessonLength } from '@maple/ts/domain';
+import { LESSON_LENGTHS } from '@maple/ts/domain';
+import {
+  formatCents,
+  HOPE_MONTHLY_EQUIVALENT_CENTS,
+  HOPE_PER_LESSON_RATE_CENTS,
+} from './hope-rates';
+
+interface HopeRatesTableProps {
+  /**
+   * If provided, the corresponding row is highlighted to draw Katie's eye
+   * to the student's current tier.
+   */
+  highlightTier?: LessonLength;
+  /**
+   * Optional section heading rendered above the table. Pass `null` to
+   * suppress. Defaults to "WV Hope per-lesson rates".
+   */
+  heading?: string | null;
+}
+
+const TIER_LABELS: Record<LessonLength, string> = {
+  '30-min-initial': '30 min (initial — no group class)',
+  '30-min-full': '30 min (full — with group class + recitals)',
+  '45-min': '45 min',
+  '60-min': '60 min',
+};
+
+export function HopeRatesTable({
+  highlightTier,
+  heading = 'WV Hope per-lesson rates',
+}: HopeRatesTableProps) {
+  return (
+    <Box>
+      {heading !== null && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+          <StarsIcon fontSize="small" color="info" />
+          <Typography variant="overline" color="text.secondary">
+            {heading}
+          </Typography>
+        </Box>
+      )}
+      <TableContainer>
+        <Table size="small" aria-label="Hope Scholarship per-lesson rates">
+          <TableHead>
+            <TableRow>
+              <TableCell>Lesson length</TableCell>
+              <TableCell align="right">Per lesson</TableCell>
+              <TableCell align="right">
+                Monthly equivalent (4 lessons)
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {LESSON_LENGTHS.map((tier) => {
+              const isHighlighted = tier === highlightTier;
+              return (
+                <TableRow
+                  key={tier}
+                  selected={isHighlighted}
+                  sx={
+                    isHighlighted
+                      ? {
+                          bgcolor: 'action.selected',
+                          '& td': { fontWeight: 600 },
+                        }
+                      : undefined
+                  }
+                >
+                  <TableCell>{TIER_LABELS[tier]}</TableCell>
+                  <TableCell align="right">
+                    {formatCents(HOPE_PER_LESSON_RATE_CENTS[tier])}
+                  </TableCell>
+                  <TableCell align="right">
+                    {formatCents(HOPE_MONTHLY_EQUIVALENT_CENTS[tier])}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ display: 'block', mt: 1 }}
+      >
+        Rates assume ~4 lessons per month. Update if studio pricing changes.
+      </Typography>
+    </Box>
+  );
+}

--- a/libs/react/lessons/src/lib/HopeScholarshipBanner.stories.tsx
+++ b/libs/react/lessons/src/lib/HopeScholarshipBanner.stories.tsx
@@ -1,0 +1,124 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { HopeScholarshipBanner } from './HopeScholarshipBanner';
+
+const meta = {
+  component: HopeScholarshipBanner,
+  title: 'Lessons/HopeScholarshipBanner',
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof HopeScholarshipBanner>;
+
+export default meta;
+type Story = StoryObj<typeof HopeScholarshipBanner>;
+
+// ============================================================
+// VISUAL STATES
+// ============================================================
+
+export const WithInitialTier: Story = {
+  args: { registeredLessonLength: '30-min-initial' },
+};
+
+export const WithFullTier: Story = {
+  args: { registeredLessonLength: '30-min-full' },
+};
+
+export const With45Min: Story = {
+  args: { registeredLessonLength: '45-min' },
+};
+
+export const With60Min: Story = {
+  args: { registeredLessonLength: '60-min' },
+};
+
+export const WithoutTier: Story = {
+  args: {},
+};
+
+export const RatesExpandedByDefault: Story = {
+  args: {
+    registeredLessonLength: '45-min',
+    defaultRatesExpanded: true,
+  },
+};
+
+// ============================================================
+// INTERACTION TESTS
+// ============================================================
+
+export const BillingRulesAreRendered: Story = {
+  args: { registeredLessonLength: '30-min-initial' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(() => {
+      expect(canvas.getByText(/Hope Scholarship/i)).toBeInTheDocument();
+      expect(canvas.getByText(/per lesson after it is rendered/i)).toBeInTheDocument();
+      expect(
+        canvas.getByText(/cannot be retained for services not rendered/i)
+      ).toBeInTheDocument();
+      expect(
+        canvas.getByText(/credit back to the Hope account/i)
+      ).toBeInTheDocument();
+    });
+  },
+};
+
+export const CurrentRateChipShowsPerLessonAmount: Story = {
+  args: { registeredLessonLength: '45-min' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(() => {
+      expect(
+        canvas.getByText(/Current rate: \$58\.75 \/ lesson/i)
+      ).toBeInTheDocument();
+      expect(canvas.getByText(/Monthly equiv: \$235\.00/i)).toBeInTheDocument();
+    });
+  },
+};
+
+export const NoRateChipWhenTierNotSet: Story = {
+  args: {},
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(() => {
+      expect(canvas.getByText(/Hope Scholarship/i)).toBeInTheDocument();
+    });
+    expect(canvas.queryByText(/Current rate:/i)).toBeNull();
+  },
+};
+
+export const ExpandRatesShowsTable: Story = {
+  args: { registeredLessonLength: '30-min-full' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Table should not be visible initially
+    expect(canvas.queryByRole('table')).toBeNull();
+
+    const toggle = canvas.getByRole('button', { name: /view all rates/i });
+    await userEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(canvas.getByRole('table')).toBeInTheDocument();
+      // Button label flips
+      expect(
+        canvas.getByRole('button', { name: /hide all rates/i })
+      ).toBeInTheDocument();
+    });
+  },
+};
+
+export const ExpandedTableHighlightsCurrentTier: Story = {
+  args: {
+    registeredLessonLength: '60-min',
+    defaultRatesExpanded: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(() => {
+      // Row containing $75.00 (60-min rate) should be highlighted
+      const row = canvas.getByText('$75.00').closest('tr');
+      expect(row?.className).toMatch(/Mui-selected/);
+    });
+  },
+};

--- a/libs/react/lessons/src/lib/HopeScholarshipBanner.tsx
+++ b/libs/react/lessons/src/lib/HopeScholarshipBanner.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+/**
+ * Banner shown on a Hope Scholarship student's pages explaining the
+ * external-invoicing / per-rendered-lesson billing rules, and surfacing
+ * the current per-lesson rate plus an expandable rates table.
+ *
+ * Billing rules are frozen in the component copy (not fetched) — they come
+ * from the ESP Handbook and the studio policy tension documented in #282.
+ */
+
+import { useState } from 'react';
+import {
+  Alert,
+  AlertTitle,
+  Box,
+  Button,
+  Chip,
+  Collapse,
+  Typography,
+} from '@mui/material';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import StarsIcon from '@mui/icons-material/Stars';
+import type { LessonLength } from '@maple/ts/domain';
+import { HopeRatesTable } from './HopeRatesTable';
+import {
+  formatCents,
+  getHopeMonthlyEquivalentCents,
+  getHopePerLessonRateCents,
+} from './hope-rates';
+
+interface HopeScholarshipBannerProps {
+  /**
+   * The student's registered tier. When present, the current rate is
+   * called out inline and the rates table highlights the matching row.
+   */
+  registeredLessonLength?: LessonLength;
+  /** Default expanded state for the rates table. Defaults to collapsed. */
+  defaultRatesExpanded?: boolean;
+}
+
+export function HopeScholarshipBanner({
+  registeredLessonLength,
+  defaultRatesExpanded = false,
+}: HopeScholarshipBannerProps) {
+  const [ratesExpanded, setRatesExpanded] = useState(defaultRatesExpanded);
+
+  const perLessonCents = registeredLessonLength
+    ? getHopePerLessonRateCents(registeredLessonLength)
+    : undefined;
+  const monthlyCents = registeredLessonLength
+    ? getHopeMonthlyEquivalentCents(registeredLessonLength)
+    : undefined;
+
+  return (
+    <Alert
+      severity="info"
+      icon={<StarsIcon />}
+      sx={{ mb: 3, alignItems: 'flex-start' }}
+    >
+      <AlertTitle>WV Hope Scholarship student</AlertTitle>
+      <Typography variant="body2" sx={{ mb: 1 }}>
+        Invoicing goes through the Hope / EMA portal —{' '}
+        <strong>not</strong> through Maple &amp; Spruce.
+      </Typography>
+      <Box component="ul" sx={{ pl: 2, mt: 0, mb: 1 }}>
+        <li>
+          <Typography variant="body2">
+            Invoice <strong>per lesson after it is rendered</strong>, not
+            monthly in advance.
+          </Typography>
+        </li>
+        <li>
+          <Typography variant="body2">
+            Hope funds cannot be retained for services not rendered — only
+            bill for lessons marked <em>rendered</em> below.
+          </Typography>
+        </li>
+        <li>
+          <Typography variant="body2">
+            Refunds credit back to the Hope account, not to the parent.
+          </Typography>
+        </li>
+        <li>
+          <Typography variant="body2">
+            Post-termination 30-day tuition in the studio policy is{' '}
+            <strong>private-pay only</strong>; it cannot be drawn from Hope.
+          </Typography>
+        </li>
+      </Box>
+
+      {perLessonCents !== undefined && monthlyCents !== undefined && (
+        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 1 }}>
+          <Chip
+            label={`Current rate: ${formatCents(perLessonCents)} / lesson`}
+            color="info"
+            size="small"
+          />
+          <Chip
+            label={`Monthly equiv: ${formatCents(monthlyCents)}`}
+            variant="outlined"
+            size="small"
+          />
+        </Box>
+      )}
+
+      <Button
+        size="small"
+        onClick={() => setRatesExpanded((v) => !v)}
+        startIcon={
+          ratesExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />
+        }
+        sx={{ mt: 0.5 }}
+        aria-expanded={ratesExpanded}
+        aria-controls="hope-rates-details"
+      >
+        {ratesExpanded ? 'Hide all rates' : 'View all rates'}
+      </Button>
+      <Collapse in={ratesExpanded} id="hope-rates-details">
+        <Box sx={{ mt: 2 }}>
+          <HopeRatesTable
+            highlightTier={registeredLessonLength}
+            heading={null}
+          />
+        </Box>
+      </Collapse>
+    </Alert>
+  );
+}

--- a/libs/react/lessons/src/lib/LessonList.stories.tsx
+++ b/libs/react/lessons/src/lib/LessonList.stories.tsx
@@ -7,6 +7,7 @@ import {
   mockLessonUpcomingSeries,
   mockLessonUpcomingSubstitute,
   mockLessonPastRendered,
+  mockLessonPastScheduled,
   mockLessonCancelled,
   mockInstructor,
   mockInstructor2,
@@ -23,6 +24,7 @@ const meta = {
   args: {
     onEdit: fn(),
     onCancel: fn(),
+    onMarkRendered: fn(),
     instructors,
     primaryTeacherId: mockInstructor.id,
     now: fixedNow,
@@ -181,5 +183,99 @@ export const SubstituteChipAppearsWhenTeacherDiffers: Story = {
     await waitFor(() => {
       expect(canvas.getByText(/substitute/i)).toBeInTheDocument();
     });
+  },
+};
+
+// ============================================================
+// MARK RENDERED (added in #282)
+// ============================================================
+
+export const MarkRenderedShownOnPastScheduledLesson: Story = {
+  args: {
+    lessonsState: {
+      status: 'success',
+      data: [mockLessonPastScheduled],
+    } as RequestState<Lesson[]>,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(() => {
+      expect(
+        canvas.getByRole('button', { name: /mark lesson as rendered/i })
+      ).toBeInTheDocument();
+    });
+  },
+};
+
+export const MarkRenderedHiddenOnUpcomingLesson: Story = {
+  args: {
+    lessonsState: {
+      status: 'success',
+      data: [mockLessonUpcomingSingle],
+    } as RequestState<Lesson[]>,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(
+      canvas.queryByRole('button', { name: /mark lesson as rendered/i })
+    ).toBeNull();
+    // Edit + Cancel still present
+    expect(
+      canvas.getByRole('button', { name: /edit lesson/i })
+    ).toBeInTheDocument();
+  },
+};
+
+export const MarkRenderedHiddenWhenHandlerOmitted: Story = {
+  args: {
+    lessonsState: {
+      status: 'success',
+      data: [mockLessonPastScheduled],
+    } as RequestState<Lesson[]>,
+    onMarkRendered: undefined,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(
+      canvas.queryByRole('button', { name: /mark lesson as rendered/i })
+    ).toBeNull();
+  },
+};
+
+export const MarkRenderedCallsHandler: Story = {
+  args: {
+    lessonsState: {
+      status: 'success',
+      data: [mockLessonPastScheduled],
+    } as RequestState<Lesson[]>,
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', {
+      name: /mark lesson as rendered/i,
+    });
+    await userEvent.click(button);
+    await waitFor(() => {
+      expect(args.onMarkRendered).toHaveBeenCalledTimes(1);
+      expect(args.onMarkRendered).toHaveBeenCalledWith(
+        mockLessonPastScheduled
+      );
+    });
+  },
+};
+
+export const MarkRenderedHiddenOnRenderedRow: Story = {
+  args: {
+    lessonsState: {
+      status: 'success',
+      data: [mockLessonPastRendered],
+    } as RequestState<Lesson[]>,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Already-rendered lesson shouldn't offer the action again
+    expect(
+      canvas.queryByRole('button', { name: /mark lesson as rendered/i })
+    ).toBeNull();
   },
 };

--- a/libs/react/lessons/src/lib/LessonList.tsx
+++ b/libs/react/lessons/src/lib/LessonList.tsx
@@ -13,6 +13,7 @@ import {
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import CancelIcon from '@mui/icons-material/Cancel';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import type { Instructor, Lesson, RequestState } from '@maple/ts/domain';
 
 interface LessonListProps {
@@ -23,6 +24,13 @@ interface LessonListProps {
   primaryTeacherId?: string;
   onEdit: (lesson: Lesson) => void;
   onCancel: (lesson: Lesson) => void;
+  /**
+   * Optional — when provided, past scheduled lessons get a
+   * "Mark rendered" action. Required for Hope Scholarship students so
+   * invoicing via EMA can only pull from rendered records; useful for
+   * private-pay too so #283 payout tracking has accurate counts.
+   */
+  onMarkRendered?: (lesson: Lesson) => void;
   /** For deterministic testing; defaults to current wall clock. */
   now?: Date;
 }
@@ -50,16 +58,24 @@ function LessonRow({
   lesson,
   teacherName,
   isSubstitute,
+  isPast,
   onEdit,
   onCancel,
+  onMarkRendered,
 }: {
   lesson: Lesson;
   teacherName: string;
   isSubstitute: boolean;
+  isPast: boolean;
   onEdit: () => void;
   onCancel: () => void;
+  onMarkRendered?: () => void;
 }) {
   const canMutate = lesson.status === 'scheduled';
+  // Mark-rendered is only meaningful for past scheduled lessons; hide it
+  // for future-dated rows so Katie doesn't mark something that hasn't
+  // happened yet.
+  const canMarkRendered = canMutate && isPast && !!onMarkRendered;
 
   return (
     <ListItem
@@ -72,6 +88,17 @@ function LessonRow({
       secondaryAction={
         canMutate ? (
           <Box sx={{ display: 'flex', gap: 0.5 }}>
+            {canMarkRendered && (
+              <IconButton
+                edge="end"
+                onClick={onMarkRendered}
+                size="small"
+                aria-label="Mark lesson as rendered"
+                color="success"
+              >
+                <CheckCircleIcon fontSize="small" />
+              </IconButton>
+            )}
             <IconButton
               edge="end"
               onClick={onEdit}
@@ -151,6 +178,7 @@ export function LessonList({
   primaryTeacherId,
   onEdit,
   onCancel,
+  onMarkRendered,
   now = new Date(),
 }: LessonListProps) {
   if (lessonsState.status === 'loading') {
@@ -204,8 +232,12 @@ export function LessonList({
         primaryTeacherId !== undefined &&
         lesson.teacherId !== primaryTeacherId
       }
+      isPast={lesson.scheduledAt.getTime() <= now.getTime()}
       onEdit={() => onEdit(lesson)}
       onCancel={() => onCancel(lesson)}
+      onMarkRendered={
+        onMarkRendered ? () => onMarkRendered(lesson) : undefined
+      }
     />
   );
 

--- a/libs/react/lessons/src/lib/hope-rates.spec.ts
+++ b/libs/react/lessons/src/lib/hope-rates.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatCents,
+  getHopeMonthlyEquivalentCents,
+  getHopePerLessonRateCents,
+  HOPE_MONTHLY_EQUIVALENT_CENTS,
+  HOPE_PER_LESSON_RATE_CENTS,
+} from './hope-rates';
+
+describe('Hope rates', () => {
+  it('exposes per-lesson rates for every LessonLength tier', () => {
+    expect(HOPE_PER_LESSON_RATE_CENTS).toEqual({
+      '30-min-initial': 3250,
+      '30-min-full': 4125,
+      '45-min': 5875,
+      '60-min': 7500,
+    });
+  });
+
+  it('exposes monthly equivalents that are ~4× the per-lesson rate', () => {
+    expect(HOPE_MONTHLY_EQUIVALENT_CENTS['30-min-initial']).toBe(13000);
+    expect(HOPE_MONTHLY_EQUIVALENT_CENTS['30-min-full']).toBe(16500);
+    expect(HOPE_MONTHLY_EQUIVALENT_CENTS['45-min']).toBe(23500);
+    expect(HOPE_MONTHLY_EQUIVALENT_CENTS['60-min']).toBe(30000);
+
+    // Sanity: monthly should be exactly 4× per-lesson for every tier
+    for (const tier of [
+      '30-min-initial',
+      '30-min-full',
+      '45-min',
+      '60-min',
+    ] as const) {
+      expect(HOPE_MONTHLY_EQUIVALENT_CENTS[tier]).toBe(
+        HOPE_PER_LESSON_RATE_CENTS[tier] * 4
+      );
+    }
+  });
+
+  it('getHopePerLessonRateCents returns the expected value', () => {
+    expect(getHopePerLessonRateCents('30-min-initial')).toBe(3250);
+    expect(getHopePerLessonRateCents('60-min')).toBe(7500);
+  });
+
+  it('getHopeMonthlyEquivalentCents returns the expected value', () => {
+    expect(getHopeMonthlyEquivalentCents('30-min-initial')).toBe(13000);
+    expect(getHopeMonthlyEquivalentCents('60-min')).toBe(30000);
+  });
+});
+
+describe('formatCents', () => {
+  it('formats whole dollars with 2 decimal places', () => {
+    expect(formatCents(7500)).toBe('$75.00');
+    expect(formatCents(10000)).toBe('$100.00');
+  });
+
+  it('formats fractional dollars', () => {
+    expect(formatCents(3250)).toBe('$32.50');
+    expect(formatCents(4125)).toBe('$41.25');
+    expect(formatCents(5875)).toBe('$58.75');
+  });
+
+  it('handles zero', () => {
+    expect(formatCents(0)).toBe('$0.00');
+  });
+});

--- a/libs/react/lessons/src/lib/hope-rates.ts
+++ b/libs/react/lessons/src/lib/hope-rates.ts
@@ -1,0 +1,51 @@
+/**
+ * West Virginia Hope Scholarship per-lesson rates.
+ *
+ * Hope students are invoiced via the EMA portal per lesson *after* it is
+ * rendered — not monthly in advance. These rates are the cents-per-lesson
+ * equivalents of Katie's studio monthly tuition (assuming ~4 lessons per
+ * month). Update both this map and `HOPE_MONTHLY_EQUIVALENT_CENTS` when
+ * studio pricing changes.
+ *
+ * Source: ESP Handbook + Katie's studio rates (docs captured in #282).
+ */
+import type { LessonLength } from '@maple/ts/domain';
+
+/**
+ * Per-lesson rate in cents, indexed by the student's registered lesson
+ * length tier.
+ */
+export const HOPE_PER_LESSON_RATE_CENTS: Record<LessonLength, number> = {
+  '30-min-initial': 3250, // $32.50/lesson  ($130/mo)
+  '30-min-full': 4125, // $41.25/lesson  ($165/mo)
+  '45-min': 5875, // $58.75/lesson  ($235/mo)
+  '60-min': 7500, // $75.00/lesson  ($300/mo)
+};
+
+/**
+ * Monthly equivalent (4 lessons) in cents — shown alongside the per-lesson
+ * rate on the rates table so Katie can sanity-check against studio policy.
+ */
+export const HOPE_MONTHLY_EQUIVALENT_CENTS: Record<LessonLength, number> = {
+  '30-min-initial': 13000,
+  '30-min-full': 16500,
+  '45-min': 23500,
+  '60-min': 30000,
+};
+
+export function getHopePerLessonRateCents(
+  lessonLength: LessonLength
+): number {
+  return HOPE_PER_LESSON_RATE_CENTS[lessonLength];
+}
+
+export function getHopeMonthlyEquivalentCents(
+  lessonLength: LessonLength
+): number {
+  return HOPE_MONTHLY_EQUIVALENT_CENTS[lessonLength];
+}
+
+/** Format a cents value as "$12.34" for display. */
+export function formatCents(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}


### PR DESCRIPTION
## Summary

Closes #282. Surfaces WV Hope Scholarship billing rules on the student detail page and adds the per-lesson **"mark rendered"** action that Hope invoicing (through the EMA portal) requires.

## UX changes

- **Hope banner on the student detail page** (`HopeScholarshipBanner`). Explains external EMA invoicing, per-rendered-lesson billing, the no-retention rule, and where refunds go. Shows the student's **current per-lesson rate** as a chip plus an expandable **4-tier rates table** with the current tier highlighted.
- **Mark lesson rendered** — third action button on `LessonList` rows, gated to **past scheduled lessons only** so Katie can't mark something that hasn't happened yet. Useful for both Hope (required for EMA billing) and private-pay (the #283 payout tracking will aggregate rendered records).
- **`HopeRatesTable`** — standalone component reused inside the banner; available for future Hope surfaces too.
- **Hope filter on `/students`** — All / Hope only / Private-pay only toggle, client-side since roster is small.

## Rates (per ESP Handbook + studio pricing)

All rates live in \`hope-rates.ts\` with per-lesson and monthly-equivalent (×4) constants. Update there when studio pricing shifts.

| Tier | Per lesson | Monthly (×4) |
|------|-----------:|-------------:|
| 30 min (initial, no group class) | \$32.50 | \$130.00 |
| 30 min (full, w/ group + recitals) | \$41.25 | \$165.00 |
| 45 min | \$58.75 | \$235.00 |
| 60 min | \$75.00 | \$300.00 |

## Testing

- [x] \`hope-rates.spec.ts\` — 7 unit tests pass (rates correctness, \`formatCents\`, ×4 invariant)
- [x] Storybook interaction tests — **18 new**, **70 total** in \`react-lessons\` + \`react-students\`, all green:
  - \`HopeRatesTable\` — all tiers render, amounts formatted, highlight row matches prop
  - \`HopeScholarshipBanner\` — billing rules render, current-rate chip shows correct amount, expand/collapse, highlighted row in expanded table
  - \`LessonList\` — mark-rendered shown on past scheduled, hidden on future/rendered/cancelled/no-handler, handler receives the lesson
- [x] \`tsc --noEmit\` clean for \`apps/maple-spruce\`
- [x] No backend changes — \`Lesson.status\` already included \`'rendered'\` from #279

## Not in scope (future issues)

- Excluding Hope students from the in-app invoice flow — waiting on **#280** to even have an invoice flow; will add the guard there.
- Teacher payout aggregation — **#283**; data is already flowing since rendered lessons carry \`teacherId\`.

Closes #282
Part of #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)