### PR TITLE
feat: Square-delivered invoice payment + webhook attribution (#281)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -153,7 +153,27 @@
       "WebFetch(domain:docs.cloud.google.com)",
       "WebFetch(domain:www.ayrshare.com)",
       "Bash(pnpm exec:*)",
-      "Bash(apps/functions-integration-tests/project.json:*)"
+      "Bash(apps/functions-integration-tests/project.json:*)",
+      "Bash(pnpm nx *)",
+      "Bash(./tools/validate-function-tsconfigs.sh)",
+      "Bash(./tools/validate-function-tsconfigs.sh --fix)",
+      "Bash(cp -r libs/react/instructors libs/react/students)",
+      "Bash(rm libs/react/students/src/lib/*.tsx)",
+      "Bash(cp -r libs/react/students libs/react/lessons)",
+      "Bash(rm libs/react/lessons/src/lib/*.tsx libs/react/lessons/src/lib/*.ts)",
+      "Bash(cp -r libs/react/lessons libs/react/invoices)",
+      "Bash(rm -rf libs/react/invoices/src/lib/*)",
+      "WebFetch(domain:developer.squareup.com)",
+      "WebFetch(domain:squareup.com)",
+      "Bash(cat libs/firebase/square/vitest.config.ts)",
+      "Bash(find libs/firebase/square -name \"vitest.config*\")",
+      "Bash(ls vitest.config.*)",
+      "Bash(cat vitest.config.ts)",
+      "Bash(sed -n '145,152p' libs/ts/domain/src/lib/invoice.ts)",
+      "Bash(sed -n '36,60p' libs/firebase/maple-functions/sync-invoice-to-square/src/lib/sync-invoice-to-square.ts)",
+      "Bash(awk '{print $1, $3}')",
+      "Bash(sort -k2 -n)",
+      "Bash(awk -F'|' '{gsub\\(/^[[:space:]]+|[[:space:]]+$/, \"\", $1\\); gsub\\(/^[[:space:]]+|[[:space:]]+$/, \"\", $2\\); if \\($2+0 < 75 && $2 != \"\"\\) print $1, \"|\", $2}')"
     ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 3. **Read before acting** -- Start sessions by reading AGENTS.md, .claude/CLAUDE.md, and `docs/sessions/SESSION.md`.
 4. **Check GitHub issues** -- Run `gh issue list` for current work. Issues are the source of truth.
 5. **Use feature branches** -- Never commit directly to main. See `git-workflow` skill.
-6. **Always write tests** -- Unit tests for new functions/utilities. Run `pnpm test` before PRs. Use `vi.mock()` for Cloud Functions (ADR-017).
+6. **Always write tests** -- Unit tests for new functions/utilities. Run `pnpm test` before PRs. Use `vi.mock()` for Cloud Functions (ADR-017). Aim for **~90% coverage on new code** — the 80% CI threshold is a floor, not a target. See `docs/reference/code-standards.md` for per-file-type guidance.
 7. **Use GitHub issues for tracking** -- Reference issues in PRs (`Closes #XX`).
 8. **Never deploy manually** -- CI/CD deploys on merge to main. Claude writes code and creates PRs.
 9. **No package.json in libs** -- Root `package.json` and `tsconfig.base.json` manage all dependencies.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 3. **Read before acting** -- Start sessions by reading AGENTS.md, .claude/CLAUDE.md, and `docs/sessions/SESSION.md`.
 4. **Check GitHub issues** -- Run `gh issue list` for current work. Issues are the source of truth.
 5. **Use feature branches** -- Never commit directly to main. See `git-workflow` skill.
-6. **Always write tests** -- Unit tests for new functions/utilities. Run `pnpm test` before PRs. Use `vi.mock()` for Cloud Functions (ADR-017). Aim for **~90% coverage on new code** — the 80% CI threshold is a floor, not a target. See `docs/reference/code-standards.md` for per-file-type guidance.
+6. **Always write tests** -- Unit tests for new functions/utilities. Run `pnpm test` before PRs. Use `vi.mock()` for Cloud Functions (ADR-017). Aim for **~85% coverage on new code** — the 80% CI threshold is a floor, not a target. See `docs/reference/code-standards.md` for per-file-type guidance.
 7. **Use GitHub issues for tracking** -- Reference issues in PRs (`Closes #XX`).
 8. **Never deploy manually** -- CI/CD deploys on merge to main. Claude writes code and creates PRs.
 9. **No package.json in libs** -- Root `package.json` and `tsconfig.base.json` manage all dependencies.

--- a/apps/functions-integration-tests-invoice/src/invoice-functions.spec.ts
+++ b/apps/functions-integration-tests-invoice/src/invoice-functions.spec.ts
@@ -247,7 +247,7 @@ describe('Invoice Functions', () => {
       expect(result.data!.invoice.paidAt).toBeUndefined();
     });
 
-    it('transitions sent → paid and stamps paidAt', async () => {
+    it('transitions sent → paid and stamps paidAt + paymentRecord (admin-manual)', async () => {
       const result = await callFunction<
         UpdateInvoiceRequest,
         UpdateInvoiceResponse
@@ -261,6 +261,10 @@ describe('Invoice Functions', () => {
       expect(result.data!.invoice.status).toBe('paid');
       expect(result.data!.invoice.paidAt).toBeTruthy();
       expect(result.data!.invoice.issuedAt).toBeTruthy();
+      // Manual paid transitions are attributed to the admin (#281).
+      expect(result.data!.invoice.paymentRecord).toBeTruthy();
+      expect(result.data!.invoice.paymentRecord?.source).toBe('admin-manual');
+      expect(result.data!.invoice.paymentRecord?.squarePaymentId).toBeUndefined();
     });
 
     it('rejects paid → sent (invalid transition)', async () => {

--- a/apps/functions-square/src/index.ts
+++ b/apps/functions-square/src/index.ts
@@ -27,3 +27,6 @@ export { cancelRegistration } from '@maple/firebase/maple-functions/cancel-regis
 // Sync conflict resolution (Square catalog comparison)
 export { detectSyncConflicts } from '@maple/firebase/maple-functions/detect-sync-conflicts';
 export { resolveSyncConflict } from '@maple/firebase/maple-functions/resolve-sync-conflict';
+
+// Invoice → Square sync (Firestore trigger on invoices/{id})
+export { syncInvoiceToSquare } from '@maple/firebase/maple-functions/sync-invoice-to-square';

--- a/apps/functions-square/tsconfig.app.json
+++ b/apps/functions-square/tsconfig.app.json
@@ -14,6 +14,7 @@
     "../../libs/firebase/maple-functions/cancel-registration/**/*.ts",
     "../../libs/firebase/maple-functions/detect-sync-conflicts/**/*.ts",
     "../../libs/firebase/maple-functions/resolve-sync-conflict/**/*.ts",
+    "../../libs/firebase/maple-functions/sync-invoice-to-square/**/*.ts",
     "../../libs/firebase/database/src/**/*.ts",
     "../../libs/firebase/functions/src/**/*.ts",
     "../../libs/firebase/square/src/**/*.ts",

--- a/apps/maple-spruce/.storybook/fixtures/invoices.ts
+++ b/apps/maple-spruce/.storybook/fixtures/invoices.ts
@@ -39,8 +39,43 @@ export const mockInvoicePaid: Invoice = {
   totalCents: 13000,
   issuedAt: new Date('2026-03-21T09:00:00Z'),
   paidAt: new Date('2026-03-25T09:00:00Z'),
+  paymentRecord: {
+    source: 'square-webhook',
+    squarePaymentId: 'SQ-PAYMENT-abc123',
+    recordedAt: new Date('2026-03-25T09:00:00Z'),
+  },
+  squareOrderId: 'SQ-ORDER-1',
+  squareInvoiceId: 'SQ-INVOICE-1',
   createdAt: new Date('2026-03-20T09:00:00Z'),
   updatedAt: new Date('2026-03-25T09:00:00Z'),
+};
+
+export const mockInvoicePaidManually: Invoice = {
+  id: 'inv-003-manual',
+  studentId: 'student-001',
+  status: 'paid',
+  lineItems: [aprilTuition],
+  totalCents: 13000,
+  issuedAt: new Date('2026-02-20T09:00:00Z'),
+  paidAt: new Date('2026-02-24T09:00:00Z'),
+  paymentRecord: {
+    source: 'admin-manual',
+    recordedAt: new Date('2026-02-24T09:00:00Z'),
+  },
+  createdAt: new Date('2026-02-20T09:00:00Z'),
+  updatedAt: new Date('2026-02-24T09:00:00Z'),
+};
+
+export const mockInvoiceSyncError: Invoice = {
+  id: 'inv-sync-error',
+  studentId: 'student-001',
+  status: 'sent',
+  lineItems: [aprilTuition],
+  totalCents: 13000,
+  issuedAt: new Date('2026-04-21T09:00:00Z'),
+  squareSyncError: 'Square order error: INVALID_REQUEST',
+  createdAt: new Date('2026-04-21T09:00:00Z'),
+  updatedAt: new Date('2026-04-21T09:00:00Z'),
 };
 
 export const mockInvoiceVoid: Invoice = {
@@ -90,6 +125,8 @@ export const mockInvoices: Invoice[] = [
   mockInvoiceDraft,
   mockInvoiceSent,
   mockInvoicePaid,
+  mockInvoicePaidManually,
   mockInvoiceVoid,
   mockInvoiceMultiLine,
+  mockInvoiceSyncError,
 ];

--- a/docs/reference/code-standards.md
+++ b/docs/reference/code-standards.md
@@ -68,16 +68,17 @@ Always use MUI theme colors, not hardcoded hex values.
 
 ## Testing & Coverage
 
-CI runs `nyc check-coverage --lines 80 --functions 80 --statements 80 --branches 50` against the merged coverage report. That 80 is a **floor, not a target** — write enough tests that a PR comfortably clears it.
+CI runs `nyc check-coverage --lines 80 --functions 80 --statements 80 --branches 50` against the merged coverage report. **80% is the CI floor; aim for ~85% on new code.** PRs that scrape by at 80.1% are fragile — a single unrelated refactor elsewhere can drag the merged number back under the line and break CI without anyone changing the tested code. 85% gives headroom while staying achievable.
 
-**Aim for ~90% line/statement coverage on new code.** PRs that scrape by at 80.1% are fragile: a single unrelated refactor elsewhere can drag the merged number under the line and break CI without anyone changing the tested code. 90% gives headroom.
+What's in coverage: production `src/**/*.ts`/`*.tsx` under `libs/` and `apps/` excluding the integration-test mock server, integration-test harness, Storybook config, and e2e harness (see `vitest.config.ts` exclude list). Integration tests and Storybook interaction tests are complementary signals, not a substitute — line/branch coverage comes from unit tests only.
 
 Concretely, when you add a new file:
 
-- **Cloud function handler** (`*.ts` in `libs/firebase/maple-functions/{name}/src/lib/`) — add a sibling `.spec.ts`. Mock repositories + Square/Webflow services with `vi.mock()` per ADR-017. Test each branch: happy path, not-found / permission rejections, Square-side errors.
-- **Firestore trigger** — export the inner handler so the spec can invoke it directly; mock `onDocumentWritten` to return the handler. See `libs/firebase/maple-functions/sync-invoice-to-square/src/lib/sync-invoice-to-square.spec.ts` for the pattern.
-- **New repository method** — add a spec in `libs/firebase/database/src/lib/{entity}.repository.spec.ts`. Mock `./utilities/database.config`. See `invoice.repository.spec.ts` for the pattern.
-- **New Square / Webflow service method** — add a sibling spec mocking the SDK client at the method level. See `invoices.service.spec.ts`.
+- **Cloud function handler** (`libs/firebase/maple-functions/{name}/src/lib/`) — add a sibling `.spec.ts`. Mock the `createAdminFunction` / `createAuthenticatedFunction` wrapper to return the handler directly so you can invoke it as a plain function. Mock repositories + Square/Webflow services with `vi.mock()` per ADR-017. Test each branch: happy path, not-found / permission rejections, service-side errors. See `libs/firebase/maple-functions/create-invoice/src/lib/create-invoice.spec.ts` and `.../update-invoice.spec.ts`.
+- **Firestore trigger** — export the inner handler so the spec can invoke it directly; mock `onDocumentWritten` to return the handler. See `libs/firebase/maple-functions/sync-invoice-to-square/src/lib/sync-invoice-to-square.spec.ts` for the pattern (draft→sent happy path, each guard, status-transition no-ops, Timestamp/string coercion branches).
+- **HTTPS endpoint** — mock `onRequest` similarly; exercise signature verification, method rejection, event dispatch, and the catch-all error path. See `libs/firebase/maple-functions/square-webhook/src/lib/square-webhook.spec.ts` (endpoint describe block).
+- **Repository method** — add a spec in `libs/firebase/database/src/lib/{entity}.repository.spec.ts`. Mock `./utilities/database.config`. See `invoice.repository.spec.ts` and `registration.repository.spec.ts` for the mock-chain pattern.
+- **Square / Webflow service method** — add a sibling spec mocking the SDK client at the method level. See `libs/firebase/square/src/lib/invoices.service.spec.ts`.
 - **New lib with tests** — also add the lib's `vitest.config.ts` to `vitest.workspace.ts`, otherwise the merged coverage report won't include it.
 
-Integration tests (emulator-backed) and Storybook interaction tests are complementary, not a substitute — coverage is measured from unit tests only.
+If you're adding a new large handler to an existing test-covered file (like `square-webhook.ts`), **export the handler** so the spec can target it directly rather than going through the HTTPS endpoint wrapper for every branch.

--- a/docs/reference/code-standards.md
+++ b/docs/reference/code-standards.md
@@ -65,3 +65,19 @@ const snapshot = await getDocs(collection(db, 'artists'));
 ```
 
 Always use MUI theme colors, not hardcoded hex values.
+
+## Testing & Coverage
+
+CI runs `nyc check-coverage --lines 80 --functions 80 --statements 80 --branches 50` against the merged coverage report. That 80 is a **floor, not a target** — write enough tests that a PR comfortably clears it.
+
+**Aim for ~90% line/statement coverage on new code.** PRs that scrape by at 80.1% are fragile: a single unrelated refactor elsewhere can drag the merged number under the line and break CI without anyone changing the tested code. 90% gives headroom.
+
+Concretely, when you add a new file:
+
+- **Cloud function handler** (`*.ts` in `libs/firebase/maple-functions/{name}/src/lib/`) — add a sibling `.spec.ts`. Mock repositories + Square/Webflow services with `vi.mock()` per ADR-017. Test each branch: happy path, not-found / permission rejections, Square-side errors.
+- **Firestore trigger** — export the inner handler so the spec can invoke it directly; mock `onDocumentWritten` to return the handler. See `libs/firebase/maple-functions/sync-invoice-to-square/src/lib/sync-invoice-to-square.spec.ts` for the pattern.
+- **New repository method** — add a spec in `libs/firebase/database/src/lib/{entity}.repository.spec.ts`. Mock `./utilities/database.config`. See `invoice.repository.spec.ts` for the pattern.
+- **New Square / Webflow service method** — add a sibling spec mocking the SDK client at the method level. See `invoices.service.spec.ts`.
+- **New lib with tests** — also add the lib's `vitest.config.ts` to `vitest.workspace.ts`, otherwise the merged coverage report won't include it.
+
+Integration tests (emulator-backed) and Storybook interaction tests are complementary, not a substitute — coverage is measured from unit tests only.

--- a/docs/reference/deployed-functions.md
+++ b/docs/reference/deployed-functions.md
@@ -27,6 +27,8 @@ Core CRUD operations, auth, triggers, and admin functions. No heavy third-party 
 
 ### Music Lesson Invoices (private-pay)
 - `getInvoices`, `createInvoice`, `updateInvoice`, `deleteInvoice`
+- `syncInvoiceToSquare` _(Firestore trigger on `invoices/{id}` — sends via Square Invoices API on draft → sent, cancels on sent → void)_
+- `squareWebhook` now additionally handles `invoice.payment_made` → flips matching invoice to `paid` with `paymentRecord.source = 'square-webhook'`
 
 ### Classes
 - `getClasses`, `getClass`, `createClass`, `updateClass`, `deleteClass`, `uploadClassImage`

--- a/docs/reference/implementation-status.md
+++ b/docs/reference/implementation-status.md
@@ -167,6 +167,24 @@ Phased rollout of customer-facing interactions on the Webflow site.
 
 ## Phase 4: Music Lessons - Epic #10
 
+### Parent Invoice Delivery + Online Payment (#281, Complete)
+
+Uses Square Invoices API rather than a custom Webflow payment page — Square sends the parent the email + hosted payment page, handles receipts and reminders, and webhooks us back when paid.
+
+| Feature | Status | Location |
+|---------|--------|----------|
+| Invoice extended with `paymentRecord` / `squareOrderId` / `squareInvoiceId` / `squareSyncError` | **Complete** | `libs/ts/domain/src/lib/invoice.ts` |
+| `InvoicesService` wrapper (Square Customers + Orders + Invoices APIs) | **Complete** | `libs/firebase/square/src/lib/invoices.service.ts` |
+| `syncInvoiceToSquare` Firestore trigger (draft → sent → Square; sent → void → cancel) | **Complete** | `libs/firebase/maple-functions/sync-invoice-to-square/` |
+| `square-webhook` extended to handle `invoice.payment_made` | **Complete** | `libs/firebase/maple-functions/square-webhook/src/lib/square-webhook.ts` |
+| `InvoiceRepository.markPaidBySquareWebhook` + `findBySquareInvoiceId` | **Complete** | `libs/firebase/database/src/lib/invoice.repository.ts` |
+| Payment attribution — manual mark-paid stamps `source: 'admin-manual'` | **Complete** | `InvoiceRepository.update` stamp on paid transition |
+| `InvoiceList` surfaces "Paid via Square" / "Marked paid manually" / sync-error chips | **Complete** | `libs/react/invoices/src/lib/InvoiceList.tsx` |
+| Unit tests: webhook handler + invoice domain paymentRecord shapes | **Complete** | 4 new (13 total in square-webhook.spec) + 2 new in invoice.spec |
+| Integration test: manual mark-paid stamps admin-manual attribution | **Complete** | `apps/functions-integration-tests-invoice/` |
+| Storybook interaction tests: attribution badges, sync-error badge | **Complete** | 4 new (32 total in Invoices family) |
+| Drive-by: migrated `invoiceValidation` from `create` → `staticSuite` | **Complete** | matches #293 |
+
 ### Invoice Initiation — Private Pay (#280, Complete)
 
 | Feature | Status | Location |

--- a/function-codebases.json
+++ b/function-codebases.json
@@ -20,6 +20,7 @@
     "firebase-maple-functions-cancel-registration": "maple-square",
     "firebase-maple-functions-detect-sync-conflicts": "maple-square",
     "firebase-maple-functions-resolve-sync-conflict": "maple-square",
+    "firebase-maple-functions-sync-invoice-to-square": "maple-square",
     "firebase-maple-functions-sync-artist-to-webflow": "maple-sync",
     "firebase-maple-functions-sync-instructor-to-webflow": "maple-sync",
     "firebase-maple-functions-sync-class-to-webflow": "maple-sync",

--- a/libs/firebase/database/src/lib/invoice.repository.spec.ts
+++ b/libs/firebase/database/src/lib/invoice.repository.spec.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the database config module
+vi.mock('./utilities/database.config', () => ({
+  db: {
+    collection: vi.fn(),
+  },
+  toDate: (value: unknown, fallback: Date = new Date()): Date => {
+    if (value === null || value === undefined) return fallback;
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      'toDate' in value &&
+      typeof (value as { toDate: unknown }).toDate === 'function'
+    ) {
+      return (value as { toDate: () => Date }).toDate();
+    }
+    if (value instanceof Date) return value;
+    if (typeof value === 'string' || typeof value === 'number') {
+      const parsed = new Date(value);
+      return isNaN(parsed.getTime()) ? fallback : parsed;
+    }
+    return fallback;
+  },
+}));
+
+import { InvoiceRepository } from './invoice.repository';
+import { db } from './utilities/database.config';
+
+function mockDocSnapshot(
+  id: string,
+  data: Record<string, unknown> | null
+): {
+  id: string;
+  exists: boolean;
+  data: () => Record<string, unknown> | undefined;
+} {
+  return {
+    id,
+    exists: data !== null,
+    data: () => (data !== null ? data : undefined),
+  };
+}
+
+/** Minimal invoice data stored in Firestore */
+function firestoreInvoice(overrides: Record<string, unknown> = {}) {
+  return {
+    studentId: 'student-1',
+    status: 'sent',
+    lineItems: [
+      {
+        id: 'line-1',
+        description: 'April tuition',
+        quantity: 4,
+        unitAmountCents: 3250,
+        subtotalCents: 13000,
+      },
+    ],
+    totalCents: 13000,
+    issuedAt: new Date('2026-04-20T10:00:00Z'),
+    createdAt: new Date('2026-04-20T10:00:00Z'),
+    updatedAt: new Date('2026-04-20T10:00:00Z'),
+    ...overrides,
+  };
+}
+
+describe('InvoiceRepository (new methods added in #281)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── findBySquareInvoiceId ────────────────────────────────────────────
+
+  describe('findBySquareInvoiceId', () => {
+    it('returns the invoice when one matches', async () => {
+      const snap = mockDocSnapshot(
+        'inv-1',
+        firestoreInvoice({
+          squareOrderId: 'SQ-ORDER',
+          squareInvoiceId: 'SQ-INVOICE-1',
+        })
+      );
+      const mockGet = vi.fn().mockResolvedValue({ empty: false, docs: [snap] });
+      const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
+      const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+      vi.mocked(db.collection).mockReturnValue({
+        where: mockWhere,
+      } as unknown as FirebaseFirestore.CollectionReference);
+
+      const invoice = await InvoiceRepository.findBySquareInvoiceId(
+        'SQ-INVOICE-1'
+      );
+
+      expect(mockWhere).toHaveBeenCalledWith(
+        'squareInvoiceId',
+        '==',
+        'SQ-INVOICE-1'
+      );
+      expect(mockLimit).toHaveBeenCalledWith(1);
+      expect(invoice?.id).toBe('inv-1');
+      expect(invoice?.squareInvoiceId).toBe('SQ-INVOICE-1');
+    });
+
+    it('returns undefined when no invoice matches', async () => {
+      const mockGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
+      const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
+      const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+      vi.mocked(db.collection).mockReturnValue({
+        where: mockWhere,
+      } as unknown as FirebaseFirestore.CollectionReference);
+
+      const invoice = await InvoiceRepository.findBySquareInvoiceId(
+        'SQ-UNKNOWN'
+      );
+      expect(invoice).toBeUndefined();
+    });
+  });
+
+  // ── markPaidBySquareWebhook ──────────────────────────────────────────
+
+  describe('markPaidBySquareWebhook', () => {
+    function setupDoc(existing: Record<string, unknown>, id = 'inv-1') {
+      const snapBefore = mockDocSnapshot(id, existing);
+      const snapAfter = mockDocSnapshot(id, {
+        ...existing,
+        status: 'paid',
+        paymentRecord: {
+          source: 'square-webhook',
+          squarePaymentId: 'SQ-PAY-1',
+          recordedAt: new Date(),
+        },
+        paidAt: new Date(),
+      });
+
+      const mockUpdate = vi.fn().mockResolvedValue(undefined);
+      const mockGet = vi
+        .fn()
+        // First call: current state before update
+        .mockResolvedValueOnce(snapBefore)
+        // Second call: state after update
+        .mockResolvedValueOnce(snapAfter);
+      const mockDoc = vi.fn().mockReturnValue({
+        get: mockGet,
+        update: mockUpdate,
+      });
+      vi.mocked(db.collection).mockReturnValue({
+        doc: mockDoc,
+      } as unknown as FirebaseFirestore.CollectionReference);
+
+      return { mockUpdate, mockGet, mockDoc };
+    }
+
+    it('flips a sent invoice to paid with square-webhook attribution', async () => {
+      const { mockUpdate } = setupDoc(
+        firestoreInvoice({ squareInvoiceId: 'SQ-1' })
+      );
+
+      const result = await InvoiceRepository.markPaidBySquareWebhook({
+        id: 'inv-1',
+        squarePaymentId: 'SQ-PAY-1',
+      });
+
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+      const payload = mockUpdate.mock.calls[0][0];
+      expect(payload.status).toBe('paid');
+      expect(payload.paymentRecord.source).toBe('square-webhook');
+      expect(payload.paymentRecord.squarePaymentId).toBe('SQ-PAY-1');
+      expect(payload.paymentRecord.recordedAt).toBeInstanceOf(Date);
+      expect(result.status).toBe('paid');
+    });
+
+    it('is idempotent when invoice is already paid — returns early without writing', async () => {
+      const existing = firestoreInvoice({
+        status: 'paid',
+        paidAt: new Date('2026-04-23'),
+        paymentRecord: {
+          source: 'admin-manual',
+          recordedAt: new Date('2026-04-23'),
+        },
+      });
+      const snap = mockDocSnapshot('inv-1', existing);
+      const mockUpdate = vi.fn();
+      const mockGet = vi.fn().mockResolvedValue(snap);
+      const mockDoc = vi.fn().mockReturnValue({
+        get: mockGet,
+        update: mockUpdate,
+      });
+      vi.mocked(db.collection).mockReturnValue({
+        doc: mockDoc,
+      } as unknown as FirebaseFirestore.CollectionReference);
+
+      const result = await InvoiceRepository.markPaidBySquareWebhook({
+        id: 'inv-1',
+        squarePaymentId: 'SQ-PAY-LATE',
+      });
+
+      expect(mockUpdate).not.toHaveBeenCalled();
+      // Existing attribution preserved (admin-manual stays)
+      expect(result.paymentRecord?.source).toBe('admin-manual');
+    });
+
+    it('throws when invoice does not exist', async () => {
+      const snap = mockDocSnapshot('inv-missing', null);
+      const mockGet = vi.fn().mockResolvedValue(snap);
+      const mockDoc = vi.fn().mockReturnValue({
+        get: mockGet,
+        update: vi.fn(),
+      });
+      vi.mocked(db.collection).mockReturnValue({
+        doc: mockDoc,
+      } as unknown as FirebaseFirestore.CollectionReference);
+
+      await expect(
+        InvoiceRepository.markPaidBySquareWebhook({
+          id: 'inv-missing',
+          squarePaymentId: 'SQ-PAY-1',
+        })
+      ).rejects.toThrow(/not found/);
+    });
+  });
+
+  // ── markSquareSynced ─────────────────────────────────────────────────
+
+  describe('markSquareSynced', () => {
+    it('stamps square ids and clears prior error', async () => {
+      const mockUpdate = vi.fn().mockResolvedValue(undefined);
+      const mockDoc = vi.fn().mockReturnValue({ update: mockUpdate });
+      vi.mocked(db.collection).mockReturnValue({
+        doc: mockDoc,
+      } as unknown as FirebaseFirestore.CollectionReference);
+
+      await InvoiceRepository.markSquareSynced({
+        id: 'inv-1',
+        squareOrderId: 'SQ-ORDER',
+        squareInvoiceId: 'SQ-INVOICE',
+      });
+
+      const payload = mockUpdate.mock.calls[0][0];
+      expect(payload.squareOrderId).toBe('SQ-ORDER');
+      expect(payload.squareInvoiceId).toBe('SQ-INVOICE');
+      expect(payload.squareSyncError).toBeNull();
+      expect(payload.updatedAt).toBeInstanceOf(Date);
+    });
+  });
+
+  // ── recordSquareSyncError ────────────────────────────────────────────
+
+  describe('recordSquareSyncError', () => {
+    it('writes the error message and bumps updatedAt', async () => {
+      const mockUpdate = vi.fn().mockResolvedValue(undefined);
+      const mockDoc = vi.fn().mockReturnValue({ update: mockUpdate });
+      vi.mocked(db.collection).mockReturnValue({
+        doc: mockDoc,
+      } as unknown as FirebaseFirestore.CollectionReference);
+
+      await InvoiceRepository.recordSquareSyncError({
+        id: 'inv-1',
+        error: 'Square API timeout',
+      });
+
+      const payload = mockUpdate.mock.calls[0][0];
+      expect(payload.squareSyncError).toBe('Square API timeout');
+      expect(payload.updatedAt).toBeInstanceOf(Date);
+    });
+  });
+
+  // ── paymentRecord round-trip ────────────────────────────────────────
+
+  describe('paymentRecord round-trip via docToInvoice', () => {
+    it('hydrates paymentRecord from Firestore-shaped data', async () => {
+      const snap = mockDocSnapshot(
+        'inv-1',
+        firestoreInvoice({
+          squareInvoiceId: 'SQ-1',
+          paymentRecord: {
+            source: 'square-webhook',
+            squarePaymentId: 'SQ-PAY',
+            recordedAt: new Date('2026-04-23T14:00:00Z'),
+          },
+        })
+      );
+      const mockGet = vi.fn().mockResolvedValue({
+        empty: false,
+        docs: [snap],
+      });
+      const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
+      const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+      vi.mocked(db.collection).mockReturnValue({
+        where: mockWhere,
+      } as unknown as FirebaseFirestore.CollectionReference);
+
+      const invoice = await InvoiceRepository.findBySquareInvoiceId('SQ-1');
+      expect(invoice?.paymentRecord).toEqual({
+        source: 'square-webhook',
+        squarePaymentId: 'SQ-PAY',
+        recordedAt: new Date('2026-04-23T14:00:00Z'),
+      });
+    });
+  });
+});

--- a/libs/firebase/database/src/lib/invoice.repository.ts
+++ b/libs/firebase/database/src/lib/invoice.repository.ts
@@ -4,12 +4,17 @@
  * Private-pay music lesson invoices. See `invoice.ts` for status
  * transition rules — the repository applies issuedAt / paidAt stamps
  * automatically when status transitions into sent / paid.
+ *
+ * Paid transitions also stamp a `paymentRecord` so the admin can
+ * attribute the payment to a specific event (admin-manual vs. the Square
+ * `invoice.payment_made` webhook).
  */
 import { db, toDate } from './utilities/database.config';
 import type {
   Invoice,
   CreateInvoiceInput,
   InvoiceLineItem,
+  InvoicePaymentRecord,
   InvoiceStatus,
   UpdateInvoiceInput,
 } from '@maple/ts/domain';
@@ -25,6 +30,14 @@ function docToInvoice(
   }
 
   const data = doc.data()!;
+  const rawPaymentRecord = data.paymentRecord as
+    | {
+        source: InvoicePaymentRecord['source'];
+        squarePaymentId?: string;
+        recordedAt: unknown;
+      }
+    | undefined;
+
   return {
     id: doc.id,
     studentId: data.studentId,
@@ -33,6 +46,16 @@ function docToInvoice(
     totalCents: data.totalCents ?? 0,
     issuedAt: data.issuedAt ? toDate(data.issuedAt) : undefined,
     paidAt: data.paidAt ? toDate(data.paidAt) : undefined,
+    paymentRecord: rawPaymentRecord
+      ? {
+          source: rawPaymentRecord.source,
+          squarePaymentId: rawPaymentRecord.squarePaymentId,
+          recordedAt: toDate(rawPaymentRecord.recordedAt),
+        }
+      : undefined,
+    squareOrderId: data.squareOrderId,
+    squareInvoiceId: data.squareInvoiceId,
+    squareSyncError: data.squareSyncError,
     notes: data.notes,
     createdAt: toDate(data.createdAt),
     updatedAt: toDate(data.updatedAt),
@@ -78,6 +101,26 @@ export const InvoiceRepository = {
     return docToInvoice(doc);
   },
 
+  /**
+   * Find an invoice by the Square invoice id — used by the payment_made
+   * webhook to look up the Firestore record that needs to flip to paid.
+   */
+  async findBySquareInvoiceId(
+    squareInvoiceId: string
+  ): Promise<Invoice | undefined> {
+    const snapshot = await db
+      .collection(COLLECTION)
+      .where('squareInvoiceId', '==', squareInvoiceId)
+      .limit(1)
+      .get();
+
+    if (snapshot.empty) {
+      return undefined;
+    }
+
+    return docToInvoice(snapshot.docs[0]);
+  },
+
   async create(input: CreateInvoiceInput): Promise<Invoice> {
     const docRef = db.collection(COLLECTION).doc();
     const now = new Date();
@@ -95,6 +138,15 @@ export const InvoiceRepository = {
       // as the Firestore doc — normal flow starts as draft with these unset.
       issuedAt: status === 'sent' || status === 'paid' ? now : undefined,
       paidAt: status === 'paid' ? now : undefined,
+      // Direct-to-paid creates imply manual admin attribution since no
+      // Square event has fired yet.
+      paymentRecord:
+        status === 'paid'
+          ? {
+              source: 'admin-manual' as const,
+              recordedAt: now,
+            }
+          : undefined,
       createdAt: now,
       updatedAt: now,
     };
@@ -109,6 +161,7 @@ export const InvoiceRepository = {
       totalCents,
       issuedAt: data.issuedAt,
       paidAt: data.paidAt,
+      paymentRecord: data.paymentRecord,
       notes: data.notes,
       createdAt: now,
       updatedAt: now,
@@ -135,9 +188,11 @@ export const InvoiceRepository = {
 
     // Apply transition side-effects:
     // - first time entering sent: stamp issuedAt
-    // - first time entering paid: stamp paidAt (and issuedAt if not set)
+    // - first time entering paid: stamp paidAt (and issuedAt if not set) +
+    //   attribute payment to admin-manual (webhook path uses a different method)
     let issuedAt = existing.issuedAt;
     let paidAt = existing.paidAt;
+    let paymentRecord = existing.paymentRecord;
 
     if (nextStatus === 'sent' && !issuedAt) {
       issuedAt = now;
@@ -145,6 +200,12 @@ export const InvoiceRepository = {
     if (nextStatus === 'paid') {
       if (!issuedAt) issuedAt = now;
       if (!paidAt) paidAt = now;
+      if (!paymentRecord) {
+        paymentRecord = {
+          source: 'admin-manual',
+          recordedAt: now,
+        };
+      }
     }
 
     const payload: Record<string, unknown> = {
@@ -153,6 +214,7 @@ export const InvoiceRepository = {
       totalCents: nextTotalCents,
       issuedAt,
       paidAt,
+      paymentRecord,
       updatedAt: now,
     };
 
@@ -168,6 +230,82 @@ export const InvoiceRepository = {
       throw new Error(`Invoice ${id} not found after update`);
     }
     return invoice;
+  },
+
+  /**
+   * Flip an invoice to paid from the Square `invoice.payment_made` webhook,
+   * attributing the payment to Square. Idempotent — if the invoice is
+   * already paid, leaves the earlier paymentRecord intact.
+   */
+  async markPaidBySquareWebhook(args: {
+    id: string;
+    squarePaymentId: string;
+  }): Promise<Invoice> {
+    const docRef = db.collection(COLLECTION).doc(args.id);
+    const existingSnap = await docRef.get();
+    const existing = docToInvoice(existingSnap);
+    if (!existing) {
+      throw new Error(`Invoice ${args.id} not found`);
+    }
+
+    // Idempotent: already paid → no-op return current state.
+    if (existing.status === 'paid') {
+      return existing;
+    }
+
+    const now = new Date();
+    const payload: Record<string, unknown> = {
+      status: 'paid' as InvoiceStatus,
+      paidAt: existing.paidAt ?? now,
+      issuedAt: existing.issuedAt ?? now,
+      paymentRecord: {
+        source: 'square-webhook' as const,
+        squarePaymentId: args.squarePaymentId,
+        recordedAt: now,
+      },
+      updatedAt: now,
+    };
+
+    await docRef.update(payload);
+
+    const updated = await docRef.get();
+    const invoice = docToInvoice(updated);
+    if (!invoice) {
+      throw new Error(`Invoice ${args.id} not found after webhook update`);
+    }
+    return invoice;
+  },
+
+  /**
+   * Persist the Square ids stamped during a successful send, and clear
+   * any prior sync error.
+   */
+  async markSquareSynced(args: {
+    id: string;
+    squareOrderId: string;
+    squareInvoiceId: string;
+  }): Promise<void> {
+    await db.collection(COLLECTION).doc(args.id).update({
+      squareOrderId: args.squareOrderId,
+      squareInvoiceId: args.squareInvoiceId,
+      squareSyncError: null,
+      updatedAt: new Date(),
+    });
+  },
+
+  /**
+   * Persist a Square sync error so the admin UI can surface it. The
+   * invoice stays in whatever status it was in; only the error field is
+   * updated.
+   */
+  async recordSquareSyncError(args: {
+    id: string;
+    error: string;
+  }): Promise<void> {
+    await db.collection(COLLECTION).doc(args.id).update({
+      squareSyncError: args.error,
+      updatedAt: new Date(),
+    });
   },
 
   async delete(id: string): Promise<void> {

--- a/libs/firebase/maple-functions/create-invoice/src/lib/create-invoice.spec.ts
+++ b/libs/firebase/maple-functions/create-invoice/src/lib/create-invoice.spec.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Unit tests for the createInvoice cloud function handler.
+ *
+ * createAdminFunction is mocked to return the handler directly so we can
+ * invoke it like a plain function. Repositories are mocked; the real
+ * `invoiceValidation` suite is used so malformed input fails fast.
+ */
+
+const mocks = vi.hoisted(() => ({
+  studentFindById: vi.fn(),
+  invoiceCreate: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/functions', () => ({
+  createAdminFunction: <TReq, TRes>(
+    handler: (data: TReq, ctx: unknown) => Promise<TRes>
+  ) => handler,
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  StudentRepository: { findById: mocks.studentFindById },
+  InvoiceRepository: { create: mocks.invoiceCreate },
+}));
+
+import { createInvoice } from './create-invoice';
+
+type Handler = (data: unknown, ctx?: unknown) => Promise<unknown>;
+const handler = createInvoice as unknown as Handler;
+
+const privateStudent = {
+  id: 'student-1',
+  isHopeScholarship: false,
+  name: 'Olive',
+  primaryContactEmail: 'rita@x.com',
+};
+
+const hopeStudent = { ...privateStudent, id: 'hope-1', isHopeScholarship: true };
+
+const validPayload = () => ({
+  studentId: 'student-1',
+  lineItems: [
+    {
+      id: 'line-1',
+      description: 'April tuition',
+      quantity: 4,
+      unitAmountCents: 3250,
+      subtotalCents: 13000,
+    },
+  ],
+});
+
+describe('createInvoice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates an invoice for a private-pay student', async () => {
+    mocks.studentFindById.mockResolvedValue(privateStudent);
+    mocks.invoiceCreate.mockResolvedValue({
+      id: 'inv-new',
+      status: 'draft',
+      totalCents: 13000,
+    });
+
+    const result = (await handler(validPayload())) as {
+      invoice: { id: string };
+    };
+
+    expect(mocks.studentFindById).toHaveBeenCalledWith('student-1');
+    expect(mocks.invoiceCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ studentId: 'student-1' })
+    );
+    expect(result.invoice.id).toBe('inv-new');
+  });
+
+  it('rejects a Hope Scholarship student (defense-in-depth server guard)', async () => {
+    mocks.studentFindById.mockResolvedValue(hopeStudent);
+
+    await expect(
+      handler({ ...validPayload(), studentId: 'hope-1' })
+    ).rejects.toThrow(/Hope Scholarship/);
+
+    expect(mocks.invoiceCreate).not.toHaveBeenCalled();
+  });
+
+  it('throws when the student does not exist', async () => {
+    mocks.studentFindById.mockResolvedValue(undefined);
+
+    await expect(
+      handler({ ...validPayload(), studentId: 'missing' })
+    ).rejects.toThrow(/Student not found/);
+
+    expect(mocks.invoiceCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty lineItems list via Vest validation', async () => {
+    await expect(handler({ studentId: 'student-1', lineItems: [] })).rejects.toThrow(
+      /Validation failed/
+    );
+    expect(mocks.studentFindById).not.toHaveBeenCalled();
+  });
+
+  it('rejects a line item with zero quantity via Vest validation', async () => {
+    await expect(
+      handler({
+        studentId: 'student-1',
+        lineItems: [
+          {
+            id: 'x',
+            description: 'Test',
+            quantity: 0,
+            unitAmountCents: 1000,
+            subtotalCents: 0,
+          },
+        ],
+      })
+    ).rejects.toThrow(/Validation failed/);
+  });
+
+  it('rejects a missing studentId via Vest validation', async () => {
+    await expect(
+      handler({ studentId: '', lineItems: validPayload().lineItems })
+    ).rejects.toThrow(/Validation failed/);
+  });
+});

--- a/libs/firebase/maple-functions/create-invoice/vitest.config.ts
+++ b/libs/firebase/maple-functions/create-invoice/vitest.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  root: __dirname,
+  test: {
+    name: 'firebase-maple-functions-create-invoice',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov', 'json-summary', 'json'],
+      reportsDirectory:
+        '../../../../coverage/libs/firebase/maple-functions/create-invoice',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.spec.ts', 'src/index.ts'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@maple/ts/domain': resolve(__dirname, '../../../ts/domain/src/index.ts'),
+      '@maple/ts/validation': resolve(
+        __dirname,
+        '../../../ts/validation/src/index.ts'
+      ),
+      '@maple/ts/firebase/api-types': resolve(
+        __dirname,
+        '../../../ts/firebase/api-types/src/index.ts'
+      ),
+      '@maple/firebase/database': resolve(
+        __dirname,
+        '../../../firebase/database/src/index.ts'
+      ),
+      '@maple/firebase/functions': resolve(
+        __dirname,
+        '../../../firebase/functions/src/index.ts'
+      ),
+    },
+  },
+});

--- a/libs/firebase/maple-functions/square-webhook/src/lib/square-webhook.spec.ts
+++ b/libs/firebase/maple-functions/square-webhook/src/lib/square-webhook.spec.ts
@@ -12,14 +12,20 @@ const mocks = vi.hoisted(() => {
   return {
     findAll: vi.fn(),
     updateCachedQuantity: vi.fn(),
+    findBySquareInvoiceId: vi.fn(),
+    markPaidBySquareWebhook: vi.fn(),
   };
 });
 
-// Mock ProductRepository
+// Mock ProductRepository + InvoiceRepository
 vi.mock('@maple/firebase/database', () => ({
   ProductRepository: {
     findAll: mocks.findAll,
     updateCachedQuantity: mocks.updateCachedQuantity,
+  },
+  InvoiceRepository: {
+    findBySquareInvoiceId: mocks.findBySquareInvoiceId,
+    markPaidBySquareWebhook: mocks.markPaidBySquareWebhook,
   },
 }));
 
@@ -232,6 +238,115 @@ describe('Square Webhook - Inventory Handler', () => {
       await mocks.updateCachedQuantity('prod-001', 9);
 
       expect(mocks.updateCachedQuantity).toHaveBeenCalledWith('prod-001', 9);
+    });
+  });
+});
+
+describe('Square Webhook - invoice.payment_made handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /** Realistic-ish Square invoice.payment_made payload. */
+  const makeEvent = (
+    squareInvoiceId: string,
+    squarePaymentId: string
+  ) => ({
+    merchant_id: 'ML1TB2DX6N1B0',
+    type: 'invoice.payment_made' as const,
+    event_id: 'evt-1',
+    created_at: '2026-04-23T14:00:00Z',
+    data: {
+      type: 'invoice',
+      id: squareInvoiceId,
+      object: {
+        invoice: {
+          id: squareInvoiceId,
+          payment_requests: [
+            {
+              completed_payment_ids: [squarePaymentId],
+            },
+          ],
+        },
+      },
+    },
+  });
+
+  it('flips a matching Firestore invoice to paid with square-webhook attribution', async () => {
+    mocks.findBySquareInvoiceId.mockResolvedValue({
+      id: 'firebase-inv-1',
+      status: 'sent',
+    });
+    mocks.markPaidBySquareWebhook.mockResolvedValue({ id: 'firebase-inv-1' });
+
+    const { handleInvoicePaymentMade } = await import('./square-webhook');
+    const result = await handleInvoicePaymentMade(
+      makeEvent('SQ-INV-1', 'SQ-PAY-1')
+    );
+
+    expect(mocks.findBySquareInvoiceId).toHaveBeenCalledWith('SQ-INV-1');
+    expect(mocks.markPaidBySquareWebhook).toHaveBeenCalledWith({
+      id: 'firebase-inv-1',
+      squarePaymentId: 'SQ-PAY-1',
+    });
+    expect(result.action).toBe('paid');
+  });
+
+  it('is idempotent when the invoice is already paid', async () => {
+    mocks.findBySquareInvoiceId.mockResolvedValue({
+      id: 'firebase-inv-2',
+      status: 'paid',
+    });
+
+    const { handleInvoicePaymentMade } = await import('./square-webhook');
+    const result = await handleInvoicePaymentMade(
+      makeEvent('SQ-INV-2', 'SQ-PAY-2')
+    );
+
+    expect(mocks.markPaidBySquareWebhook).not.toHaveBeenCalled();
+    expect(result.action).toBe('skipped');
+    expect(result.details).toMatch(/already paid/i);
+  });
+
+  it('skips gracefully when no matching Firestore invoice exists', async () => {
+    mocks.findBySquareInvoiceId.mockResolvedValue(undefined);
+
+    const { handleInvoicePaymentMade } = await import('./square-webhook');
+    const result = await handleInvoicePaymentMade(
+      makeEvent('SQ-INV-UNKNOWN', 'SQ-PAY-3')
+    );
+
+    expect(mocks.markPaidBySquareWebhook).not.toHaveBeenCalled();
+    expect(result.action).toBe('skipped');
+  });
+
+  it('falls back to "unknown" when no completed_payment_ids in payload', async () => {
+    mocks.findBySquareInvoiceId.mockResolvedValue({
+      id: 'firebase-inv-3',
+      status: 'sent',
+    });
+    mocks.markPaidBySquareWebhook.mockResolvedValue({ id: 'firebase-inv-3' });
+
+    const event = {
+      merchant_id: 'ML1TB2DX6N1B0',
+      type: 'invoice.payment_made' as const,
+      event_id: 'evt-4',
+      created_at: '2026-04-23T14:00:00Z',
+      data: {
+        type: 'invoice',
+        id: 'SQ-INV-3',
+        object: {
+          invoice: { id: 'SQ-INV-3' }, // no payment_requests
+        },
+      },
+    };
+
+    const { handleInvoicePaymentMade } = await import('./square-webhook');
+    await handleInvoicePaymentMade(event);
+
+    expect(mocks.markPaidBySquareWebhook).toHaveBeenCalledWith({
+      id: 'firebase-inv-3',
+      squarePaymentId: 'unknown',
     });
   });
 });

--- a/libs/firebase/maple-functions/square-webhook/src/lib/square-webhook.spec.ts
+++ b/libs/firebase/maple-functions/square-webhook/src/lib/square-webhook.spec.ts
@@ -11,9 +11,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const mocks = vi.hoisted(() => {
   return {
     findAll: vi.fn(),
+    findBySquareItemId: vi.fn(),
     updateCachedQuantity: vi.fn(),
+    updateSquareCache: vi.fn(),
+    createProduct: vi.fn(),
     findBySquareInvoiceId: vi.fn(),
     markPaidBySquareWebhook: vi.fn(),
+    // Square catalogService
+    getItem: vi.fn(),
+    listItems: vi.fn(),
+    getItemImageUrl: vi.fn(),
   };
 });
 
@@ -21,7 +28,10 @@ const mocks = vi.hoisted(() => {
 vi.mock('@maple/firebase/database', () => ({
   ProductRepository: {
     findAll: mocks.findAll,
+    findBySquareItemId: mocks.findBySquareItemId,
     updateCachedQuantity: mocks.updateCachedQuantity,
+    updateSquareCache: mocks.updateSquareCache,
+    create: mocks.createProduct,
   },
   InvoiceRepository: {
     findBySquareInvoiceId: mocks.findBySquareInvoiceId,
@@ -46,7 +56,15 @@ vi.mock('firebase-functions/params', () => ({
 vi.mock('@maple/firebase/functions', () => ({
   FirebaseProject: {
     functionUrl: vi.fn().mockReturnValue('https://mock-url.com/squareWebhook'),
+    isDev: false,
+    projectId: 'mock-project',
   },
+}));
+
+// Mock firebase-functions/v2/https — return the handler directly so we
+// can invoke squareWebhook as a plain function.
+vi.mock('firebase-functions/v2/https', () => ({
+  onRequest: vi.fn((_config, handler) => handler),
 }));
 
 describe('Square Webhook - Inventory Handler', () => {
@@ -348,5 +366,679 @@ describe('Square Webhook - invoice.payment_made handler', () => {
       id: 'firebase-inv-3',
       squarePaymentId: 'unknown',
     });
+  });
+});
+
+describe('Square Webhook - handleCatalogUpdate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const makeCatalogEvent = (catalogObjectId?: string) => ({
+    merchant_id: 'ML1TB2DX6N1B0',
+    type: 'catalog.version.updated' as const,
+    event_id: 'evt-cat',
+    created_at: '2026-04-23T14:00:00Z',
+    data: {
+      type: 'catalog_item',
+      id: catalogObjectId ?? '',
+    },
+  });
+
+  const makeSquare = () => ({
+    locationId: 'LW0MMBZ',
+    catalogService: {
+      getItem: mocks.getItem,
+      listItems: mocks.listItems,
+      getItemImageUrl: mocks.getItemImageUrl,
+    },
+  });
+
+  describe('single-item path', () => {
+    it('updates an existing product when the catalog item is already tracked', async () => {
+      const existing = {
+        id: 'prod-1',
+        squareItemId: 'ITEM_1',
+        squareCache: {
+          name: 'Old name',
+          description: 'Old desc',
+          priceCents: 1000,
+          sku: 'OLD-SKU',
+          imageUrl: 'old.jpg',
+        },
+      };
+      mocks.findBySquareItemId.mockResolvedValue(existing);
+      mocks.getItem.mockResolvedValue({
+        id: 'ITEM_1',
+        type: 'ITEM',
+        version: 42,
+        itemData: {
+          name: 'New name',
+          description: 'New desc',
+          variations: [
+            {
+              id: 'VAR_1',
+              itemVariationData: {
+                sku: 'NEW-SKU',
+                priceMoney: { amount: 2500n },
+              },
+            },
+          ],
+        },
+      });
+      mocks.getItemImageUrl.mockResolvedValue('new.jpg');
+      mocks.updateSquareCache.mockResolvedValue(undefined);
+
+      const { handleCatalogUpdate } = await import('./square-webhook');
+      const result = await handleCatalogUpdate(
+        makeCatalogEvent('ITEM_1'),
+        makeSquare() as unknown as Parameters<typeof handleCatalogUpdate>[1]
+      );
+
+      expect(mocks.updateSquareCache).toHaveBeenCalledWith(
+        'prod-1',
+        expect.objectContaining({
+          name: 'New name',
+          description: 'New desc',
+          priceCents: 2500,
+          sku: 'NEW-SKU',
+          imageUrl: 'new.jpg',
+        }),
+        42
+      );
+      expect(result.action).toBe('updated');
+    });
+
+    it('creates a draft product when the catalog item is new', async () => {
+      mocks.findBySquareItemId.mockResolvedValue(undefined);
+      mocks.getItem.mockResolvedValue({
+        id: 'ITEM_NEW',
+        type: 'ITEM',
+        version: 1,
+        itemData: {
+          name: 'Brand new',
+          description: 'desc',
+          variations: [
+            {
+              id: 'VAR_NEW',
+              itemVariationData: {
+                sku: 'SKU-NEW',
+                priceMoney: { amount: 5000n },
+              },
+            },
+          ],
+        },
+      });
+      mocks.getItemImageUrl.mockResolvedValue(undefined);
+      mocks.createProduct.mockResolvedValue({ id: 'prod-new' });
+
+      const { handleCatalogUpdate } = await import('./square-webhook');
+      const result = await handleCatalogUpdate(
+        makeCatalogEvent('ITEM_NEW'),
+        makeSquare() as unknown as Parameters<typeof handleCatalogUpdate>[1]
+      );
+
+      expect(mocks.createProduct).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Brand new',
+          status: 'draft',
+          priceCents: 5000,
+        }),
+        expect.objectContaining({
+          squareItemId: 'ITEM_NEW',
+          squareVariationId: 'VAR_NEW',
+          sku: 'SKU-NEW',
+        })
+      );
+      expect(result.action).toBe('created');
+    });
+
+    it('skips a single-item update when the catalog object is not an ITEM', async () => {
+      mocks.getItem.mockResolvedValue({
+        id: 'CAT_1',
+        type: 'CATEGORY',
+      });
+
+      const { handleCatalogUpdate } = await import('./square-webhook');
+      const result = await handleCatalogUpdate(
+        makeCatalogEvent('CAT_1'),
+        makeSquare() as unknown as Parameters<typeof handleCatalogUpdate>[1]
+      );
+
+      expect(result.action).toBe('skipped');
+      expect(result.details).toMatch(/non-ITEM/);
+    });
+
+    it('skips when the catalog object is not found in Square (deleted)', async () => {
+      mocks.getItem.mockResolvedValue(undefined);
+
+      const { handleCatalogUpdate } = await import('./square-webhook');
+      const result = await handleCatalogUpdate(
+        makeCatalogEvent('ITEM_GONE'),
+        makeSquare() as unknown as Parameters<typeof handleCatalogUpdate>[1]
+      );
+
+      expect(result.action).toBe('skipped');
+      expect(result.details).toMatch(/not found/);
+    });
+
+    it('skips when a new item has no variation', async () => {
+      mocks.findBySquareItemId.mockResolvedValue(undefined);
+      mocks.getItem.mockResolvedValue({
+        id: 'ITEM_NO_VAR',
+        type: 'ITEM',
+        itemData: { name: 'No variation', variations: [] },
+      });
+
+      const { handleCatalogUpdate } = await import('./square-webhook');
+      const result = await handleCatalogUpdate(
+        makeCatalogEvent('ITEM_NO_VAR'),
+        makeSquare() as unknown as Parameters<typeof handleCatalogUpdate>[1]
+      );
+
+      expect(mocks.createProduct).not.toHaveBeenCalled();
+      expect(result.action).toBe('skipped');
+    });
+  });
+
+  describe('batch path (no catalogObjectId — version bump)', () => {
+    it('syncs every Square item, updating tracked + creating new', async () => {
+      mocks.findAll.mockResolvedValue([
+        {
+          id: 'prod-1',
+          squareItemId: 'ITEM_A',
+          squareCache: {
+            name: 'A',
+            description: 'a',
+            priceCents: 100,
+            sku: 'A',
+            imageUrl: '',
+          },
+        },
+      ]);
+      mocks.listItems.mockResolvedValue([
+        {
+          id: 'ITEM_A',
+          type: 'ITEM',
+          version: 2,
+          itemData: {
+            name: 'A updated',
+            variations: [
+              {
+                id: 'VAR_A',
+                itemVariationData: {
+                  sku: 'A',
+                  priceMoney: { amount: 150n },
+                },
+              },
+            ],
+          },
+        },
+        {
+          id: 'ITEM_B',
+          type: 'ITEM',
+          version: 1,
+          itemData: {
+            name: 'B new',
+            variations: [
+              {
+                id: 'VAR_B',
+                itemVariationData: {
+                  sku: 'B',
+                  priceMoney: { amount: 200n },
+                },
+              },
+            ],
+          },
+        },
+      ]);
+      mocks.getItemImageUrl.mockResolvedValue('image.jpg');
+      mocks.updateSquareCache.mockResolvedValue(undefined);
+      mocks.createProduct.mockResolvedValue({ id: 'prod-new' });
+
+      const { handleCatalogUpdate } = await import('./square-webhook');
+      const result = await handleCatalogUpdate(
+        makeCatalogEvent(undefined),
+        makeSquare() as unknown as Parameters<typeof handleCatalogUpdate>[1]
+      );
+
+      expect(mocks.updateSquareCache).toHaveBeenCalled(); // prod-1 updated
+      expect(mocks.createProduct).toHaveBeenCalled(); // ITEM_B created as new product
+      expect(result.action).toBe('synced');
+    });
+
+    it('ignores non-ITEM catalog objects during batch sync', async () => {
+      mocks.findAll.mockResolvedValue([]);
+      mocks.listItems.mockResolvedValue([
+        { id: 'CAT_1', type: 'CATEGORY' },
+        { id: 'TAX_1', type: 'TAX' },
+      ]);
+
+      const { handleCatalogUpdate } = await import('./square-webhook');
+      const result = await handleCatalogUpdate(
+        makeCatalogEvent(undefined),
+        makeSquare() as unknown as Parameters<typeof handleCatalogUpdate>[1]
+      );
+
+      expect(mocks.createProduct).not.toHaveBeenCalled();
+      expect(mocks.updateSquareCache).not.toHaveBeenCalled();
+      expect(result.action).toBe('synced');
+    });
+
+    it('skips Square items with no variation during batch sync', async () => {
+      mocks.findAll.mockResolvedValue([]);
+      mocks.listItems.mockResolvedValue([
+        {
+          id: 'ITEM_X',
+          type: 'ITEM',
+          itemData: { name: 'X', variations: [] },
+        },
+      ]);
+
+      const { handleCatalogUpdate } = await import('./square-webhook');
+      const result = await handleCatalogUpdate(
+        makeCatalogEvent(undefined),
+        makeSquare() as unknown as Parameters<typeof handleCatalogUpdate>[1]
+      );
+
+      expect(mocks.createProduct).not.toHaveBeenCalled();
+      expect(result.action).toBe('synced');
+    });
+
+    it('logs and skips when updateSquareCache throws (degrades gracefully)', async () => {
+      mocks.findAll.mockResolvedValue([
+        {
+          id: 'prod-1',
+          squareItemId: 'ITEM_A',
+          squareCache: { name: 'A', priceCents: 100, sku: 'A', imageUrl: '' },
+        },
+      ]);
+      mocks.listItems.mockResolvedValue([
+        {
+          id: 'ITEM_A',
+          type: 'ITEM',
+          version: 2,
+          itemData: {
+            name: 'A',
+            variations: [
+              {
+                id: 'VAR_A',
+                itemVariationData: { sku: 'A', priceMoney: { amount: 150n } },
+              },
+            ],
+          },
+        },
+      ]);
+      mocks.getItemImageUrl.mockResolvedValue('image.jpg');
+      mocks.updateSquareCache.mockRejectedValueOnce(new Error('Firestore down'));
+
+      const { handleCatalogUpdate } = await import('./square-webhook');
+      const result = await handleCatalogUpdate(
+        makeCatalogEvent(undefined),
+        makeSquare() as unknown as Parameters<typeof handleCatalogUpdate>[1]
+      );
+
+      // Failure is caught internally — the trigger still returns 'synced' to
+      // ack the webhook (we don't want Square to retry forever).
+      expect(result.action).toBe('synced');
+    });
+
+    it('logs and skips when createProduct throws during batch path', async () => {
+      mocks.findAll.mockResolvedValue([]);
+      mocks.listItems.mockResolvedValue([
+        {
+          id: 'ITEM_NEW',
+          type: 'ITEM',
+          itemData: {
+            name: 'Z',
+            variations: [
+              {
+                id: 'VAR_Z',
+                itemVariationData: { sku: 'Z', priceMoney: { amount: 10n } },
+              },
+            ],
+          },
+        },
+      ]);
+      mocks.createProduct.mockRejectedValueOnce(new Error('create failed'));
+
+      const { handleCatalogUpdate } = await import('./square-webhook');
+      const result = await handleCatalogUpdate(
+        makeCatalogEvent(undefined),
+        makeSquare() as unknown as Parameters<typeof handleCatalogUpdate>[1]
+      );
+
+      expect(result.action).toBe('synced');
+    });
+  });
+
+  describe('image fetch edge cases', () => {
+    it('falls back to undefined image URL when getItemImageUrl throws', async () => {
+      mocks.findBySquareItemId.mockResolvedValue(undefined);
+      mocks.getItem.mockResolvedValue({
+        id: 'ITEM_1',
+        type: 'ITEM',
+        itemData: {
+          name: 'no-image',
+          variations: [
+            {
+              id: 'VAR_1',
+              itemVariationData: { sku: 'X', priceMoney: { amount: 100n } },
+            },
+          ],
+        },
+      });
+      mocks.getItemImageUrl.mockRejectedValueOnce(new Error('image 404'));
+      mocks.createProduct.mockResolvedValue({ id: 'prod-new' });
+
+      const { handleCatalogUpdate } = await import('./square-webhook');
+      const result = await handleCatalogUpdate(
+        makeCatalogEvent('ITEM_1'),
+        makeSquare() as unknown as Parameters<typeof handleCatalogUpdate>[1]
+      );
+
+      expect(result.action).toBe('created');
+    });
+  });
+});
+
+describe('Square Webhook - handleInventoryUpdate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const makeInventoryEvent = (
+    counts: Array<{
+      catalog_object_id?: string;
+      quantity?: string;
+      location_id?: string;
+      state?: string;
+    }>
+  ) => ({
+    merchant_id: 'ML1TB2DX6N1B0',
+    type: 'inventory.count.updated' as const,
+    event_id: 'evt-inv',
+    created_at: '2026-04-23T14:00:00Z',
+    data: {
+      type: 'inventory_counts',
+      id: 'a8c7a224',
+      object: { inventory_counts: counts },
+    },
+  });
+
+  it('updates cached quantity for each tracked variation', async () => {
+    mocks.findAll.mockResolvedValue([
+      {
+        id: 'prod-001',
+        squareItemId: 'ITEM_001',
+        squareVariationId: 'VAR_A',
+      },
+      {
+        id: 'prod-002',
+        squareItemId: 'ITEM_002',
+        squareVariationId: 'VAR_B',
+      },
+    ]);
+    mocks.updateCachedQuantity.mockResolvedValue(undefined);
+
+    const { handleInventoryUpdate } = await import('./square-webhook');
+    const result = await handleInventoryUpdate(
+      makeInventoryEvent([
+        { catalog_object_id: 'VAR_A', quantity: '5', state: 'IN_STOCK' },
+        { catalog_object_id: 'VAR_B', quantity: '9', state: 'IN_STOCK' },
+      ])
+    );
+
+    expect(mocks.updateCachedQuantity).toHaveBeenCalledWith('prod-001', 5);
+    expect(mocks.updateCachedQuantity).toHaveBeenCalledWith('prod-002', 9);
+    expect(result.action).toBe('updated');
+  });
+
+  it('skips variations that we do not track (no product match)', async () => {
+    mocks.findAll.mockResolvedValue([
+      {
+        id: 'prod-001',
+        squareItemId: 'ITEM_001',
+        squareVariationId: 'VAR_A',
+      },
+    ]);
+
+    const { handleInventoryUpdate } = await import('./square-webhook');
+    const result = await handleInventoryUpdate(
+      makeInventoryEvent([
+        { catalog_object_id: 'VAR_UNKNOWN', quantity: '5' },
+      ])
+    );
+
+    expect(mocks.updateCachedQuantity).not.toHaveBeenCalled();
+    expect(result.details).toMatch(/not tracked/);
+  });
+
+  it('skips counts with no catalog_object_id', async () => {
+    mocks.findAll.mockResolvedValue([]);
+
+    const { handleInventoryUpdate } = await import('./square-webhook');
+    const result = await handleInventoryUpdate(
+      makeInventoryEvent([{ quantity: '5' }])
+    );
+
+    expect(mocks.updateCachedQuantity).not.toHaveBeenCalled();
+    expect(result.details).toMatch(/no catalog_object_id/);
+  });
+
+  it('returns skipped when inventory_counts is empty', async () => {
+    const { handleInventoryUpdate } = await import('./square-webhook');
+    const result = await handleInventoryUpdate(makeInventoryEvent([]));
+
+    expect(result.action).toBe('skipped');
+    expect(result.details).toMatch(/No inventory_counts/);
+  });
+
+  it('returns skipped when inventory_counts is absent entirely', async () => {
+    const event = {
+      merchant_id: 'ML1TB2DX6N1B0',
+      type: 'inventory.count.updated' as const,
+      event_id: 'evt',
+      created_at: '2026-04-23T14:00:00Z',
+      data: {
+        type: 'inventory_counts',
+        id: 'a',
+        object: {}, // no inventory_counts key
+      },
+    };
+
+    const { handleInventoryUpdate } = await import('./square-webhook');
+    const result = await handleInventoryUpdate(event);
+
+    expect(result.action).toBe('skipped');
+  });
+
+  it('defaults missing quantity to 0', async () => {
+    mocks.findAll.mockResolvedValue([
+      { id: 'prod-1', squareVariationId: 'VAR_A' },
+    ]);
+
+    const { handleInventoryUpdate } = await import('./square-webhook');
+    await handleInventoryUpdate(
+      makeInventoryEvent([{ catalog_object_id: 'VAR_A' }])
+    );
+
+    expect(mocks.updateCachedQuantity).toHaveBeenCalledWith('prod-1', 0);
+  });
+});
+
+describe('Square Webhook - squareWebhook endpoint', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeReq(
+    body: Record<string, unknown>,
+    signature?: string,
+    method = 'POST'
+  ) {
+    return {
+      method,
+      body,
+      headers: signature
+        ? { 'x-square-hmacsha256-signature': signature }
+        : {},
+    };
+  }
+
+  function makeRes() {
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      send: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    };
+    return res as unknown as {
+      status: ReturnType<typeof vi.fn>;
+      send: ReturnType<typeof vi.fn>;
+      json: ReturnType<typeof vi.fn>;
+    };
+  }
+
+  /** HMAC-SHA256 the same way the webhook verifier does. */
+  async function signBody(body: Record<string, unknown>): Promise<string> {
+    const { createHmac } = await import('crypto');
+    return createHmac('sha256', 'mock-secret')
+      .update('https://mock-url.com/squareWebhook' + JSON.stringify(body))
+      .digest('base64');
+  }
+
+  it('rejects non-POST with 405', async () => {
+    const { squareWebhook } = await import('./square-webhook');
+    const fn = squareWebhook as unknown as (
+      req: unknown,
+      res: unknown
+    ) => Promise<void>;
+    const res = makeRes();
+    await fn(makeReq({}, undefined, 'GET'), res);
+
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+
+  it('rejects requests with no signature with 401', async () => {
+    const { squareWebhook } = await import('./square-webhook');
+    const fn = squareWebhook as unknown as (
+      req: unknown,
+      res: unknown
+    ) => Promise<void>;
+    const res = makeRes();
+    await fn(makeReq({ type: 'catalog.version.updated' }), res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it('rejects requests with a bad signature with 401', async () => {
+    const { squareWebhook } = await import('./square-webhook');
+    const fn = squareWebhook as unknown as (
+      req: unknown,
+      res: unknown
+    ) => Promise<void>;
+    const res = makeRes();
+    await fn(makeReq({ type: 'catalog.version.updated' }, 'not-the-right-hmac'), res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it('dispatches invoice.payment_made events to the invoice handler', async () => {
+    mocks.findBySquareInvoiceId.mockResolvedValue({
+      id: 'fb-inv-1',
+      status: 'sent',
+    });
+    mocks.markPaidBySquareWebhook.mockResolvedValue({
+      id: 'fb-inv-1',
+      status: 'paid',
+    });
+
+    const body = {
+      merchant_id: 'ML1',
+      type: 'invoice.payment_made',
+      event_id: 'evt-1',
+      created_at: '2026-04-23T14:00:00Z',
+      data: {
+        type: 'invoice',
+        id: 'SQ-INV-1',
+        object: {
+          invoice: {
+            id: 'SQ-INV-1',
+            payment_requests: [
+              { completed_payment_ids: ['SQ-PAY-1'] },
+            ],
+          },
+        },
+      },
+    };
+    const sig = await signBody(body);
+
+    const { squareWebhook } = await import('./square-webhook');
+    const fn = squareWebhook as unknown as (
+      req: unknown,
+      res: unknown
+    ) => Promise<void>;
+    const res = makeRes();
+    await fn(makeReq(body, sig), res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mocks.markPaidBySquareWebhook).toHaveBeenCalledWith({
+      id: 'fb-inv-1',
+      squarePaymentId: 'SQ-PAY-1',
+    });
+  });
+
+  it('acknowledges unhandled event types with 200 skipped', async () => {
+    const body = {
+      merchant_id: 'ML1',
+      type: 'some.unhandled.event',
+      event_id: 'evt-2',
+      created_at: '2026-04-23T14:00:00Z',
+      data: { type: 'x', id: 'y' },
+    };
+    const sig = await signBody(body);
+
+    const { squareWebhook } = await import('./square-webhook');
+    const fn = squareWebhook as unknown as (
+      req: unknown,
+      res: unknown
+    ) => Promise<void>;
+    const res = makeRes();
+    await fn(makeReq(body, sig), res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    // json body should include action: 'skipped'
+    const jsonArg = res.json.mock.calls[0][0];
+    expect(jsonArg.action).toBe('skipped');
+  });
+
+  it('returns 500 when a handler throws (so Square retries)', async () => {
+    // Force the invoice handler to throw by making the repository reject
+    mocks.findBySquareInvoiceId.mockRejectedValue(
+      new Error('Firestore unavailable')
+    );
+
+    const body = {
+      merchant_id: 'ML1',
+      type: 'invoice.payment_made',
+      event_id: 'evt-3',
+      created_at: '2026-04-23T14:00:00Z',
+      data: {
+        type: 'invoice',
+        id: 'SQ-INV-X',
+        object: { invoice: { id: 'SQ-INV-X' } },
+      },
+    };
+    const sig = await signBody(body);
+
+    const { squareWebhook } = await import('./square-webhook');
+    const fn = squareWebhook as unknown as (
+      req: unknown,
+      res: unknown
+    ) => Promise<void>;
+    const res = makeRes();
+    await fn(makeReq(body, sig), res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
   });
 });

--- a/libs/firebase/maple-functions/square-webhook/src/lib/square-webhook.ts
+++ b/libs/firebase/maple-functions/square-webhook/src/lib/square-webhook.ts
@@ -99,7 +99,7 @@ async function extractImageUrl(
  * Fired when a catalog item is created or updated in Square.
  * We need to sync the changes to our Firestore record.
  */
-async function handleCatalogUpdate(
+export async function handleCatalogUpdate(
   event: WebhookEvent,
   square: Square
 ): Promise<{ action: string; details: string }> {
@@ -321,7 +321,7 @@ async function handleCatalogUpdate(
  *   }
  * }
  */
-async function handleInventoryUpdate(
+export async function handleInventoryUpdate(
   event: WebhookEvent
 ): Promise<{ action: string; details: string }> {
   // The inventory counts are nested inside object.inventory_counts array

--- a/libs/firebase/maple-functions/square-webhook/src/lib/square-webhook.ts
+++ b/libs/firebase/maple-functions/square-webhook/src/lib/square-webhook.ts
@@ -20,7 +20,10 @@
 import { onRequest } from 'firebase-functions/v2/https';
 import { defineSecret, defineString } from 'firebase-functions/params';
 import { createHmac } from 'crypto';
-import { ProductRepository } from '@maple/firebase/database';
+import {
+  InvoiceRepository,
+  ProductRepository,
+} from '@maple/firebase/database';
 import {
   Square,
   SQUARE_SECRET_NAMES,
@@ -31,7 +34,8 @@ import { FirebaseProject } from '@maple/firebase/functions';
 // Webhook event types we handle
 type WebhookEventType =
   | 'catalog.version.updated'
-  | 'inventory.count.updated';
+  | 'inventory.count.updated'
+  | 'invoice.payment_made';
 
 interface WebhookEvent {
   merchant_id: string;
@@ -370,6 +374,74 @@ async function handleInventoryUpdate(
   };
 }
 
+/**
+ * Handle invoice.payment_made webhook
+ *
+ * Fired when a customer completes payment on a Square invoice we sent.
+ * Match by squareInvoiceId and flip our Firestore invoice to paid with
+ * paymentRecord { source: 'square-webhook', squarePaymentId }.
+ *
+ * Payload shape (per Square docs):
+ *   data.object.invoice.id                                → Square invoice id
+ *   data.object.invoice.payment_requests[0]
+ *     .completed_payment_ids[0]                           → Square payment id
+ */
+export async function handleInvoicePaymentMade(
+  event: WebhookEvent
+): Promise<{ action: string; details: string }> {
+  const payload = event.data.object as
+    | {
+        invoice?: {
+          id?: string;
+          payment_requests?: Array<{
+            completed_payment_ids?: string[];
+          }>;
+        };
+      }
+    | undefined;
+
+  const squareInvoiceId = payload?.invoice?.id ?? event.data.id;
+  const squarePaymentId =
+    payload?.invoice?.payment_requests?.[0]?.completed_payment_ids?.[0] ??
+    'unknown';
+
+  if (!squareInvoiceId) {
+    return {
+      action: 'skipped',
+      details: 'No invoice id in invoice.payment_made payload',
+    };
+  }
+
+  const invoice = await InvoiceRepository.findBySquareInvoiceId(
+    squareInvoiceId
+  );
+
+  if (!invoice) {
+    return {
+      action: 'skipped',
+      details: `No Firestore invoice with squareInvoiceId ${squareInvoiceId}`,
+    };
+  }
+
+  // Idempotent: already paid by a prior event → no-op.
+  if (invoice.status === 'paid') {
+    return {
+      action: 'skipped',
+      details: `Invoice ${invoice.id} already paid (idempotent)`,
+    };
+  }
+
+  await InvoiceRepository.markPaidBySquareWebhook({
+    id: invoice.id,
+    squarePaymentId,
+  });
+
+  return {
+    action: 'paid',
+    details: `Invoice ${invoice.id} → paid (squarePaymentId=${squarePaymentId})`,
+  };
+}
+
 // Define secrets INLINE in the function options to avoid cold start delays
 // These are NOT defined at module level - they are created when the function is registered
 const webhookSignatureKey = defineSecret('SQUARE_WEBHOOK_SIGNATURE_KEY');
@@ -450,6 +522,10 @@ export const squareWebhook = onRequest(
 
         case 'inventory.count.updated':
           result = await handleInventoryUpdate(event);
+          break;
+
+        case 'invoice.payment_made':
+          result = await handleInvoicePaymentMade(event);
           break;
 
         default:

--- a/libs/firebase/maple-functions/sync-invoice-to-square/README.md
+++ b/libs/firebase/maple-functions/sync-invoice-to-square/README.md
@@ -1,0 +1,7 @@
+# sync-artist-to-webflow
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build sync-artist-to-webflow` to build the library.

--- a/libs/firebase/maple-functions/sync-invoice-to-square/eslint.config.mjs
+++ b/libs/firebase/maple-functions/sync-invoice-to-square/eslint.config.mjs
@@ -1,0 +1,22 @@
+import baseConfig from '../../../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredFiles: [
+            '{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}',
+            '{projectRoot}/esbuild.config.{js,ts,mjs,mts}',
+          ],
+        },
+      ],
+    },
+    languageOptions: {
+      parser: await import('jsonc-eslint-parser'),
+    },
+  },
+];

--- a/libs/firebase/maple-functions/sync-invoice-to-square/project.json
+++ b/libs/firebase/maple-functions/sync-invoice-to-square/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-sync-invoice-to-square",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/sync-invoice-to-square/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/sync-invoice-to-square/src/index.ts
+++ b/libs/firebase/maple-functions/sync-invoice-to-square/src/index.ts
@@ -1,0 +1,1 @@
+export { syncInvoiceToSquare } from './lib/sync-invoice-to-square';

--- a/libs/firebase/maple-functions/sync-invoice-to-square/src/lib/sync-invoice-to-square.spec.ts
+++ b/libs/firebase/maple-functions/sync-invoice-to-square/src/lib/sync-invoice-to-square.spec.ts
@@ -1,0 +1,403 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Unit tests for the sync-invoice-to-square Firestore trigger.
+ *
+ * We mock the trigger's firebase wrappers so the exported handler runs
+ * directly, plus mock the Square client / repositories to verify the
+ * orchestration logic around status transitions:
+ *  - draft → sent: send via Square, stamp ids
+ *  - sent  → void: cancel on Square
+ *  - everything else: no-op
+ *
+ * Also covers error handling: sync failures persist `squareSyncError`
+ * on the invoice rather than throwing (the trigger must return cleanly
+ * or Firestore will retry the event forever).
+ */
+
+const mocks = vi.hoisted(() => {
+  return {
+    // Firestore trigger — return the handler directly so we can invoke it
+    onDocumentWritten: vi.fn(),
+    // Repositories
+    studentFindById: vi.fn(),
+    markSquareSynced: vi.fn(),
+    recordSquareSyncError: vi.fn(),
+    // Square
+    sendInvoice: vi.fn(),
+    cancelInvoice: vi.fn(),
+  };
+});
+
+vi.mock('firebase-functions/v2/firestore', () => ({
+  onDocumentWritten: vi.fn((_config, handler) => {
+    mocks.onDocumentWritten(_config, handler);
+    return handler;
+  }),
+}));
+
+vi.mock('firebase-functions/params', () => ({
+  defineSecret: vi.fn((name: string) => ({
+    name,
+    value: () => `mock-${name}`,
+  })),
+  defineString: vi.fn((name: string) => ({
+    name,
+    value: () => `mock-${name}`,
+  })),
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  InvoiceRepository: {
+    markSquareSynced: mocks.markSquareSynced,
+    recordSquareSyncError: mocks.recordSquareSyncError,
+  },
+  StudentRepository: {
+    findById: mocks.studentFindById,
+  },
+}));
+
+vi.mock('@maple/firebase/square', () => {
+  return {
+    Square: class MockSquare {
+      locationId = 'LW0MMBZ';
+      invoicesService = {
+        sendInvoice: mocks.sendInvoice,
+        cancelInvoice: mocks.cancelInvoice,
+      };
+    },
+    SQUARE_SECRET_NAMES: ['SQUARE_ACCESS_TOKEN'] as const,
+    SQUARE_STRING_NAMES: ['SQUARE_ENV', 'SQUARE_LOCATION_ID', 'SALES_TAX_RATE'] as const,
+  };
+});
+
+// Import after mocks
+import { syncInvoiceToSquare } from './sync-invoice-to-square';
+
+type Handler = (event: unknown) => Promise<void>;
+const handler = syncInvoiceToSquare as unknown as Handler;
+
+function makeSnap(
+  exists: boolean,
+  data?: Record<string, unknown>,
+  id = 'inv-1'
+): unknown {
+  return {
+    id,
+    exists,
+    data: () => (exists ? data : undefined),
+  };
+}
+
+const baseSent = {
+  studentId: 'student-1',
+  status: 'sent',
+  lineItems: [
+    {
+      id: 'line-1',
+      description: 'April tuition',
+      quantity: 4,
+      unitAmountCents: 3250,
+      subtotalCents: 13000,
+    },
+  ],
+  totalCents: 13000,
+  issuedAt: new Date('2026-04-20T10:00:00Z'),
+  createdAt: new Date('2026-04-20T10:00:00Z'),
+  updatedAt: new Date('2026-04-20T10:00:00Z'),
+};
+
+const sampleStudent = {
+  id: 'student-1',
+  name: 'Olive Thompson',
+  instrument: 'violin',
+  isAdultStudent: false,
+  primaryTeacherId: 'instructor-1',
+  isHopeScholarship: false,
+  primaryContactName: 'Rita Thompson',
+  primaryContactEmail: 'rita@example.com',
+  primaryContactPhone: '555-111-2222',
+  status: 'active',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('syncInvoiceToSquare trigger', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('draft → sent', () => {
+    beforeEach(() => {
+      mocks.studentFindById.mockResolvedValue(sampleStudent);
+      mocks.sendInvoice.mockResolvedValue({
+        squareCustomerId: 'SQ-CUST',
+        squareOrderId: 'SQ-ORDER',
+        squareInvoiceId: 'SQ-INV',
+      });
+    });
+
+    it('sends the invoice via Square and stamps ids', async () => {
+      await handler({
+        params: { invoiceId: 'inv-1' },
+        data: {
+          before: makeSnap(true, { ...baseSent, status: 'draft' }),
+          after: makeSnap(true, baseSent),
+        },
+      });
+
+      expect(mocks.sendInvoice).toHaveBeenCalledTimes(1);
+      const arg = mocks.sendInvoice.mock.calls[0][0];
+      expect(arg.idempotencyKey).toBe('inv-1');
+      expect(arg.locationId).toBe('LW0MMBZ');
+      expect(arg.customer.email).toBe('rita@example.com');
+      expect(arg.customer.name).toBe('Rita Thompson');
+      expect(arg.lineItems[0].unitAmountCents).toBe(3250);
+
+      expect(mocks.markSquareSynced).toHaveBeenCalledWith({
+        id: 'inv-1',
+        squareOrderId: 'SQ-ORDER',
+        squareInvoiceId: 'SQ-INV',
+      });
+      expect(mocks.recordSquareSyncError).not.toHaveBeenCalled();
+    });
+
+    it('skips when invoice already has a squareInvoiceId (idempotent)', async () => {
+      await handler({
+        params: { invoiceId: 'inv-1' },
+        data: {
+          before: makeSnap(true, { ...baseSent, status: 'draft' }),
+          after: makeSnap(true, {
+            ...baseSent,
+            squareInvoiceId: 'SQ-INV-PRIOR',
+          }),
+        },
+      });
+
+      expect(mocks.sendInvoice).not.toHaveBeenCalled();
+      expect(mocks.markSquareSynced).not.toHaveBeenCalled();
+    });
+
+    it('skips when invoice has a prior sync error (waits for admin retry)', async () => {
+      await handler({
+        params: { invoiceId: 'inv-1' },
+        data: {
+          before: makeSnap(true, { ...baseSent, status: 'draft' }),
+          after: makeSnap(true, {
+            ...baseSent,
+            squareSyncError: 'Previous error',
+          }),
+        },
+      });
+
+      expect(mocks.sendInvoice).not.toHaveBeenCalled();
+    });
+
+    it('records sync error when student not found', async () => {
+      mocks.studentFindById.mockResolvedValue(undefined);
+
+      await handler({
+        params: { invoiceId: 'inv-1' },
+        data: {
+          before: makeSnap(true, { ...baseSent, status: 'draft' }),
+          after: makeSnap(true, baseSent),
+        },
+      });
+
+      expect(mocks.sendInvoice).not.toHaveBeenCalled();
+      expect(mocks.recordSquareSyncError).toHaveBeenCalledWith({
+        id: 'inv-1',
+        error: expect.stringMatching(/Student not found/),
+      });
+    });
+
+    it('records sync error when student is Hope Scholarship (defense-in-depth)', async () => {
+      mocks.studentFindById.mockResolvedValue({
+        ...sampleStudent,
+        isHopeScholarship: true,
+      });
+
+      await handler({
+        params: { invoiceId: 'inv-1' },
+        data: {
+          before: makeSnap(true, { ...baseSent, status: 'draft' }),
+          after: makeSnap(true, baseSent),
+        },
+      });
+
+      expect(mocks.sendInvoice).not.toHaveBeenCalled();
+      expect(mocks.recordSquareSyncError).toHaveBeenCalledWith({
+        id: 'inv-1',
+        error: expect.stringMatching(/Hope Scholarship/),
+      });
+    });
+
+    it('records sync error when Square API throws', async () => {
+      mocks.sendInvoice.mockRejectedValue(new Error('Square was down'));
+
+      await handler({
+        params: { invoiceId: 'inv-1' },
+        data: {
+          before: makeSnap(true, { ...baseSent, status: 'draft' }),
+          after: makeSnap(true, baseSent),
+        },
+      });
+
+      expect(mocks.markSquareSynced).not.toHaveBeenCalled();
+      expect(mocks.recordSquareSyncError).toHaveBeenCalledWith({
+        id: 'inv-1',
+        error: 'Square was down',
+      });
+    });
+
+    it('records a generic error when Square throws a non-Error', async () => {
+      mocks.sendInvoice.mockRejectedValue('something weird');
+
+      await handler({
+        params: { invoiceId: 'inv-1' },
+        data: {
+          before: makeSnap(true, { ...baseSent, status: 'draft' }),
+          after: makeSnap(true, baseSent),
+        },
+      });
+
+      expect(mocks.recordSquareSyncError).toHaveBeenCalledWith({
+        id: 'inv-1',
+        error: expect.stringMatching(/Unknown Square sync error/i),
+      });
+    });
+  });
+
+  describe('sent → void', () => {
+    it('cancels on Square when the invoice has a squareInvoiceId', async () => {
+      mocks.cancelInvoice.mockResolvedValue(undefined);
+
+      await handler({
+        params: { invoiceId: 'inv-1' },
+        data: {
+          before: makeSnap(true, {
+            ...baseSent,
+            squareInvoiceId: 'SQ-INV-1',
+          }),
+          after: makeSnap(true, {
+            ...baseSent,
+            status: 'void',
+            squareInvoiceId: 'SQ-INV-1',
+          }),
+        },
+      });
+
+      expect(mocks.cancelInvoice).toHaveBeenCalledWith('SQ-INV-1');
+      // Clear prior sync error after a successful cancel
+      expect(mocks.recordSquareSyncError).toHaveBeenCalledWith({
+        id: 'inv-1',
+        error: '',
+      });
+    });
+
+    it('skips cancel when transitioning paid → void (Square rejects it)', async () => {
+      await handler({
+        params: { invoiceId: 'inv-1' },
+        data: {
+          before: makeSnap(true, {
+            ...baseSent,
+            status: 'paid',
+            squareInvoiceId: 'SQ-INV-1',
+          }),
+          after: makeSnap(true, {
+            ...baseSent,
+            status: 'void',
+            squareInvoiceId: 'SQ-INV-1',
+          }),
+        },
+      });
+
+      expect(mocks.cancelInvoice).not.toHaveBeenCalled();
+    });
+
+    it('skips cancel when no squareInvoiceId on the invoice', async () => {
+      await handler({
+        params: { invoiceId: 'inv-1' },
+        data: {
+          before: makeSnap(true, { ...baseSent }),
+          after: makeSnap(true, { ...baseSent, status: 'void' }),
+        },
+      });
+
+      expect(mocks.cancelInvoice).not.toHaveBeenCalled();
+    });
+
+    it('records sync error when Square cancel throws', async () => {
+      mocks.cancelInvoice.mockRejectedValue(new Error('INVALID_INVOICE_STATUS'));
+
+      await handler({
+        params: { invoiceId: 'inv-1' },
+        data: {
+          before: makeSnap(true, {
+            ...baseSent,
+            squareInvoiceId: 'SQ-INV-1',
+          }),
+          after: makeSnap(true, {
+            ...baseSent,
+            status: 'void',
+            squareInvoiceId: 'SQ-INV-1',
+          }),
+        },
+      });
+
+      expect(mocks.recordSquareSyncError).toHaveBeenCalledWith({
+        id: 'inv-1',
+        error: 'INVALID_INVOICE_STATUS',
+      });
+    });
+  });
+
+  describe('no-op paths', () => {
+    it('skips when the doc is deleted (no after snapshot)', async () => {
+      await handler({
+        params: { invoiceId: 'inv-1' },
+        data: {
+          before: makeSnap(true, baseSent),
+          after: makeSnap(false),
+        },
+      });
+
+      expect(mocks.sendInvoice).not.toHaveBeenCalled();
+      expect(mocks.cancelInvoice).not.toHaveBeenCalled();
+      expect(mocks.markSquareSynced).not.toHaveBeenCalled();
+    });
+
+    it('skips when status is draft (not yet sent)', async () => {
+      await handler({
+        params: { invoiceId: 'inv-1' },
+        data: {
+          before: makeSnap(false),
+          after: makeSnap(true, { ...baseSent, status: 'draft' }),
+        },
+      });
+
+      expect(mocks.sendInvoice).not.toHaveBeenCalled();
+      expect(mocks.cancelInvoice).not.toHaveBeenCalled();
+    });
+
+    it('skips when status is paid (webhook already handled it)', async () => {
+      await handler({
+        params: { invoiceId: 'inv-1' },
+        data: {
+          before: makeSnap(true, {
+            ...baseSent,
+            squareInvoiceId: 'SQ-INV-1',
+          }),
+          after: makeSnap(true, {
+            ...baseSent,
+            status: 'paid',
+            squareInvoiceId: 'SQ-INV-1',
+          }),
+        },
+      });
+
+      expect(mocks.sendInvoice).not.toHaveBeenCalled();
+      expect(mocks.cancelInvoice).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/firebase/maple-functions/sync-invoice-to-square/src/lib/sync-invoice-to-square.spec.ts
+++ b/libs/firebase/maple-functions/sync-invoice-to-square/src/lib/sync-invoice-to-square.spec.ts
@@ -352,6 +352,106 @@ describe('syncInvoiceToSquare trigger', () => {
     });
   });
 
+  describe('Firestore Timestamp / string coercion', () => {
+    it('coerces Timestamp-ish objects (with .toDate) to Date', async () => {
+      mocks.studentFindById.mockResolvedValue(sampleStudent);
+      mocks.sendInvoice.mockResolvedValue({
+        squareCustomerId: 'SQ-CUST',
+        squareOrderId: 'SQ-ORDER',
+        squareInvoiceId: 'SQ-INV',
+      });
+
+      const timestampLike = {
+        toDate: () => new Date('2026-04-20T10:00:00Z'),
+      };
+
+      await handler({
+        params: { invoiceId: 'inv-1' },
+        data: {
+          before: makeSnap(true, { ...baseSent, status: 'draft' }),
+          after: makeSnap(true, {
+            ...baseSent,
+            createdAt: timestampLike,
+            updatedAt: timestampLike,
+            issuedAt: timestampLike,
+          }),
+        },
+      });
+
+      expect(mocks.sendInvoice).toHaveBeenCalledTimes(1);
+    });
+
+    it('coerces ISO date strings to Date', async () => {
+      mocks.studentFindById.mockResolvedValue(sampleStudent);
+      mocks.sendInvoice.mockResolvedValue({
+        squareCustomerId: 'SQ-CUST',
+        squareOrderId: 'SQ-ORDER',
+        squareInvoiceId: 'SQ-INV',
+      });
+
+      await handler({
+        params: { invoiceId: 'inv-1' },
+        data: {
+          before: makeSnap(true, { ...baseSent, status: 'draft' }),
+          after: makeSnap(true, {
+            ...baseSent,
+            createdAt: '2026-04-20T10:00:00Z',
+            updatedAt: '2026-04-20T10:00:00Z',
+            issuedAt: '2026-04-20T10:00:00Z',
+          }),
+        },
+      });
+
+      expect(mocks.sendInvoice).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles an invalid date string gracefully (returns undefined)', async () => {
+      mocks.studentFindById.mockResolvedValue(sampleStudent);
+      mocks.sendInvoice.mockResolvedValue({
+        squareCustomerId: 'SQ-CUST',
+        squareOrderId: 'SQ-ORDER',
+        squareInvoiceId: 'SQ-INV',
+      });
+
+      await handler({
+        params: { invoiceId: 'inv-1' },
+        data: {
+          before: makeSnap(true, { ...baseSent, status: 'draft' }),
+          after: makeSnap(true, {
+            ...baseSent,
+            createdAt: 'not-a-real-date',
+          }),
+        },
+      });
+
+      expect(mocks.sendInvoice).toHaveBeenCalledTimes(1);
+    });
+
+    it('extracts paymentRecord when present on the Firestore doc', async () => {
+      // Paid status with partially-shaped paymentRecord — the extractor
+      // reads paymentRecord and coerces its recordedAt to Date.
+      await handler({
+        params: { invoiceId: 'inv-1' },
+        data: {
+          before: makeSnap(true, baseSent),
+          after: makeSnap(true, {
+            ...baseSent,
+            status: 'paid',
+            paymentRecord: {
+              source: 'square-webhook',
+              squarePaymentId: 'SQ-PAY-1',
+              // recordedAt absent — extractor falls back to new Date()
+            },
+            squareInvoiceId: 'SQ-INV-1',
+          }),
+        },
+      });
+
+      expect(mocks.sendInvoice).not.toHaveBeenCalled();
+      expect(mocks.cancelInvoice).not.toHaveBeenCalled();
+    });
+  });
+
   describe('no-op paths', () => {
     it('skips when the doc is deleted (no after snapshot)', async () => {
       await handler({

--- a/libs/firebase/maple-functions/sync-invoice-to-square/src/lib/sync-invoice-to-square.ts
+++ b/libs/firebase/maple-functions/sync-invoice-to-square/src/lib/sync-invoice-to-square.ts
@@ -1,0 +1,210 @@
+/**
+ * Sync Invoice to Square Cloud Function
+ *
+ * Firestore trigger that pushes private-pay invoice lifecycle events
+ * to Square's Invoices API:
+ * - draft → sent: create Square customer (upsert by email), order, and
+ *   invoice; publish it so Square emails the parent a hosted payment
+ *   page. Stamp squareOrderId + squareInvoiceId back on the Firestore
+ *   doc.
+ * - sent → void (before payment): cancel the Square invoice.
+ * - Anything else: no-op. Paid transitions flow back in via the
+ *   square-webhook handler; we don't re-sync on paid.
+ *
+ * Errors are logged and persisted on the invoice (`squareSyncError`) so
+ * Katie can retry from the admin UI without digging through function logs.
+ */
+import {
+  onDocumentWritten,
+  type Change,
+  type DocumentSnapshot,
+} from 'firebase-functions/v2/firestore';
+import { defineSecret, defineString } from 'firebase-functions/params';
+import type { Invoice } from '@maple/ts/domain';
+import {
+  Square,
+  SQUARE_SECRET_NAMES,
+  SQUARE_STRING_NAMES,
+} from '@maple/firebase/square';
+import {
+  InvoiceRepository,
+  StudentRepository,
+} from '@maple/firebase/database';
+
+const squareSecretParams = SQUARE_SECRET_NAMES.map((name) => defineSecret(name));
+const squareStringParams = SQUARE_STRING_NAMES.map((name) => defineString(name));
+
+/** Firestore Timestamp-ish → Date helper. */
+function toDateLike(value: unknown): Date | undefined {
+  if (!value) return undefined;
+  if (value instanceof Date) return value;
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    'toDate' in value &&
+    typeof (value as { toDate: unknown }).toDate === 'function'
+  ) {
+    return (value as { toDate: () => Date }).toDate();
+  }
+  if (typeof value === 'string') {
+    const d = new Date(value);
+    return Number.isFinite(d.getTime()) ? d : undefined;
+  }
+  return undefined;
+}
+
+function extractInvoice(snapshot?: DocumentSnapshot): Invoice | undefined {
+  if (!snapshot?.exists) return undefined;
+  const data = snapshot.data();
+  if (!data) return undefined;
+
+  const paymentRecord = data['paymentRecord'] as
+    | {
+        source: 'admin-manual' | 'square-webhook';
+        squarePaymentId?: string;
+        recordedAt: unknown;
+      }
+    | undefined;
+
+  return {
+    id: snapshot.id,
+    studentId: data['studentId'],
+    status: data['status'],
+    lineItems: data['lineItems'] ?? [],
+    totalCents: data['totalCents'] ?? 0,
+    issuedAt: toDateLike(data['issuedAt']),
+    paidAt: toDateLike(data['paidAt']),
+    paymentRecord: paymentRecord
+      ? {
+          source: paymentRecord.source,
+          squarePaymentId: paymentRecord.squarePaymentId,
+          recordedAt: toDateLike(paymentRecord.recordedAt) ?? new Date(),
+        }
+      : undefined,
+    squareOrderId: data['squareOrderId'],
+    squareInvoiceId: data['squareInvoiceId'],
+    squareSyncError: data['squareSyncError'],
+    notes: data['notes'],
+    createdAt: toDateLike(data['createdAt']) ?? new Date(),
+    updatedAt: toDateLike(data['updatedAt']) ?? new Date(),
+  };
+}
+
+export const syncInvoiceToSquare = onDocumentWritten(
+  {
+    document: 'invoices/{invoiceId}',
+    region: 'us-east4',
+    secrets: squareSecretParams,
+  },
+  async (event) => {
+    const change: Change<DocumentSnapshot> = event.data!;
+    const before = extractInvoice(change.before);
+    const after = extractInvoice(change.after);
+    const invoiceId = event.params.invoiceId;
+
+    // Doc deleted or never existed — nothing to sync.
+    if (!after) {
+      console.log(`[sync-invoice] ${invoiceId} deleted, no-op`);
+      return;
+    }
+
+    const needsSend =
+      after.status === 'sent' && !after.squareInvoiceId && !after.squareSyncError;
+
+    const needsCancel =
+      after.status === 'void' &&
+      before?.status !== 'void' &&
+      !!after.squareInvoiceId &&
+      // Don't try to cancel an already-paid Square invoice — Square rejects it.
+      before?.status !== 'paid';
+
+    if (!needsSend && !needsCancel) {
+      console.log(
+        `[sync-invoice] ${invoiceId} no action (status=${after.status}, squareInvoiceId=${after.squareInvoiceId ?? '∅'})`
+      );
+      return;
+    }
+
+    // Build Square client at trigger time (secrets resolve here, not at cold start)
+    const secrets = Object.fromEntries(
+      squareSecretParams.map((s) => [s.name, s.value()])
+    ) as Record<(typeof SQUARE_SECRET_NAMES)[number], string>;
+
+    const strings = Object.fromEntries(
+      squareStringParams.map((s) => [s.name, s.value()])
+    ) as Record<(typeof SQUARE_STRING_NAMES)[number], string>;
+
+    const square = new Square(secrets, strings);
+
+    if (needsSend) {
+      try {
+        const student = await StudentRepository.findById(after.studentId);
+        if (!student) {
+          throw new Error(`Student not found: ${after.studentId}`);
+        }
+        if (student.isHopeScholarship) {
+          throw new Error(
+            'Hope Scholarship students must not flow through Square invoicing'
+          );
+        }
+
+        const result = await square.invoicesService.sendInvoice({
+          locationId: square.locationId,
+          idempotencyKey: invoiceId,
+          customer: {
+            email: student.primaryContactEmail,
+            name: student.primaryContactName,
+            phone: student.primaryContactPhone,
+          },
+          title: `Music lessons — ${student.name}`,
+          description: after.notes,
+          lineItems: after.lineItems.map((line) => ({
+            name: line.description,
+            quantity: String(line.quantity),
+            unitAmountCents: line.unitAmountCents,
+          })),
+        });
+
+        await InvoiceRepository.markSquareSynced({
+          id: invoiceId,
+          squareOrderId: result.squareOrderId,
+          squareInvoiceId: result.squareInvoiceId,
+        });
+
+        console.log(
+          `[sync-invoice] ${invoiceId} sent via Square (invoice=${result.squareInvoiceId})`
+        );
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Unknown Square sync error';
+        console.error(`[sync-invoice] ${invoiceId} send failed:`, message);
+        await InvoiceRepository.recordSquareSyncError({
+          id: invoiceId,
+          error: message,
+        });
+      }
+      return;
+    }
+
+    if (needsCancel && after.squareInvoiceId) {
+      try {
+        await square.invoicesService.cancelInvoice(after.squareInvoiceId);
+        await InvoiceRepository.recordSquareSyncError({
+          id: invoiceId,
+          error: '',
+        });
+        console.log(
+          `[sync-invoice] ${invoiceId} cancelled on Square (invoice=${after.squareInvoiceId})`
+        );
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Unknown Square sync error';
+        console.error(`[sync-invoice] ${invoiceId} cancel failed:`, message);
+        await InvoiceRepository.recordSquareSyncError({
+          id: invoiceId,
+          error: message,
+        });
+      }
+    }
+  }
+);

--- a/libs/firebase/maple-functions/sync-invoice-to-square/tsconfig.json
+++ b/libs/firebase/maple-functions/sync-invoice-to-square/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/sync-invoice-to-square/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/sync-invoice-to-square/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/libs/firebase/maple-functions/sync-invoice-to-square/vitest.config.ts
+++ b/libs/firebase/maple-functions/sync-invoice-to-square/vitest.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  root: __dirname,
+  test: {
+    name: 'firebase-maple-functions-sync-invoice-to-square',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov', 'json-summary', 'json'],
+      reportsDirectory:
+        '../../../../coverage/libs/firebase/maple-functions/sync-invoice-to-square',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.spec.ts', 'src/index.ts'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@maple/ts/domain': resolve(__dirname, '../../../ts/domain/src/index.ts'),
+      '@maple/firebase/database': resolve(
+        __dirname,
+        '../../../firebase/database/src/index.ts'
+      ),
+      '@maple/firebase/square': resolve(
+        __dirname,
+        '../../../firebase/square/src/index.ts'
+      ),
+      '@maple/firebase/functions': resolve(
+        __dirname,
+        '../../../firebase/functions/src/index.ts'
+      ),
+    },
+  },
+});

--- a/libs/firebase/maple-functions/update-invoice/src/lib/update-invoice.spec.ts
+++ b/libs/firebase/maple-functions/update-invoice/src/lib/update-invoice.spec.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Unit tests for the updateInvoice cloud function handler.
+ *
+ * Mocks createAdminFunction + throwNotFound so the handler runs as a
+ * plain function, and mocks InvoiceRepository so we can assert what the
+ * handler forwards. Uses the real invoiceValidation + real
+ * isInvoiceStatusTransitionAllowed so the transition rules aren't
+ * re-implemented in the spec.
+ */
+
+const mocks = vi.hoisted(() => ({
+  findById: vi.fn(),
+  update: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/functions', () => ({
+  createAdminFunction: <TReq, TRes>(
+    handler: (data: TReq, ctx: unknown) => Promise<TRes>
+  ) => handler,
+  throwNotFound: (entity: string, id: string) => {
+    throw new Error(`${entity} not found: ${id}`);
+  },
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  InvoiceRepository: {
+    findById: mocks.findById,
+    update: mocks.update,
+  },
+}));
+
+import { updateInvoice } from './update-invoice';
+
+type Handler = (data: unknown, ctx?: unknown) => Promise<unknown>;
+const handler = updateInvoice as unknown as Handler;
+
+const existingDraft = {
+  id: 'inv-1',
+  studentId: 'student-1',
+  status: 'draft',
+  lineItems: [
+    {
+      id: 'l1',
+      description: 'April tuition',
+      quantity: 4,
+      unitAmountCents: 3250,
+      subtotalCents: 13000,
+    },
+  ],
+  totalCents: 13000,
+  notes: undefined,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('updateInvoice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends the update to the repository on a valid status transition', async () => {
+    mocks.findById.mockResolvedValue(existingDraft);
+    mocks.update.mockResolvedValue({
+      ...existingDraft,
+      status: 'sent',
+      issuedAt: new Date(),
+    });
+
+    const result = (await handler({ id: 'inv-1', status: 'sent' })) as {
+      invoice: { status: string };
+    };
+
+    expect(mocks.update).toHaveBeenCalledWith(
+      { id: 'inv-1', status: 'sent' },
+      existingDraft
+    );
+    expect(result.invoice.status).toBe('sent');
+  });
+
+  it('throws not-found when the invoice does not exist', async () => {
+    mocks.findById.mockResolvedValue(undefined);
+
+    await expect(handler({ id: 'missing', status: 'sent' })).rejects.toThrow(
+      /Invoice not found/
+    );
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects an illegal status transition (paid → sent)', async () => {
+    mocks.findById.mockResolvedValue({ ...existingDraft, status: 'paid' });
+
+    await expect(handler({ id: 'inv-1', status: 'sent' })).rejects.toThrow(
+      /Invalid status transition/
+    );
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects from terminal void back to anything', async () => {
+    mocks.findById.mockResolvedValue({ ...existingDraft, status: 'void' });
+
+    await expect(handler({ id: 'inv-1', status: 'draft' })).rejects.toThrow(
+      /Invalid status transition/
+    );
+  });
+
+  it('merges partial line-item updates and validates the merged shape', async () => {
+    mocks.findById.mockResolvedValue(existingDraft);
+    mocks.update.mockResolvedValue(existingDraft);
+
+    await handler({
+      id: 'inv-1',
+      lineItems: [
+        {
+          id: 'l-new',
+          description: 'Refined tuition',
+          quantity: 2,
+          unitAmountCents: 3250,
+          subtotalCents: 6500,
+        },
+      ],
+    });
+
+    expect(mocks.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a merged line-items update with a blank description', async () => {
+    mocks.findById.mockResolvedValue(existingDraft);
+
+    await expect(
+      handler({
+        id: 'inv-1',
+        lineItems: [
+          {
+            id: 'l-bad',
+            description: '',
+            quantity: 1,
+            unitAmountCents: 1000,
+            subtotalCents: 1000,
+          },
+        ],
+      })
+    ).rejects.toThrow(/Validation failed/);
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it('passes through a notes-only update without touching status or line items', async () => {
+    mocks.findById.mockResolvedValue(existingDraft);
+    mocks.update.mockResolvedValue({ ...existingDraft, notes: 'Mailed 4/20' });
+
+    await handler({ id: 'inv-1', notes: 'Mailed 4/20' });
+
+    expect(mocks.update).toHaveBeenCalledWith(
+      { id: 'inv-1', notes: 'Mailed 4/20' },
+      existingDraft
+    );
+  });
+});

--- a/libs/firebase/maple-functions/update-invoice/vitest.config.ts
+++ b/libs/firebase/maple-functions/update-invoice/vitest.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  root: __dirname,
+  test: {
+    name: 'firebase-maple-functions-update-invoice',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov', 'json-summary', 'json'],
+      reportsDirectory:
+        '../../../../coverage/libs/firebase/maple-functions/update-invoice',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.spec.ts', 'src/index.ts'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@maple/ts/domain': resolve(__dirname, '../../../ts/domain/src/index.ts'),
+      '@maple/ts/validation': resolve(
+        __dirname,
+        '../../../ts/validation/src/index.ts'
+      ),
+      '@maple/ts/firebase/api-types': resolve(
+        __dirname,
+        '../../../ts/firebase/api-types/src/index.ts'
+      ),
+      '@maple/firebase/database': resolve(
+        __dirname,
+        '../../../firebase/database/src/index.ts'
+      ),
+      '@maple/firebase/functions': resolve(
+        __dirname,
+        '../../../firebase/functions/src/index.ts'
+      ),
+    },
+  },
+});

--- a/libs/firebase/square/src/index.ts
+++ b/libs/firebase/square/src/index.ts
@@ -47,3 +47,12 @@ export {
   type RefundPaymentResult,
   type GetPaymentResult,
 } from './lib/payments.service';
+
+// Invoices service
+export {
+  InvoicesService,
+  type SendInvoiceInput,
+  type SendInvoiceResult,
+  type InvoiceCustomerInput,
+  type InvoiceLineItemInput,
+} from './lib/invoices.service';

--- a/libs/firebase/square/src/lib/invoices.service.spec.ts
+++ b/libs/firebase/square/src/lib/invoices.service.spec.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { InvoicesService } from './invoices.service';
+import type { SquareClient } from 'square';
+
+/**
+ * Unit tests for the Square InvoicesService wrapper. Mocks the Square
+ * client at the method level and verifies our orchestration:
+ *   upsertCustomer → createInvoiceOrder → createDraftInvoice → publishInvoice
+ * plus cancelInvoice + error paths.
+ */
+
+interface MockClient {
+  customers: {
+    search: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+  orders: {
+    create: ReturnType<typeof vi.fn>;
+  };
+  invoices: {
+    create: ReturnType<typeof vi.fn>;
+    publish: ReturnType<typeof vi.fn>;
+    get: ReturnType<typeof vi.fn>;
+    cancel: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeMockClient(): MockClient {
+  return {
+    customers: {
+      search: vi.fn(),
+      create: vi.fn(),
+    },
+    orders: {
+      create: vi.fn(),
+    },
+    invoices: {
+      create: vi.fn(),
+      publish: vi.fn(),
+      get: vi.fn(),
+      cancel: vi.fn(),
+    },
+  };
+}
+
+const sampleInput = () => ({
+  locationId: 'LW0MMBZ',
+  idempotencyKey: 'firebase-inv-123',
+  customer: {
+    email: 'parent@example.com',
+    name: 'Rita Thompson',
+  },
+  lineItems: [
+    {
+      name: 'April tuition',
+      quantity: '4',
+      unitAmountCents: 3250,
+    },
+  ],
+  title: 'Music lessons — Olive',
+  description: 'Mailed 4/20',
+});
+
+describe('InvoicesService.sendInvoice', () => {
+  let client: MockClient;
+  let service: InvoicesService;
+
+  beforeEach(() => {
+    client = makeMockClient();
+    service = new InvoicesService(client as unknown as SquareClient);
+
+    client.orders.create.mockResolvedValue({
+      errors: [],
+      order: { id: 'SQ-ORDER-1', totalMoney: { amount: 13000n } },
+    });
+    client.invoices.create.mockResolvedValue({
+      errors: [],
+      invoice: { id: 'SQ-INVOICE-1', version: 0 },
+    });
+    client.invoices.publish.mockResolvedValue({
+      errors: [],
+      invoice: {
+        id: 'SQ-INVOICE-1',
+        publicUrl: 'https://squareup.com/pay/abc',
+      },
+    });
+  });
+
+  it('reuses an existing Square customer when one is found by email', async () => {
+    client.customers.search.mockResolvedValue({
+      customers: [{ id: 'SQ-CUST-EXISTING' }],
+    });
+
+    const result = await service.sendInvoice(sampleInput());
+
+    expect(client.customers.search).toHaveBeenCalledWith({
+      query: { filter: { emailAddress: { exact: 'parent@example.com' } } },
+    });
+    expect(client.customers.create).not.toHaveBeenCalled();
+    expect(result.squareCustomerId).toBe('SQ-CUST-EXISTING');
+  });
+
+  it('creates a Square customer when none exists for the email', async () => {
+    client.customers.search.mockResolvedValue({ customers: [] });
+    client.customers.create.mockResolvedValue({
+      errors: [],
+      customer: { id: 'SQ-CUST-NEW' },
+    });
+
+    const result = await service.sendInvoice(sampleInput());
+
+    expect(client.customers.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        idempotencyKey: 'customer-parent@example.com',
+        givenName: 'Rita',
+        familyName: 'Thompson',
+        emailAddress: 'parent@example.com',
+      })
+    );
+    expect(result.squareCustomerId).toBe('SQ-CUST-NEW');
+  });
+
+  it('splits a one-word name into givenName only', async () => {
+    client.customers.search.mockResolvedValue({ customers: [] });
+    client.customers.create.mockResolvedValue({
+      errors: [],
+      customer: { id: 'SQ-CUST-NEW' },
+    });
+
+    await service.sendInvoice({
+      ...sampleInput(),
+      customer: { email: 'x@y.com', name: 'Cher' },
+    });
+
+    const createArg = client.customers.create.mock.calls[0][0];
+    expect(createArg.givenName).toBe('Cher');
+    expect(createArg.familyName).toBeUndefined();
+  });
+
+  it('creates a Square order with the line items', async () => {
+    client.customers.search.mockResolvedValue({
+      customers: [{ id: 'SQ-CUST' }],
+    });
+
+    await service.sendInvoice(sampleInput());
+
+    const orderArg = client.orders.create.mock.calls[0][0];
+    expect(orderArg.idempotencyKey).toBe('firebase-inv-123-order');
+    expect(orderArg.order.locationId).toBe('LW0MMBZ');
+    expect(orderArg.order.lineItems).toHaveLength(1);
+    expect(orderArg.order.lineItems[0]).toEqual({
+      name: 'April tuition',
+      quantity: '4',
+      basePriceMoney: { amount: 3250n, currency: 'USD' },
+    });
+  });
+
+  it('creates a draft invoice pointing at the order + customer, card-only', async () => {
+    client.customers.search.mockResolvedValue({
+      customers: [{ id: 'SQ-CUST' }],
+    });
+
+    await service.sendInvoice(sampleInput());
+
+    const invoiceArg = client.invoices.create.mock.calls[0][0];
+    expect(invoiceArg.idempotencyKey).toBe('firebase-inv-123-invoice');
+    expect(invoiceArg.invoice.orderId).toBe('SQ-ORDER-1');
+    expect(invoiceArg.invoice.primaryRecipient).toEqual({
+      customerId: 'SQ-CUST',
+    });
+    expect(invoiceArg.invoice.deliveryMethod).toBe('EMAIL');
+    expect(invoiceArg.invoice.acceptedPaymentMethods).toEqual({
+      card: true,
+      squareGiftCard: false,
+      bankAccount: false,
+      buyNowPayLater: false,
+      cashAppPay: false,
+    });
+    expect(invoiceArg.invoice.paymentRequests).toHaveLength(1);
+    expect(invoiceArg.invoice.paymentRequests[0].requestType).toBe('BALANCE');
+  });
+
+  it('publishes the draft invoice with the current version and returns the hosted URL', async () => {
+    client.customers.search.mockResolvedValue({
+      customers: [{ id: 'SQ-CUST' }],
+    });
+    client.invoices.create.mockResolvedValue({
+      errors: [],
+      invoice: { id: 'SQ-INVOICE-2', version: 3 },
+    });
+
+    const result = await service.sendInvoice(sampleInput());
+
+    expect(client.invoices.publish).toHaveBeenCalledWith({
+      invoiceId: 'SQ-INVOICE-2',
+      version: 3,
+      idempotencyKey: 'firebase-inv-123-publish',
+    });
+    expect(result.squareInvoiceId).toBe('SQ-INVOICE-2');
+    expect(result.publicUrl).toBe('https://squareup.com/pay/abc');
+  });
+
+  it('throws if Square returns errors on customer create', async () => {
+    client.customers.search.mockResolvedValue({ customers: [] });
+    client.customers.create.mockResolvedValue({
+      errors: [{ code: 'INVALID_EMAIL_ADDRESS', detail: 'bad email' }],
+    });
+
+    await expect(service.sendInvoice(sampleInput())).rejects.toThrow(
+      /create customer/
+    );
+  });
+
+  it('throws if Square returns errors on order create', async () => {
+    client.customers.search.mockResolvedValue({
+      customers: [{ id: 'SQ-CUST' }],
+    });
+    client.orders.create.mockResolvedValue({
+      errors: [{ code: 'INVALID_REQUEST', detail: 'bad line items' }],
+    });
+
+    await expect(service.sendInvoice(sampleInput())).rejects.toThrow(
+      /create order/
+    );
+  });
+
+  it('throws if the order response is missing an id', async () => {
+    client.customers.search.mockResolvedValue({
+      customers: [{ id: 'SQ-CUST' }],
+    });
+    client.orders.create.mockResolvedValue({ errors: [], order: {} });
+
+    await expect(service.sendInvoice(sampleInput())).rejects.toThrow(
+      /no id/
+    );
+  });
+
+  it('throws if the invoice response is missing id or version', async () => {
+    client.customers.search.mockResolvedValue({
+      customers: [{ id: 'SQ-CUST' }],
+    });
+    client.invoices.create.mockResolvedValue({
+      errors: [],
+      invoice: { id: undefined, version: 0 },
+    });
+
+    await expect(service.sendInvoice(sampleInput())).rejects.toThrow(
+      /no id\/version/
+    );
+  });
+});
+
+describe('InvoicesService.cancelInvoice', () => {
+  let client: MockClient;
+  let service: InvoicesService;
+
+  beforeEach(() => {
+    client = makeMockClient();
+    service = new InvoicesService(client as unknown as SquareClient);
+  });
+
+  it('fetches the current invoice version before cancelling', async () => {
+    client.invoices.get.mockResolvedValue({
+      invoice: { id: 'SQ-INVOICE-1', version: 7 },
+    });
+    client.invoices.cancel.mockResolvedValue({ errors: [] });
+
+    await service.cancelInvoice('SQ-INVOICE-1');
+
+    expect(client.invoices.get).toHaveBeenCalledWith({
+      invoiceId: 'SQ-INVOICE-1',
+    });
+    expect(client.invoices.cancel).toHaveBeenCalledWith({
+      invoiceId: 'SQ-INVOICE-1',
+      version: 7,
+    });
+  });
+
+  it('throws if Square returns no version (unknown invoice)', async () => {
+    client.invoices.get.mockResolvedValue({ invoice: {} });
+
+    await expect(service.cancelInvoice('missing')).rejects.toThrow(
+      /no version/
+    );
+    expect(client.invoices.cancel).not.toHaveBeenCalled();
+  });
+
+  it('throws if Square returns errors on cancel', async () => {
+    client.invoices.get.mockResolvedValue({
+      invoice: { id: 'SQ-1', version: 1 },
+    });
+    client.invoices.cancel.mockResolvedValue({
+      errors: [{ code: 'INVALID_INVOICE_STATUS', detail: 'already paid' }],
+    });
+
+    await expect(service.cancelInvoice('SQ-1')).rejects.toThrow(
+      /cancel invoice/
+    );
+  });
+});

--- a/libs/firebase/square/src/lib/invoices.service.ts
+++ b/libs/firebase/square/src/lib/invoices.service.ts
@@ -1,0 +1,266 @@
+/**
+ * Square Invoices API service
+ *
+ * Sends private-pay music lesson invoices via Square:
+ * 1. Ensures a Square Customer exists for the parent/adult student (email-keyed)
+ * 2. Creates a Square Order with the invoice's line items
+ * 3. Creates a Square Invoice referencing the order + customer
+ * 4. Publishes the invoice — Square then emails the customer a hosted
+ *    payment page and handles reminders / receipts automatically.
+ *
+ * Payment completion flows back via the `invoice.payment_made` webhook
+ * event (handled in square-webhook) which updates our Firestore Invoice
+ * record with paymentRecord { source: 'square-webhook', squarePaymentId }.
+ *
+ * @see https://developer.squareup.com/docs/invoices-api/overview
+ */
+import { SquareClient, Square } from 'square';
+
+export interface InvoiceCustomerInput {
+  /** Primary contact email — used as idempotency key for Square customer lookup. */
+  email: string;
+  /** Customer display name. */
+  name: string;
+  phone?: string;
+}
+
+export interface InvoiceLineItemInput {
+  name: string;
+  /** Stringified quantity, per Square's Orders API. */
+  quantity: string;
+  /** Base price per unit in cents. */
+  unitAmountCents: number;
+}
+
+export interface SendInvoiceInput {
+  /** Square location id. */
+  locationId: string;
+  /** Idempotency key (typically the Firestore invoice id). */
+  idempotencyKey: string;
+  customer: InvoiceCustomerInput;
+  lineItems: InvoiceLineItemInput[];
+  /** Short title shown on the hosted payment page. */
+  title: string;
+  /** Optional longer description / notes shown on the invoice. */
+  description?: string;
+}
+
+export interface SendInvoiceResult {
+  squareCustomerId: string;
+  squareOrderId: string;
+  squareInvoiceId: string;
+  /** Hosted payment page URL Square returns on publish. */
+  publicUrl?: string;
+}
+
+export class InvoicesService {
+  constructor(private readonly client: SquareClient) {}
+
+  /**
+   * Full happy-path send: upsert customer, create order, create invoice,
+   * publish it. Returns the Square ids for our Firestore record.
+   */
+  async sendInvoice(input: SendInvoiceInput): Promise<SendInvoiceResult> {
+    const squareCustomerId = await this.upsertCustomer(input.customer);
+
+    const orderId = await this.createInvoiceOrder(input);
+
+    const { invoiceId, version } = await this.createDraftInvoice({
+      orderId,
+      customerId: squareCustomerId,
+      idempotencyKey: `${input.idempotencyKey}-invoice`,
+      title: input.title,
+      description: input.description,
+    });
+
+    const publishResult = await this.publishInvoice({
+      invoiceId,
+      version,
+      idempotencyKey: `${input.idempotencyKey}-publish`,
+    });
+
+    return {
+      squareCustomerId,
+      squareOrderId: orderId,
+      squareInvoiceId: invoiceId,
+      publicUrl: publishResult.publicUrl,
+    };
+  }
+
+  /**
+   * Cancel a published Square invoice. Used when our Invoice transitions
+   * to `void` before the customer has paid.
+   */
+  async cancelInvoice(squareInvoiceId: string): Promise<void> {
+    // Fetch current version first — Square requires optimistic concurrency.
+    const current = await this.client.invoices.get({
+      invoiceId: squareInvoiceId,
+    });
+    const version = current.invoice?.version;
+    if (version === undefined) {
+      throw new Error(
+        `Square invoice ${squareInvoiceId} has no version; cannot cancel`
+      );
+    }
+
+    const response = await this.client.invoices.cancel({
+      invoiceId: squareInvoiceId,
+      version,
+    });
+
+    throwIfErrors(response.errors, 'cancel invoice');
+  }
+
+  /**
+   * Look up a Square Customer by email; create one if not found. Square
+   * customers are not strictly deduplicated, so email-first lookup keeps
+   * us from creating duplicates when Katie resends to the same parent.
+   */
+  private async upsertCustomer(
+    customer: InvoiceCustomerInput
+  ): Promise<string> {
+    // Attempt to find an existing customer by email
+    const searchResponse = await this.client.customers.search({
+      query: {
+        filter: {
+          emailAddress: { exact: customer.email },
+        },
+      },
+    });
+
+    const existingId = searchResponse.customers?.[0]?.id;
+    if (existingId) {
+      return existingId;
+    }
+
+    // Not found — create a new customer
+    const [givenName, ...familyNameParts] = customer.name.split(' ');
+    const familyName = familyNameParts.join(' ') || undefined;
+
+    const createResponse = await this.client.customers.create({
+      idempotencyKey: `customer-${customer.email}`,
+      givenName: givenName || customer.name,
+      familyName,
+      emailAddress: customer.email,
+      phoneNumber: customer.phone,
+    });
+
+    throwIfErrors(createResponse.errors, 'create customer');
+
+    const newId = createResponse.customer?.id;
+    if (!newId) {
+      throw new Error('Square customer create returned no id');
+    }
+    return newId;
+  }
+
+  /**
+   * Create a Square Order for the invoice's line items. The order lives
+   * in OPEN state until the invoice charges it; no tax applied here since
+   * music lessons are a service (not subject to WV sales tax under
+   * §11-15-3). The order's total equals the invoice's pre-payment total.
+   */
+  private async createInvoiceOrder(
+    input: SendInvoiceInput
+  ): Promise<string> {
+    const response = await this.client.orders.create({
+      idempotencyKey: `${input.idempotencyKey}-order`,
+      order: {
+        locationId: input.locationId,
+        lineItems: input.lineItems.map((line) => ({
+          name: line.name,
+          quantity: line.quantity,
+          basePriceMoney: {
+            amount: BigInt(line.unitAmountCents),
+            currency: 'USD',
+          },
+        })),
+      },
+    });
+
+    throwIfErrors(response.errors, 'create order');
+
+    const orderId = response.order?.id;
+    if (!orderId) {
+      throw new Error('Square order create returned no id');
+    }
+    return orderId;
+  }
+
+  /**
+   * Create an unpublished (draft) invoice. Payment request defaults to
+   * the full balance, due on send, card-only accepted methods.
+   */
+  private async createDraftInvoice(args: {
+    orderId: string;
+    customerId: string;
+    idempotencyKey: string;
+    title: string;
+    description?: string;
+  }): Promise<{ invoiceId: string; version: number }> {
+    const response = await this.client.invoices.create({
+      idempotencyKey: args.idempotencyKey,
+      invoice: {
+        orderId: args.orderId,
+        title: args.title,
+        description: args.description,
+        primaryRecipient: { customerId: args.customerId },
+        paymentRequests: [
+          {
+            requestType: 'BALANCE',
+            dueDate: new Date().toISOString().slice(0, 10),
+            automaticPaymentSource: 'NONE',
+          },
+        ],
+        deliveryMethod: 'EMAIL',
+        acceptedPaymentMethods: {
+          card: true,
+          squareGiftCard: false,
+          bankAccount: false,
+          buyNowPayLater: false,
+          cashAppPay: false,
+        },
+      },
+    });
+
+    throwIfErrors(response.errors, 'create invoice');
+
+    const invoiceId = response.invoice?.id;
+    const version = response.invoice?.version;
+    if (!invoiceId || version === undefined) {
+      throw new Error('Square invoice create returned no id/version');
+    }
+    return { invoiceId, version };
+  }
+
+  /**
+   * Publish a draft invoice — this triggers Square to email the customer
+   * the hosted payment page. Returns the page URL.
+   */
+  private async publishInvoice(args: {
+    invoiceId: string;
+    version: number;
+    idempotencyKey: string;
+  }): Promise<{ publicUrl?: string }> {
+    const response = await this.client.invoices.publish({
+      invoiceId: args.invoiceId,
+      version: args.version,
+      idempotencyKey: args.idempotencyKey,
+    });
+
+    throwIfErrors(response.errors, 'publish invoice');
+
+    return { publicUrl: response.invoice?.publicUrl };
+  }
+}
+
+function throwIfErrors(
+  errors: Square.Error_[] | undefined,
+  operation: string
+): void {
+  if (!errors || errors.length === 0) return;
+  const msg = errors
+    .map((e) => e.detail || e.code || 'Unknown error')
+    .join('; ');
+  throw new Error(`Square ${operation} error: ${msg}`);
+}

--- a/libs/firebase/square/src/lib/square.utility.ts
+++ b/libs/firebase/square/src/lib/square.utility.ts
@@ -15,6 +15,7 @@ import { CatalogService } from './catalog.service';
 import { InventoryService } from './inventory.service';
 import { OrdersService } from './orders.service';
 import { PaymentsService } from './payments.service';
+import { InvoicesService } from './invoices.service';
 
 /**
  * Secret names for Firebase Functions secrets
@@ -81,6 +82,7 @@ export class Square {
   private readonly _inventoryService: InventoryService;
   private readonly _ordersService: OrdersService;
   private readonly _paymentsService: PaymentsService;
+  private readonly _invoicesService: InvoicesService;
   public readonly locationId: string;
   public readonly taxRatePercent: number;
 
@@ -125,6 +127,7 @@ export class Square {
     this._inventoryService = new InventoryService(this.client);
     this._ordersService = new OrdersService(this.client);
     this._paymentsService = new PaymentsService(this.client);
+    this._invoicesService = new InvoicesService(this.client);
   }
 
   /**
@@ -167,6 +170,13 @@ export class Square {
    */
   get paymentsService(): PaymentsService {
     return this._paymentsService;
+  }
+
+  /**
+   * Get the invoices service for sending hosted-payment invoices
+   */
+  get invoicesService(): InvoicesService {
+    return this._invoicesService;
   }
 
   /**

--- a/libs/react/data/src/lib/useInvoices.ts
+++ b/libs/react/data/src/lib/useInvoices.ts
@@ -32,6 +32,12 @@ function hydrateInvoice(invoice: Invoice): Invoice {
     ...invoice,
     issuedAt: invoice.issuedAt ? new Date(invoice.issuedAt) : undefined,
     paidAt: invoice.paidAt ? new Date(invoice.paidAt) : undefined,
+    paymentRecord: invoice.paymentRecord
+      ? {
+          ...invoice.paymentRecord,
+          recordedAt: new Date(invoice.paymentRecord.recordedAt),
+        }
+      : undefined,
     createdAt: new Date(invoice.createdAt),
     updatedAt: new Date(invoice.updatedAt),
   };

--- a/libs/react/invoices/src/lib/InvoiceList.stories.tsx
+++ b/libs/react/invoices/src/lib/InvoiceList.stories.tsx
@@ -6,8 +6,10 @@ import {
   mockInvoiceDraft,
   mockInvoiceSent,
   mockInvoicePaid,
+  mockInvoicePaidManually,
   mockInvoiceVoid,
   mockInvoiceMultiLine,
+  mockInvoiceSyncError,
 } from '../../../../../apps/maple-spruce/.storybook/fixtures';
 import type { Invoice, RequestState } from '@maple/ts/domain';
 
@@ -276,5 +278,71 @@ export const TotalFormattedAsDollars: Story = {
       // $18750 cents → $187.50
       expect(canvas.getByText('$187.50')).toBeInTheDocument();
     });
+  },
+};
+
+// ============================================================
+// INTERACTION TESTS — payment attribution + sync error (added in #281)
+// ============================================================
+
+export const PaidViaSquareBadge: Story = {
+  args: {
+    invoicesState: {
+      status: 'success',
+      data: [mockInvoicePaid],
+    } as RequestState<Invoice[]>,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(() => {
+      expect(canvas.getByText(/paid via square/i)).toBeInTheDocument();
+    });
+    // Manual badge should NOT appear for a Square-paid invoice
+    expect(canvas.queryByText(/marked paid manually/i)).toBeNull();
+  },
+};
+
+export const PaidManuallyBadge: Story = {
+  args: {
+    invoicesState: {
+      status: 'success',
+      data: [mockInvoicePaidManually],
+    } as RequestState<Invoice[]>,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(() => {
+      expect(canvas.getByText(/marked paid manually/i)).toBeInTheDocument();
+    });
+    expect(canvas.queryByText(/paid via square/i)).toBeNull();
+  },
+};
+
+export const SquareSyncErrorBadge: Story = {
+  args: {
+    invoicesState: {
+      status: 'success',
+      data: [mockInvoiceSyncError],
+    } as RequestState<Invoice[]>,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(() => {
+      expect(canvas.getByText(/square sync failed/i)).toBeInTheDocument();
+    });
+  },
+};
+
+export const PaymentBadgeAbsentOnDraftAndSent: Story = {
+  args: {
+    invoicesState: {
+      status: 'success',
+      data: [mockInvoiceDraft, mockInvoiceSent],
+    } as RequestState<Invoice[]>,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.queryByText(/paid via square/i)).toBeNull();
+    expect(canvas.queryByText(/marked paid manually/i)).toBeNull();
   },
 };

--- a/libs/react/invoices/src/lib/InvoiceList.tsx
+++ b/libs/react/invoices/src/lib/InvoiceList.tsx
@@ -18,6 +18,9 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import SendIcon from '@mui/icons-material/Send';
 import BlockIcon from '@mui/icons-material/Block';
 import MonetizationOnIcon from '@mui/icons-material/MonetizationOn';
+import CreditCardIcon from '@mui/icons-material/CreditCard';
+import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import type {
   Invoice,
   InvoiceStatus,
@@ -150,6 +153,34 @@ function InvoiceRow({
               color={statusColor[status]}
               variant={status === 'paid' ? 'filled' : 'outlined'}
             />
+            {status === 'paid' && invoice.paymentRecord && (
+              <Chip
+                icon={
+                  invoice.paymentRecord.source === 'square-webhook' ? (
+                    <CreditCardIcon />
+                  ) : (
+                    <PersonOutlineIcon />
+                  )
+                }
+                label={
+                  invoice.paymentRecord.source === 'square-webhook'
+                    ? 'Paid via Square'
+                    : 'Marked paid manually'
+                }
+                size="small"
+                variant="outlined"
+              />
+            )}
+            {invoice.squareSyncError && (
+              <Chip
+                icon={<WarningAmberIcon />}
+                label="Square sync failed"
+                size="small"
+                color="error"
+                variant="outlined"
+                title={invoice.squareSyncError}
+              />
+            )}
             <Typography variant="body2" color="text.secondary">
               {invoice.lineItems.length} line
               {invoice.lineItems.length === 1 ? '' : 's'}

--- a/libs/ts/domain/src/lib/invoice.spec.ts
+++ b/libs/ts/domain/src/lib/invoice.spec.ts
@@ -117,5 +117,64 @@ describe('Invoice domain helpers', () => {
       };
       expect(invoice.lineItems[0].subtotalCents).toBe(13000);
     });
+
+    it('accepts a paid invoice with Square payment attribution', () => {
+      const invoice: Invoice = {
+        id: 'inv-2',
+        studentId: 'student-1',
+        status: 'paid',
+        lineItems: [
+          {
+            id: 'l1',
+            description: 'April tuition',
+            quantity: 1,
+            unitAmountCents: 13000,
+            subtotalCents: 13000,
+          },
+        ],
+        totalCents: 13000,
+        issuedAt: new Date('2026-04-20T10:00:00Z'),
+        paidAt: new Date('2026-04-23T14:00:00Z'),
+        paymentRecord: {
+          source: 'square-webhook',
+          squarePaymentId: 'SQ-PAYMENT-123',
+          recordedAt: new Date('2026-04-23T14:00:00Z'),
+        },
+        squareOrderId: 'SQ-ORDER-1',
+        squareInvoiceId: 'SQ-INVOICE-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      expect(invoice.paymentRecord?.source).toBe('square-webhook');
+      expect(invoice.squareInvoiceId).toBe('SQ-INVOICE-1');
+    });
+
+    it('accepts a paid invoice attributed to a manual admin action', () => {
+      const invoice: Invoice = {
+        id: 'inv-3',
+        studentId: 'student-1',
+        status: 'paid',
+        lineItems: [
+          {
+            id: 'l1',
+            description: 'April tuition',
+            quantity: 1,
+            unitAmountCents: 13000,
+            subtotalCents: 13000,
+          },
+        ],
+        totalCents: 13000,
+        issuedAt: new Date('2026-04-20T10:00:00Z'),
+        paidAt: new Date('2026-04-21T09:00:00Z'),
+        paymentRecord: {
+          source: 'admin-manual',
+          recordedAt: new Date('2026-04-21T09:00:00Z'),
+        },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      expect(invoice.paymentRecord?.source).toBe('admin-manual');
+      expect(invoice.paymentRecord?.squarePaymentId).toBeUndefined();
+    });
   });
 });

--- a/libs/ts/domain/src/lib/invoice.ts
+++ b/libs/ts/domain/src/lib/invoice.ts
@@ -42,6 +42,23 @@ export interface InvoiceLineItem {
   subtotalCents: number;
 }
 
+/**
+ * How the invoice became `paid`. Stamped by the server on the transition
+ * into paid so the admin UI can attribute the payment to a specific event
+ * (customer paid via Square vs. Katie flipped the switch manually).
+ */
+export type InvoicePaymentSource = 'admin-manual' | 'square-webhook';
+
+export interface InvoicePaymentRecord {
+  source: InvoicePaymentSource;
+  /** Square payment id when the payment came in via the Square webhook. */
+  squarePaymentId?: string;
+  /** When the payment was recorded (distinct from paidAt which is the
+   *  invoice status transition timestamp — typically the same but the
+   *  two can differ if the webhook is delayed). */
+  recordedAt: Date;
+}
+
 export interface Invoice {
   id: string;
   studentId: string;
@@ -53,6 +70,18 @@ export interface Invoice {
   issuedAt?: Date;
   /** Set on the transition sent → paid. */
   paidAt?: Date;
+  /** How the payment was recorded. Present only for paid invoices. */
+  paymentRecord?: InvoicePaymentRecord;
+  /** Square Order id created during the sent transition (source of line items in Square). */
+  squareOrderId?: string;
+  /** Square Invoice id created during the sent transition. */
+  squareInvoiceId?: string;
+  /**
+   * Last Square sync error, if any. Set by the Firestore trigger when it
+   * can't successfully send/cancel the Square invoice; cleared on the
+   * next successful sync. Admin surfaces this so Katie can retry.
+   */
+  squareSyncError?: string;
   notes?: string;
   createdAt: Date;
   updatedAt: Date;

--- a/libs/ts/validation/src/lib/invoice.validation.ts
+++ b/libs/ts/validation/src/lib/invoice.validation.ts
@@ -4,12 +4,12 @@
  * Vest validation for private-pay music lesson invoices. Used both by the
  * admin form and the cloud-function createInvoice/updateInvoice handlers.
  */
-import { create, test, enforce, only } from 'vest';
+import { staticSuite, test, enforce, only } from 'vest';
 import type { CreateInvoiceInput } from '@maple/ts/domain';
 import { INVOICE_STATUSES } from '@maple/ts/domain';
 
-export const invoiceValidation = create(
-  (data: Partial<CreateInvoiceInput>, field?: string) => {
+export const invoiceValidation = staticSuite(
+  (data: Partial<CreateInvoiceInput>, field?: string | string[]) => {
     only(field);
 
     test('studentId', 'Student is required', () => {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -87,6 +87,9 @@
       "@maple/firebase/maple-functions/square-webhook": [
         "libs/firebase/maple-functions/square-webhook/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/sync-invoice-to-square": [
+        "libs/firebase/maple-functions/sync-invoice-to-square/src/index.ts"
+      ],
       "@maple/react/theme": ["libs/react/theme/src/index.ts"],
       "@maple/react/ui": ["libs/react/ui/src/index.ts"],
       "@maple/react/auth": ["libs/react/auth/src/index.ts"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -34,6 +34,20 @@ export default defineConfig({
       reportsDirectory: './coverage/unit',
       // Merge coverage from all workspace projects
       all: false,
+      // Exclude test infrastructure + integration-test harness code from
+      // coverage — it's not production code and is only exercised by the
+      // (emulator-backed) integration tests, which don't run in the unit
+      // coverage path.
+      exclude: [
+        '**/*.spec.ts',
+        '**/*.spec.tsx',
+        '**/*.stories.tsx',
+        'libs/firebase/integration-test-mock-server/**',
+        'libs/firebase/integration-test-utils/**',
+        'apps/functions-integration-tests*/**',
+        'apps/maple-spruce-e2e/**',
+        'apps/maple-spruce/.storybook/**',
+      ],
       // Coverage thresholds enforced in CI via nyc check-coverage after
       // merging unit + Storybook coverage reports. See build-check.yml.
       // Local reference: lines 80%, functions 80%, statements 80%, branches 50%

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -9,6 +9,7 @@ export default defineWorkspace([
   'libs/firebase/square/vitest.config.ts',
   'libs/firebase/maple-functions/detect-sync-conflicts/vitest.config.ts',
   'libs/firebase/maple-functions/square-webhook/vitest.config.ts',
+  'libs/firebase/maple-functions/sync-invoice-to-square/vitest.config.ts',
   'libs/firebase/maple-functions/calendar-embed/vitest.config.ts',
   'libs/react/classes/vitest.config.ts',
   'libs/react/signals/vitest.config.ts',

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -10,6 +10,8 @@ export default defineWorkspace([
   'libs/firebase/maple-functions/detect-sync-conflicts/vitest.config.ts',
   'libs/firebase/maple-functions/square-webhook/vitest.config.ts',
   'libs/firebase/maple-functions/sync-invoice-to-square/vitest.config.ts',
+  'libs/firebase/maple-functions/create-invoice/vitest.config.ts',
+  'libs/firebase/maple-functions/update-invoice/vitest.config.ts',
   'libs/firebase/maple-functions/calendar-embed/vitest.config.ts',
   'libs/react/classes/vitest.config.ts',
   'libs/react/signals/vitest.config.ts',


### PR DESCRIPTION
## Summary

Closes #281. Parent-facing invoice delivery + online payment now flows through **Square Invoices API** — Square emails the parent a hosted payment page, handles receipts and reminders, and webhooks us back when paid. Our Firestore Invoice stays the source of truth; Square is the rail.

This was a design pivot from the original plan (custom Webflow CMS page + React payment component). Research showed Square Invoices saves ~1000 lines of code, same 2.5% fee, and parents get a consistent Square UX.

## Flow

\`\`\`
Katie "Send" → updateInvoice(status: sent)
    │
    ▼  (Firestore trigger: sync-invoice-to-square)
Square: upsert customer → create order → create invoice → publish
    └──▶ Square emails parent, hosts payment page
    │
    ▼  (Parent pays)
    │
    ▼  (Square webhook: invoice.payment_made)
square-webhook → InvoiceRepository.markPaidBySquareWebhook
    │
    ▼
Firestore Invoice: status=paid, paymentRecord={ source: 'square-webhook' }
\`\`\`

## Payment attribution

Per the feedback on #280, a paid invoice now records **how** it was paid so the admin UI can surface that:

- \`paymentRecord.source = 'square-webhook'\` + \`squarePaymentId\` — flipped by the Square \`invoice.payment_made\` webhook
- \`paymentRecord.source = 'admin-manual'\` — Katie manually flipped via "Mark paid"

The InvoiceList row now shows a chip ("Paid via Square" / "Marked paid manually") alongside the status so she can see at a glance whether a payment event actually fired vs. she marked it herself (e.g., cash handoff).

## Backend

- **\`InvoicesService\`** (\`libs/firebase/square/\`) — upsertCustomer (email-keyed), createInvoiceOrder, createDraftInvoice, publishInvoice, cancelInvoice. Idempotent via the Firestore invoice id. Card-only accepted payment methods; automatic email delivery.
- **\`sync-invoice-to-square\`** Firestore trigger on \`invoices/{id}\` (in the **maple-square** codebase). Logs and persists \`squareSyncError\` so Katie sees what broke without reading function logs.
- **\`square-webhook\`** now dispatches \`invoice.payment_made\` to a new \`handleInvoicePaymentMade\` that matches by \`squareInvoiceId\` and **idempotently** flips the invoice to paid.
- **\`InvoiceRepository.markPaidBySquareWebhook\`** — dedicated path that stamps \`source: 'square-webhook'\`. Manual admin flips via \`update()\` stamp \`source: 'admin-manual'\` so the two paths don't collide.
- **\`findBySquareInvoiceId\`** repo method for the webhook to match up.

## Frontend

- \`useInvoices\` hydrates \`paymentRecord.recordedAt\` as a Date.
- \`InvoiceList\` adds three chips on the row:
  - **"Paid via Square"** (card icon) — \`source='square-webhook'\`
  - **"Marked paid manually"** (person icon) — \`source='admin-manual'\`
  - **"Square sync failed"** (warning, red) — \`squareSyncError\` present; \`title\` attribute shows the error detail on hover
- New fixtures: paid-via-square, paid-manually, sync-error invoices.
- 4 new Storybook interaction tests (**32 total** in Invoices family, **102 total** across music-lessons family).

## Drive-by

- Migrated \`invoiceValidation\` from \`create\` → \`staticSuite\` to match #293 (lesson + student + others already migrated on main).

## Testing

- [x] \`nx test domain\` — 28 green (+2 for new paymentRecord shape tests)
- [x] \`nx test validation\` — 17 green (still passing after staticSuite migration)
- [x] \`pnpm vitest run libs/firebase/maple-functions/square-webhook\` — **13 green** (4 new for \`handleInvoicePaymentMade\`: matching invoice flips to paid, idempotent when already paid, no-op when no matching invoice, fallback to \`'unknown'\` when payload missing \`completed_payment_ids\`)
- [x] Storybook interaction tests — **102 green** across react-invoices, react-lessons, react-students
- [x] \`tsc --noEmit\` clean for \`apps/functions-square\`, admin app, all libs I touched
- [x] \`validate-function-tsconfigs.sh\` passes for all 72 functions
- [ ] Integration tests run against emulator — deferred to CI

## Not in scope / future

- Refund flow (Square supports via \`invoice.refunded\` webhook; we'd need \`paid → refunded\` domain status and UI; future issue)
- Webflow MCP setup — the user mentioned hooking this up for Claude review; unrelated to this PR since we don't have a Webflow collection anymore
- Square Invoices Plus (\$20/mo) — not needed for our use case

Closes #281
Part of #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)