### PR TITLE
feat: read-only Etsy listing import flow (pull into catalog) (#4)

### DIFF
--- a/apps/functions-integration-tests-etsy/project.json
+++ b/apps/functions-integration-tests-etsy/project.json
@@ -1,0 +1,27 @@
+{
+  "name": "functions-integration-tests-etsy",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/functions-integration-tests-etsy/src",
+  "projectType": "application",
+  "tags": ["type:e2e"],
+  "implicitDependencies": [
+    "firebase-maple-functions-list-etsy-listings",
+    "firebase-maple-functions-import-etsy-listings",
+    "firebase-maple-functions-get-etsy-templates",
+    "firebase-maple-functions-save-etsy-category-template",
+    "firebase-maple-functions-save-etsy-artist-template",
+    "firebase-maple-functions-etsy-auth-url",
+    "firebase-maple-functions-etsy-auth-callback",
+    "firebase-maple-functions-get-etsy-connection-status",
+    "firebase-integration-test-utils",
+    "firebase-etsy-test-mock-server"
+  ],
+  "targets": {
+    "test": {
+      "executor": "@nx/vite:test",
+      "options": {
+        "config": "apps/functions-integration-tests-etsy/vitest.config.ts"
+      }
+    }
+  }
+}

--- a/apps/functions-integration-tests-etsy/src/etsy-auth-callback.spec.ts
+++ b/apps/functions-integration-tests-etsy/src/etsy-auth-callback.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * Integration tests for etsyAuthCallback Cloud Function.
+ *
+ * Completes the OAuth flow: validates the PKCE state, exchanges the
+ * authorization code with the Etsy token endpoint (mocked), then fetches
+ * the user's shop ID (mocked). Asserts the token + shop ID persist to
+ * Firestore under _config/etsy-tokens.
+ */
+import {
+  createTestUser,
+  clearAuthEmulator,
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  getFirestoreDoc,
+  deleteFirestoreDoc,
+  callFunction,
+} from '@maple/firebase/integration-test-utils';
+import type { TestUser } from '@maple/firebase/integration-test-utils';
+import {
+  ADMIN_USER,
+  NON_ADMIN_USER,
+} from '@maple/firebase/integration-test-utils';
+import type {
+  EtsyAuthCallbackRequest,
+  EtsyAuthCallbackResponse,
+} from '@maple/ts/firebase/api-types';
+import { resetMock } from './helpers/etsy-mock-client';
+
+describe('etsyAuthCallback', () => {
+  let adminUser: TestUser;
+  let nonAdminUser: TestUser;
+
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+    adminUser = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
+    nonAdminUser = await createTestUser(
+      NON_ADMIN_USER.email,
+      NON_ADMIN_USER.password
+    );
+    await setFirestoreDoc('admins', adminUser.uid, {
+      userId: adminUser.uid,
+      email: adminUser.email,
+    });
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  beforeEach(async () => {
+    await resetMock();
+    await deleteFirestoreDoc('_config', 'etsy-tokens');
+    await deleteFirestoreDoc('_config', 'etsy-oauth-state');
+  });
+
+  it('rejects non-admin users', async () => {
+    const result = await callFunction<EtsyAuthCallbackRequest>({
+      functionName: 'etsyAuthCallback',
+      data: { code: 'abc', state: 'xyz' },
+      idToken: nonAdminUser.idToken,
+    });
+    expect(result.status).not.toBe(200);
+  });
+
+  it('rejects an unknown state', async () => {
+    const result = await callFunction<EtsyAuthCallbackRequest>({
+      functionName: 'etsyAuthCallback',
+      data: { code: 'abc', state: 'never-saved' },
+      idToken: adminUser.idToken,
+    });
+    expect(result.status).not.toBe(200);
+  });
+
+  it('exchanges the code, fetches shop ID, and persists tokens', async () => {
+    // Seed a valid OAuth state as if etsyAuthUrl had run before.
+    await setFirestoreDoc('_config', 'etsy-oauth-state', {
+      state: 'state-ok',
+      codeVerifier: 'verifier-xyz',
+      createdAt: new Date(),
+    });
+
+    const result = await callFunction<
+      EtsyAuthCallbackRequest,
+      EtsyAuthCallbackResponse
+    >({
+      functionName: 'etsyAuthCallback',
+      data: { code: 'auth-code', state: 'state-ok' },
+      idToken: adminUser.idToken,
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data!.success).toBe(true);
+    expect(result.data!.shopId).toBe('22222');
+    expect(result.data!.userId).toBe('11111');
+
+    const saved = await getFirestoreDoc('_config', 'etsy-tokens');
+    expect(saved).not.toBeNull();
+    expect(saved!.accessToken).toBe('11111.valid-access-token');
+    expect(saved!.shopId).toBe('22222');
+  });
+});

--- a/apps/functions-integration-tests-etsy/src/etsy-auth-url.spec.ts
+++ b/apps/functions-integration-tests-etsy/src/etsy-auth-url.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * Integration tests for etsyAuthUrl Cloud Function.
+ *
+ * Generates an OAuth URL with PKCE state. No Etsy API calls — the state
+ * is persisted to Firestore for the callback to consume later.
+ */
+import {
+  createTestUser,
+  clearAuthEmulator,
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  getFirestoreDoc,
+  callFunction,
+} from '@maple/firebase/integration-test-utils';
+import type { TestUser } from '@maple/firebase/integration-test-utils';
+import {
+  ADMIN_USER,
+  NON_ADMIN_USER,
+} from '@maple/firebase/integration-test-utils';
+import type {
+  EtsyAuthUrlRequest,
+  EtsyAuthUrlResponse,
+} from '@maple/ts/firebase/api-types';
+
+describe('etsyAuthUrl', () => {
+  let adminUser: TestUser;
+  let nonAdminUser: TestUser;
+
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+    adminUser = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
+    nonAdminUser = await createTestUser(
+      NON_ADMIN_USER.email,
+      NON_ADMIN_USER.password
+    );
+    await setFirestoreDoc('admins', adminUser.uid, {
+      userId: adminUser.uid,
+      email: adminUser.email,
+    });
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  it('rejects non-admin users', async () => {
+    const result = await callFunction<EtsyAuthUrlRequest>({
+      functionName: 'etsyAuthUrl',
+      data: {},
+      idToken: nonAdminUser.idToken,
+    });
+    expect(result.status).not.toBe(200);
+  });
+
+  it('returns an OAuth URL and persists PKCE state to Firestore', async () => {
+    const result = await callFunction<
+      EtsyAuthUrlRequest,
+      EtsyAuthUrlResponse
+    >({
+      functionName: 'etsyAuthUrl',
+      data: {},
+      idToken: adminUser.idToken,
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data!.url).toContain('https://www.etsy.com/oauth/connect');
+    expect(result.data!.url).toContain('code_challenge=');
+    expect(result.data!.state).toBeTruthy();
+
+    const saved = await getFirestoreDoc('_config', 'etsy-oauth-state');
+    expect(saved).not.toBeNull();
+    expect(saved!.state).toBe(result.data!.state);
+    expect(saved!.codeVerifier).toBeTruthy();
+  });
+
+  it('accepts a custom scopes parameter', async () => {
+    const result = await callFunction<
+      EtsyAuthUrlRequest,
+      EtsyAuthUrlResponse
+    >({
+      functionName: 'etsyAuthUrl',
+      data: { scopes: 'shops_r' },
+      idToken: adminUser.idToken,
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data!.url).toContain('scope=shops_r');
+  });
+});

--- a/apps/functions-integration-tests-etsy/src/etsy-connection-status.spec.ts
+++ b/apps/functions-integration-tests-etsy/src/etsy-connection-status.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * Integration tests for getEtsyConnectionStatus Cloud Function.
+ *
+ * Pure Firestore read — reports whether OAuth tokens exist and whether
+ * the access token is still valid. No Etsy API calls.
+ */
+import {
+  createTestUser,
+  clearAuthEmulator,
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  deleteFirestoreDoc,
+  callFunction,
+} from '@maple/firebase/integration-test-utils';
+import type { TestUser } from '@maple/firebase/integration-test-utils';
+import {
+  ADMIN_USER,
+  NON_ADMIN_USER,
+} from '@maple/firebase/integration-test-utils';
+import type {
+  GetEtsyConnectionStatusRequest,
+  GetEtsyConnectionStatusResponse,
+} from '@maple/ts/firebase/api-types';
+
+describe('getEtsyConnectionStatus', () => {
+  let adminUser: TestUser;
+  let nonAdminUser: TestUser;
+
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+    adminUser = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
+    nonAdminUser = await createTestUser(
+      NON_ADMIN_USER.email,
+      NON_ADMIN_USER.password
+    );
+    await setFirestoreDoc('admins', adminUser.uid, {
+      userId: adminUser.uid,
+      email: adminUser.email,
+    });
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  beforeEach(async () => {
+    await deleteFirestoreDoc('_config', 'etsy-tokens');
+  });
+
+  it('rejects non-admin users', async () => {
+    const result = await callFunction<GetEtsyConnectionStatusRequest>({
+      functionName: 'getEtsyConnectionStatus',
+      data: {},
+      idToken: nonAdminUser.idToken,
+    });
+    expect(result.status).not.toBe(200);
+  });
+
+  it('reports connected=false when no token document exists', async () => {
+    const result = await callFunction<
+      GetEtsyConnectionStatusRequest,
+      GetEtsyConnectionStatusResponse
+    >({
+      functionName: 'getEtsyConnectionStatus',
+      data: {},
+      idToken: adminUser.idToken,
+    });
+    expect(result.status).toBe(200);
+    expect(result.data!.connected).toBe(false);
+    expect(result.data!.tokenValid).toBe(false);
+  });
+
+  it('reports connected=true + tokenValid=true for a fresh token', async () => {
+    await setFirestoreDoc('_config', 'etsy-tokens', {
+      accessToken: '11111.access',
+      refreshToken: '11111.refresh',
+      expiresAt: Date.now() + 3600000,
+      shopId: '22222',
+      userId: '11111',
+    });
+
+    const result = await callFunction<
+      GetEtsyConnectionStatusRequest,
+      GetEtsyConnectionStatusResponse
+    >({
+      functionName: 'getEtsyConnectionStatus',
+      data: {},
+      idToken: adminUser.idToken,
+    });
+    expect(result.status).toBe(200);
+    expect(result.data!.connected).toBe(true);
+    expect(result.data!.tokenValid).toBe(true);
+    expect(result.data!.shopId).toBe('22222');
+  });
+
+  it('reports tokenValid=false for an expired token', async () => {
+    await setFirestoreDoc('_config', 'etsy-tokens', {
+      accessToken: '11111.access',
+      refreshToken: '11111.refresh',
+      expiresAt: Date.now() - 1000,
+      shopId: '22222',
+      userId: '11111',
+    });
+
+    const result = await callFunction<
+      GetEtsyConnectionStatusRequest,
+      GetEtsyConnectionStatusResponse
+    >({
+      functionName: 'getEtsyConnectionStatus',
+      data: {},
+      idToken: adminUser.idToken,
+    });
+    expect(result.status).toBe(200);
+    expect(result.data!.connected).toBe(true);
+    expect(result.data!.tokenValid).toBe(false);
+  });
+});

--- a/apps/functions-integration-tests-etsy/src/etsy-templates.spec.ts
+++ b/apps/functions-integration-tests-etsy/src/etsy-templates.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * Integration tests for Etsy template functions.
+ *
+ * Backfill coverage for getEtsyTemplates, saveEtsyCategoryTemplate, and
+ * saveEtsyArtistTemplate. These are pure Firestore functions (no Etsy
+ * API calls) so no mock server is required for this suite.
+ */
+import {
+  createTestUser,
+  clearAuthEmulator,
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  callFunction,
+} from '@maple/firebase/integration-test-utils';
+import type { TestUser } from '@maple/firebase/integration-test-utils';
+import {
+  ADMIN_USER,
+  NON_ADMIN_USER,
+} from '@maple/firebase/integration-test-utils';
+import type {
+  GetEtsyTemplatesRequest,
+  GetEtsyTemplatesResponse,
+  SaveEtsyCategoryTemplateRequest,
+  SaveEtsyCategoryTemplateResponse,
+  SaveEtsyArtistTemplateRequest,
+} from '@maple/ts/firebase/api-types';
+
+describe('Etsy template functions', () => {
+  let adminUser: TestUser;
+  let nonAdminUser: TestUser;
+
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+    adminUser = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
+    nonAdminUser = await createTestUser(
+      NON_ADMIN_USER.email,
+      NON_ADMIN_USER.password
+    );
+    await setFirestoreDoc('admins', adminUser.uid, {
+      userId: adminUser.uid,
+      email: adminUser.email,
+    });
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  describe('Auth guards', () => {
+    it('rejects non-admin from saveEtsyCategoryTemplate', async () => {
+      const result = await callFunction<SaveEtsyCategoryTemplateRequest>({
+        functionName: 'saveEtsyCategoryTemplate',
+        data: {
+          categoryId: 'cat-1',
+          categoryName: 'Mugs',
+          defaults: { taxonomyId: 68 },
+        },
+        idToken: nonAdminUser.idToken,
+      });
+      expect(result.status).not.toBe(200);
+    });
+
+    it('rejects non-admin from getEtsyTemplates', async () => {
+      const result = await callFunction<GetEtsyTemplatesRequest>({
+        functionName: 'getEtsyTemplates',
+        data: { categoryId: 'cat-1' },
+        idToken: nonAdminUser.idToken,
+      });
+      expect(result.status).not.toBe(200);
+    });
+  });
+
+  describe('Happy path', () => {
+    it('saves a category template and reads it back via getEtsyTemplates', async () => {
+      const save = await callFunction<
+        SaveEtsyCategoryTemplateRequest,
+        SaveEtsyCategoryTemplateResponse
+      >({
+        functionName: 'saveEtsyCategoryTemplate',
+        data: {
+          categoryId: 'cat-pottery',
+          categoryName: 'Pottery',
+          defaults: {
+            taxonomyId: 68,
+            tags: ['pottery', 'ceramic'],
+            whoMade: 'i_did',
+            whenMade: '2020_2025',
+          },
+        },
+        idToken: adminUser.idToken,
+      });
+      expect(save.status).toBe(200);
+      expect(save.data!.template.id).toBe('cat-pottery');
+      expect(save.data!.template.taxonomyId).toBe(68);
+
+      const get = await callFunction<
+        GetEtsyTemplatesRequest,
+        GetEtsyTemplatesResponse
+      >({
+        functionName: 'getEtsyTemplates',
+        data: { categoryId: 'cat-pottery' },
+        idToken: adminUser.idToken,
+      });
+      expect(get.status).toBe(200);
+      expect(get.data!.categoryTemplate?.taxonomyId).toBe(68);
+      expect(get.data!.merged.taxonomyId).toBe(68);
+      expect(get.data!.merged.tags).toEqual(
+        expect.arrayContaining(['pottery', 'ceramic'])
+      );
+    });
+
+    it('merges artist overrides on top of category base', async () => {
+      // Category base
+      await callFunction<SaveEtsyCategoryTemplateRequest>({
+        functionName: 'saveEtsyCategoryTemplate',
+        data: {
+          categoryId: 'cat-merge',
+          categoryName: 'Merge Test',
+          defaults: {
+            taxonomyId: 100,
+            tags: ['handmade'],
+            whoMade: 'someone_else',
+          },
+        },
+        idToken: adminUser.idToken,
+      });
+
+      // Artist override
+      await callFunction<SaveEtsyArtistTemplateRequest>({
+        functionName: 'saveEtsyArtistTemplate',
+        data: {
+          artistId: 'artist-merge',
+          artistName: 'Merge Artist',
+          defaults: {
+            whoMade: 'i_did', // override
+            tags: ['artisan'], // additive
+          },
+        },
+        idToken: adminUser.idToken,
+      });
+
+      const get = await callFunction<
+        GetEtsyTemplatesRequest,
+        GetEtsyTemplatesResponse
+      >({
+        functionName: 'getEtsyTemplates',
+        data: { categoryId: 'cat-merge', artistId: 'artist-merge' },
+        idToken: adminUser.idToken,
+      });
+      expect(get.status).toBe(200);
+      expect(get.data!.merged.whoMade).toBe('i_did'); // artist wins
+      expect(get.data!.merged.taxonomyId).toBe(100); // category base preserved
+      expect(get.data!.merged.tags).toEqual(
+        expect.arrayContaining(['handmade', 'artisan'])
+      );
+    });
+
+    it('returns empty merged result when no templates exist', async () => {
+      const get = await callFunction<
+        GetEtsyTemplatesRequest,
+        GetEtsyTemplatesResponse
+      >({
+        functionName: 'getEtsyTemplates',
+        data: { categoryId: 'cat-unknown', artistId: 'artist-unknown' },
+        idToken: adminUser.idToken,
+      });
+      expect(get.status).toBe(200);
+      expect(get.data!.categoryTemplate).toBeUndefined();
+      expect(get.data!.artistTemplate).toBeUndefined();
+      expect(get.data!.merged.taxonomyId).toBeUndefined();
+    });
+  });
+});

--- a/apps/functions-integration-tests-etsy/src/helpers/etsy-mock-client.ts
+++ b/apps/functions-integration-tests-etsy/src/helpers/etsy-mock-client.ts
@@ -1,0 +1,36 @@
+/**
+ * Thin client for interacting with the Etsy mock server *from the test
+ * process*. The mock server itself runs in its own process (started via
+ * tools/run-integration-tests.sh), so tests POST fixture updates to it
+ * over HTTP and read recorded requests the same way.
+ *
+ * Endpoints added here are served by a tiny admin router registered in
+ * create-etsy-mock-server so tests can drive the mock's state without
+ * any shared-memory coupling.
+ */
+import { EMULATOR_CONFIG } from '@maple/firebase/integration-test-utils';
+import type { MockListingSeed } from '@maple/firebase/etsy-test-mock-server';
+
+export async function setMockListings(seeds: MockListingSeed[]): Promise<void> {
+  const res = await fetch(
+    `${EMULATOR_CONFIG.etsyMockServerUrl}/_mock/listings`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ seeds }),
+    }
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to seed listings: ${res.status} ${await res.text()}`);
+  }
+}
+
+export async function resetMock(): Promise<void> {
+  const res = await fetch(
+    `${EMULATOR_CONFIG.etsyMockServerUrl}/_mock/reset`,
+    { method: 'POST' }
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to reset mock: ${res.status}`);
+  }
+}

--- a/apps/functions-integration-tests-etsy/src/import-etsy-listings.spec.ts
+++ b/apps/functions-integration-tests-etsy/src/import-etsy-listings.spec.ts
@@ -1,0 +1,243 @@
+/**
+ * Integration tests for importEtsyListings Cloud Function.
+ *
+ * Covers the full pull-only import pipeline:
+ *   Etsy listing fetch (mocked) → Square catalog create (mocked)
+ *   → Firestore Product + etsyCache + etsy-imports snapshot.
+ *
+ * Scope caveat: the monolithic mock server doesn't currently implement
+ * Square's /v2/inventory/changes or /v2/catalog/images endpoints. Until
+ * those land (tracked by the mock-server-split issue), these tests seed
+ * listings with quantity=0 and no images so the import skips the
+ * best-effort inventory + image-copy paths. Unit tests cover those paths
+ * via vi.mock() on the Square services directly.
+ */
+import {
+  createTestUser,
+  clearAuthEmulator,
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  getFirestoreDoc,
+  callFunction,
+} from '@maple/firebase/integration-test-utils';
+import type { TestUser } from '@maple/firebase/integration-test-utils';
+import {
+  ADMIN_USER,
+  NON_ADMIN_USER,
+} from '@maple/firebase/integration-test-utils';
+import type {
+  ImportEtsyListingsRequest,
+  ImportEtsyListingsResponse,
+} from '@maple/ts/firebase/api-types';
+import { makeListing } from '@maple/firebase/etsy-test-mock-server';
+import { setMockListings, resetMock } from './helpers/etsy-mock-client';
+
+describe('importEtsyListings', () => {
+  let adminUser: TestUser;
+  let nonAdminUser: TestUser;
+
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+    adminUser = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
+    nonAdminUser = await createTestUser(
+      NON_ADMIN_USER.email,
+      NON_ADMIN_USER.password
+    );
+    await setFirestoreDoc('admins', adminUser.uid, {
+      userId: adminUser.uid,
+      email: adminUser.email,
+    });
+    await setFirestoreDoc('_config', 'etsy-tokens', {
+      accessToken: '11111.valid-access-token',
+      refreshToken: '11111.valid-refresh',
+      expiresAt: Date.now() + 3600000,
+      shopId: '22222',
+      userId: '11111',
+    });
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  beforeEach(async () => {
+    await resetMock();
+  });
+
+  it('rejects non-admin users', async () => {
+    const result = await callFunction<ImportEtsyListingsRequest>({
+      functionName: 'importEtsyListings',
+      data: {
+        listings: [{ listingId: '1' }],
+        artistId: 'a',
+        status: 'active',
+      },
+      idToken: nonAdminUser.idToken,
+    });
+    expect(result.status).not.toBe(200);
+  });
+
+  it('returns empty results for empty input', async () => {
+    const result = await callFunction<
+      ImportEtsyListingsRequest,
+      ImportEtsyListingsResponse
+    >({
+      functionName: 'importEtsyListings',
+      data: { listings: [], artistId: 'a', status: 'active' },
+      idToken: adminUser.idToken,
+    });
+    expect(result.status).toBe(200);
+    expect(result.data!.results).toEqual([]);
+    expect(result.data!.successCount).toBe(0);
+  });
+
+  it('flags multi-variant listings without calling Square', async () => {
+    await setMockListings([
+      makeListing({
+        listing_id: 9001,
+        title: 'Multi-variant',
+        productSkus: ['v1', 'v2', 'v3'],
+        quantity: 0,
+      }),
+    ]);
+
+    const result = await callFunction<
+      ImportEtsyListingsRequest,
+      ImportEtsyListingsResponse
+    >({
+      functionName: 'importEtsyListings',
+      data: {
+        listings: [{ listingId: '9001' }],
+        artistId: 'artist-1',
+        status: 'active',
+      },
+      idToken: adminUser.idToken,
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data!.successCount).toBe(0);
+    expect(result.data!.results[0].success).toBe(false);
+    expect(result.data!.results[0].errorCode).toBe('MULTI_VARIANT_NOT_SUPPORTED');
+  });
+
+  it('short-circuits listings that are already imported', async () => {
+    await setFirestoreDoc('products', 'existing-prod', {
+      artistId: 'artist-old',
+      status: 'active',
+      squareItemId: 'sq-item-old',
+      squareVariationId: 'sq-var-old',
+      etsyListingId: '9100',
+      squareCache: {
+        name: 'Already here',
+        priceCents: 1000,
+        quantity: 0,
+        sku: 'sku-old',
+        syncedAt: new Date(),
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await setMockListings([
+      makeListing({ listing_id: 9100, title: 'Already imported', quantity: 0 }),
+    ]);
+
+    const result = await callFunction<
+      ImportEtsyListingsRequest,
+      ImportEtsyListingsResponse
+    >({
+      functionName: 'importEtsyListings',
+      data: {
+        listings: [{ listingId: '9100' }],
+        artistId: 'artist-new',
+        status: 'active',
+      },
+      idToken: adminUser.idToken,
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data!.results[0].success).toBe(false);
+    expect(result.data!.results[0].errorCode).toBe('ALREADY_IMPORTED');
+    expect(result.data!.results[0].productId).toBe('existing-prod');
+  });
+
+  it('imports a simple listing end-to-end: Square + Product + etsyCache + snapshot', async () => {
+    await setMockListings([
+      makeListing({
+        listing_id: 9200,
+        title: 'Import Me',
+        description: 'A thing',
+        priceAmount: 3500,
+        priceDivisor: 100,
+        taxonomy_id: 99,
+        tags: ['pottery', 'gift'],
+        quantity: 0, // avoid hitting inventory endpoint (not in monolith mock)
+        imageUrls: [], // avoid hitting image endpoint (not in monolith mock)
+        productSkus: ['etsy-sku-9200'],
+      }),
+    ]);
+
+    const result = await callFunction<
+      ImportEtsyListingsRequest,
+      ImportEtsyListingsResponse
+    >({
+      functionName: 'importEtsyListings',
+      data: {
+        listings: [{ listingId: '9200' }],
+        artistId: 'artist-import',
+        categoryId: 'cat-import',
+        status: 'active',
+      },
+      idToken: adminUser.idToken,
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data!.successCount).toBe(1);
+    const row = result.data!.results[0];
+    expect(row.success).toBe(true);
+    const productId = row.productId!;
+    expect(productId).toBeTruthy();
+
+    // Firestore product exists with Etsy + Square links
+    const product = await getFirestoreDoc('products', productId);
+    expect(product).not.toBeNull();
+    expect(product!.etsyListingId).toBe('9200');
+    expect(product!.artistId).toBe('artist-import');
+    expect(product!.categoryId).toBe('cat-import');
+    expect(product!.status).toBe('active');
+
+    // etsyCache populated
+    const etsyCache = product!.etsyCache as Record<string, unknown>;
+    expect(etsyCache.title).toBe('Import Me');
+    expect(etsyCache.priceCents).toBe(3500);
+    expect(etsyCache.taxonomyId).toBe(99);
+
+    // Raw snapshot written to etsy-imports collection
+    const snapshot = await getFirestoreDoc('etsy-imports', productId);
+    expect(snapshot).not.toBeNull();
+    expect(snapshot!.listingId).toBe('9200');
+    expect(snapshot!.importedBy).toBe(adminUser.uid);
+    expect(snapshot!.variantCount).toBe(1);
+  });
+
+  it('reports LISTING_NOT_FOUND when Etsy returns 404', async () => {
+    // No listings seeded — the mock will 404 on any listing id.
+    const result = await callFunction<
+      ImportEtsyListingsRequest,
+      ImportEtsyListingsResponse
+    >({
+      functionName: 'importEtsyListings',
+      data: {
+        listings: [{ listingId: '99999' }],
+        artistId: 'artist-1',
+        status: 'active',
+      },
+      idToken: adminUser.idToken,
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data!.results[0].success).toBe(false);
+    expect(result.data!.results[0].errorCode).toBe('LISTING_NOT_FOUND');
+  });
+});

--- a/apps/functions-integration-tests-etsy/src/list-etsy-listings.spec.ts
+++ b/apps/functions-integration-tests-etsy/src/list-etsy-listings.spec.ts
@@ -47,7 +47,8 @@ describe('listEtsyListings', () => {
 
     // Seed the Etsy token so the function thinks OAuth is already connected.
     // listEtsyListings reads tokenStorage.getTokens() to resolve the shop ID.
-    await setFirestoreDoc('etsy-tokens', 'default', {
+    // Token storage path is _config/etsy-tokens (see etsy-token.repository.ts).
+    await setFirestoreDoc('_config', 'etsy-tokens', {
       accessToken: '11111.valid-access-token',
       refreshToken: '11111.valid-refresh',
       expiresAt: Date.now() + 3600000,

--- a/apps/functions-integration-tests-etsy/src/list-etsy-listings.spec.ts
+++ b/apps/functions-integration-tests-etsy/src/list-etsy-listings.spec.ts
@@ -1,0 +1,211 @@
+/**
+ * Integration tests for listEtsyListings Cloud Function.
+ *
+ * Runs in the Firebase emulator against real Firestore, with Etsy API
+ * calls intercepted by the standalone etsy-test-mock-server (started via
+ * tools/run-integration-tests.sh). Tests seed the mock's in-memory
+ * listing store over HTTP and assert on the function's cross-reference
+ * between Etsy listings and existing Products in Firestore.
+ */
+import {
+  createTestUser,
+  clearAuthEmulator,
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  callFunction,
+} from '@maple/firebase/integration-test-utils';
+import type { TestUser } from '@maple/firebase/integration-test-utils';
+import {
+  ADMIN_USER,
+  NON_ADMIN_USER,
+} from '@maple/firebase/integration-test-utils';
+import type {
+  ListEtsyListingsRequest,
+  ListEtsyListingsResponse,
+} from '@maple/ts/firebase/api-types';
+import { makeListing } from '@maple/firebase/etsy-test-mock-server';
+import { setMockListings, resetMock } from './helpers/etsy-mock-client';
+
+describe('listEtsyListings', () => {
+  let adminUser: TestUser;
+  let nonAdminUser: TestUser;
+
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+
+    adminUser = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
+    nonAdminUser = await createTestUser(
+      NON_ADMIN_USER.email,
+      NON_ADMIN_USER.password
+    );
+
+    await setFirestoreDoc('admins', adminUser.uid, {
+      userId: adminUser.uid,
+      email: adminUser.email,
+    });
+
+    // Seed the Etsy token so the function thinks OAuth is already connected.
+    // listEtsyListings reads tokenStorage.getTokens() to resolve the shop ID.
+    await setFirestoreDoc('etsy-tokens', 'default', {
+      accessToken: '11111.valid-access-token',
+      refreshToken: '11111.valid-refresh',
+      expiresAt: Date.now() + 3600000,
+      shopId: '22222',
+      userId: '11111',
+    });
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  beforeEach(async () => {
+    await resetMock();
+  });
+
+  describe('Auth guard', () => {
+    it('should reject unauthenticated requests', async () => {
+      await setMockListings([makeListing({ listing_id: 1 })]);
+      const result = await callFunction<ListEtsyListingsRequest>({
+        functionName: 'listEtsyListings',
+        data: {},
+      });
+      expect(result.status).not.toBe(200);
+    });
+
+    it('should reject non-admin users', async () => {
+      const result = await callFunction<ListEtsyListingsRequest>({
+        functionName: 'listEtsyListings',
+        data: {},
+        idToken: nonAdminUser.idToken,
+      });
+      expect(result.status).not.toBe(200);
+    });
+  });
+
+  describe('Happy path', () => {
+    it('returns empty list when the Etsy shop has no listings', async () => {
+      await setMockListings([]);
+
+      const result = await callFunction<
+        ListEtsyListingsRequest,
+        ListEtsyListingsResponse
+      >({
+        functionName: 'listEtsyListings',
+        data: {},
+        idToken: adminUser.idToken,
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.data!.listings).toEqual([]);
+      expect(result.data!.total).toBe(0);
+    });
+
+    it('returns listings with imported=false when no Products match', async () => {
+      await setMockListings([
+        makeListing({ listing_id: 101, title: 'Mug A' }),
+        makeListing({ listing_id: 102, title: 'Mug B' }),
+      ]);
+
+      const result = await callFunction<
+        ListEtsyListingsRequest,
+        ListEtsyListingsResponse
+      >({
+        functionName: 'listEtsyListings',
+        data: {},
+        idToken: adminUser.idToken,
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.data!.listings).toHaveLength(2);
+      for (const item of result.data!.listings) {
+        expect(item.imported).toBe(false);
+        expect(item.productId).toBeUndefined();
+      }
+      expect(result.data!.total).toBe(2);
+    });
+
+    it('flags a listing as imported when a matching Product exists', async () => {
+      await setMockListings([
+        makeListing({ listing_id: 201, title: 'Matched' }),
+        makeListing({ listing_id: 202, title: 'Unmatched' }),
+      ]);
+
+      await setFirestoreDoc('products', 'prod-existing', {
+        artistId: 'artist-1',
+        status: 'active',
+        squareItemId: 'sq-item-1',
+        squareVariationId: 'sq-var-1',
+        etsyListingId: '201',
+        squareCache: {
+          name: 'Matched',
+          priceCents: 2500,
+          quantity: 3,
+          sku: 'sku-201',
+          syncedAt: new Date(),
+        },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await callFunction<
+        ListEtsyListingsRequest,
+        ListEtsyListingsResponse
+      >({
+        functionName: 'listEtsyListings',
+        data: {},
+        idToken: adminUser.idToken,
+      });
+
+      expect(result.status).toBe(200);
+      const matched = result.data!.listings.find(
+        (l) => l.listing.listing_id === 201
+      )!;
+      const unmatched = result.data!.listings.find(
+        (l) => l.listing.listing_id === 202
+      )!;
+
+      expect(matched.imported).toBe(true);
+      expect(matched.productId).toBe('prod-existing');
+      expect(unmatched.imported).toBe(false);
+    });
+
+    it('reports variantCount and isSimple correctly', async () => {
+      await setMockListings([
+        makeListing({
+          listing_id: 301,
+          title: 'Simple',
+          productSkus: ['sku-simple'],
+        }),
+        makeListing({
+          listing_id: 302,
+          title: 'Variants',
+          productSkus: ['sku-a', 'sku-b', 'sku-c'],
+        }),
+      ]);
+
+      const result = await callFunction<
+        ListEtsyListingsRequest,
+        ListEtsyListingsResponse
+      >({
+        functionName: 'listEtsyListings',
+        data: {},
+        idToken: adminUser.idToken,
+      });
+
+      const simple = result.data!.listings.find(
+        (l) => l.listing.listing_id === 301
+      )!;
+      const variants = result.data!.listings.find(
+        (l) => l.listing.listing_id === 302
+      )!;
+
+      expect(simple.variantCount).toBe(1);
+      expect(simple.isSimple).toBe(true);
+      expect(variants.variantCount).toBe(3);
+      expect(variants.isSimple).toBe(false);
+    });
+  });
+});

--- a/apps/functions-integration-tests-etsy/tsconfig.json
+++ b/apps/functions-integration-tests-etsy/tsconfig.json
@@ -1,14 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "module": "commonjs",
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
-  },
   "files": [],
   "include": [],
   "references": [

--- a/apps/functions-integration-tests-etsy/tsconfig.json
+++ b/apps/functions-integration-tests-etsy/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/apps/functions-integration-tests-etsy/tsconfig.spec.json
+++ b/apps/functions-integration-tests-etsy/tsconfig.spec.json
@@ -2,7 +2,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": ["vitest/globals", "vitest/importMeta", "node"]
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "types": ["vitest/globals", "node"]
   },
-  "include": ["src/**/*.spec.ts", "src/**/*.ts"]
+  "include": ["src/**/*.ts"]
 }

--- a/apps/functions-integration-tests-etsy/tsconfig.spec.json
+++ b/apps/functions-integration-tests-etsy/tsconfig.spec.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": ["vitest/globals", "vitest/importMeta", "node"]
+  },
+  "include": ["src/**/*.spec.ts", "src/**/*.ts"]
+}

--- a/apps/functions-integration-tests-etsy/vitest.config.ts
+++ b/apps/functions-integration-tests-etsy/vitest.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@maple/firebase/integration-test-utils': path.resolve(
+        __dirname,
+        '../../libs/firebase/integration-test-utils/src/index.ts'
+      ),
+      '@maple/firebase/etsy-test-mock-server': path.resolve(
+        __dirname,
+        '../../libs/firebase/etsy-test-mock-server/src/index.ts'
+      ),
+      '@maple/ts/firebase/api-types': path.resolve(
+        __dirname,
+        '../../libs/ts/firebase/api-types/src/index.ts'
+      ),
+      '@maple/ts/domain': path.resolve(
+        __dirname,
+        '../../libs/ts/domain/src/index.ts'
+      ),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    root: path.resolve(__dirname),
+    include: ['src/**/*.spec.ts'],
+    setupFiles: ['../../libs/firebase/integration-test-utils/src/lib/setup.ts'],
+    testTimeout: 30000,
+    hookTimeout: 30000,
+    fileParallelism: false,
+    sequence: {
+      concurrent: false,
+    },
+  },
+});

--- a/apps/functions-square/src/index.ts
+++ b/apps/functions-square/src/index.ts
@@ -27,3 +27,6 @@ export { cancelRegistration } from '@maple/firebase/maple-functions/cancel-regis
 // Sync conflict resolution (Square catalog comparison)
 export { detectSyncConflicts } from '@maple/firebase/maple-functions/detect-sync-conflicts';
 export { resolveSyncConflict } from '@maple/firebase/maple-functions/resolve-sync-conflict';
+
+// Etsy listing import (pull-only; creates Square catalog items for imported listings)
+export { importEtsyListings } from '@maple/firebase/maple-functions/import-etsy-listings';

--- a/apps/functions-square/tsconfig.app.json
+++ b/apps/functions-square/tsconfig.app.json
@@ -14,6 +14,7 @@
     "../../libs/firebase/maple-functions/cancel-registration/**/*.ts",
     "../../libs/firebase/maple-functions/detect-sync-conflicts/**/*.ts",
     "../../libs/firebase/maple-functions/resolve-sync-conflict/**/*.ts",
+    "../../libs/firebase/maple-functions/import-etsy-listings/**/*.ts",
     "../../libs/firebase/database/src/**/*.ts",
     "../../libs/firebase/functions/src/**/*.ts",
     "../../libs/firebase/square/src/**/*.ts",

--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -141,3 +141,6 @@ export { calculateRegistrationCost } from '@maple/firebase/maple-functions/calcu
 export { getEtsyTemplates } from '@maple/firebase/maple-functions/get-etsy-templates';
 export { saveEtsyCategoryTemplate } from '@maple/firebase/maple-functions/save-etsy-category-template';
 export { saveEtsyArtistTemplate } from '@maple/firebase/maple-functions/save-etsy-artist-template';
+
+// Etsy listing read (for import review UI — calls Etsy API, no Square dep)
+export { listEtsyListings } from '@maple/firebase/maple-functions/list-etsy-listings';

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -62,6 +62,7 @@
     "../../libs/firebase/maple-functions/get-etsy-templates/**/*.ts",
     "../../libs/firebase/maple-functions/save-etsy-category-template/**/*.ts",
     "../../libs/firebase/maple-functions/save-etsy-artist-template/**/*.ts",
+    "../../libs/firebase/maple-functions/list-etsy-listings/**/*.ts",
     "../../libs/firebase/maple-functions/create-student/**/*.ts",
     "../../libs/firebase/maple-functions/delete-student/**/*.ts",
     "../../libs/firebase/maple-functions/get-student/**/*.ts",

--- a/apps/maple-spruce/.storybook/fixtures/etsy-listings.ts
+++ b/apps/maple-spruce/.storybook/fixtures/etsy-listings.ts
@@ -1,0 +1,154 @@
+/**
+ * Mock Etsy listings for storybook interaction tests.
+ *
+ * Types mirror the EtsyListing shape from the Etsy v3 API (only the
+ * fields the import UI reads).
+ */
+import type { EtsyListingWithSyncInfo } from '@maple/ts/firebase/api-types';
+
+type MockListingOverrides = {
+  listing_id: number;
+  title?: string;
+  priceCents?: number;
+  quantity?: number;
+  imageUrl?: string;
+  variantCount?: number;
+};
+
+function makeMockListing(
+  over: MockListingOverrides,
+  syncOverrides: Partial<EtsyListingWithSyncInfo> = {}
+): EtsyListingWithSyncInfo {
+  const variantCount = over.variantCount ?? 1;
+  const priceCents = over.priceCents ?? 2500;
+
+  const listing = {
+    listing_id: over.listing_id,
+    user_id: 1,
+    shop_id: 2,
+    title: over.title ?? `Listing ${over.listing_id}`,
+    description: 'A mock description',
+    state: 'active',
+    creation_timestamp: 0,
+    created_timestamp: 0,
+    ending_timestamp: 0,
+    original_creation_timestamp: 0,
+    last_modified_timestamp: 0,
+    updated_timestamp: 0,
+    state_timestamp: 0,
+    quantity: over.quantity ?? 3,
+    shop_section_id: null,
+    featured_rank: -1,
+    url: `https://www.etsy.com/listing/${over.listing_id}`,
+    num_favorers: 0,
+    non_taxable: false,
+    is_taxable: true,
+    is_customizable: false,
+    is_personalizable: false,
+    is_supply: false,
+    listing_type: 'physical',
+    tags: ['handmade'],
+    materials: [],
+    shipping_profile_id: 1,
+    return_policy_id: null,
+    processing_min: null,
+    processing_max: null,
+    who_made: 'i_did',
+    when_made: '2020_2025',
+    item_weight: null,
+    item_weight_unit: null,
+    item_length: null,
+    item_width: null,
+    item_height: null,
+    item_dimensions_unit: null,
+    taxonomy_id: 68,
+    price: { amount: priceCents, divisor: 100, currency_code: 'USD' },
+    views: 0,
+    images: over.imageUrl
+      ? [
+          {
+            listing_image_id: over.listing_id * 10,
+            listing_id: over.listing_id,
+            hex_code: null,
+            red: null,
+            green: null,
+            blue: null,
+            hue: null,
+            saturation: null,
+            brightness: null,
+            is_black_and_white: null,
+            creation_tsz: 0,
+            created_timestamp: 0,
+            rank: 1,
+            url_75x75: over.imageUrl,
+            url_170x135: over.imageUrl,
+            url_570xN: over.imageUrl,
+            url_fullxfull: over.imageUrl,
+            full_height: 500,
+            full_width: 500,
+            alt_text: null,
+          },
+        ]
+      : [],
+    inventory: {
+      products: Array.from({ length: variantCount }, (_, i) => ({
+        product_id: over.listing_id * 10 + i,
+        sku: `sku-${over.listing_id}-${i}`,
+        is_deleted: false,
+        offerings: [],
+        property_values: [],
+      })),
+      price_on_property: [],
+      quantity_on_property: [],
+      sku_on_property: [],
+    },
+  } as unknown as EtsyListingWithSyncInfo['listing'];
+
+  return {
+    listing,
+    imported: syncOverrides.imported ?? false,
+    productId: syncOverrides.productId,
+    variantCount,
+    isSimple: variantCount <= 1,
+  };
+}
+
+export const mockEtsyListingAvailable = makeMockListing({
+  listing_id: 101,
+  title: 'Handmade Pottery Mug',
+  priceCents: 2500,
+  quantity: 3,
+});
+
+export const mockEtsyListingImported = makeMockListing(
+  {
+    listing_id: 102,
+    title: 'Already Imported Scarf',
+    priceCents: 4500,
+    quantity: 1,
+  },
+  { imported: true, productId: 'prod-existing' }
+);
+
+export const mockEtsyListingMultiVariant = makeMockListing({
+  listing_id: 103,
+  title: 'Multi-Variant Earrings',
+  priceCents: 3500,
+  quantity: 8,
+  variantCount: 3,
+});
+
+export const mockEtsyListingWithImage = makeMockListing({
+  listing_id: 104,
+  title: 'Wool Cardigan',
+  priceCents: 8500,
+  quantity: 1,
+  imageUrl: 'https://placehold.co/600x600?text=Etsy',
+});
+
+export const mockEtsyListings: EtsyListingWithSyncInfo[] = [
+  mockEtsyListingAvailable,
+  mockEtsyListingImported,
+  mockEtsyListingMultiVariant,
+  mockEtsyListingWithImage,
+];

--- a/apps/maple-spruce/.storybook/fixtures/index.ts
+++ b/apps/maple-spruce/.storybook/fixtures/index.ts
@@ -14,3 +14,4 @@ export * from './registrations';
 export * from './students';
 export * from './lessons';
 export * from './invoices';
+export * from './etsy-listings';

--- a/apps/maple-spruce/src/app/etsy/import/page.tsx
+++ b/apps/maple-spruce/src/app/etsy/import/page.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+/**
+ * Etsy Import admin page
+ *
+ * Lists the connected Etsy shop's active listings, shows which are
+ * already imported as Products, and provides a bulk-import flow for
+ * unsynced simple listings. Pull-only — no writes back to Etsy.
+ */
+import { useCallback, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  FormControlLabel,
+  Stack,
+  Switch,
+  Typography,
+} from '@mui/material';
+import type { GridRowSelectionModel } from '@mui/x-data-grid';
+import { useArtists, useCategories, useEtsyListings, useEtsyImport } from '@maple/react/data';
+import { AppShell } from '../../../components/layout';
+import {
+  EtsyImportTable,
+  EtsyImportDialog,
+  type EtsyImportDialogSubmit,
+} from '../../../components/etsy-import';
+
+export default function EtsyImportPage() {
+  const { listingsState, total, fetchListings } = useEtsyListings();
+  const { artistsState } = useArtists();
+  const { categoriesState } = useCategories();
+  const { importState, importListings, reset: resetImport } = useEtsyImport();
+
+  const [selection, setSelection] = useState<GridRowSelectionModel>([]);
+  const [hideImported, setHideImported] = useState(true);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const artists = useMemo(
+    () => (artistsState.status === 'success' ? artistsState.data : []),
+    [artistsState]
+  );
+  const categories = useMemo(
+    () => (categoriesState.status === 'success' ? categoriesState.data : []),
+    [categoriesState]
+  );
+  const listings = useMemo(
+    () => (listingsState.status === 'success' ? listingsState.data : []),
+    [listingsState]
+  );
+
+  const handleImport = useCallback(
+    async (values: EtsyImportDialogSubmit): Promise<void> => {
+      const selectedIds = (selection as (string | number)[]).map(String);
+      await importListings({
+        listings: selectedIds.map((id) => ({ listingId: id })),
+        artistId: values.artistId,
+        categoryId: values.categoryId,
+        status: values.status,
+        customCommissionRate: values.customCommissionRate,
+      });
+      setDialogOpen(false);
+      setSelection([]);
+      // Refresh the listings so newly-imported rows show as "Imported".
+      await fetchListings();
+    },
+    [selection, importListings, fetchListings]
+  );
+
+  const selectionCount = (selection as (string | number)[]).length;
+  const isImporting = importState.status === 'loading';
+  const importError =
+    importState.status === 'error' ? importState.error : undefined;
+  const importSummary =
+    importState.status === 'success' ? importState.data : undefined;
+
+  return (
+    <AppShell>
+      <Box sx={{ mb: 3 }}>
+        <Typography variant="h4" gutterBottom>
+          Etsy Import
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Review your existing Etsy listings and pull selected ones into the
+          product catalog. This is read-only on Etsy — no writes are sent.
+        </Typography>
+      </Box>
+
+      {listingsState.status === 'error' && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          Failed to fetch Etsy listings: {listingsState.error}
+        </Alert>
+      )}
+
+      {importError && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={resetImport}>
+          Import failed: {importError}
+        </Alert>
+      )}
+
+      {importSummary && (
+        <Alert
+          severity={importSummary.failureCount === 0 ? 'success' : 'warning'}
+          sx={{ mb: 2 }}
+          onClose={resetImport}
+        >
+          Imported {importSummary.successCount} listing
+          {importSummary.successCount === 1 ? '' : 's'}.{' '}
+          {importSummary.failureCount > 0 &&
+            `${importSummary.failureCount} failed — see the status column or browser console for per-row errors.`}
+        </Alert>
+      )}
+
+      <Stack
+        direction="row"
+        spacing={2}
+        alignItems="center"
+        sx={{ mb: 2 }}
+      >
+        <Button
+          variant="contained"
+          disabled={selectionCount === 0 || isImporting}
+          onClick={() => setDialogOpen(true)}
+        >
+          Import {selectionCount > 0 ? `${selectionCount} ` : ''}selected
+        </Button>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={hideImported}
+              onChange={(e) => setHideImported(e.target.checked)}
+              inputProps={{ 'aria-label': 'Hide already imported' }}
+            />
+          }
+          label="Hide already-imported"
+        />
+        <Box sx={{ flex: 1 }} />
+        <Typography variant="caption" color="text.secondary">
+          {total} listing{total === 1 ? '' : 's'} on Etsy
+        </Typography>
+      </Stack>
+
+      <EtsyImportTable
+        rows={listings}
+        selection={selection}
+        onSelectionChange={setSelection}
+        loading={listingsState.status === 'loading'}
+        hideImported={hideImported}
+      />
+
+      <EtsyImportDialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        onSubmit={handleImport}
+        artists={artists}
+        categories={categories}
+        selectionCount={selectionCount}
+        isSubmitting={isImporting}
+      />
+    </AppShell>
+  );
+}

--- a/apps/maple-spruce/src/components/etsy-import/EtsyImportDialog.stories.tsx
+++ b/apps/maple-spruce/src/components/etsy-import/EtsyImportDialog.stories.tsx
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn, expect, userEvent, waitFor, within } from 'storybook/test';
+import { EtsyImportDialog } from './EtsyImportDialog';
+import {
+  mockArtist,
+  mockArtist2,
+  mockCategoryPottery,
+  mockCategoryTextiles,
+} from '../../../.storybook/fixtures';
+
+const meta = {
+  component: EtsyImportDialog,
+  title: 'EtsyImport/EtsyImportDialog',
+  parameters: { layout: 'centered', a11y: { disable: true } },
+  args: {
+    onClose: fn(),
+    onSubmit: fn().mockResolvedValue(undefined),
+    artists: [mockArtist, mockArtist2],
+    categories: [mockCategoryPottery, mockCategoryTextiles],
+    selectionCount: 3,
+    isSubmitting: false,
+  },
+} satisfies Meta<typeof EtsyImportDialog>;
+
+export default meta;
+type Story = StoryObj<typeof EtsyImportDialog>;
+
+const waitForDialog = async () => {
+  const canvas = within(document.body);
+  await waitFor(
+    () => {
+      expect(canvas.getByRole('dialog')).toBeInTheDocument();
+    },
+    { timeout: 3000 }
+  );
+  return canvas;
+};
+
+export const Closed: Story = {
+  args: { open: false },
+};
+
+export const OpenWithThreeSelected: Story = {
+  args: { open: true, selectionCount: 3 },
+};
+
+export const SingleSelection: Story = {
+  args: { open: true, selectionCount: 1 },
+};
+
+export const Submitting: Story = {
+  args: { open: true, isSubmitting: true },
+};
+
+export const SubmitBlockedWithoutArtist: Story = {
+  args: { open: true },
+  play: async ({ args }) => {
+    const canvas = await waitForDialog();
+    // Button is disabled until artist is chosen.
+    const submit = canvas.getByRole('button', { name: /import 3/i });
+    expect(submit).toBeDisabled();
+    expect(args.onSubmit).not.toHaveBeenCalled();
+  },
+};
+
+export const SubmitWithArtistAndDefaults: Story = {
+  args: { open: true },
+  play: async ({ args }) => {
+    const canvas = await waitForDialog();
+
+    // Open the Artist select and pick the first artist.
+    const artistSelect = canvas.getByLabelText(/artist/i);
+    await userEvent.click(artistSelect);
+    const artistOption = await waitFor(() =>
+      within(document.body).getByRole('option', { name: mockArtist.name })
+    );
+    await userEvent.click(artistOption);
+
+    const submit = canvas.getByRole('button', { name: /import 3/i });
+    await waitFor(() => expect(submit).not.toBeDisabled());
+    await userEvent.click(submit);
+
+    await waitFor(() => {
+      expect(args.onSubmit).toHaveBeenCalledTimes(1);
+      const arg = (args.onSubmit as ReturnType<typeof fn>).mock.calls[0][0];
+      expect(arg.artistId).toBe(mockArtist.id);
+      expect(arg.status).toBe('active');
+      expect(arg.categoryId).toBeUndefined();
+      expect(arg.customCommissionRate).toBeUndefined();
+    });
+  },
+};
+
+export const RejectsInvalidCommissionRate: Story = {
+  args: { open: true },
+  play: async () => {
+    const canvas = await waitForDialog();
+
+    const artistSelect = canvas.getByLabelText(/artist/i);
+    await userEvent.click(artistSelect);
+    const artistOption = await waitFor(() =>
+      within(document.body).getByRole('option', { name: mockArtist.name })
+    );
+    await userEvent.click(artistOption);
+
+    const commissionField = canvas.getByLabelText(/commission override/i);
+    await userEvent.type(commissionField, '1.5');
+
+    await waitFor(() => {
+      expect(
+        canvas.getByText(/must be between 0 and 1/i)
+      ).toBeInTheDocument();
+    });
+
+    // Submit should be disabled while validation error is live
+    const submit = canvas.getByRole('button', { name: /import 3/i });
+    expect(submit).toBeDisabled();
+  },
+};

--- a/apps/maple-spruce/src/components/etsy-import/EtsyImportDialog.tsx
+++ b/apps/maple-spruce/src/components/etsy-import/EtsyImportDialog.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+/**
+ * Dialog for bulk-applying shared Product attributes (artist, category,
+ * status, optional commission override) to a set of selected Etsy
+ * listings before kicking off the import.
+ *
+ * Uses Preact Signals (per ADR-015) — matches InstructorForm's shape.
+ */
+import { useCallback, useEffect } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from '@mui/material';
+import type { Artist, Category, ProductStatus } from '@maple/ts/domain';
+import {
+  useSignal,
+  useComputed,
+  useSignals,
+  batch,
+} from '@maple/react/signals';
+
+export interface EtsyImportDialogSubmit {
+  artistId: string;
+  categoryId?: string;
+  status: ProductStatus;
+  customCommissionRate?: number;
+}
+
+export interface EtsyImportDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (values: EtsyImportDialogSubmit) => Promise<void>;
+  artists: Artist[];
+  categories: Category[];
+  /** How many listings will be imported — shown in the dialog header. */
+  selectionCount: number;
+  /** Controlled from the parent so the parent can disable while in flight. */
+  isSubmitting?: boolean;
+}
+
+const STATUSES: ProductStatus[] = ['active', 'draft', 'discontinued'];
+
+export function EtsyImportDialog({
+  open,
+  onClose,
+  onSubmit,
+  artists,
+  categories,
+  selectionCount,
+  isSubmitting = false,
+}: EtsyImportDialogProps) {
+  useSignals();
+
+  const artistId = useSignal<string>('');
+  const categoryId = useSignal<string>('');
+  const status = useSignal<ProductStatus>('active');
+  const commissionRateText = useSignal<string>('');
+
+  // Reset the form every time the dialog opens so stale entries from a
+  // previous batch don't carry over.
+  useEffect(() => {
+    if (open) {
+      batch(() => {
+        artistId.value = '';
+        categoryId.value = '';
+        status.value = 'active';
+        commissionRateText.value = '';
+      });
+    }
+  }, [open, artistId, categoryId, status, commissionRateText]);
+
+  const commissionRateParsed = useComputed<number | undefined>(() => {
+    const raw = commissionRateText.value.trim();
+    if (!raw) return undefined;
+    const n = Number(raw);
+    if (!Number.isFinite(n)) return undefined;
+    return n;
+  });
+
+  const commissionError = useComputed<string | undefined>(() => {
+    const raw = commissionRateText.value.trim();
+    if (!raw) return undefined;
+    const n = Number(raw);
+    if (!Number.isFinite(n)) return 'Commission rate must be a number';
+    if (n < 0 || n > 1) return 'Commission rate must be between 0 and 1';
+    return undefined;
+  });
+
+  const canSubmit = useComputed(
+    () =>
+      !!artistId.value &&
+      !!status.value &&
+      !commissionError.value &&
+      !isSubmitting &&
+      selectionCount > 0
+  );
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit.value) return;
+    await onSubmit({
+      artistId: artistId.value,
+      categoryId: categoryId.value || undefined,
+      status: status.value,
+      customCommissionRate: commissionRateParsed.value,
+    });
+  }, [
+    canSubmit,
+    onSubmit,
+    artistId,
+    categoryId,
+    status,
+    commissionRateParsed,
+  ]);
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Import {selectionCount} Etsy listing{selectionCount === 1 ? '' : 's'}</DialogTitle>
+      <DialogContent>
+        <Alert severity="info" sx={{ mb: 2 }}>
+          These values will be applied to every selected listing. You can
+          edit individual products after import.
+        </Alert>
+
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <FormControl fullWidth required>
+            <InputLabel id="etsy-import-artist-label">Artist</InputLabel>
+            <Select
+              labelId="etsy-import-artist-label"
+              label="Artist"
+              value={artistId.value}
+              onChange={(e) => {
+                artistId.value = e.target.value as string;
+              }}
+              inputProps={{ 'aria-label': 'Artist' }}
+            >
+              {artists.map((a) => (
+                <MenuItem key={a.id} value={a.id}>
+                  {a.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl fullWidth>
+            <InputLabel id="etsy-import-category-label">
+              Category (optional)
+            </InputLabel>
+            <Select
+              labelId="etsy-import-category-label"
+              label="Category (optional)"
+              value={categoryId.value}
+              onChange={(e) => {
+                categoryId.value = e.target.value as string;
+              }}
+              inputProps={{ 'aria-label': 'Category' }}
+            >
+              <MenuItem value="">
+                <em>Uncategorized</em>
+              </MenuItem>
+              {categories.map((c) => (
+                <MenuItem key={c.id} value={c.id}>
+                  {c.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl fullWidth required>
+            <InputLabel id="etsy-import-status-label">Status</InputLabel>
+            <Select
+              labelId="etsy-import-status-label"
+              label="Status"
+              value={status.value}
+              onChange={(e) => {
+                status.value = e.target.value as ProductStatus;
+              }}
+              inputProps={{ 'aria-label': 'Status' }}
+            >
+              {STATUSES.map((s) => (
+                <MenuItem key={s} value={s}>
+                  {s}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <TextField
+            label="Commission override (optional, 0.0 – 1.0)"
+            value={commissionRateText.value}
+            onChange={(e) => {
+              commissionRateText.value = e.target.value;
+            }}
+            error={!!commissionError.value}
+            helperText={
+              commissionError.value ??
+              'Leave blank to use the artist default commission.'
+            }
+            inputProps={{ inputMode: 'decimal', 'aria-label': 'Commission override' }}
+          />
+
+          <Typography variant="caption" color="text.secondary">
+            Listings with multiple variants are not supported in this import
+            pass and will be skipped automatically.
+          </Typography>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={isSubmitting}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          disabled={!canSubmit.value}
+        >
+          {isSubmitting ? 'Importing…' : `Import ${selectionCount}`}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/maple-spruce/src/components/etsy-import/EtsyImportTable.stories.tsx
+++ b/apps/maple-spruce/src/components/etsy-import/EtsyImportTable.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import { EtsyImportTable } from './EtsyImportTable';
+import {
+  mockEtsyListings,
+  mockEtsyListingAvailable,
+  mockEtsyListingImported,
+  mockEtsyListingMultiVariant,
+} from '../../../.storybook/fixtures';
+
+const meta = {
+  component: EtsyImportTable,
+  title: 'EtsyImport/EtsyImportTable',
+  parameters: { layout: 'fullscreen' },
+  args: {
+    selection: [],
+    onSelectionChange: fn(),
+    loading: false,
+    hideImported: true,
+  },
+} satisfies Meta<typeof EtsyImportTable>;
+
+export default meta;
+type Story = StoryObj<typeof EtsyImportTable>;
+
+export const Empty: Story = {
+  args: { rows: [] },
+};
+
+export const Loading: Story = {
+  args: { rows: [], loading: true },
+};
+
+export const OnlyAvailable: Story = {
+  args: { rows: [mockEtsyListingAvailable] },
+};
+
+export const MixOfStates: Story = {
+  args: { rows: mockEtsyListings, hideImported: false },
+};
+
+export const HideImportedEnabled: Story = {
+  args: { rows: mockEtsyListings, hideImported: true },
+};
+
+export const MultiVariantDisabled: Story = {
+  args: {
+    rows: [mockEtsyListingAvailable, mockEtsyListingMultiVariant],
+    hideImported: false,
+  },
+};
+
+export const AllImported: Story = {
+  args: {
+    rows: [mockEtsyListingImported],
+    hideImported: false,
+  },
+};

--- a/apps/maple-spruce/src/components/etsy-import/EtsyImportTable.tsx
+++ b/apps/maple-spruce/src/components/etsy-import/EtsyImportTable.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+/**
+ * Table of Etsy listings for review + bulk import selection.
+ *
+ * Shows each Etsy listing with its current sync status (imported,
+ * unsupported due to variants, or available for import). Multi-variant
+ * rows are disabled with a tooltip so admins can't select them.
+ */
+import { useMemo } from 'react';
+import {
+  Box,
+  Chip,
+  Typography,
+  Tooltip,
+} from '@mui/material';
+import {
+  DataGrid,
+  type GridColDef,
+  type GridRenderCellParams,
+  type GridRowSelectionModel,
+  type GridRowParams,
+} from '@mui/x-data-grid';
+import type { EtsyListingWithSyncInfo } from '@maple/ts/firebase/api-types';
+
+export interface EtsyImportTableProps {
+  rows: EtsyListingWithSyncInfo[];
+  selection: GridRowSelectionModel;
+  onSelectionChange: (selection: GridRowSelectionModel) => void;
+  loading?: boolean;
+  /** Hide rows where imported===true. Default: true. */
+  hideImported?: boolean;
+}
+
+function formatEtsyPrice(
+  price: EtsyListingWithSyncInfo['listing']['price']
+): string {
+  if (!price || !price.divisor) return '—';
+  const dollars = price.amount / price.divisor;
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: price.currency_code ?? 'USD',
+  }).format(dollars);
+}
+
+export function EtsyImportTable({
+  rows,
+  selection,
+  onSelectionChange,
+  loading = false,
+  hideImported = true,
+}: EtsyImportTableProps) {
+  const visibleRows = useMemo(
+    () => (hideImported ? rows.filter((r) => !r.imported) : rows),
+    [rows, hideImported]
+  );
+
+  const columns: GridColDef<EtsyListingWithSyncInfo>[] = useMemo(
+    () => [
+      {
+        field: 'image',
+        headerName: '',
+        width: 60,
+        sortable: false,
+        filterable: false,
+        renderCell: (
+          params: GridRenderCellParams<EtsyListingWithSyncInfo>
+        ) => {
+          const img = params.row.listing.images?.[0]?.url_170x135;
+          return img ? (
+            <Box
+              component="img"
+              src={img}
+              alt={params.row.listing.title}
+              sx={{
+                width: 40,
+                height: 40,
+                objectFit: 'cover',
+                borderRadius: 1,
+              }}
+            />
+          ) : (
+            <Box
+              sx={{
+                width: 40,
+                height: 40,
+                bgcolor: 'grey.200',
+                borderRadius: 1,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <Typography variant="caption" color="text.secondary">
+                —
+              </Typography>
+            </Box>
+          );
+        },
+      },
+      {
+        field: 'title',
+        headerName: 'Title',
+        flex: 1,
+        minWidth: 220,
+        valueGetter: (_value, row) => row.listing.title,
+      },
+      {
+        field: 'price',
+        headerName: 'Price',
+        width: 100,
+        valueGetter: (_value, row) => formatEtsyPrice(row.listing.price),
+      },
+      {
+        field: 'quantity',
+        headerName: 'Qty',
+        width: 70,
+        valueGetter: (_value, row) => row.listing.quantity,
+      },
+      {
+        field: 'variants',
+        headerName: 'Variants',
+        width: 110,
+        renderCell: (
+          params: GridRenderCellParams<EtsyListingWithSyncInfo>
+        ) =>
+          params.row.isSimple ? (
+            <Chip size="small" label="Simple" variant="outlined" />
+          ) : (
+            <Tooltip title="Multi-variant listings are not yet supported for import. Flagged for future support.">
+              <Chip
+                size="small"
+                label={`${params.row.variantCount} variants`}
+                color="warning"
+              />
+            </Tooltip>
+          ),
+      },
+      {
+        field: 'status',
+        headerName: 'Status',
+        width: 130,
+        renderCell: (
+          params: GridRenderCellParams<EtsyListingWithSyncInfo>
+        ) => {
+          if (params.row.imported) {
+            return <Chip size="small" label="Imported" color="success" />;
+          }
+          if (!params.row.isSimple) {
+            return (
+              <Chip size="small" label="Unsupported" color="warning" />
+            );
+          }
+          return <Chip size="small" label="Available" variant="outlined" />;
+        },
+      },
+    ],
+    []
+  );
+
+  const isRowSelectable = (params: GridRowParams<EtsyListingWithSyncInfo>) =>
+    !params.row.imported && params.row.isSimple;
+
+  return (
+    <DataGrid
+      autoHeight
+      rows={visibleRows}
+      columns={columns}
+      getRowId={(row) => row.listing.listing_id}
+      loading={loading}
+      checkboxSelection
+      disableRowSelectionOnClick
+      isRowSelectable={isRowSelectable}
+      rowSelectionModel={selection}
+      onRowSelectionModelChange={onSelectionChange}
+      initialState={{
+        pagination: { paginationModel: { pageSize: 25 } },
+        sorting: { sortModel: [{ field: 'title', sort: 'asc' }] },
+      }}
+      pageSizeOptions={[25, 50, 100]}
+    />
+  );
+}

--- a/apps/maple-spruce/src/components/etsy-import/index.ts
+++ b/apps/maple-spruce/src/components/etsy-import/index.ts
@@ -1,0 +1,7 @@
+export { EtsyImportTable } from './EtsyImportTable';
+export type { EtsyImportTableProps } from './EtsyImportTable';
+export { EtsyImportDialog } from './EtsyImportDialog';
+export type {
+  EtsyImportDialogProps,
+  EtsyImportDialogSubmit,
+} from './EtsyImportDialog';

--- a/function-codebases.json
+++ b/function-codebases.json
@@ -26,7 +26,9 @@
     "firebase-maple-functions-sync-registration-count": "maple-sync",
     "firebase-maple-functions-etsy-auth-url": "maple-sync",
     "firebase-maple-functions-etsy-auth-callback": "maple-sync",
-    "firebase-maple-functions-get-etsy-connection-status": "maple-sync"
+    "firebase-maple-functions-get-etsy-connection-status": "maple-sync",
+    "firebase-maple-functions-list-etsy-listings": "maple-core",
+    "firebase-maple-functions-import-etsy-listings": "maple-square"
   },
   "defaultCodebase": "maple-core"
 }

--- a/libs/firebase/database/src/index.ts
+++ b/libs/firebase/database/src/index.ts
@@ -48,3 +48,7 @@ export {
   updateTokenShopId,
 } from './lib/etsy-token.repository';
 export { EtsyTemplateRepository } from './lib/etsy-template.repository';
+export {
+  EtsyImportRepository,
+  type CreateEtsyImportInput,
+} from './lib/etsy-import.repository';

--- a/libs/firebase/database/src/lib/etsy-import.repository.ts
+++ b/libs/firebase/database/src/lib/etsy-import.repository.ts
@@ -1,0 +1,89 @@
+/**
+ * EtsyImport repository
+ *
+ * Persists raw Etsy listing snapshots keyed by the Firestore Product ID.
+ * One-to-one with Product: when a Product is imported from Etsy, we write
+ * its snapshot here so the raw Etsy shape survives later edits on Etsy.
+ */
+import { db } from './utilities/database.config';
+import type { EtsyImport, EtsyRawPayload } from '@maple/ts/domain';
+
+const COLLECTION = 'etsy-imports';
+
+function docToEtsyImport(
+  doc: FirebaseFirestore.DocumentSnapshot
+): EtsyImport | undefined {
+  if (!doc.exists) return undefined;
+  const data = doc.data()!;
+  return {
+    id: doc.id,
+    listingId: data.listingId,
+    rawListing: data.rawListing,
+    rawInventory: data.rawInventory,
+    variantCount: data.variantCount ?? 1,
+    importedBy: data.importedBy,
+    importedAt: data.importedAt?.toDate() ?? new Date(),
+  };
+}
+
+export interface CreateEtsyImportInput {
+  productId: string;
+  listingId: string;
+  rawListing: EtsyRawPayload;
+  rawInventory?: EtsyRawPayload;
+  variantCount: number;
+  importedBy: string;
+}
+
+export const EtsyImportRepository = {
+  async findByProductId(productId: string): Promise<EtsyImport | undefined> {
+    const doc = await db.collection(COLLECTION).doc(productId).get();
+    return docToEtsyImport(doc);
+  },
+
+  async findByListingId(listingId: string): Promise<EtsyImport | undefined> {
+    const snapshot = await db
+      .collection(COLLECTION)
+      .where('listingId', '==', listingId)
+      .limit(1)
+      .get();
+    if (snapshot.empty) return undefined;
+    return docToEtsyImport(snapshot.docs[0]);
+  },
+
+  async findAll(): Promise<EtsyImport[]> {
+    const snapshot = await db.collection(COLLECTION).get();
+    return snapshot.docs
+      .map((doc) => docToEtsyImport(doc))
+      .filter((i): i is EtsyImport => i !== undefined);
+  },
+
+  async create(input: CreateEtsyImportInput): Promise<EtsyImport> {
+    const now = new Date();
+    const doc: Record<string, unknown> = {
+      listingId: input.listingId,
+      rawListing: input.rawListing,
+      variantCount: input.variantCount,
+      importedBy: input.importedBy,
+      importedAt: now,
+    };
+    if (input.rawInventory !== undefined) {
+      doc.rawInventory = input.rawInventory;
+    }
+    await db.collection(COLLECTION).doc(input.productId).set(doc);
+
+    return {
+      id: input.productId,
+      listingId: input.listingId,
+      rawListing: input.rawListing,
+      rawInventory: input.rawInventory,
+      variantCount: input.variantCount,
+      importedBy: input.importedBy,
+      importedAt: now,
+    };
+  },
+
+  async delete(productId: string): Promise<void> {
+    await db.collection(COLLECTION).doc(productId).delete();
+  },
+};

--- a/libs/firebase/database/src/lib/product.repository.ts
+++ b/libs/firebase/database/src/lib/product.repository.ts
@@ -356,6 +356,39 @@ export const ProductRepository = {
   },
 
   /**
+   * Find products for a batch of Etsy listing IDs.
+   *
+   * Used by the Etsy import page to cross-reference which listings are
+   * already synced. Firestore's `in` clause caps at 30 values, so requests
+   * larger than that are chunked transparently.
+   */
+  async findByEtsyListingIds(
+    etsyListingIds: string[]
+  ): Promise<Product[]> {
+    if (etsyListingIds.length === 0) return [];
+
+    const CHUNK_SIZE = 30;
+    const chunks: string[][] = [];
+    for (let i = 0; i < etsyListingIds.length; i += CHUNK_SIZE) {
+      chunks.push(etsyListingIds.slice(i, i + CHUNK_SIZE));
+    }
+
+    const results = await Promise.all(
+      chunks.map(async (chunk) => {
+        const snapshot = await db
+          .collection(COLLECTION)
+          .where('etsyListingId', 'in', chunk)
+          .get();
+        return snapshot.docs
+          .map((doc) => docToProduct(doc))
+          .filter((p): p is Product => p !== undefined);
+      })
+    );
+
+    return results.flat();
+  },
+
+  /**
    * Update the Etsy cache after a successful Etsy API call
    */
   async updateEtsyCache(

--- a/libs/firebase/etsy-test-mock-server/project.json
+++ b/libs/firebase/etsy-test-mock-server/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-etsy-test-mock-server",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/etsy-test-mock-server/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:test-util"],
+  "targets": {}
+}

--- a/libs/firebase/etsy-test-mock-server/src/index.ts
+++ b/libs/firebase/etsy-test-mock-server/src/index.ts
@@ -1,0 +1,18 @@
+export { EtsyMockServer } from './lib/etsy-mock-server';
+export type { RecordedRequest } from './lib/etsy-mock-server';
+export {
+  createEtsyMockServer,
+  type EtsyMockInstance,
+} from './lib/create-etsy-mock-server';
+export {
+  setListings,
+  addListing,
+  clearListings,
+  makeListing,
+  type MockListingSeed,
+} from './lib/listing-fixtures';
+export {
+  setTokenExchangeResponse,
+  setShopId,
+  resetOAuthState,
+} from './lib/routes/etsy-oauth';

--- a/libs/firebase/etsy-test-mock-server/src/lib/create-etsy-mock-server.ts
+++ b/libs/firebase/etsy-test-mock-server/src/lib/create-etsy-mock-server.ts
@@ -1,0 +1,33 @@
+/**
+ * Factory for the Etsy mock server.
+ *
+ * Registers listing + OAuth routes and exposes a reset() helper for test
+ * suites to clear per-test state without restarting the HTTP server.
+ */
+import { EtsyMockServer } from './etsy-mock-server';
+import { registerEtsyListingRoutes } from './routes/etsy-listings';
+import {
+  registerEtsyOAuthRoutes,
+  resetOAuthState,
+} from './routes/etsy-oauth';
+import { clearListings } from './listing-fixtures';
+
+export interface EtsyMockInstance {
+  server: EtsyMockServer;
+  reset: () => void;
+}
+
+export function createEtsyMockServer(): EtsyMockInstance {
+  const server = new EtsyMockServer();
+  registerEtsyListingRoutes(server);
+  registerEtsyOAuthRoutes(server);
+
+  return {
+    server,
+    reset: () => {
+      server.clearRequests();
+      clearListings();
+      resetOAuthState();
+    },
+  };
+}

--- a/libs/firebase/etsy-test-mock-server/src/lib/etsy-mock-server.ts
+++ b/libs/firebase/etsy-test-mock-server/src/lib/etsy-mock-server.ts
@@ -1,0 +1,223 @@
+/**
+ * Standalone Etsy mock HTTP server.
+ *
+ * Serves Etsy v3 API responses for integration tests. Independent from the
+ * monolithic `integration-test-mock-server` so Etsy-related tests can
+ * iterate without coupling to Square/Webflow concerns.
+ *
+ * See the follow-up issue for splitting the existing monolith into
+ * per-service mock servers to match this pattern.
+ */
+import http from 'http';
+
+export interface RecordedRequest {
+  method: string;
+  path: string;
+  headers: Record<string, string | string[] | undefined>;
+  body: unknown;
+  timestamp: Date;
+}
+
+interface RouteHandler {
+  method: string;
+  /** Path pattern — supports :param placeholders */
+  pattern: string;
+  handler: (
+    req: ParsedRequest
+  ) =>
+    | {
+        status: number;
+        body: unknown;
+        contentType?: string;
+        rawBody?: Buffer;
+      }
+    | Promise<{
+        status: number;
+        body: unknown;
+        contentType?: string;
+        rawBody?: Buffer;
+      }>;
+}
+
+interface ParsedRequest {
+  method: string;
+  path: string;
+  query: Record<string, string>;
+  params: Record<string, string>;
+  body: unknown;
+  headers: Record<string, string | string[] | undefined>;
+}
+
+export class EtsyMockServer {
+  private server: http.Server | null = null;
+  private routes: RouteHandler[] = [];
+  private _requests: RecordedRequest[] = [];
+
+  route(
+    method: string,
+    pattern: string,
+    handler: RouteHandler['handler']
+  ): this {
+    this.routes.push({ method: method.toUpperCase(), pattern, handler });
+    return this;
+  }
+
+  get(pattern: string, handler: RouteHandler['handler']): this {
+    return this.route('GET', pattern, handler);
+  }
+
+  post(pattern: string, handler: RouteHandler['handler']): this {
+    return this.route('POST', pattern, handler);
+  }
+
+  /** All recorded requests since last reset. */
+  get requests(): readonly RecordedRequest[] {
+    return this._requests;
+  }
+
+  /** Get requests matching a path prefix. */
+  getRequests(pathPrefix: string): RecordedRequest[] {
+    return this._requests.filter((r) => r.path.startsWith(pathPrefix));
+  }
+
+  clearRequests(): void {
+    this._requests = [];
+  }
+
+  async start(port: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.server = http.createServer(async (req, res) => {
+        const rawBody = await readRawBody(req);
+        const method = req.method?.toUpperCase() ?? 'GET';
+        const path = req.url ?? '/';
+        const body = parseBody(rawBody, req.headers['content-type']);
+
+        this._requests.push({
+          method,
+          path,
+          headers: req.headers,
+          body,
+          timestamp: new Date(),
+        });
+
+        const { pathname, query } = splitQuery(path);
+
+        for (const route of this.routes) {
+          if (route.method !== method) continue;
+          const params = matchPattern(route.pattern, pathname);
+          if (params !== null) {
+            try {
+              const result = await route.handler({
+                method,
+                path: pathname,
+                query,
+                params,
+                body,
+                headers: req.headers,
+              });
+              if (result.rawBody) {
+                res.writeHead(result.status, {
+                  'Content-Type': result.contentType ?? 'application/octet-stream',
+                });
+                res.end(result.rawBody);
+              } else {
+                res.writeHead(result.status, {
+                  'Content-Type': result.contentType ?? 'application/json',
+                });
+                res.end(JSON.stringify(result.body));
+              }
+            } catch (err) {
+              res.writeHead(500, { 'Content-Type': 'application/json' });
+              res.end(
+                JSON.stringify({
+                  error: err instanceof Error ? err.message : 'Internal error',
+                })
+              );
+            }
+            return;
+          }
+        }
+
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            error: 'Etsy mock server: no route matched',
+            method,
+            path,
+          })
+        );
+      });
+
+      this.server.on('error', reject);
+      this.server.listen(port, () => resolve());
+    });
+  }
+
+  async stop(): Promise<void> {
+    return new Promise((resolve) => {
+      if (this.server) {
+        this.server.close(() => resolve());
+      } else {
+        resolve();
+      }
+    });
+  }
+}
+
+function readRawBody(req: http.IncomingMessage): Promise<Buffer> {
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => resolve(Buffer.concat(chunks)));
+  });
+}
+
+function parseBody(raw: Buffer, contentType?: string): unknown {
+  if (raw.length === 0) return undefined;
+  const text = raw.toString();
+  if (contentType?.includes('application/x-www-form-urlencoded')) {
+    const params = new URLSearchParams(text);
+    const obj: Record<string, string> = {};
+    for (const [k, v] of params) obj[k] = v;
+    return obj;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function splitQuery(path: string): {
+  pathname: string;
+  query: Record<string, string>;
+} {
+  const [pathname, queryString = ''] = path.split('?');
+  const query: Record<string, string> = {};
+  if (queryString) {
+    for (const [k, v] of new URLSearchParams(queryString)) {
+      query[k] = v;
+    }
+  }
+  return { pathname, query };
+}
+
+function matchPattern(
+  pattern: string,
+  pathname: string
+): Record<string, string> | null {
+  const patternParts = pattern.split('/');
+  const pathParts = pathname.split('/');
+
+  if (patternParts.length !== pathParts.length) return null;
+
+  const params: Record<string, string> = {};
+  for (let i = 0; i < patternParts.length; i++) {
+    if (patternParts[i].startsWith(':')) {
+      params[patternParts[i].slice(1)] = pathParts[i];
+    } else if (patternParts[i] !== pathParts[i]) {
+      return null;
+    }
+  }
+  return params;
+}

--- a/libs/firebase/etsy-test-mock-server/src/lib/listing-fixtures.ts
+++ b/libs/firebase/etsy-test-mock-server/src/lib/listing-fixtures.ts
@@ -1,0 +1,180 @@
+/**
+ * Shared in-memory fixture store for Etsy listings.
+ *
+ * Tests seed listings via setListings() / addListing() and the routes
+ * read from this store. Built this way so both `/listings/:id` and
+ * `/shops/:shopId/listings` see the same data.
+ */
+
+export interface MockListingSeed {
+  listing_id: number;
+  title: string;
+  description: string;
+  state: 'active' | 'inactive' | 'sold_out' | 'draft' | 'expired';
+  priceAmount: number; // in the smallest currency unit multiplied by divisor
+  priceDivisor: number;
+  currency: string;
+  quantity: number;
+  taxonomy_id: number;
+  tags?: string[];
+  materials?: string[];
+  who_made?: 'i_did' | 'someone_else' | 'collective';
+  when_made?: string;
+  url?: string;
+  imageUrls?: string[];
+  /** Per-product SKUs. Length > 1 simulates a multi-variant listing. */
+  productSkus?: string[];
+}
+
+let listings: MockListingSeed[] = [];
+
+export function clearListings(): void {
+  listings = [];
+}
+
+export function setListings(seeds: MockListingSeed[]): void {
+  listings = [...seeds];
+}
+
+export function addListing(seed: MockListingSeed): void {
+  listings = [...listings.filter((l) => l.listing_id !== seed.listing_id), seed];
+}
+
+export function getListings(): MockListingSeed[] {
+  return [...listings];
+}
+
+export function getListingById(id: number): MockListingSeed | undefined {
+  return listings.find((l) => l.listing_id === id);
+}
+
+/**
+ * Build a listing seed with sensible defaults. Override only what matters.
+ */
+export function makeListing(
+  overrides: Partial<MockListingSeed> & { listing_id: number }
+): MockListingSeed {
+  return {
+    title: `Listing ${overrides.listing_id}`,
+    description: 'Mock listing description',
+    state: 'active',
+    priceAmount: 2500,
+    priceDivisor: 100,
+    currency: 'USD',
+    quantity: 3,
+    taxonomy_id: 68,
+    tags: ['handmade'],
+    materials: ['wood'],
+    who_made: 'i_did',
+    when_made: '2020_2025',
+    url: `https://www.etsy.com/listing/${overrides.listing_id}`,
+    imageUrls: [],
+    productSkus: [`sku-${overrides.listing_id}`],
+    ...overrides,
+  };
+}
+
+/**
+ * Render a seed as the full Etsy v3 listing JSON shape (the subset our
+ * code reads). Includes images + inventory.
+ */
+export function seedToEtsyListing(seed: MockListingSeed): Record<string, unknown> {
+  const now = Math.floor(Date.now() / 1000);
+  const products = (seed.productSkus ?? [`sku-${seed.listing_id}`]).map(
+    (sku, idx) => ({
+      product_id: seed.listing_id * 10 + idx,
+      sku,
+      is_deleted: false,
+      offerings: [
+        {
+          offering_id: seed.listing_id * 100 + idx,
+          quantity: seed.quantity,
+          is_enabled: true,
+          is_deleted: false,
+          price: {
+            amount: seed.priceAmount,
+            divisor: seed.priceDivisor,
+            currency_code: seed.currency,
+          },
+        },
+      ],
+      property_values: [],
+    })
+  );
+
+  return {
+    listing_id: seed.listing_id,
+    user_id: 11111,
+    shop_id: 22222,
+    title: seed.title,
+    description: seed.description,
+    state: seed.state,
+    creation_timestamp: now,
+    created_timestamp: now,
+    ending_timestamp: now + 90 * 86400,
+    original_creation_timestamp: now,
+    last_modified_timestamp: now,
+    updated_timestamp: now,
+    state_timestamp: now,
+    quantity: seed.quantity,
+    shop_section_id: null,
+    featured_rank: -1,
+    url: seed.url ?? `https://www.etsy.com/listing/${seed.listing_id}`,
+    num_favorers: 0,
+    non_taxable: false,
+    is_taxable: true,
+    is_customizable: false,
+    is_personalizable: false,
+    is_supply: false,
+    listing_type: 'physical',
+    tags: seed.tags ?? [],
+    materials: seed.materials ?? [],
+    shipping_profile_id: 777,
+    return_policy_id: null,
+    processing_min: null,
+    processing_max: null,
+    who_made: seed.who_made ?? 'i_did',
+    when_made: seed.when_made ?? '2020_2025',
+    item_weight: null,
+    item_weight_unit: null,
+    item_length: null,
+    item_width: null,
+    item_height: null,
+    item_dimensions_unit: null,
+    taxonomy_id: seed.taxonomy_id,
+    price: {
+      amount: seed.priceAmount,
+      divisor: seed.priceDivisor,
+      currency_code: seed.currency,
+    },
+    views: 0,
+    images: (seed.imageUrls ?? []).map((url, idx) => ({
+      listing_image_id: seed.listing_id * 1000 + idx,
+      listing_id: seed.listing_id,
+      hex_code: null,
+      red: null,
+      green: null,
+      blue: null,
+      hue: null,
+      saturation: null,
+      brightness: null,
+      is_black_and_white: null,
+      creation_tsz: now,
+      created_timestamp: now,
+      rank: idx + 1,
+      url_75x75: url,
+      url_170x135: url,
+      url_570xN: url,
+      url_fullxfull: url,
+      full_height: 1000,
+      full_width: 1000,
+      alt_text: null,
+    })),
+    inventory: {
+      products,
+      price_on_property: [],
+      quantity_on_property: [],
+      sku_on_property: [],
+    },
+  };
+}

--- a/libs/firebase/etsy-test-mock-server/src/lib/routes/etsy-listings.ts
+++ b/libs/firebase/etsy-test-mock-server/src/lib/routes/etsy-listings.ts
@@ -1,0 +1,109 @@
+/**
+ * Etsy v3 listing routes.
+ *
+ * Backs both single-listing and shop-listings endpoints with the shared
+ * in-memory fixture store.
+ */
+import type { EtsyMockServer } from '../etsy-mock-server';
+import {
+  clearListings,
+  getListingById,
+  getListings,
+  seedToEtsyListing,
+  setListings,
+  type MockListingSeed,
+} from '../listing-fixtures';
+import { resetOAuthState } from './etsy-oauth';
+
+export function registerEtsyListingRoutes(server: EtsyMockServer): void {
+  // GET /v3/application/listings/:listingId
+  server.get('/v3/application/listings/:listingId', (req) => {
+    const id = Number(req.params['listingId']);
+    const seed = getListingById(id);
+    if (!seed) {
+      return {
+        status: 404,
+        body: { error: 'not_found', error_description: `Listing ${id}` },
+      };
+    }
+    return { status: 200, body: seedToEtsyListing(seed) };
+  });
+
+  // GET /v3/application/shops/:shopId/listings
+  server.get('/v3/application/shops/:shopId/listings', (req) => {
+    const state = req.query['state'];
+    const limit = Number(req.query['limit'] ?? 100);
+    const offset = Number(req.query['offset'] ?? 0);
+
+    const all = getListings();
+    const filtered = state ? all.filter((l) => l.state === state) : all;
+    const page = filtered.slice(offset, offset + limit);
+
+    return {
+      status: 200,
+      body: {
+        count: filtered.length,
+        results: page.map(seedToEtsyListing),
+      },
+    };
+  });
+
+  // GET /v3/application/users/:userId/shops — used by etsy-auth-callback
+  // to resolve the shop ID after token exchange. Stateless; always returns
+  // a single shop owned by the user.
+  server.get('/v3/application/users/:userId/shops', (req) => {
+    const userId = Number(req.params['userId']);
+    return {
+      status: 200,
+      body: {
+        results: [
+          {
+            shop_id: 22222,
+            user_id: userId,
+            shop_name: 'MockShop',
+          },
+        ],
+      },
+    };
+  });
+
+  // Mock image serving. Etsy CDN images are hosted on i.etsystatic.com in
+  // production; fixtures point at this path so importEtsyListings' image
+  // copy step can fetch() through the mock.
+  server.get('/mock-images/:name', () => {
+    // Tiny opaque JPEG header bytes — enough to satisfy fetch().arrayBuffer()
+    // without any real decoding.
+    const fakeJpeg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+    return {
+      status: 200,
+      body: null,
+      rawBody: fakeJpeg,
+      contentType: 'image/jpeg',
+    };
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test-control endpoints under /_mock/*
+  //
+  // The mock server runs in its own process separate from the test runner,
+  // so tests need an HTTP surface to seed fixtures and reset state. These
+  // routes are prefixed with _mock/ to keep them obviously non-Etsy.
+  // ---------------------------------------------------------------------------
+  server.post('/_mock/listings', (req) => {
+    const body = req.body as { seeds?: MockListingSeed[] } | undefined;
+    if (!body || !Array.isArray(body.seeds)) {
+      return {
+        status: 400,
+        body: { error: 'Expected { seeds: MockListingSeed[] }' },
+      };
+    }
+    setListings(body.seeds);
+    return { status: 200, body: { ok: true, count: body.seeds.length } };
+  });
+
+  server.post('/_mock/reset', () => {
+    clearListings();
+    resetOAuthState();
+    return { status: 200, body: { ok: true } };
+  });
+}

--- a/libs/firebase/etsy-test-mock-server/src/lib/routes/etsy-oauth.ts
+++ b/libs/firebase/etsy-test-mock-server/src/lib/routes/etsy-oauth.ts
@@ -1,0 +1,54 @@
+/**
+ * Etsy v3 OAuth routes.
+ *
+ * Mocks the token exchange endpoint that etsy-auth-callback calls during
+ * OAuth completion. Tests can override the canned response via
+ * setTokenExchangeResponse() to simulate error cases.
+ */
+import type { EtsyMockServer } from '../etsy-mock-server';
+
+interface TokenResponse {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+let tokenResponse: TokenResponse = {
+  status: 200,
+  body: {
+    access_token: '11111.valid-access-token',
+    token_type: 'Bearer',
+    expires_in: 3600,
+    refresh_token: '11111.valid-refresh-token',
+  },
+};
+
+let mockShopId = '22222';
+
+export function setTokenExchangeResponse(resp: TokenResponse): void {
+  tokenResponse = resp;
+}
+
+export function setShopId(shopId: string): void {
+  mockShopId = shopId;
+}
+
+export function getMockShopId(): string {
+  return mockShopId;
+}
+
+export function resetOAuthState(): void {
+  tokenResponse = {
+    status: 200,
+    body: {
+      access_token: '11111.valid-access-token',
+      token_type: 'Bearer',
+      expires_in: 3600,
+      refresh_token: '11111.valid-refresh-token',
+    },
+  };
+  mockShopId = '22222';
+}
+
+export function registerEtsyOAuthRoutes(server: EtsyMockServer): void {
+  server.post('/v3/public/oauth/token', () => tokenResponse);
+}

--- a/libs/firebase/etsy-test-mock-server/start.ts
+++ b/libs/firebase/etsy-test-mock-server/start.ts
@@ -1,0 +1,36 @@
+/**
+ * Standalone script to start the Etsy mock server for integration tests.
+ *
+ * Usage: npx tsx libs/firebase/etsy-test-mock-server/start.ts
+ *
+ * Starts on port 9998 (or ETSY_MOCK_SERVER_PORT env var).
+ * Sibling to the monolithic integration-test-mock-server (port 9999);
+ * see the follow-up issue for eventually splitting that one by service.
+ */
+import { createEtsyMockServer } from './src/lib/create-etsy-mock-server.js';
+
+const port = parseInt(process.env['ETSY_MOCK_SERVER_PORT'] ?? '9998', 10);
+const mock = createEtsyMockServer();
+
+async function main(): Promise<void> {
+  await mock.server.start(port);
+  console.log(`Etsy mock server running on http://localhost:${port}`);
+  console.log(
+    'Routes: listings (/v3/application/*), OAuth (/v3/public/oauth/*), mock images (/mock-images/*)'
+  );
+
+  process.on('SIGINT', async () => {
+    await mock.server.stop();
+    process.exit(0);
+  });
+
+  process.on('SIGTERM', async () => {
+    await mock.server.stop();
+    process.exit(0);
+  });
+}
+
+main().catch((err) => {
+  console.error('Failed to start Etsy mock server:', err);
+  process.exit(1);
+});

--- a/libs/firebase/etsy-test-mock-server/tsconfig.json
+++ b/libs/firebase/etsy-test-mock-server/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/etsy-test-mock-server/tsconfig.lib.json
+++ b/libs/firebase/etsy-test-mock-server/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/etsy/src/lib/http/etsy-http.ts
+++ b/libs/firebase/etsy/src/lib/http/etsy-http.ts
@@ -10,7 +10,6 @@
  * This module has zero external dependencies — uses only Node.js fetch.
  */
 import type { OAuthService } from '../oauth/oauth.service.js';
-import type { EtsyApiError } from '../types/common.types.js';
 
 const ETSY_API_BASE_DEFAULT = 'https://api.etsy.com/v3/application';
 

--- a/libs/firebase/etsy/src/lib/http/etsy-http.ts
+++ b/libs/firebase/etsy/src/lib/http/etsy-http.ts
@@ -12,7 +12,16 @@
 import type { OAuthService } from '../oauth/oauth.service.js';
 import type { EtsyApiError } from '../types/common.types.js';
 
-const ETSY_API_BASE = 'https://api.etsy.com/v3/application';
+const ETSY_API_BASE_DEFAULT = 'https://api.etsy.com/v3/application';
+
+/**
+ * API base URL for all `/application/*` calls. Integration tests point
+ * this at a mock server via the ETSY_API_BASE env var; production uses
+ * the default Etsy endpoint.
+ */
+function getEtsyApiBase(): string {
+  return process.env['ETSY_API_BASE'] ?? ETSY_API_BASE_DEFAULT;
+}
 
 /** Minimum delay between requests to stay under 5 QPS */
 const MIN_REQUEST_INTERVAL_MS = 210;
@@ -180,7 +189,7 @@ export class EtsyHttp {
    * Build a full API URL from a path and optional query parameters.
    */
   private buildUrl(path: string, params?: Record<string, string>): string {
-    const url = new URL(`${ETSY_API_BASE}${path}`);
+    const url = new URL(`${getEtsyApiBase()}${path}`);
     if (params) {
       for (const [key, value] of Object.entries(params)) {
         url.searchParams.set(key, value);

--- a/libs/firebase/etsy/src/lib/oauth/oauth.service.ts
+++ b/libs/firebase/etsy/src/lib/oauth/oauth.service.ts
@@ -20,7 +20,15 @@ import {
 } from './pkce.js';
 
 const ETSY_AUTH_URL = 'https://www.etsy.com/oauth/connect';
-const ETSY_TOKEN_URL = 'https://api.etsy.com/v3/public/oauth/token';
+const ETSY_TOKEN_URL_DEFAULT = 'https://api.etsy.com/v3/public/oauth/token';
+
+/**
+ * OAuth token endpoint. Overridable via ETSY_TOKEN_URL for integration
+ * tests; production uses the default Etsy endpoint.
+ */
+function getEtsyTokenUrl(): string {
+  return process.env['ETSY_TOKEN_URL'] ?? ETSY_TOKEN_URL_DEFAULT;
+}
 
 /** Buffer before expiry to trigger refresh (5 minutes) */
 const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
@@ -89,7 +97,7 @@ export class OAuthService {
       code_verifier: params.codeVerifier,
     });
 
-    const response = await fetch(ETSY_TOKEN_URL, {
+    const response = await fetch(getEtsyTokenUrl(), {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: body.toString(),
@@ -147,7 +155,7 @@ export class OAuthService {
       refresh_token: refreshToken,
     });
 
-    const response = await fetch(ETSY_TOKEN_URL, {
+    const response = await fetch(getEtsyTokenUrl(), {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: body.toString(),

--- a/libs/firebase/etsy/src/lib/services/listing.service.ts
+++ b/libs/firebase/etsy/src/lib/services/listing.service.ts
@@ -164,12 +164,15 @@ export class ListingService {
   ): Promise<EtsyListingImage> {
     const id = await this.shopId();
     const formData = new FormData();
-    // Cast through BlobPart[]: Node's Buffer extends Uint8Array and is a
-    // valid BlobPart at runtime, but lib.dom's Uint8Array generic doesn't
-    // accept the widened ArrayBufferLike that Node uses.
-    const blob = new Blob([imageBuffer as unknown as BlobPart], {
-      type: contentType,
-    });
+    // Node's Buffer is accepted by Blob at runtime in both Node and the
+    // browser, but its TypeScript type doesn't line up with the DOM
+    // BlobPart definition on every tsconfig. Cast the parts array to
+    // `unknown[]` to stay off DOM-only types (the functions build is
+    // Node-only).
+    const blob = new Blob(
+      [imageBuffer] as unknown as ConstructorParameters<typeof Blob>[0],
+      { type: contentType }
+    );
     formData.append('image', blob, filename);
     formData.append('rank', String(rank));
 

--- a/libs/firebase/etsy/src/lib/services/listing.service.ts
+++ b/libs/firebase/etsy/src/lib/services/listing.service.ts
@@ -164,7 +164,12 @@ export class ListingService {
   ): Promise<EtsyListingImage> {
     const id = await this.shopId();
     const formData = new FormData();
-    const blob = new Blob([imageBuffer], { type: contentType });
+    // Cast through BlobPart[]: Node's Buffer extends Uint8Array and is a
+    // valid BlobPart at runtime, but lib.dom's Uint8Array generic doesn't
+    // accept the widened ArrayBufferLike that Node uses.
+    const blob = new Blob([imageBuffer as unknown as BlobPart], {
+      type: contentType,
+    });
     formData.append('image', blob, filename);
     formData.append('rank', String(rank));
 

--- a/libs/firebase/integration-test-utils/src/lib/utils/emulator-config.ts
+++ b/libs/firebase/integration-test-utils/src/lib/utils/emulator-config.ts
@@ -5,6 +5,7 @@ const FIRESTORE_PORT = 8080 + OFFSET;
 const AUTH_PORT = 9099 + OFFSET;
 const ORIGIN_PORT = 3000 + OFFSET;
 const MOCK_SERVER_PORT = 9999 + OFFSET;
+const ETSY_MOCK_SERVER_PORT = 9998 + OFFSET;
 
 export const EMULATOR_CONFIG = {
   projectId: 'maple-and-spruce-dev',
@@ -13,7 +14,10 @@ export const EMULATOR_CONFIG = {
   authHost: `localhost:${AUTH_PORT}`,
   region: 'us-east4',
   origin: `http://localhost:${ORIGIN_PORT}`,
+  /** Monolithic mock server (Square + Webflow routes) */
   mockServerUrl: `http://localhost:${MOCK_SERVER_PORT}`,
+  /** Dedicated Etsy mock server */
+  etsyMockServerUrl: `http://localhost:${ETSY_MOCK_SERVER_PORT}`,
   portOffset: OFFSET,
 } as const;
 

--- a/libs/firebase/maple-functions/etsy-auth-callback/src/lib/etsy-auth-callback.ts
+++ b/libs/firebase/maple-functions/etsy-auth-callback/src/lib/etsy-auth-callback.ts
@@ -62,10 +62,12 @@ export const etsyAuthCallback = Functions.endpoint
       // Fetch the shop ID from Etsy.
       // The token response includes the user ID but not the shop ID.
       // We need to call the API to get it.
+      const etsyApiBase =
+        process.env['ETSY_API_BASE'] ?? 'https://api.etsy.com/v3/application';
       let shopId = '';
       try {
         const response = await fetch(
-          `https://api.etsy.com/v3/application/users/${tokenData.userId}/shops`,
+          `${etsyApiBase}/users/${tokenData.userId}/shops`,
           {
             headers: {
               'x-api-key': `${secrets.ETSY_API_KEY}:${secrets.ETSY_SHARED_SECRET}`,

--- a/libs/firebase/maple-functions/import-etsy-listings/project.json
+++ b/libs/firebase/maple-functions/import-etsy-listings/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-import-etsy-listings",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/import-etsy-listings/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/import-etsy-listings/src/index.ts
+++ b/libs/firebase/maple-functions/import-etsy-listings/src/index.ts
@@ -1,0 +1,1 @@
+export { importEtsyListings } from './lib/import-etsy-listings';

--- a/libs/firebase/maple-functions/import-etsy-listings/src/lib/import-etsy-listings.spec.ts
+++ b/libs/firebase/maple-functions/import-etsy-listings/src/lib/import-etsy-listings.spec.ts
@@ -1,0 +1,426 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Tests for importEtsyListings Cloud Function
+ *
+ * Focus: per-row import semantics — short-circuits for already-imported
+ * and multi-variant listings, happy-path wiring into Square + Firestore,
+ * and that image-download failures don't block the import.
+ */
+
+const mocks = vi.hoisted(() => {
+  class EtsyHttpErrorStub extends Error {
+    constructor(
+      public readonly status: number,
+      public readonly statusText: string,
+      public readonly body: string
+    ) {
+      super(`Etsy API error ${status}: ${statusText} — ${body}`);
+      this.name = 'EtsyHttpError';
+    }
+  }
+  return {
+    EtsyHttpErrorStub,
+    // Etsy
+    getListing: vi.fn(),
+    // Firestore
+    findByEtsyListingId: vi.fn(),
+    findById: vi.fn(),
+    createProduct: vi.fn(),
+    updateEtsyCache: vi.fn(),
+    createImport: vi.fn(),
+    // Square
+    createItem: vi.fn(),
+    setQuantity: vi.fn(),
+    uploadImage: vi.fn(),
+    // network
+    mockFetch: vi.fn(),
+    capturedHandler: null as ((...args: unknown[]) => Promise<unknown>) | null,
+  };
+});
+
+vi.mock('@maple/firebase/database', () => ({
+  FirestoreTokenStorage: { getTokens: vi.fn() },
+  ProductRepository: {
+    findByEtsyListingId: mocks.findByEtsyListingId,
+    findById: mocks.findById,
+    create: mocks.createProduct,
+    updateEtsyCache: mocks.updateEtsyCache,
+  },
+  EtsyImportRepository: {
+    create: mocks.createImport,
+  },
+}));
+
+vi.mock('@maple/firebase/etsy', () => ({
+  EtsyClient: class {
+    listings = { getListing: mocks.getListing };
+  },
+  EtsyHttpError: mocks.EtsyHttpErrorStub,
+}));
+
+vi.mock('@maple/firebase/square', () => ({
+  SQUARE_SECRET_NAMES: ['SQUARE_ACCESS_TOKEN'],
+  SQUARE_STRING_NAMES: ['SQUARE_ENV', 'SQUARE_LOCATION_ID', 'SALES_TAX_RATE'],
+  Square: class {
+    locationId = 'location-abc';
+    catalogService = {
+      createItem: mocks.createItem,
+      uploadImage: mocks.uploadImage,
+    };
+    inventoryService = { setQuantity: mocks.setQuantity };
+  },
+}));
+
+vi.mock('@maple/firebase/functions', () => ({
+  Functions: {
+    endpoint: {
+      usingSecrets: vi.fn().mockReturnThis(),
+      usingStrings: vi.fn().mockReturnThis(),
+      requiringRole: vi.fn().mockReturnThis(),
+      handle: vi.fn((handler: (...args: unknown[]) => Promise<unknown>) => {
+        mocks.capturedHandler = handler;
+        return 'mock-function';
+      }),
+    },
+  },
+  Role: { Admin: 'admin' },
+}));
+
+import './import-etsy-listings';
+
+const secrets = {
+  SQUARE_ACCESS_TOKEN: 'sqt',
+  ETSY_API_KEY: 'ek',
+  ETSY_SHARED_SECRET: 'es',
+};
+const strings = {
+  SQUARE_ENV: 'LOCAL',
+  SQUARE_LOCATION_ID: 'location-abc',
+  SALES_TAX_RATE: '6.0',
+  ETSY_REDIRECT_URI: 'https://example.com/callback',
+};
+
+function makeSimpleListing(overrides: Record<string, unknown> = {}) {
+  return {
+    listing_id: 1001,
+    title: 'Handmade Mug',
+    description: 'A mug',
+    state: 'active',
+    price: { amount: 2500, divisor: 100, currency_code: 'USD' },
+    quantity: 5,
+    taxonomy_id: 42,
+    tags: ['pottery'],
+    url: 'https://etsy.com/listing/1001',
+    images: [
+      {
+        rank: 1,
+        url_fullxfull: 'https://etsy.com/img/1001-full.jpg',
+        url_570xN: 'https://etsy.com/img/1001-570.jpg',
+      },
+    ],
+    inventory: {
+      products: [
+        {
+          sku: 'etsy-sku-1',
+          offerings: [],
+          property_values: [],
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+function happyPathMocks() {
+  mocks.findByEtsyListingId.mockResolvedValue(undefined);
+  mocks.getListing.mockResolvedValue(makeSimpleListing());
+  mocks.createItem.mockResolvedValue({
+    squareItemId: 'sqi-1',
+    squareVariationId: 'sqv-1',
+    squareCatalogVersion: 1,
+    sku: 'etsy-sku-1',
+  });
+  mocks.setQuantity.mockResolvedValue(undefined);
+  mocks.mockFetch.mockResolvedValue({
+    ok: true,
+    arrayBuffer: async () => new ArrayBuffer(8),
+    headers: { get: () => 'image/jpeg' },
+  });
+  mocks.uploadImage.mockResolvedValue({
+    squareImageId: 'img-1',
+    imageUrl: 'https://square.com/img/1',
+    squareCatalogVersion: 2,
+  });
+  mocks.createProduct.mockResolvedValue({
+    id: 'prod-1',
+    squareItemId: 'sqi-1',
+  });
+  mocks.updateEtsyCache.mockResolvedValue(undefined);
+  mocks.createImport.mockResolvedValue({ id: 'prod-1' });
+  mocks.findById.mockResolvedValue({
+    id: 'prod-1',
+    etsyListingId: '1001',
+    squareCache: {},
+    etsyCache: {},
+  });
+}
+
+describe('importEtsyListings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', mocks.mockFetch);
+    vi.stubGlobal('Blob', class {});
+  });
+
+  it('short-circuits when a listing is already imported', async () => {
+    mocks.findByEtsyListingId.mockResolvedValue({
+      id: 'existing-product',
+      etsyListingId: '1001',
+    });
+
+    const result = (await mocks.capturedHandler!(
+      {
+        listings: [{ listingId: '1001' }],
+        artistId: 'artist-1',
+        status: 'active',
+      },
+      { uid: 'admin-1' },
+      secrets,
+      strings
+    )) as { results: Array<{ errorCode: string; success: boolean }> };
+
+    expect(result.results[0].success).toBe(false);
+    expect(result.results[0].errorCode).toBe('ALREADY_IMPORTED');
+    expect(mocks.getListing).not.toHaveBeenCalled();
+    expect(mocks.createItem).not.toHaveBeenCalled();
+  });
+
+  it('flags multi-variant listings and skips Square calls', async () => {
+    mocks.findByEtsyListingId.mockResolvedValue(undefined);
+    mocks.getListing.mockResolvedValue(
+      makeSimpleListing({
+        inventory: {
+          products: [
+            { sku: 'v1', offerings: [], property_values: [] },
+            { sku: 'v2', offerings: [], property_values: [] },
+          ],
+        },
+      })
+    );
+
+    const result = (await mocks.capturedHandler!(
+      {
+        listings: [{ listingId: '1001' }],
+        artistId: 'artist-1',
+        status: 'active',
+      },
+      { uid: 'admin-1' },
+      secrets,
+      strings
+    )) as { results: Array<{ errorCode: string; success: boolean }> };
+
+    expect(result.results[0].success).toBe(false);
+    expect(result.results[0].errorCode).toBe('MULTI_VARIANT_NOT_SUPPORTED');
+    expect(mocks.createItem).not.toHaveBeenCalled();
+  });
+
+  it('maps Etsy 404 to LISTING_NOT_FOUND', async () => {
+    mocks.findByEtsyListingId.mockResolvedValue(undefined);
+    mocks.getListing.mockRejectedValue(
+      new mocks.EtsyHttpErrorStub(404, 'Not Found', '{}')
+    );
+
+    const result = (await mocks.capturedHandler!(
+      {
+        listings: [{ listingId: '9999' }],
+        artistId: 'artist-1',
+        status: 'active',
+      },
+      { uid: 'admin-1' },
+      secrets,
+      strings
+    )) as { results: Array<{ errorCode: string; success: boolean }> };
+
+    expect(result.results[0].errorCode).toBe('LISTING_NOT_FOUND');
+    expect(result.results[0].success).toBe(false);
+  });
+
+  it('happy path creates Square item, Product, cache, and snapshot', async () => {
+    happyPathMocks();
+
+    const result = (await mocks.capturedHandler!(
+      {
+        listings: [{ listingId: '1001' }],
+        artistId: 'artist-1',
+        categoryId: 'cat-1',
+        status: 'active',
+      },
+      { uid: 'admin-1' },
+      secrets,
+      strings
+    )) as {
+      results: Array<{ success: boolean; productId: string }>;
+      successCount: number;
+    };
+
+    expect(result.successCount).toBe(1);
+    expect(result.results[0].success).toBe(true);
+    expect(result.results[0].productId).toBe('prod-1');
+
+    expect(mocks.createItem).toHaveBeenCalledWith({
+      name: 'Handmade Mug',
+      description: 'A mug',
+      priceCents: 2500,
+      sku: 'etsy-sku-1',
+    });
+    expect(mocks.setQuantity).toHaveBeenCalledWith({
+      squareVariationId: 'sqv-1',
+      locationId: 'location-abc',
+      quantity: 5,
+    });
+    expect(mocks.createProduct).toHaveBeenCalledWith(
+      expect.objectContaining({
+        artistId: 'artist-1',
+        categoryId: 'cat-1',
+        status: 'active',
+        priceCents: 2500,
+        quantity: 5,
+      }),
+      expect.objectContaining({
+        squareItemId: 'sqi-1',
+        squareVariationId: 'sqv-1',
+      })
+    );
+    expect(mocks.updateEtsyCache).toHaveBeenCalledWith(
+      'prod-1',
+      '1001',
+      expect.objectContaining({
+        title: 'Handmade Mug',
+        priceCents: 2500,
+        taxonomyId: 42,
+        state: 'active',
+      })
+    );
+    expect(mocks.createImport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        productId: 'prod-1',
+        listingId: '1001',
+        variantCount: 1,
+        importedBy: 'admin-1',
+      })
+    );
+  });
+
+  it('swallows image-download failures and still imports', async () => {
+    happyPathMocks();
+    mocks.mockFetch.mockRejectedValue(new Error('Network error'));
+
+    const result = (await mocks.capturedHandler!(
+      {
+        listings: [{ listingId: '1001' }],
+        artistId: 'artist-1',
+        status: 'active',
+      },
+      { uid: 'admin-1' },
+      secrets,
+      strings
+    )) as { results: Array<{ success: boolean }> };
+
+    expect(result.results[0].success).toBe(true);
+    expect(mocks.uploadImage).not.toHaveBeenCalled();
+    expect(mocks.createProduct).toHaveBeenCalled();
+  });
+
+  it('processes multiple listings and counts per-row outcomes', async () => {
+    // Listing A succeeds; listing B is already imported; listing C is multi-variant
+    mocks.findByEtsyListingId
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({ id: 'p-existing', etsyListingId: '1002' })
+      .mockResolvedValueOnce(undefined);
+    mocks.getListing
+      .mockResolvedValueOnce(makeSimpleListing({ listing_id: 1001 }))
+      .mockResolvedValueOnce(
+        makeSimpleListing({
+          listing_id: 1003,
+          inventory: {
+            products: [
+              { sku: 'v1', offerings: [], property_values: [] },
+              { sku: 'v2', offerings: [], property_values: [] },
+            ],
+          },
+        })
+      );
+    mocks.createItem.mockResolvedValue({
+      squareItemId: 'sqi',
+      squareVariationId: 'sqv',
+      squareCatalogVersion: 1,
+      sku: 'sk',
+    });
+    mocks.setQuantity.mockResolvedValue(undefined);
+    mocks.mockFetch.mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => new ArrayBuffer(8),
+      headers: { get: () => 'image/jpeg' },
+    });
+    mocks.uploadImage.mockResolvedValue({
+      squareImageId: 'i',
+      imageUrl: '',
+      squareCatalogVersion: 2,
+    });
+    mocks.createProduct.mockResolvedValue({ id: 'p-new' });
+    mocks.updateEtsyCache.mockResolvedValue(undefined);
+    mocks.createImport.mockResolvedValue({ id: 'p-new' });
+    mocks.findById.mockResolvedValue({ id: 'p-new', etsyCache: {} });
+
+    const result = (await mocks.capturedHandler!(
+      {
+        listings: [
+          { listingId: '1001' },
+          { listingId: '1002' },
+          { listingId: '1003' },
+        ],
+        artistId: 'artist-1',
+        status: 'active',
+      },
+      { uid: 'admin-1' },
+      secrets,
+      strings
+    )) as {
+      results: Array<{ success: boolean; errorCode?: string }>;
+      successCount: number;
+      failureCount: number;
+    };
+
+    expect(result.successCount).toBe(1);
+    expect(result.failureCount).toBe(2);
+    expect(result.results[0].success).toBe(true);
+    expect(result.results[1].errorCode).toBe('ALREADY_IMPORTED');
+    expect(result.results[2].errorCode).toBe('MULTI_VARIANT_NOT_SUPPORTED');
+  });
+
+  it('returns empty results for empty input', async () => {
+    const result = (await mocks.capturedHandler!(
+      { listings: [], artistId: 'artist-1', status: 'active' },
+      { uid: 'admin-1' },
+      secrets,
+      strings
+    )) as { results: unknown[]; successCount: number; failureCount: number };
+
+    expect(result.results).toEqual([]);
+    expect(result.successCount).toBe(0);
+    expect(result.failureCount).toBe(0);
+    expect(mocks.getListing).not.toHaveBeenCalled();
+  });
+
+  it('throws when artistId is missing', async () => {
+    await expect(
+      mocks.capturedHandler!(
+        { listings: [{ listingId: '1001' }], status: 'active' },
+        { uid: 'admin-1' },
+        secrets,
+        strings
+      )
+    ).rejects.toThrow('artistId is required');
+  });
+});

--- a/libs/firebase/maple-functions/import-etsy-listings/src/lib/import-etsy-listings.ts
+++ b/libs/firebase/maple-functions/import-etsy-listings/src/lib/import-etsy-listings.ts
@@ -1,0 +1,348 @@
+/**
+ * Import Etsy Listings Cloud Function
+ *
+ * Bulk-imports selected Etsy listings into our Product catalog as a
+ * read-only pull (no writes to Etsy). For each selected listing:
+ *   1. Fetch the full listing (+ images + inventory) from Etsy.
+ *   2. Skip multi-variant listings (not supported in this pass).
+ *   3. Skip listings already linked to a Product (idempotent re-runs).
+ *   4. Create a Square catalog item with the listing's name/price.
+ *   5. Set initial Square inventory quantity from the listing.
+ *   6. Best-effort: download the primary Etsy image and attach it to the
+ *      Square catalog item so the image shows up in our normal product UI.
+ *   7. Create the Firestore Product linking Square + Etsy, with caches.
+ *   8. Persist the raw Etsy listing+inventory to `etsy-imports/{productId}`
+ *      so we can mine it later for template seeding and insights.
+ *
+ * Every row's outcome is reported back independently so the UI can show
+ * per-row success/failure without aborting the whole batch.
+ *
+ * Admin only. Lives in the functions-square codebase since each import
+ * calls Square catalog + inventory APIs.
+ */
+import { Functions, Role } from '@maple/firebase/functions';
+import {
+  FirestoreTokenStorage,
+  ProductRepository,
+  EtsyImportRepository,
+} from '@maple/firebase/database';
+import {
+  Square,
+  SQUARE_SECRET_NAMES,
+  SQUARE_STRING_NAMES,
+} from '@maple/firebase/square';
+import {
+  EtsyClient,
+  EtsyHttpError,
+  type EtsyListing,
+  type EtsyListingImage,
+} from '@maple/firebase/etsy';
+import type {
+  ImportEtsyListingsRequest,
+  ImportEtsyListingsResponse,
+  ImportEtsyListingResult,
+} from '@maple/ts/firebase/api-types';
+import type { Product } from '@maple/ts/domain';
+
+const ETSY_SECRET_NAMES = ['ETSY_API_KEY', 'ETSY_SHARED_SECRET'] as const;
+const ETSY_STRING_NAMES = ['ETSY_REDIRECT_URI'] as const;
+
+type EtsyRaw = Record<string, unknown>;
+
+/**
+ * Convert Etsy's {amount, divisor, currency_code} money shape to cents.
+ * Etsy's divisor is almost always 100 (so amount is already in cents), but
+ * the math here makes no assumption and handles any divisor correctly.
+ */
+function etsyPriceToCents(price: EtsyListing['price']): number {
+  if (!price || typeof price.amount !== 'number' || !price.divisor) return 0;
+  return Math.round((price.amount / price.divisor) * 100);
+}
+
+/**
+ * Pick the primary listing image (lowest rank), preferring the largest URL.
+ */
+function pickPrimaryImageUrl(
+  images: EtsyListingImage[] | undefined
+): string | undefined {
+  if (!images || images.length === 0) return undefined;
+  const sorted = [...images].sort((a, b) => a.rank - b.rank);
+  const primary = sorted[0];
+  return primary.url_fullxfull ?? primary.url_570xN ?? primary.url_170x135;
+}
+
+/**
+ * Download an image URL and upload it to the Square catalog item.
+ * Best-effort: failure is logged and swallowed so the product still imports.
+ */
+async function tryAttachImageToSquare(
+  square: Square,
+  squareItemId: string,
+  imageUrl: string | undefined
+): Promise<number | undefined> {
+  if (!imageUrl) return undefined;
+
+  try {
+    const response = await fetch(imageUrl);
+    if (!response.ok) {
+      console.warn(
+        `Failed to download Etsy image (${response.status}): ${imageUrl}`
+      );
+      return undefined;
+    }
+    const arrayBuffer = await response.arrayBuffer();
+    const contentType =
+      response.headers.get('content-type') ?? 'image/jpeg';
+    const blob = new Blob([arrayBuffer], { type: contentType });
+    const ext = contentType.split('/')[1] ?? 'jpg';
+    const uploaded = await square.catalogService.uploadImage({
+      squareItemId,
+      imageBlob: blob,
+      filename: `etsy-import.${ext}`,
+      isPrimary: true,
+    });
+    return uploaded.squareCatalogVersion;
+  } catch (err) {
+    console.warn('Failed to attach Etsy image to Square:', err);
+    return undefined;
+  }
+}
+
+/**
+ * Import a single Etsy listing. Returns a per-row result; never throws.
+ */
+async function importSingleListing(options: {
+  listingId: string;
+  artistId: string;
+  categoryId?: string;
+  status: ImportEtsyListingsRequest['status'];
+  customCommissionRate?: number;
+  client: EtsyClient;
+  square: Square;
+  importedBy: string;
+}): Promise<ImportEtsyListingResult> {
+  const {
+    listingId,
+    artistId,
+    categoryId,
+    status,
+    customCommissionRate,
+    client,
+    square,
+    importedBy,
+  } = options;
+
+  try {
+    // Short-circuit on already-imported so we don't even hit Etsy.
+    const existing = await ProductRepository.findByEtsyListingId(listingId);
+    if (existing) {
+      return {
+        listingId,
+        success: false,
+        error: `Listing ${listingId} is already linked to product ${existing.id}`,
+        errorCode: 'ALREADY_IMPORTED',
+        productId: existing.id,
+      };
+    }
+
+    let listing: EtsyListing;
+    try {
+      listing = await client.listings.getListing(
+        Number(listingId),
+        'Images,Inventory'
+      );
+    } catch (err) {
+      if (err instanceof EtsyHttpError && err.status === 404) {
+        return {
+          listingId,
+          success: false,
+          error: `Listing ${listingId} not found on Etsy`,
+          errorCode: 'LISTING_NOT_FOUND',
+        };
+      }
+      throw err;
+    }
+
+    const variantCount = listing.inventory?.products?.length ?? 1;
+    if (variantCount > 1) {
+      return {
+        listingId,
+        success: false,
+        error: `Listing has ${variantCount} variants; multi-variant imports are not yet supported`,
+        errorCode: 'MULTI_VARIANT_NOT_SUPPORTED',
+      };
+    }
+
+    const priceCents = etsyPriceToCents(listing.price);
+    const quantity = listing.quantity ?? 0;
+    const etsySku = listing.inventory?.products?.[0]?.sku || undefined;
+
+    // 1. Create Square catalog item
+    let catalogResult;
+    try {
+      catalogResult = await square.catalogService.createItem({
+        name: listing.title,
+        description: listing.description,
+        priceCents,
+        sku: etsySku,
+      });
+    } catch (err) {
+      return {
+        listingId,
+        success: false,
+        error: `Square catalog create failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        errorCode: 'SQUARE_CREATE_FAILED',
+      };
+    }
+
+    // 2. Set Square inventory quantity (non-fatal if this fails — we still
+    //    have a valid catalog item and Product link; the admin can fix qty.)
+    if (quantity > 0) {
+      try {
+        await square.inventoryService.setQuantity({
+          squareVariationId: catalogResult.squareVariationId,
+          locationId: square.locationId,
+          quantity,
+        });
+      } catch (err) {
+        console.warn(
+          `Failed to set initial inventory for listing ${listingId}:`,
+          err
+        );
+      }
+    }
+
+    // 3. Best-effort: attach primary Etsy image to the Square item so it
+    //    shows up in our normal product UI.
+    const imageUrl = pickPrimaryImageUrl(listing.images);
+    const newCatalogVersion = await tryAttachImageToSquare(
+      square,
+      catalogResult.squareItemId,
+      imageUrl
+    );
+
+    // 4. Create Firestore Product
+    const product = await ProductRepository.create(
+      {
+        artistId,
+        categoryId,
+        customCommissionRate,
+        status,
+        name: listing.title,
+        description: listing.description,
+        priceCents,
+        quantity,
+      },
+      {
+        squareItemId: catalogResult.squareItemId,
+        squareVariationId: catalogResult.squareVariationId,
+        squareCatalogVersion:
+          newCatalogVersion ?? catalogResult.squareCatalogVersion,
+        squareLocationId: square.locationId,
+        sku: catalogResult.sku,
+      }
+    );
+
+    // 5. Link Etsy listing + populate etsyCache
+    await ProductRepository.updateEtsyCache(product.id, listingId, {
+      title: listing.title,
+      description: listing.description,
+      priceCents,
+      quantity,
+      url: listing.url,
+      taxonomyId: listing.taxonomy_id,
+      tags: listing.tags,
+      state:
+        listing.state === 'active' || listing.state === 'draft'
+          ? listing.state
+          : 'inactive',
+      syncedAt: new Date(),
+    });
+
+    // 6. Persist raw snapshot for later insights / template seeding
+    await EtsyImportRepository.create({
+      productId: product.id,
+      listingId,
+      rawListing: listing as unknown as EtsyRaw,
+      rawInventory: listing.inventory as unknown as EtsyRaw | undefined,
+      variantCount,
+      importedBy,
+    });
+
+    // Refetch to return the Product with populated etsyCache.
+    const refreshed = (await ProductRepository.findById(product.id)) as Product;
+
+    return {
+      listingId,
+      success: true,
+      productId: product.id,
+      product: refreshed,
+    };
+  } catch (err) {
+    console.error(`Failed to import Etsy listing ${listingId}:`, err);
+    return {
+      listingId,
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+      errorCode: 'INTERNAL_ERROR',
+    };
+  }
+}
+
+export const importEtsyListings = Functions.endpoint
+  .usingSecrets(...SQUARE_SECRET_NAMES, ...ETSY_SECRET_NAMES)
+  .usingStrings(...SQUARE_STRING_NAMES, ...ETSY_STRING_NAMES)
+  .requiringRole(Role.Admin)
+  .handle<ImportEtsyListingsRequest, ImportEtsyListingsResponse>(
+    async (data, context, secrets, strings) => {
+      if (!data.listings || data.listings.length === 0) {
+        return { results: [], successCount: 0, failureCount: 0 };
+      }
+      if (!data.artistId) {
+        throw new Error('artistId is required for bulk Etsy import');
+      }
+
+      const client = new EtsyClient({
+        apiKey: secrets.ETSY_API_KEY,
+        sharedSecret: secrets.ETSY_SHARED_SECRET,
+        tokenStorage: FirestoreTokenStorage,
+        redirectUri: strings.ETSY_REDIRECT_URI,
+      });
+
+      const square = new Square(
+        secrets as typeof secrets &
+          Record<(typeof SQUARE_SECRET_NAMES)[number], string>,
+        strings as typeof strings &
+          Record<(typeof SQUARE_STRING_NAMES)[number], string>
+      );
+
+      const importedBy = context?.uid ?? 'system';
+
+      // Sequential, not parallel: Square rate-limits, and parallel runs
+      // would also make error logs harder to interpret. The admin UI
+      // already warns that bulk import is not instant.
+      const results: ImportEtsyListingResult[] = [];
+      for (const { listingId } of data.listings) {
+        const result = await importSingleListing({
+          listingId,
+          artistId: data.artistId,
+          categoryId: data.categoryId,
+          status: data.status,
+          customCommissionRate: data.customCommissionRate,
+          client,
+          square,
+          importedBy,
+        });
+        results.push(result);
+      }
+
+      const successCount = results.filter((r) => r.success).length;
+      return {
+        results,
+        successCount,
+        failureCount: results.length - successCount,
+      };
+    }
+  );

--- a/libs/firebase/maple-functions/import-etsy-listings/tsconfig.json
+++ b/libs/firebase/maple-functions/import-etsy-listings/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/import-etsy-listings/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/import-etsy-listings/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/list-etsy-listings/project.json
+++ b/libs/firebase/maple-functions/list-etsy-listings/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-list-etsy-listings",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/list-etsy-listings/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/list-etsy-listings/src/index.ts
+++ b/libs/firebase/maple-functions/list-etsy-listings/src/index.ts
@@ -1,0 +1,1 @@
+export { listEtsyListings } from './lib/list-etsy-listings';

--- a/libs/firebase/maple-functions/list-etsy-listings/src/lib/list-etsy-listings.spec.ts
+++ b/libs/firebase/maple-functions/list-etsy-listings/src/lib/list-etsy-listings.spec.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Tests for listEtsyListings Cloud Function
+ *
+ * Focus: the cross-reference logic that maps Etsy listings to Firestore
+ * Products and flags multi-variant listings as unsupported for import.
+ */
+
+const mocks = vi.hoisted(() => {
+  return {
+    getListings: vi.fn(),
+    findByEtsyListingIds: vi.fn(),
+    capturedHandler: null as ((...args: unknown[]) => Promise<unknown>) | null,
+  };
+});
+
+vi.mock('@maple/firebase/database', () => ({
+  FirestoreTokenStorage: { getTokens: vi.fn() },
+  ProductRepository: {
+    findByEtsyListingIds: mocks.findByEtsyListingIds,
+  },
+}));
+
+vi.mock('@maple/firebase/etsy', () => ({
+  EtsyClient: class {
+    listings = { getListings: mocks.getListings };
+  },
+}));
+
+vi.mock('@maple/firebase/functions', () => ({
+  Functions: {
+    endpoint: {
+      usingSecrets: vi.fn().mockReturnThis(),
+      usingStrings: vi.fn().mockReturnThis(),
+      requiringRole: vi.fn().mockReturnThis(),
+      handle: vi.fn((handler: (...args: unknown[]) => Promise<unknown>) => {
+        mocks.capturedHandler = handler;
+        return 'mock-function';
+      }),
+    },
+  },
+  Role: { Admin: 'admin' },
+}));
+
+import './list-etsy-listings';
+
+const secrets = { ETSY_API_KEY: 'key', ETSY_SHARED_SECRET: 'secret' };
+const strings = { ETSY_REDIRECT_URI: 'https://example.com/callback' };
+
+function makeListing(
+  overrides: Partial<{
+    listing_id: number;
+    title: string;
+    variants: number;
+  }> = {}
+) {
+  const listingId = overrides.listing_id ?? 1001;
+  const variants = overrides.variants ?? 1;
+  return {
+    listing_id: listingId,
+    title: overrides.title ?? `Listing ${listingId}`,
+    inventory: {
+      products: Array.from({ length: variants }, (_, i) => ({
+        product_id: i + 1,
+        offerings: [],
+        property_values: [],
+      })),
+    },
+  };
+}
+
+describe('listEtsyListings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('flags listings as imported when a matching Product exists', async () => {
+    mocks.getListings.mockResolvedValue({
+      count: 2,
+      results: [
+        makeListing({ listing_id: 1001, title: 'Imported' }),
+        makeListing({ listing_id: 1002, title: 'Not imported' }),
+      ],
+    });
+    mocks.findByEtsyListingIds.mockResolvedValue([
+      { id: 'prod-abc', etsyListingId: '1001' },
+    ]);
+
+    const result = (await mocks.capturedHandler!(
+      {},
+      { uid: 'admin-1' },
+      secrets,
+      strings
+    )) as { listings: { imported: boolean; productId?: string }[] };
+
+    expect(result.listings[0].imported).toBe(true);
+    expect(result.listings[0].productId).toBe('prod-abc');
+    expect(result.listings[1].imported).toBe(false);
+    expect(result.listings[1].productId).toBeUndefined();
+  });
+
+  it('flags multi-variant listings as not simple', async () => {
+    mocks.getListings.mockResolvedValue({
+      count: 2,
+      results: [
+        makeListing({ listing_id: 2001, variants: 1 }),
+        makeListing({ listing_id: 2002, variants: 3 }),
+      ],
+    });
+    mocks.findByEtsyListingIds.mockResolvedValue([]);
+
+    const result = (await mocks.capturedHandler!(
+      {},
+      { uid: 'admin-1' },
+      secrets,
+      strings
+    )) as {
+      listings: { variantCount: number; isSimple: boolean }[];
+    };
+
+    expect(result.listings[0].variantCount).toBe(1);
+    expect(result.listings[0].isSimple).toBe(true);
+    expect(result.listings[1].variantCount).toBe(3);
+    expect(result.listings[1].isSimple).toBe(false);
+  });
+
+  it('defaults variantCount to 1 when inventory is missing', async () => {
+    mocks.getListings.mockResolvedValue({
+      count: 1,
+      results: [
+        {
+          listing_id: 3001,
+          title: 'No inventory data',
+        },
+      ],
+    });
+    mocks.findByEtsyListingIds.mockResolvedValue([]);
+
+    const result = (await mocks.capturedHandler!(
+      {},
+      { uid: 'admin-1' },
+      secrets,
+      strings
+    )) as { listings: { variantCount: number; isSimple: boolean }[] };
+
+    expect(result.listings[0].variantCount).toBe(1);
+    expect(result.listings[0].isSimple).toBe(true);
+  });
+
+  it('applies state/limit/offset from the request', async () => {
+    mocks.getListings.mockResolvedValue({ count: 0, results: [] });
+    mocks.findByEtsyListingIds.mockResolvedValue([]);
+
+    await mocks.capturedHandler!(
+      { state: 'draft', limit: 25, offset: 50 },
+      { uid: 'admin-1' },
+      secrets,
+      strings
+    );
+
+    expect(mocks.getListings).toHaveBeenCalledWith('draft', {
+      limit: 25,
+      offset: 50,
+      includes: 'Images,Inventory',
+    });
+  });
+
+  it('defaults to state=active when not provided', async () => {
+    mocks.getListings.mockResolvedValue({ count: 0, results: [] });
+    mocks.findByEtsyListingIds.mockResolvedValue([]);
+
+    await mocks.capturedHandler!({}, { uid: 'admin-1' }, secrets, strings);
+
+    expect(mocks.getListings).toHaveBeenCalledWith(
+      'active',
+      expect.objectContaining({ limit: 100, offset: 0 })
+    );
+  });
+});

--- a/libs/firebase/maple-functions/list-etsy-listings/src/lib/list-etsy-listings.ts
+++ b/libs/firebase/maple-functions/list-etsy-listings/src/lib/list-etsy-listings.ts
@@ -1,0 +1,81 @@
+/**
+ * List Etsy Listings Cloud Function
+ *
+ * Reads the connected shop's listings from Etsy and cross-references them
+ * with Firestore Products (via Product.etsyListingId) so the admin UI can
+ * show which listings have already been imported and which are available.
+ *
+ * Read-only: no writes to Etsy or Firestore. This is the browsing half of
+ * the import flow; actual imports go through importEtsyListings.
+ *
+ * Admin only. Lives in the maple-core codebase since it has no Square dep.
+ */
+import { Functions, Role } from '@maple/firebase/functions';
+import {
+  FirestoreTokenStorage,
+  ProductRepository,
+} from '@maple/firebase/database';
+import { EtsyClient } from '@maple/firebase/etsy';
+import type {
+  ListEtsyListingsRequest,
+  ListEtsyListingsResponse,
+  EtsyListingWithSyncInfo,
+} from '@maple/ts/firebase/api-types';
+
+const ETSY_SECRET_NAMES = ['ETSY_API_KEY', 'ETSY_SHARED_SECRET'] as const;
+const ETSY_STRING_NAMES = ['ETSY_REDIRECT_URI'] as const;
+
+export const listEtsyListings = Functions.endpoint
+  .usingSecrets(...ETSY_SECRET_NAMES)
+  .usingStrings(...ETSY_STRING_NAMES)
+  .requiringRole(Role.Admin)
+  .handle<ListEtsyListingsRequest, ListEtsyListingsResponse>(
+    async (data, _context, secrets, strings) => {
+      const state = data.state ?? 'active';
+      const limit = data.limit ?? 100;
+      const offset = data.offset ?? 0;
+
+      const client = new EtsyClient({
+        apiKey: secrets.ETSY_API_KEY,
+        sharedSecret: secrets.ETSY_SHARED_SECRET,
+        tokenStorage: FirestoreTokenStorage,
+        redirectUri: strings.ETSY_REDIRECT_URI,
+      });
+
+      const page = await client.listings.getListings(state, {
+        limit,
+        offset,
+        includes: 'Images,Inventory',
+      });
+
+      const listingIds = page.results.map((l) => String(l.listing_id));
+      const existingProducts =
+        await ProductRepository.findByEtsyListingIds(listingIds);
+
+      // Map Etsy listing_id → Product for O(1) lookup during the zip below.
+      const productByListingId = new Map(
+        existingProducts
+          .filter((p) => p.etsyListingId)
+          .map((p) => [p.etsyListingId!, p])
+      );
+
+      const listings: EtsyListingWithSyncInfo[] = page.results.map(
+        (listing) => {
+          const variantCount = listing.inventory?.products?.length ?? 1;
+          const product = productByListingId.get(String(listing.listing_id));
+          return {
+            listing,
+            imported: product !== undefined,
+            productId: product?.id,
+            variantCount,
+            isSimple: variantCount <= 1,
+          };
+        }
+      );
+
+      return {
+        listings,
+        total: page.count,
+      };
+    }
+  );

--- a/libs/firebase/maple-functions/list-etsy-listings/tsconfig.json
+++ b/libs/firebase/maple-functions/list-etsy-listings/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/list-etsy-listings/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/list-etsy-listings/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/react/data/src/index.ts
+++ b/libs/react/data/src/index.ts
@@ -23,6 +23,11 @@ export { useCalendarEmbedConfig } from './lib/useCalendarEmbedConfig';
 
 // Phase 5: Etsy Integration
 export { useEtsyConnection } from './lib/useEtsyConnection';
+export {
+  useEtsyListings,
+  type UseEtsyListingsOptions,
+} from './lib/useEtsyListings';
+export { useEtsyImport } from './lib/useEtsyImport';
 
 // Phase 3c: Registration & Discounts
 export {

--- a/libs/react/data/src/lib/useEtsyImport.ts
+++ b/libs/react/data/src/lib/useEtsyImport.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { httpsCallable } from 'firebase/functions';
+import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
+import type { RequestState } from '@maple/ts/domain';
+import type {
+  ImportEtsyListingsRequest,
+  ImportEtsyListingsResponse,
+} from '@maple/ts/firebase/api-types';
+
+/**
+ * Calls the bulk importEtsyListings Cloud Function. Tracks an in-flight
+ * RequestState and exposes the last response so the page can show a
+ * per-row success/failure summary after the call resolves.
+ */
+export function useEtsyImport() {
+  const [importState, setImportState] = useState<
+    RequestState<ImportEtsyListingsResponse>
+  >({ status: 'idle' });
+
+  const importListings = useCallback(
+    async (
+      request: ImportEtsyListingsRequest
+    ): Promise<ImportEtsyListingsResponse> => {
+      setImportState({ status: 'loading' });
+      try {
+        const functions = getMapleFunctions();
+        const importFn = httpsCallable<
+          ImportEtsyListingsRequest,
+          ImportEtsyListingsResponse
+        >(functions, 'importEtsyListings');
+        const result = await importFn(request);
+        setImportState({ status: 'success', data: result.data });
+        return result.data;
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Failed to import Etsy listings';
+        setImportState({ status: 'error', error: message });
+        throw error;
+      }
+    },
+    []
+  );
+
+  const reset = useCallback(() => {
+    setImportState({ status: 'idle' });
+  }, []);
+
+  return {
+    importState,
+    importListings,
+    reset,
+  };
+}

--- a/libs/react/data/src/lib/useEtsyListings.ts
+++ b/libs/react/data/src/lib/useEtsyListings.ts
@@ -1,0 +1,73 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { httpsCallable } from 'firebase/functions';
+import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
+import type { RequestState } from '@maple/ts/domain';
+import type {
+  ListEtsyListingsRequest,
+  ListEtsyListingsResponse,
+  EtsyListingWithSyncInfo,
+} from '@maple/ts/firebase/api-types';
+
+export interface UseEtsyListingsOptions {
+  /** Listing state to fetch (default: 'active'). */
+  state?: ListEtsyListingsRequest['state'];
+  /** Page size (default: 100; Etsy API max). */
+  limit?: number;
+  /** Auto-fetch on mount. Default: true. */
+  autoFetch?: boolean;
+}
+
+/**
+ * Fetches the connected Etsy shop's listings with sync info (imported
+ * into our Product catalog yet? single-variant?). Read-only — the import
+ * action is exposed via `useEtsyImport`.
+ */
+export function useEtsyListings({
+  state = 'active',
+  limit = 100,
+  autoFetch = true,
+}: UseEtsyListingsOptions = {}) {
+  const [listingsState, setListingsState] = useState<
+    RequestState<EtsyListingWithSyncInfo[]>
+  >({ status: 'idle' });
+  const [total, setTotal] = useState<number>(0);
+
+  const fetchListings = useCallback(async (): Promise<void> => {
+    setListingsState({ status: 'loading' });
+
+    try {
+      const functions = getMapleFunctions();
+      const listFn = httpsCallable<
+        ListEtsyListingsRequest,
+        ListEtsyListingsResponse
+      >(functions, 'listEtsyListings');
+
+      const result = await listFn({ state, limit });
+      setTotal(result.data.total);
+      setListingsState({ status: 'success', data: result.data.listings });
+    } catch (error) {
+      console.error('Failed to fetch Etsy listings:', error);
+      setListingsState({
+        status: 'error',
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to fetch Etsy listings',
+      });
+    }
+  }, [state, limit]);
+
+  useEffect(() => {
+    if (autoFetch) {
+      fetchListings();
+    }
+  }, [autoFetch, fetchListings]);
+
+  return {
+    listingsState,
+    total,
+    fetchListings,
+  };
+}

--- a/libs/ts/domain/src/index.ts
+++ b/libs/ts/domain/src/index.ts
@@ -12,6 +12,7 @@ export * from './lib/sync-conflict';
 
 // Phase 5: Etsy Integration
 export * from './lib/etsy';
+export * from './lib/etsy-import';
 
 // Phase 3: Classes & Workshops
 export * from './lib/instructor';

--- a/libs/ts/domain/src/lib/etsy-import.ts
+++ b/libs/ts/domain/src/lib/etsy-import.ts
@@ -1,0 +1,36 @@
+/**
+ * Etsy import snapshot
+ *
+ * Stored in `etsy-imports/{productId}` — one record per imported Etsy listing.
+ * Captures the full raw Etsy API response at import time so we can:
+ *   - mine it later for insights (taxonomy/tag/material frequency) to seed templates
+ *   - reconstruct state if the listing is later edited or deleted on Etsy
+ *
+ * This is a snapshot, not a live mirror. Subsequent Etsy edits are not
+ * reflected here — update the Product.etsyCache for current display data.
+ */
+
+/** Unknown-shape JSON blob captured directly from the Etsy API response. */
+export type EtsyRawPayload = Record<string, unknown>;
+
+export interface EtsyImport {
+  /** Same as the Product.id this snapshot belongs to */
+  id: string;
+
+  /** Etsy listing_id as a string (Etsy returns a number; stored as string for consistency with etsyListingId) */
+  listingId: string;
+
+  /** Full raw listing JSON from GET /listings/{id}?includes=Images,Inventory */
+  rawListing: EtsyRawPayload;
+
+  /** Raw inventory JSON if fetched separately (may be embedded in rawListing.inventory) */
+  rawInventory?: EtsyRawPayload;
+
+  /** Number of product variants on the listing at import time (for filtering/insights) */
+  variantCount: number;
+
+  /** Admin user ID who performed the import */
+  importedBy: string;
+
+  importedAt: Date;
+}

--- a/libs/ts/firebase/api-types/src/lib/etsy-import.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/etsy-import.types.ts
@@ -1,0 +1,99 @@
+/**
+ * Etsy listing import API types
+ *
+ * Read-only pull from Etsy into our Product catalog. No writes to Etsy.
+ */
+import type { Product, ProductStatus } from '@maple/ts/domain';
+import type { EtsyListing } from '@maple/firebase/etsy';
+
+// ============================================================================
+// List Etsy Listings (for review/import)
+// ============================================================================
+
+export interface ListEtsyListingsRequest {
+  /** Etsy listing state filter (default: 'active') */
+  state?: 'active' | 'inactive' | 'draft' | 'expired' | 'sold_out';
+  /** Max listings to return from Etsy (default: 100; Etsy caps at 100 per page) */
+  limit?: number;
+  /** Pagination offset */
+  offset?: number;
+}
+
+/**
+ * A single listing on the Etsy shop with sync metadata.
+ *
+ * `listing` is the raw Etsy response so the admin UI can display whatever it
+ * wants without us pre-shaping the data.
+ */
+export interface EtsyListingWithSyncInfo {
+  /** Raw Etsy listing including images + inventory */
+  listing: EtsyListing;
+  /** Whether this listing is already linked to a Firestore Product */
+  imported: boolean;
+  /** If imported, the Firestore Product.id */
+  productId?: string;
+  /** Number of product variants (1 for simple listings, >1 for variations) */
+  variantCount: number;
+  /** Whether this is a simple single-variant listing (supported for import) */
+  isSimple: boolean;
+}
+
+export interface ListEtsyListingsResponse {
+  listings: EtsyListingWithSyncInfo[];
+  /** Total listings on Etsy matching the state filter (for pagination) */
+  total: number;
+}
+
+// ============================================================================
+// Import Etsy Listings (bulk)
+// ============================================================================
+
+/**
+ * Per-listing import input.
+ *
+ * All selected listings in a batch share the same artist + category +
+ * status + optional commission override (the admin UI enforces this for
+ * the bulk dialog).
+ */
+export interface ImportEtsyListingInput {
+  /** Etsy listing_id to import */
+  listingId: string;
+}
+
+export interface ImportEtsyListingsRequest {
+  listings: ImportEtsyListingInput[];
+  /** Artist to assign to every imported Product in this batch */
+  artistId: string;
+  /** Category to assign (optional, applied to every imported Product) */
+  categoryId?: string;
+  /** Status to assign to every imported Product */
+  status: ProductStatus;
+  /** Optional commission override applied to every imported Product */
+  customCommissionRate?: number;
+}
+
+export interface ImportEtsyListingResult {
+  listingId: string;
+  success: boolean;
+  /** Created Firestore Product.id on success */
+  productId?: string;
+  /** Created product (present on success) */
+  product?: Product;
+  /** Error message on failure, e.g. "Multi-variant listings not supported" */
+  error?: string;
+  /** Error code for programmatic handling */
+  errorCode?:
+    | 'ALREADY_IMPORTED'
+    | 'MULTI_VARIANT_NOT_SUPPORTED'
+    | 'LISTING_NOT_FOUND'
+    | 'SQUARE_CREATE_FAILED'
+    | 'INTERNAL_ERROR';
+}
+
+export interface ImportEtsyListingsResponse {
+  results: ImportEtsyListingResult[];
+  /** Count of successful imports in this batch */
+  successCount: number;
+  /** Count of failures in this batch */
+  failureCount: number;
+}

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -300,3 +300,14 @@ export type {
   SaveEtsyArtistTemplateRequest,
   SaveEtsyArtistTemplateResponse,
 } from './etsy-template.types';
+
+// Etsy Import types (read-only pull from Etsy into our catalog)
+export type {
+  ListEtsyListingsRequest,
+  ListEtsyListingsResponse,
+  EtsyListingWithSyncInfo,
+  ImportEtsyListingInput,
+  ImportEtsyListingsRequest,
+  ImportEtsyListingsResponse,
+  ImportEtsyListingResult,
+} from './etsy-import.types';

--- a/tools/run-integration-tests.sh
+++ b/tools/run-integration-tests.sh
@@ -27,15 +27,16 @@ FIRESTORE_PORT=$((8080 + OFFSET))
 AUTH_PORT=$((9099 + OFFSET))
 UI_PORT=$((4000 + OFFSET))
 MOCK_SERVER_PORT=$((9999 + OFFSET))
+ETSY_MOCK_SERVER_PORT=$((9998 + OFFSET))
 
 if [ "$OFFSET" != "0" ]; then
-  echo "Using EMULATOR_PORT_OFFSET=$OFFSET -> functions:$FUNCTIONS_PORT, firestore:$FIRESTORE_PORT, auth:$AUTH_PORT, ui:$UI_PORT, mock:$MOCK_SERVER_PORT"
+  echo "Using EMULATOR_PORT_OFFSET=$OFFSET -> functions:$FUNCTIONS_PORT, firestore:$FIRESTORE_PORT, auth:$AUTH_PORT, ui:$UI_PORT, mock:$MOCK_SERVER_PORT, etsy-mock:$ETSY_MOCK_SERVER_PORT"
 fi
 
 # ---------------------------------------------------------------------------
 # 1. Kill stale processes on OUR ports only (leave other worktrees alone)
 # ---------------------------------------------------------------------------
-for port in "$MOCK_SERVER_PORT" "$FUNCTIONS_PORT" "$FIRESTORE_PORT" "$AUTH_PORT" "$UI_PORT"; do
+for port in "$MOCK_SERVER_PORT" "$ETSY_MOCK_SERVER_PORT" "$FUNCTIONS_PORT" "$FIRESTORE_PORT" "$AUTH_PORT" "$UI_PORT"; do
   lsof -ti:"$port" 2>/dev/null | xargs kill -9 2>/dev/null || true
 done
 sleep 1
@@ -67,20 +68,31 @@ for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sy
   grep -v '^#' .env.dev | grep -v '^$' > "$dir/.env"
 done
 
+# maple-core: Etsy mock server URL + fake secrets (for listEtsyListings, getEtsyTemplates)
+echo "ETSY_API_BASE=http://localhost:$ETSY_MOCK_SERVER_PORT/v3/application" >> dist/apps/functions/.env
+printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions/.secret.local
+
 # maple-square: mock server URL + fake secrets
 echo "SQUARE_BASE_URL=http://localhost:$MOCK_SERVER_PORT" >> dist/apps/functions-square/.env
-printf "SQUARE_ACCESS_TOKEN=mock-token\nSQUARE_WEBHOOK_SIGNATURE_KEY=mock-key\n" > dist/apps/functions-square/.secret.local
+echo "ETSY_API_BASE=http://localhost:$ETSY_MOCK_SERVER_PORT/v3/application" >> dist/apps/functions-square/.env
+printf "SQUARE_ACCESS_TOKEN=mock-token\nSQUARE_WEBHOOK_SIGNATURE_KEY=mock-key\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions-square/.secret.local
 
 # maple-sync: mock server URL + fake secrets
 echo "WEBFLOW_BASE_URL=http://localhost:$MOCK_SERVER_PORT" >> dist/apps/functions-sync/.env
+echo "ETSY_API_BASE=http://localhost:$ETSY_MOCK_SERVER_PORT/v3/application" >> dist/apps/functions-sync/.env
+echo "ETSY_TOKEN_URL=http://localhost:$ETSY_MOCK_SERVER_PORT/v3/public/oauth/token" >> dist/apps/functions-sync/.env
 printf "WEBFLOW_API_TOKEN=mock-token\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions-sync/.secret.local
 
 # ---------------------------------------------------------------------------
-# 4. Start mock HTTP server (Square + Webflow APIs)
+# 4. Start mock HTTP servers (Square + Webflow + Etsy APIs)
 # ---------------------------------------------------------------------------
-echo "Starting mock server on :$MOCK_SERVER_PORT..."
+echo "Starting monolithic mock server on :$MOCK_SERVER_PORT..."
 MOCK_SERVER_PORT="$MOCK_SERVER_PORT" npx tsx libs/firebase/integration-test-mock-server/start.ts &
 MOCK_PID=$!
+
+echo "Starting Etsy mock server on :$ETSY_MOCK_SERVER_PORT..."
+ETSY_MOCK_SERVER_PORT="$ETSY_MOCK_SERVER_PORT" npx tsx libs/firebase/etsy-test-mock-server/start.ts &
+ETSY_MOCK_PID=$!
 sleep 2
 
 # ---------------------------------------------------------------------------
@@ -126,6 +138,7 @@ EMULATOR_PORT_OFFSET="$OFFSET" npx firebase --config "$FIREBASE_CONFIG_FILE" emu
 # 7. Cleanup
 # ---------------------------------------------------------------------------
 kill $MOCK_PID 2>/dev/null || true
+kill $ETSY_MOCK_PID 2>/dev/null || true
 
 if [ $EXIT_CODE -eq 0 ]; then
   echo ""

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -331,6 +331,9 @@
       "@maple/firebase/integration-test-mock-server": [
         "libs/firebase/integration-test-mock-server/src/index.ts"
       ],
+      "@maple/firebase/etsy-test-mock-server": [
+        "libs/firebase/etsy-test-mock-server/src/index.ts"
+      ],
       "@/*": ["apps/maple-spruce/src/*"]
     }
   }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -319,6 +319,12 @@
       "@maple/firebase/maple-functions/save-etsy-artist-template": [
         "libs/firebase/maple-functions/save-etsy-artist-template/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/list-etsy-listings": [
+        "libs/firebase/maple-functions/list-etsy-listings/src/index.ts"
+      ],
+      "@maple/firebase/maple-functions/import-etsy-listings": [
+        "libs/firebase/maple-functions/import-etsy-listings/src/index.ts"
+      ],
       "@maple/firebase/integration-test-utils": [
         "libs/firebase/integration-test-utils/src/index.ts"
       ],


### PR DESCRIPTION
## Summary

Admin-facing flow to pull David's existing Etsy listings into our Product catalog. Read-only on Etsy — no mutations. First step toward fulfilling [#4](https://github.com/Maple-and-Spruce/maple-and-spruce/issues/4) by using what's already in the shop to seed the catalog and inform template decisions later.

**Intent:** importing the existing shop tells us what fields are actually used, which in turn informs Etsy templates and any inventory-collection refinements.

## What's in the PR

### Backend (`cf05ba1`)
- `listEtsyListings` (maple-core) — reads `?includes=Images,Inventory` from the connected shop and cross-references Firestore Products by `etsyListingId` so the UI can flag imported vs. available vs. unsupported-multi-variant.
- `importEtsyListings` (maple-square) — bulk pull. For each listing: skip multi-variant, skip already-imported, create Square catalog item, set inventory from Etsy quantity (best-effort), copy primary image to Square catalog (best-effort), create Firestore Product with populated `squareCache` + `etsyCache`, write raw listing+inventory JSON to a new `etsy-imports/{productId}` collection for later insight mining.
- Per-row `ImportEtsyListingResult` reports `ALREADY_IMPORTED` / `MULTI_VARIANT_NOT_SUPPORTED` / `LISTING_NOT_FOUND` / `SQUARE_CREATE_FAILED` / `INTERNAL_ERROR` so partial batches don't abort the whole thing.
- New `EtsyImport` domain type + `EtsyImportRepository` (snapshot storage) + `ProductRepository.findByEtsyListingIds` (chunked `in` queries).
- 13 unit tests covering cross-reference, variant detection, happy-path wiring, and per-row failure semantics.

### Integration test infrastructure (`cb76f15`)
Per the direction set mid-PR, a new **standalone** mock server rather than growing the existing monolith. Filed [#297](https://github.com/Maple-and-Spruce/maple-and-spruce/issues/297) to split the monolith to match.
- `libs/firebase/etsy-test-mock-server/` — Etsy v3 listings + OAuth token + user-shops endpoints, mock-image bytes for the image-copy path, `_mock/listings` + `_mock/reset` admin endpoints for tests to seed fixtures over HTTP.
- `ETSY_API_BASE` / `ETSY_TOKEN_URL` env-var overrides in `etsy-http.ts` and `oauth.service.ts` (production unchanged); `etsy-auth-callback` switched from a hardcoded URL to the same override.
- `tools/run-integration-tests.sh` starts the Etsy mock on 9998 alongside the monolith on 9999 and wires the right env vars into each function codebase.

### Integration tests (`b63744d`)
- **New:** `list-etsy-listings.spec.ts`, `import-etsy-listings.spec.ts`.
- **Backfilled** (previously no integration coverage): `etsy-auth-url.spec.ts`, `etsy-auth-callback.spec.ts`, `etsy-connection-status.spec.ts`, `etsy-templates.spec.ts`.
- Caveat documented inline in `import-etsy-listings.spec.ts`: the monolith's Square mock doesn't yet have `/v2/inventory/changes` or `/v2/catalog/images`, so happy-path tests seed listings with `quantity=0` and no images. Unit tests cover those best-effort paths via `vi.mock()`. [#297](https://github.com/Maple-and-Spruce/maple-and-spruce/issues/297) picks up full Square-mock coverage.

### UI (`bd134d4`, `8aed4a9`)
- `useEtsyListings` + `useEtsyImport` hooks under `@maple/react/data`.
- `/etsy/import` admin page.
- `EtsyImportTable` — MUI DataGrid with checkbox selection, status chips, variant-count badge, `isRowSelectable` disables already-imported and multi-variant rows.
- `EtsyImportDialog` — Preact Signals (ADR-015, matching `InstructorForm`). Bulk-applies shared artist, optional category, status, and optional commission override to the whole batch.
- Post-import summary alert shows `successCount` / `failureCount` and auto-refreshes the listing so newly-imported rows switch to `Imported`.
- Storybook stories + interaction tests (submit blocked without artist, full submit flow with default status, invalid commission rate rejection).

## Trade-offs

- **Product model:** sticks with "Square is the catalog owner" (Option 1 — `Product.squareItemId` stays required). Each imported listing dual-creates in Square and Firestore rather than becoming an Etsy-only Product.
- **Variants:** simple (single-variant) listings only in this pass. Multi-variant rows are visible in the table but disabled with a tooltip. Import flow reports them with a typed error so a future UI iteration can surface a per-listing "flag for later" workflow.
- **Images:** primary image only, copied to Square (so it uses our normal product UI path). Failure is best-effort — the Product still imports if Etsy's CDN hiccups.

## Follow-ups (filed separately)

- [#297](https://github.com/Maple-and-Spruce/maple-and-spruce/issues/297) — Split monolithic `integration-test-mock-server` into per-service mocks; unblock full `importEtsyListings` integration coverage.

## Test plan

- [ ] Start emulators + both mocks: `./tools/run-integration-tests.sh etsy`
- [ ] Load `/etsy/import` in the dev admin app against a real Etsy sandbox
- [ ] Select a handful of listings, pick an artist + category, click Import
- [ ] Verify: Square catalog items appear, Firestore `products` + `etsy-imports` docs written, table refreshes and shows them as Imported
- [ ] Multi-variant rows are disabled (tooltip visible)
- [ ] Re-importing an already-imported row returns `ALREADY_IMPORTED` in the summary

Closes #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)