### PR TITLE
chore: switch PR build check to nx affected + add dev shortcuts

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -82,6 +82,11 @@ jobs:
     if: github.repository == 'Maple-and-Spruce/maple-and-spruce'
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Derive nx affected SHAs
+        uses: nrwl/nx-set-shas@v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -98,8 +103,8 @@ jobs:
           path: node_modules
           key: ${{ needs.install.outputs.cache_key }}
 
-      - name: TypeScript typecheck
-        run: pnpm exec nx run maple-spruce:typecheck
+      - name: TypeScript typecheck (affected)
+        run: pnpm exec nx affected -t typecheck
 
   build:
     name: Build
@@ -108,6 +113,11 @@ jobs:
     if: github.repository == 'Maple-and-Spruce/maple-and-spruce'
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Derive nx affected SHAs
+        uses: nrwl/nx-set-shas@v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -132,11 +142,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
 
-      - name: Build web app
-        run: pnpm exec nx run maple-spruce:build
-
-      - name: Build functions
-        run: pnpm exec nx run functions:build
+      - name: Build affected projects
+        run: pnpm exec nx affected -t build
 
   webflow-components-typecheck:
     name: Webflow Components Typecheck
@@ -275,6 +282,11 @@ jobs:
     if: github.repository == 'Maple-and-Spruce/maple-and-spruce'
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Derive nx affected SHAs
+        uses: nrwl/nx-set-shas@v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -294,8 +306,8 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
 
-      - name: Build Storybook
-        run: pnpm exec nx run maple-spruce:build-storybook
+      - name: Build Storybook (affected)
+        run: pnpm exec nx affected -t build-storybook
 
       - name: Run Storybook interaction tests with coverage
         run: pnpm exec vitest run --config vitest.storybook.config.ts --coverage --coverage.reportsDirectory=${{ github.workspace }}/coverage/storybook

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,17 @@
 | Payments | Square |
 | Monorepo | Nx |
 
+## Quick Commands
+
+```bash
+pnpm dev              # Web app (Next.js) on :3000
+pnpm dev:functions    # Functions emulator on :5001
+pnpm storybook        # Storybook on :6006
+pnpm test             # Unit tests
+```
+
+For integration tests, worktree port isolation, and emulator troubleshooting see the `local-development` skill.
+
 ## Key Patterns
 
 - **Repository Pattern** -- All Firestore via repositories, never raw `getDocs`

--- a/docs/architecture/ci-cd.md
+++ b/docs/architecture/ci-cd.md
@@ -18,10 +18,13 @@ All CI workflows use `pnpm/action-setup@v4` which reads the version from `packag
 
 **Jobs** (all depend on `install`):
 - Security audit (`pnpm audit --audit-level=high`)
-- TypeScript typecheck (`pnpm exec nx run maple-spruce:typecheck`)
-- Build web app and functions
+- TypeScript typecheck — `nx affected -t typecheck`
+- Build — `nx affected -t build`
 - Unit tests with coverage
-- Storybook build and interaction tests
+- Storybook build (`nx affected -t build-storybook`) and interaction tests
+- Integration tests (always builds the 4 functions codebases — affected conversion deferred until module boundary tags land)
+
+**Affected detection in PRs**: `nrwl/nx-set-shas@v4` derives the base/head SHAs from the PR event so `nx affected` only rebuilds projects whose source (or transitively a dependency) changed since the merge base. Jobs needing affected detection use `fetch-depth: 0` so the full git history is available.
 
 ## Functions Deploy
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "packageManager": "pnpm@11.0.0-rc.1+sha512.0d7d837668eb35b81d28f560ef8ec5e103ff5d162e249fd0d30c546c39a551d290ac9cf15709353b94d2df6eb445bfa465c7a05148d328eda32950c02e40d060",
   "scripts": {
+    "dev": "nx dev maple-spruce",
+    "dev:functions": "nx run functions:serve",
+    "storybook": "nx run maple-spruce:storybook",
     "test": "nx run-many --target=test --all",
     "test:coverage": "nx run-many --target=test --all --coverage"
   },


### PR DESCRIPTION
## Summary

PR-time CI now uses `nx affected` instead of hardcoded `nx run X:Y` for typecheck, build, and Storybook build. Adds root `pnpm dev` / `dev:functions` / `storybook` scripts so the inner dev loop is discoverable from `package.json`.

## Why

Today every PR rebuilds `maple-spruce`, `functions`, and Storybook regardless of what changed. Switching to affected lets a docs-only or function-only PR skip irrelevant work. Initial wins should be modest on small PRs and substantial on PRs that don't touch the web app or Storybook.

The deploy workflow already uses `nx affected` (see [firebase-functions-merge.yml:65](https://github.com/Maple-and-Spruce/maple-and-spruce/blob/main/.github/workflows/firebase-functions-merge.yml#L65)) — this aligns the PR-check workflow with that pattern.

## Changes

- `.github/workflows/build-check.yml`
  - typecheck job: `nx run maple-spruce:typecheck` -> `nx affected -t typecheck`
  - build job: `nx run maple-spruce:build` + `nx run functions:build` -> `nx affected -t build`
  - storybook job: `nx run maple-spruce:build-storybook` -> `nx affected -t build-storybook`
  - Each affected-using job adds `fetch-depth: 0` and `nrwl/nx-set-shas@v4` so affected detection works correctly on the PR event.
- `package.json` -- adds `dev`, `dev:functions`, `storybook` scripts.
- `AGENTS.md` -- new Quick Commands section.
- `docs/architecture/ci-cd.md` -- documents the affected pipeline.

## Deferred (intentional)

- Integration tests still always build all 4 functions codebases. The per-codebase `.env` copy step at lines 250-252 assumes those dirs exist, and gating on affected needs more nuance (skip if no functions affected vs. partial-build handling). Will revisit after module boundary tags land in PR #3 of this series.
- Unit tests / Storybook interaction tests still run via direct `vitest` invocation. Converting these to affected requires per-project test targets and will be considered separately.

## Test plan

- [ ] CI runs and `Derive nx affected SHAs` step resolves base/head correctly
- [ ] On a PR that touches only docs, build/typecheck/storybook jobs report no affected projects and pass
- [ ] On a PR that touches `libs/react/data`, the build job builds the dependent web app
- [ ] `pnpm dev`, `pnpm dev:functions`, `pnpm storybook` all start the expected processes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)