### PR TITLE
chore: migrate test targets to @nx/vitest:test executor

### DIFF
--- a/apps/functions-integration-tests-artist/project.json
+++ b/apps/functions-integration-tests-artist/project.json
@@ -15,7 +15,7 @@
   ],
   "targets": {
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "options": {
         "config": "apps/functions-integration-tests-artist/vitest.config.ts"
       }

--- a/apps/functions-integration-tests-calendar/project.json
+++ b/apps/functions-integration-tests-calendar/project.json
@@ -18,7 +18,7 @@
   ],
   "targets": {
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "options": {
         "config": "apps/functions-integration-tests-calendar/vitest.config.ts"
       }

--- a/apps/functions-integration-tests-category/project.json
+++ b/apps/functions-integration-tests-category/project.json
@@ -14,7 +14,7 @@
   ],
   "targets": {
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "options": {
         "config": "apps/functions-integration-tests-category/vitest.config.ts"
       }

--- a/apps/functions-integration-tests-class/project.json
+++ b/apps/functions-integration-tests-class/project.json
@@ -17,7 +17,7 @@
   ],
   "targets": {
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "options": {
         "config": "apps/functions-integration-tests-class/vitest.config.ts"
       }

--- a/apps/functions-integration-tests-discount/project.json
+++ b/apps/functions-integration-tests-discount/project.json
@@ -14,7 +14,7 @@
   ],
   "targets": {
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "options": {
         "config": "apps/functions-integration-tests-discount/vitest.config.ts"
       }

--- a/apps/functions-integration-tests-etsy/project.json
+++ b/apps/functions-integration-tests-etsy/project.json
@@ -18,7 +18,7 @@
   ],
   "targets": {
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "options": {
         "config": "apps/functions-integration-tests-etsy/vitest.config.ts"
       }

--- a/apps/functions-integration-tests-instructor/project.json
+++ b/apps/functions-integration-tests-instructor/project.json
@@ -14,7 +14,7 @@
   ],
   "targets": {
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "options": {
         "config": "apps/functions-integration-tests-instructor/vitest.config.ts"
       }

--- a/apps/functions-integration-tests-invoice/project.json
+++ b/apps/functions-integration-tests-invoice/project.json
@@ -14,7 +14,7 @@
   ],
   "targets": {
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "options": {
         "config": "apps/functions-integration-tests-invoice/vitest.config.ts"
       }

--- a/apps/functions-integration-tests-lesson/project.json
+++ b/apps/functions-integration-tests-lesson/project.json
@@ -15,7 +15,7 @@
   ],
   "targets": {
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "options": {
         "config": "apps/functions-integration-tests-lesson/vitest.config.ts"
       }

--- a/apps/functions-integration-tests-registration/project.json
+++ b/apps/functions-integration-tests-registration/project.json
@@ -11,7 +11,7 @@
   ],
   "targets": {
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "options": {
         "config": "apps/functions-integration-tests-registration/vitest.config.ts"
       }

--- a/apps/functions-integration-tests-square/project.json
+++ b/apps/functions-integration-tests-square/project.json
@@ -14,7 +14,7 @@
   ],
   "targets": {
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "options": {
         "config": "apps/functions-integration-tests-square/vitest.config.ts"
       }

--- a/apps/functions-integration-tests-student/project.json
+++ b/apps/functions-integration-tests-student/project.json
@@ -14,7 +14,7 @@
   ],
   "targets": {
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "options": {
         "config": "apps/functions-integration-tests-student/vitest.config.ts"
       }

--- a/apps/functions-integration-tests-utility/project.json
+++ b/apps/functions-integration-tests-utility/project.json
@@ -11,7 +11,7 @@
   ],
   "targets": {
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "options": {
         "config": "apps/functions-integration-tests-utility/vitest.config.ts"
       }

--- a/apps/webflow-components/project.json
+++ b/apps/webflow-components/project.json
@@ -9,7 +9,7 @@
   ],
   "targets": {
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "outputs": [
         "{options.reportsDirectory}"
       ],

--- a/libs/firebase/database/project.json
+++ b/libs/firebase/database/project.json
@@ -23,7 +23,7 @@
       "executor": "@nx/eslint:lint"
     },
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "defaultConfiguration": "default",
       "configurations": {
         "default": {}

--- a/libs/firebase/etsy/project.json
+++ b/libs/firebase/etsy/project.json
@@ -18,7 +18,7 @@
       }
     },
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "outputs": ["{options.reportsDirectory}"],
       "options": {
         "reportsDirectory": "{projectRoot}/../../../coverage/libs/firebase/etsy"

--- a/libs/firebase/functions/project.json
+++ b/libs/firebase/functions/project.json
@@ -30,7 +30,7 @@
       "executor": "@nx/eslint:lint"
     },
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "defaultConfiguration": "default",
       "configurations": {
         "default": {}

--- a/libs/firebase/maple-functions/detect-sync-conflicts/project.json
+++ b/libs/firebase/maple-functions/detect-sync-conflicts/project.json
@@ -6,7 +6,7 @@
   "tags": ["scope:firebase", "type:feature"],
   "targets": {
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "options": {
         "config": "libs/firebase/maple-functions/detect-sync-conflicts/vitest.config.ts"
       }

--- a/libs/firebase/maple-functions/square-webhook/project.json
+++ b/libs/firebase/maple-functions/square-webhook/project.json
@@ -7,7 +7,7 @@
   "// targets": "to see all targets run: nx show project square-webhook --web",
   "targets": {
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "options": {
         "config": "libs/firebase/maple-functions/square-webhook/vitest.config.ts"
       }

--- a/libs/firebase/maple-functions/sync-registration-count/project.json
+++ b/libs/firebase/maple-functions/sync-registration-count/project.json
@@ -6,7 +6,7 @@
   "tags": ["scope:firebase", "type:feature"],
   "targets": {
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "options": {
         "config": "libs/firebase/maple-functions/sync-registration-count/vitest.config.ts"
       }

--- a/libs/firebase/webflow/project.json
+++ b/libs/firebase/webflow/project.json
@@ -27,7 +27,7 @@
       }
     },
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "outputs": [
         "{options.reportsDirectory}"
       ],

--- a/libs/ts/calendar/project.json
+++ b/libs/ts/calendar/project.json
@@ -6,7 +6,7 @@
   "tags": ["scope:shared", "type:util"],
   "targets": {
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "options": {
         "reportsDirectory": "../../../coverage/libs/ts/calendar"
       }

--- a/libs/ts/domain/project.json
+++ b/libs/ts/domain/project.json
@@ -12,7 +12,7 @@
       "executor": "@nx/eslint:lint"
     },
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "outputs": [
         "{options.reportsDirectory}"
       ],

--- a/libs/ts/validation/project.json
+++ b/libs/ts/validation/project.json
@@ -12,7 +12,7 @@
       "executor": "@nx/eslint:lint"
     },
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "defaultConfiguration": "default",
       "configurations": {
         "default": {}


### PR DESCRIPTION
## Summary
Replaces the deprecated `@nx/vite:test` executor with `@nx/vitest:test` across all 24 `project.json` test targets. The `@nx/vite:test` executor will be removed in Nx 23.

## Changes
- Swap `"executor": "@nx/vite:test"` → `"executor": "@nx/vitest:test"` in all `project.json` files (libs + apps).
- No option changes needed — the new executor accepts the same `config`/`configFile` and `reportsDirectory` options that were already in use.
- `@nx/vitest@22.6.5` is already a dependency; no package changes required.

## Test plan
- [x] `nx test validation` — passes, no deprecation warning.
- [ ] CI runs all other `test` targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)