### PR TITLE
feat: product variant model for multi-channel inventory

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -173,7 +173,11 @@
       "Bash(sed -n '36,60p' libs/firebase/maple-functions/sync-invoice-to-square/src/lib/sync-invoice-to-square.ts)",
       "Bash(awk '{print $1, $3}')",
       "Bash(sort -k2 -n)",
-      "Bash(awk -F'|' '{gsub\\(/^[[:space:]]+|[[:space:]]+$/, \"\", $1\\); gsub\\(/^[[:space:]]+|[[:space:]]+$/, \"\", $2\\); if \\($2+0 < 75 && $2 != \"\"\\) print $1, \"|\", $2}')"
+      "Bash(awk -F'|' '{gsub\\(/^[[:space:]]+|[[:space:]]+$/, \"\", $1\\); gsub\\(/^[[:space:]]+|[[:space:]]+$/, \"\", $2\\); if \\($2+0 < 75 && $2 != \"\"\\) print $1, \"|\", $2}')",
+      "Bash(git -C /Users/davidmccoy/GitHub/maple-and-spruce worktree list)",
+      "Bash(sort -t'|' -k2 -n)",
+      "Bash(awk -F'|' '{gsub\\(/^[ \\\\t]+|[ \\\\t]+$/, \"\", $2\\); if \\($2+0 < 60 && $2+0 > 0\\) print}')",
+      "Bash(awk -F'|' '{gsub\\(/^[ \\\\t]+|[ \\\\t]+$/, \"\", $2\\); gsub\\(/^[ \\\\t]+|[ \\\\t]+$/, \"\", $6\\); if \\($2+0 < 70 && $2+0 > 0\\) print $6, $2\"%\", $0}')"
     ]
   }
 }

--- a/apps/maple-spruce/.storybook/fixtures/products.ts
+++ b/apps/maple-spruce/.storybook/fixtures/products.ts
@@ -15,6 +15,16 @@ export const mockProduct: Product = {
   squareLocationId: 'sq-loc-001',
   createdAt: new Date('2024-03-15T10:00:00Z'),
   updatedAt: new Date('2024-06-20T14:30:00Z'),
+  variants: [
+    {
+      id: 'var-001',
+      label: 'Regular',
+      sku: 'prd_abc12345',
+      priceCents: 4500,
+      quantity: 3,
+      squareVariationId: 'sq-var-001',
+    },
+  ],
   squareCache: {
     name: 'Hand-thrown Ceramic Vase',
     description:
@@ -38,6 +48,16 @@ export const mockProductNoImage: Product = {
   squareLocationId: 'sq-loc-001',
   createdAt: new Date('2024-04-10T09:00:00Z'),
   updatedAt: new Date('2024-05-15T16:45:00Z'),
+  variants: [
+    {
+      id: 'var-002',
+      label: 'Regular',
+      sku: 'prd_def67890',
+      priceCents: 8500,
+      quantity: 5,
+      squareVariationId: 'sq-var-002',
+    },
+  ],
   squareCache: {
     name: 'Maple Cutting Board',
     description: 'Handcrafted maple cutting board with live edge detail.',
@@ -59,6 +79,16 @@ export const mockProductDraft: Product = {
   squareLocationId: 'sq-loc-001',
   createdAt: new Date('2024-08-01T11:00:00Z'),
   updatedAt: new Date('2024-08-01T11:00:00Z'),
+  variants: [
+    {
+      id: 'var-003',
+      label: 'Regular',
+      sku: 'prd_ghi11223',
+      priceCents: 6000,
+      quantity: 2,
+      squareVariationId: 'sq-var-003',
+    },
+  ],
   squareCache: {
     name: 'Stoneware Mug Set (4)',
     description: 'Set of 4 handmade stoneware mugs.',
@@ -81,6 +111,16 @@ export const mockProductDiscontinued: Product = {
   squareLocationId: 'sq-loc-001',
   createdAt: new Date('2023-06-15T12:00:00Z'),
   updatedAt: new Date('2024-09-01T08:00:00Z'),
+  variants: [
+    {
+      id: 'var-004',
+      label: 'Regular',
+      sku: 'prd_jkl44556',
+      priceCents: 12000,
+      quantity: 0,
+      squareVariationId: 'sq-var-004',
+    },
+  ],
   squareCache: {
     name: 'Woven Wall Hanging',
     description: 'Macrame wall hanging with natural cotton cord.',
@@ -104,6 +144,16 @@ export const mockProductOutOfStock: Product = {
   squareLocationId: 'sq-loc-001',
   createdAt: new Date('2024-05-20T10:00:00Z'),
   updatedAt: new Date('2024-07-10T14:00:00Z'),
+  variants: [
+    {
+      id: 'var-005',
+      label: 'Regular',
+      sku: 'prd_mno77889',
+      priceCents: 7500,
+      quantity: 0,
+      squareVariationId: 'sq-var-005',
+    },
+  ],
   squareCache: {
     name: 'Silver Pendant Necklace',
     description: 'Hand-forged sterling silver pendant on a 18" chain.',

--- a/apps/maple-spruce/src/app/page.tsx
+++ b/apps/maple-spruce/src/app/page.tsx
@@ -140,8 +140,8 @@ export default function DashboardPage() {
   const lowStockProducts = useMemo(() => {
     if (productsState.status !== 'success') return [];
     return productsState.data
-      .filter((p) => p.status === 'active' && p.squareCache.quantity <= 2)
-      .sort((a, b) => a.squareCache.quantity - b.squareCache.quantity)
+      .filter((p) => p.status === 'active' && (p.squareCache.quantity ?? 0) <= 2)
+      .sort((a, b) => (a.squareCache.quantity ?? 0) - (b.squareCache.quantity ?? 0))
       .slice(0, 5);
   }, [productsState]);
 

--- a/apps/maple-spruce/src/components/inventory/ProductForm.stories.tsx
+++ b/apps/maple-spruce/src/components/inventory/ProductForm.stories.tsx
@@ -337,7 +337,7 @@ export const EditModePreFillsData: Story = {
 
     // Verify price is converted from cents to dollars
     const priceInput = canvas.getByLabelText(/price/i) as HTMLInputElement;
-    const expectedPrice = (mockProduct.squareCache.priceCents / 100).toString();
+    const expectedPrice = ((mockProduct.squareCache.priceCents ?? 0) / 100).toString();
     await expect(priceInput.value).toBe(expectedPrice);
 
     // Verify quantity
@@ -345,7 +345,7 @@ export const EditModePreFillsData: Story = {
       /quantity/i
     ) as HTMLInputElement;
     await expect(quantityInput.value).toBe(
-      mockProduct.squareCache.quantity.toString()
+      (mockProduct.squareCache.quantity ?? 0).toString()
     );
 
     // Button should say "Update" not "Add"
@@ -485,14 +485,14 @@ export const RealEditFlow: WrapperStory = {
     // Verify other fields are populated correctly
     const priceInput = dialogCanvas.getByLabelText(/price/i) as HTMLInputElement;
     expect(priceInput.value).toBe(
-      (mockProduct.squareCache.priceCents / 100).toString()
+      ((mockProduct.squareCache.priceCents ?? 0) / 100).toString()
     );
 
     const quantityInput = dialogCanvas.getByLabelText(
       /quantity/i
     ) as HTMLInputElement;
     expect(quantityInput.value).toBe(
-      mockProduct.squareCache.quantity.toString()
+      (mockProduct.squareCache.quantity ?? 0).toString()
     );
 
     // Step 4: Modify the name field
@@ -512,8 +512,8 @@ export const RealEditFlow: WrapperStory = {
       .calls[0][0];
     expect(submittedData.name).toBe('Updated Ceramic Vase');
     // Other fields should retain their original values
-    expect(submittedData.priceCents).toBe(mockProduct.squareCache.priceCents);
-    expect(submittedData.quantity).toBe(mockProduct.squareCache.quantity);
+    expect(submittedData.priceCents).toBe(mockProduct.squareCache.priceCents ?? 0);
+    expect(submittedData.quantity).toBe(mockProduct.squareCache.quantity ?? 0);
   },
 };
 
@@ -570,7 +570,7 @@ export const EditMultipleProductsSequentially: WrapperStory = {
     // Verify price matches second product
     const priceInput = dialogCanvas.getByLabelText(/price/i) as HTMLInputElement;
     expect(priceInput.value).toBe(
-      (mockProductNoImage.squareCache.priceCents / 100).toString()
+      ((mockProductNoImage.squareCache.priceCents ?? 0) / 100).toString()
     );
   },
 };

--- a/apps/maple-spruce/src/components/inventory/ProductForm.tsx
+++ b/apps/maple-spruce/src/components/inventory/ProductForm.tsx
@@ -172,8 +172,8 @@ export function ProductForm({
         categoryId.value = product.categoryId ?? '';
         name.value = product.squareCache.name;
         description.value = product.squareCache.description ?? '';
-        priceDollars.value = product.squareCache.priceCents / 100;
-        quantity.value = product.squareCache.quantity;
+        priceDollars.value = (product.squareCache.priceCents ?? 0) / 100;
+        quantity.value = product.squareCache.quantity ?? 0;
         status.value = product.status;
         commissionPercent.value =
           product.customCommissionRate !== undefined

--- a/apps/maple-spruce/src/components/inventory/ProductList.tsx
+++ b/apps/maple-spruce/src/components/inventory/ProductList.tsx
@@ -64,7 +64,7 @@ function ProductCard({
               {product.squareCache.description || 'No description'}
             </Typography>
             <Typography variant="h5" color="primary" sx={{ mb: 1 }}>
-              {formatPrice(product.squareCache.priceCents)}
+              {formatPrice(product.squareCache.priceCents ?? 0)}
             </Typography>
             <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
               <Chip
@@ -73,7 +73,7 @@ function ProductCard({
                 color={statusColors[product.status]}
               />
               <Chip
-                label={`Qty: ${product.squareCache.quantity}`}
+                label={`Qty: ${product.squareCache.quantity ?? 0}`}
                 size="small"
                 variant="outlined"
               />

--- a/docs/sessions/SESSION.md
+++ b/docs/sessions/SESSION.md
@@ -7,7 +7,7 @@
 ## Current Status
 
 **Date**: 2026-04-19
-**Status**: Phase 4 Music Lessons complete. PR #304 (teacher payout tracking) all CI green, ready to merge. Requirements and docs updated.
+**Status**: Phase 4 complete (PR #304 ready to merge). Phase 5 planning complete, implementation starting.
 
 ### Phase 4 Music Lessons — Complete
 
@@ -23,11 +23,27 @@ All 6 sub-issues of epic #10 implemented:
 
 **Requirements reviewed and updated** — REQUIREMENTS.md Phase 4 section rewritten to match actual implementation. Deferred items documented (lesson packages, teacher availability, public profiles).
 
-### Next Steps
+### Phase 5: Unified Inventory, Etsy Push, & Sales Tracking
 
-- Merge PR #304
-- Close sub-issues #278–#283 and epic #10
-- Begin Phase 5 planning (Store Opening & Sales Tracking, epic #8)
+**Planning completed 2026-04-19.** Admin app becomes single source of truth for products, pushing to Etsy + Square. Sales on either channel auto-recorded with cross-channel inventory sync.
+
+**Etsy API approved** (2026-03-27, `maplspruce-listings` app, Personal Access tier).
+
+| PR | Issue | Title | Depends On | Status |
+|----|-------|-------|------------|--------|
+| 1 | #305 | Product variant model refactor | — | **In progress** |
+| 2 | #306 | Square multi-variation catalog support | #305 | Not started |
+| 3 | #307 | Push-to-Etsy Cloud Function | #305 | Not started |
+| 4 | #308 | Etsy import multi-variant support | #305, #306 | Not started |
+| 5 | #309 | Sale recording + InventoryMovement audit log | #305 | Not started |
+| 6 | #310 | Etsy order polling + cross-channel inventory sync | #307, #309 | Not started |
+| 7 | #311 | Etsy sync conflict detection + resolution | #305, #307 | Not started |
+| 8 | #312 | Admin UI — variant management + sales page | #305, #306, #309 | Not started |
+| 9 | #313 | Artist payout calculation + admin page | #309 | Not started |
+
+**Critical path:** PR 1 → PR 2 → PR 5 → PR 6 (end-to-end sales tracking)
+
+**Full plan:** `.claude/plans/wild-scribbling-stearns.md`
 
 ### Image2Pages Webflow Widget (in flight)
 

--- a/libs/firebase/database/src/lib/product.repository.spec.ts
+++ b/libs/firebase/database/src/lib/product.repository.spec.ts
@@ -214,6 +214,9 @@ describe('ProductRepository', () => {
         squareVariationId: 'sq-var-001',
         createdAt: new Date('2024-01-01'),
         updatedAt: new Date('2024-01-02'),
+        variants: [
+          { id: 'var-001', label: 'Regular', sku: 'prd_existing', priceCents: 2500, quantity: 5, squareVariationId: 'sq-var-001' },
+        ],
         squareCache: {
           name: 'Existing Product',
           priceCents: 2500,

--- a/libs/firebase/database/src/lib/product.repository.spec.ts
+++ b/libs/firebase/database/src/lib/product.repository.spec.ts
@@ -132,6 +132,9 @@ describe('ProductRepository', () => {
         squareCatalogVersion: 1,
         squareLocationId: 'sq-loc-001',
         sku: 'prd_newsku',
+        variations: [
+          { variantId: 'var-new', squareVariationId: 'sq-var-new', sku: 'prd_newsku' },
+        ],
       };
 
       let savedData: Record<string, unknown> = {};
@@ -175,6 +178,9 @@ describe('ProductRepository', () => {
         squareCatalogVersion: 1,
         squareLocationId: 'sq-loc-001',
         sku: 'prd_nocat',
+        variations: [
+          { variantId: 'var-nocat', squareVariationId: 'sq-var-nocat', sku: 'prd_nocat' },
+        ],
       };
 
       let savedData: Record<string, unknown> = {};

--- a/libs/firebase/database/src/lib/product.repository.ts
+++ b/libs/firebase/database/src/lib/product.repository.ts
@@ -8,10 +8,12 @@
  * - Square owns catalog/inventory data
  * - Firestore owns business logic (artist links, commissions)
  * - squareCache contains cached Square data for fast reads
+ * - variants[] contains per-variant data (price, quantity, SKU, external IDs)
  */
 import { db } from './utilities/database.config';
 import type {
   Product,
+  ProductVariant,
   SquareCache,
   EtsyCache,
   CreateProductInput,
@@ -19,12 +21,22 @@ import type {
   ProductStatus,
   SquareProductResult,
 } from '@maple/ts/domain';
-import { isCacheStale } from '@maple/ts/domain';
+import {
+  isCacheStale,
+  generateVariantId,
+  generateSku,
+  resolveVariants,
+} from '@maple/ts/domain';
 
 const COLLECTION = 'products';
 
 /**
- * Convert Firestore document to Product
+ * Convert Firestore document to Product.
+ *
+ * Handles three data shapes:
+ * 1. Current: squareCache (listing-level) + variants[]
+ * 2. Legacy v2: squareCache with per-variant fields (priceCents, quantity, sku) + squareVariationId
+ * 3. Legacy v1: flat fields (name, price, quantity, sku) at top level
  */
 function docToProduct(
   doc: FirebaseFirestore.DocumentSnapshot
@@ -35,34 +47,29 @@ function docToProduct(
 
   const data = doc.data()!;
 
-  // Handle legacy flat structure or new squareCache structure
-  const squareCache: SquareCache = data.squareCache
+  // --- Square cache (listing-level fields + deprecated per-variant fields) ---
+  const squareCacheRaw = data.squareCache;
+  const squareCache: SquareCache = squareCacheRaw
     ? {
-        name: data.squareCache.name,
-        description: data.squareCache.description,
-        priceCents: data.squareCache.priceCents,
-        quantity: data.squareCache.quantity,
-        sku: data.squareCache.sku,
-        imageUrl: data.squareCache.imageUrl,
-        syncedAt: data.squareCache.syncedAt?.toDate() ?? new Date(),
+        name: squareCacheRaw.name,
+        description: squareCacheRaw.description,
+        imageUrl: squareCacheRaw.imageUrl,
+        syncedAt: squareCacheRaw.syncedAt?.toDate() ?? new Date(),
+        // Deprecated fields populated below after variants are resolved
       }
     : {
-        // Legacy fallback - convert flat fields to squareCache
+        // Legacy v1 fallback
         name: data.name ?? '',
         description: data.description,
-        priceCents: data.price ?? 0, // legacy field was 'price'
-        quantity: data.quantity ?? 0,
-        sku: data.sku ?? '',
         imageUrl: data.imageUrl,
         syncedAt: data.lastSquareSyncAt?.toDate() ?? new Date(0),
       };
 
+  // --- Etsy cache ---
   const etsyCache: EtsyCache | undefined = data.etsyCache
     ? {
         title: data.etsyCache.title,
         description: data.etsyCache.description,
-        priceCents: data.etsyCache.priceCents,
-        quantity: data.etsyCache.quantity,
         url: data.etsyCache.url,
         taxonomyId: data.etsyCache.taxonomyId,
         tags: data.etsyCache.tags,
@@ -70,6 +77,53 @@ function docToProduct(
         syncedAt: data.etsyCache.syncedAt?.toDate() ?? new Date(),
       }
     : undefined;
+
+  // --- Variants: migrate from legacy if needed ---
+  let variants: ProductVariant[];
+
+  if (data.variants && Array.isArray(data.variants) && data.variants.length > 0) {
+    // Current format
+    variants = data.variants.map((v: Record<string, unknown>) => ({
+      id: (v.id as string) ?? generateVariantId(),
+      label: (v.label as string) ?? 'Regular',
+      sku: (v.sku as string) ?? '',
+      priceCents: (v.priceCents as number) ?? 0,
+      quantity: (v.quantity as number) ?? 0,
+      squareVariationId: v.squareVariationId as string | undefined,
+      etsyProductId: v.etsyProductId as number | undefined,
+    }));
+  } else {
+    // Legacy: create single variant from squareCache or flat fields
+    const legacyPrice = data.squareCache?.priceCents ?? data.price ?? 0;
+    const legacyQty = data.squareCache?.quantity ?? data.quantity ?? 0;
+    const legacySku = data.squareCache?.sku ?? data.sku ?? '';
+    const legacyVariationId = data.squareVariationId ?? '';
+
+    variants = [
+      {
+        id: generateVariantId(),
+        label: 'Regular',
+        sku: legacySku,
+        priceCents: legacyPrice,
+        quantity: legacyQty,
+        squareVariationId: legacyVariationId || undefined,
+      },
+    ];
+  }
+
+  // Populate deprecated SquareCache fields from first variant for backward compat
+  const firstVariant = variants[0];
+  if (firstVariant) {
+    squareCache.priceCents = firstVariant.priceCents;
+    squareCache.quantity = firstVariant.quantity;
+    squareCache.sku = firstVariant.sku;
+  }
+
+  // Populate deprecated EtsyCache fields from first variant
+  if (etsyCache && firstVariant) {
+    etsyCache.priceCents = firstVariant.priceCents;
+    etsyCache.quantity = firstVariant.quantity;
+  }
 
   return {
     id: doc.id,
@@ -82,9 +136,13 @@ function docToProduct(
     createdAt: data.createdAt?.toDate() ?? new Date(),
     updatedAt: data.updatedAt?.toDate() ?? new Date(),
 
+    // Variants
+    variants,
+    variantProperties: data.variantProperties,
+
     // External system links
     squareItemId: data.squareItemId ?? '',
-    squareVariationId: data.squareVariationId ?? '',
+    squareVariationId: firstVariant?.squareVariationId,
     squareCatalogVersion: data.squareCatalogVersion,
     squareLocationId: data.squareLocationId,
     etsyListingId: data.etsyListingId,
@@ -107,28 +165,40 @@ function productToDoc(product: Omit<Product, 'id'>): Record<string, unknown> {
     createdAt: product.createdAt,
     updatedAt: product.updatedAt,
 
+    // Variants
+    variants: product.variants.map((v) => ({
+      id: v.id,
+      label: v.label,
+      sku: v.sku,
+      priceCents: v.priceCents,
+      quantity: v.quantity,
+      squareVariationId: v.squareVariationId,
+      etsyProductId: v.etsyProductId,
+    })),
+    variantProperties: product.variantProperties,
+
+    // External links (item-level)
     squareItemId: product.squareItemId,
-    squareVariationId: product.squareVariationId,
+    squareVariationId: product.squareVariationId ?? product.variants[0]?.squareVariationId,
     squareCatalogVersion: product.squareCatalogVersion,
     squareLocationId: product.squareLocationId,
     etsyListingId: product.etsyListingId,
 
+    // Cached data (listing-level + deprecated per-variant fields for compat)
     squareCache: {
       name: product.squareCache.name,
       description: product.squareCache.description,
-      priceCents: product.squareCache.priceCents,
-      quantity: product.squareCache.quantity,
-      sku: product.squareCache.sku,
       imageUrl: product.squareCache.imageUrl,
       syncedAt: product.squareCache.syncedAt,
+      priceCents: product.variants[0]?.priceCents,
+      quantity: product.variants[0]?.quantity,
+      sku: product.variants[0]?.sku,
     },
 
     ...(product.etsyCache && {
       etsyCache: {
         title: product.etsyCache.title,
         description: product.etsyCache.description,
-        priceCents: product.etsyCache.priceCents,
-        quantity: product.etsyCache.quantity,
         url: product.etsyCache.url,
         taxonomyId: product.etsyCache.taxonomyId,
         tags: product.etsyCache.tags,
@@ -221,6 +291,24 @@ export const ProductRepository = {
     const docRef = db.collection(COLLECTION).doc();
     const now = new Date();
 
+    // Resolve variants from input
+    const resolvedVariants = resolveVariants(input);
+
+    // Map Square variation results to product variants
+    const variants: ProductVariant[] = resolvedVariants.map((v, i) => {
+      const squareVar = squareResult.variations[i];
+      return {
+        id: squareVar?.variantId ?? generateVariantId(),
+        label: v.label,
+        sku: squareVar?.sku ?? v.sku ?? generateSku(),
+        priceCents: v.priceCents,
+        quantity: v.quantity,
+        squareVariationId: squareVar?.squareVariationId,
+      };
+    });
+
+    const firstVar = variants[0];
+
     const product: Omit<Product, 'id'> = {
       // Firestore-owned
       artistId: input.artistId,
@@ -230,23 +318,27 @@ export const ProductRepository = {
       createdAt: now,
       updatedAt: now,
 
+      // Variants
+      variants,
+      variantProperties: input.variantProperties,
+
       // From Square result
       squareItemId: squareResult.squareItemId,
-      squareVariationId: squareResult.squareVariationId,
+      squareVariationId: firstVar?.squareVariationId,
       squareCatalogVersion: squareResult.squareCatalogVersion,
       squareLocationId: squareResult.squareLocationId,
 
       // No Etsy yet
       etsyListingId: undefined,
 
-      // Initial cache from input (just created in Square)
+      // Listing-level cache + deprecated per-variant fields for compat
       squareCache: {
         name: input.name,
         description: input.description,
-        priceCents: input.priceCents,
-        quantity: input.quantity,
-        sku: squareResult.sku,
         syncedAt: now,
+        priceCents: firstVar?.priceCents,
+        quantity: firstVar?.quantity,
+        sku: firstVar?.sku,
       },
     };
 
@@ -293,7 +385,7 @@ export const ProductRepository = {
   },
 
   /**
-   * Update the Square cache after a successful Square API call
+   * Update the Square cache (listing-level fields) after a successful Square API call
    */
   async updateSquareCache(
     id: string,
@@ -311,13 +403,14 @@ export const ProductRepository = {
     if (cache.name !== undefined) updates['squareCache.name'] = cache.name;
     if (cache.description !== undefined)
       updates['squareCache.description'] = cache.description;
+    if (cache.imageUrl !== undefined)
+      updates['squareCache.imageUrl'] = cache.imageUrl;
+    // Deprecated per-variant fields — still written for backward compat
     if (cache.priceCents !== undefined)
       updates['squareCache.priceCents'] = cache.priceCents;
     if (cache.quantity !== undefined)
       updates['squareCache.quantity'] = cache.quantity;
     if (cache.sku !== undefined) updates['squareCache.sku'] = cache.sku;
-    if (cache.imageUrl !== undefined)
-      updates['squareCache.imageUrl'] = cache.imageUrl;
     if (squareCatalogVersion !== undefined)
       updates['squareCatalogVersion'] = squareCatalogVersion;
 
@@ -325,15 +418,107 @@ export const ProductRepository = {
   },
 
   /**
-   * Update just the cached quantity (for inventory webhooks)
+   * Update a specific variant's quantity (e.g. after a sale or inventory webhook)
    */
-  async updateCachedQuantity(id: string, quantity: number): Promise<void> {
+  async updateVariantQuantity(
+    id: string,
+    variantId: string,
+    quantity: number
+  ): Promise<void> {
     const docRef = db.collection(COLLECTION).doc(id);
+    const doc = await docRef.get();
+    const product = docToProduct(doc);
+
+    if (!product) {
+      throw new Error(`Product ${id} not found`);
+    }
+
+    const updatedVariants = product.variants.map((v) =>
+      v.id === variantId ? { ...v, quantity } : v
+    );
+
     await docRef.update({
-      'squareCache.quantity': quantity,
+      variants: updatedVariants.map((v) => ({
+        id: v.id,
+        label: v.label,
+        sku: v.sku,
+        priceCents: v.priceCents,
+        quantity: v.quantity,
+        squareVariationId: v.squareVariationId,
+        etsyProductId: v.etsyProductId,
+      })),
       'squareCache.syncedAt': new Date(),
       updatedAt: new Date(),
     });
+  },
+
+  /**
+   * Update just the cached quantity for a variant by Square variation ID.
+   * Used by inventory webhooks.
+   */
+  async updateCachedQuantity(
+    id: string,
+    quantity: number,
+    squareVariationId?: string
+  ): Promise<void> {
+    const docRef = db.collection(COLLECTION).doc(id);
+    const doc = await docRef.get();
+    const product = docToProduct(doc);
+
+    if (!product) {
+      throw new Error(`Product ${id} not found`);
+    }
+
+    const updatedVariants = product.variants.map((v) => {
+      // If squareVariationId specified, match on it; otherwise update first variant
+      const isTarget = squareVariationId
+        ? v.squareVariationId === squareVariationId
+        : true;
+      return isTarget ? { ...v, quantity } : v;
+    });
+
+    await docRef.update({
+      variants: updatedVariants.map((v) => ({
+        id: v.id,
+        label: v.label,
+        sku: v.sku,
+        priceCents: v.priceCents,
+        quantity: v.quantity,
+        squareVariationId: v.squareVariationId,
+        etsyProductId: v.etsyProductId,
+      })),
+      'squareCache.syncedAt': new Date(),
+      updatedAt: new Date(),
+    });
+  },
+
+  /**
+   * Replace all variants on a product (e.g. after Square catalog sync)
+   */
+  async updateVariants(
+    id: string,
+    variants: ProductVariant[],
+    variantProperties?: string[]
+  ): Promise<void> {
+    const docRef = db.collection(COLLECTION).doc(id);
+    const updateData: Record<string, unknown> = {
+      variants: variants.map((v) => ({
+        id: v.id,
+        label: v.label,
+        sku: v.sku,
+        priceCents: v.priceCents,
+        quantity: v.quantity,
+        squareVariationId: v.squareVariationId,
+        etsyProductId: v.etsyProductId,
+      })),
+      updatedAt: new Date(),
+    };
+
+    if (variantProperties !== undefined) {
+      updateData['variantProperties'] = variantProperties;
+    }
+
+    await docRef.update(updateData);
   },
 
   /**
@@ -402,13 +587,13 @@ export const ProductRepository = {
       etsyCache: {
         title: cache.title,
         description: cache.description,
-        priceCents: cache.priceCents,
-        quantity: cache.quantity,
         url: cache.url,
         taxonomyId: cache.taxonomyId,
         tags: cache.tags,
         state: cache.state,
         syncedAt: cache.syncedAt,
+        priceCents: cache.priceCents,
+        quantity: cache.quantity,
       },
       updatedAt: new Date(),
     });

--- a/libs/firebase/maple-functions/create-product/src/lib/create-product.ts
+++ b/libs/firebase/maple-functions/create-product/src/lib/create-product.ts
@@ -55,20 +55,23 @@ export const createProduct = Functions.endpoint
       console.log('Square client initialized, creating catalog item...');
 
       // 1. Create catalog item in Square
+      const priceCents = data.priceCents ?? 0;
+      const quantity = data.quantity ?? 0;
+
       const catalogResult = await square.catalogService.createItem({
         name: data.name,
         description: data.description,
-        priceCents: data.priceCents,
+        priceCents,
       });
 
       console.log('Square catalog item created:', catalogResult);
 
       // 2. Set initial inventory quantity
-      if (data.quantity > 0) {
+      if (quantity > 0) {
         await square.inventoryService.setQuantity({
           squareVariationId: catalogResult.squareVariationId,
           locationId: square.locationId,
-          quantity: data.quantity,
+          quantity,
         });
       }
 

--- a/libs/firebase/maple-functions/create-product/src/lib/create-product.ts
+++ b/libs/firebase/maple-functions/create-product/src/lib/create-product.ts
@@ -79,6 +79,7 @@ export const createProduct = Functions.endpoint
         squareCatalogVersion: catalogResult.squareCatalogVersion,
         squareLocationId: square.locationId,
         sku: catalogResult.sku,
+        variations: [{ variantId: 'var_compat', squareVariationId: catalogResult.squareVariationId, sku: catalogResult.sku }],
       });
 
       return { product };

--- a/libs/firebase/maple-functions/detect-sync-conflicts/src/lib/detect-sync-conflicts.spec.ts
+++ b/libs/firebase/maple-functions/detect-sync-conflicts/src/lib/detect-sync-conflicts.spec.ts
@@ -153,7 +153,7 @@ describe('Sync Conflict Detection Logic', () => {
 
       // The detection would create a conflict because 5 !== 3
       // Testing the comparison logic
-      const cachedQuantity = product.squareCache.quantity;
+      const cachedQuantity = product.squareCache.quantity ?? 0;
       const squareQuantity = 3;
 
       expect(cachedQuantity).not.toBe(squareQuantity);

--- a/libs/firebase/maple-functions/detect-sync-conflicts/src/lib/detect-sync-conflicts.spec.ts
+++ b/libs/firebase/maple-functions/detect-sync-conflicts/src/lib/detect-sync-conflicts.spec.ts
@@ -88,6 +88,14 @@ describe('Sync Conflict Detection Logic', () => {
     squareItemId: overrides.squareItemId ?? `SQ_ITEM_${id}`,
     squareVariationId: overrides.squareVariationId ?? `SQ_VAR_${id}`,
     squareCatalogVersion: 1,
+    variants: [{
+      id: 'var_1',
+      label: 'Regular',
+      sku: `SKU_${id}`,
+      priceCents: overrides.cachedPrice ?? 2500,
+      quantity: overrides.cachedQuantity ?? 5,
+      squareVariationId: overrides.squareVariationId ?? `SQ_VAR_${id}`,
+    }],
     squareCache: {
       name: overrides.cachedName ?? `Product ${id}`,
       priceCents: overrides.cachedPrice ?? 2500,

--- a/libs/firebase/maple-functions/detect-sync-conflicts/src/lib/detect-sync-conflicts.ts
+++ b/libs/firebase/maple-functions/detect-sync-conflicts/src/lib/detect-sync-conflicts.ts
@@ -153,8 +153,8 @@ async function detectSquareConflicts(
         type: 'missing_external',
         detectedAt: new Date(),
         localState: {
-          quantity: product.squareCache.quantity,
-          price: product.squareCache.priceCents,
+          quantity: product.squareCache.quantity ?? 0,
+          price: product.squareCache.priceCents ?? 0,
           name: product.squareCache.name,
         },
         externalState: {
@@ -184,14 +184,14 @@ async function detectSquareConflicts(
       : 0;
 
     // Check for quantity mismatch
-    if (product.squareCache.quantity !== squareQuantity) {
+    if ((product.squareCache.quantity ?? 0) !== squareQuantity) {
       const result = await createConflictIfNoPending({
         productId: product.id,
         type: 'quantity_mismatch',
         detectedAt: new Date(),
         localState: {
-          quantity: product.squareCache.quantity,
-          price: product.squareCache.priceCents,
+          quantity: product.squareCache.quantity ?? 0,
+          price: product.squareCache.priceCents ?? 0,
           name: product.squareCache.name,
         },
         externalState: {
@@ -206,14 +206,14 @@ async function detectSquareConflicts(
     }
 
     // Check for price mismatch
-    if (product.squareCache.priceCents !== squarePrice) {
+    if ((product.squareCache.priceCents ?? 0) !== squarePrice) {
       const result = await createConflictIfNoPending({
         productId: product.id,
         type: 'price_mismatch',
         detectedAt: new Date(),
         localState: {
-          quantity: product.squareCache.quantity,
-          price: product.squareCache.priceCents,
+          quantity: product.squareCache.quantity ?? 0,
+          price: product.squareCache.priceCents ?? 0,
           name: product.squareCache.name,
         },
         externalState: {

--- a/libs/firebase/maple-functions/import-etsy-listings/src/lib/import-etsy-listings.ts
+++ b/libs/firebase/maple-functions/import-etsy-listings/src/lib/import-etsy-listings.ts
@@ -242,6 +242,7 @@ async function importSingleListing(options: {
           newCatalogVersion ?? catalogResult.squareCatalogVersion,
         squareLocationId: square.locationId,
         sku: catalogResult.sku,
+        variations: [{ variantId: 'var_compat', squareVariationId: catalogResult.squareVariationId, sku: catalogResult.sku }],
       }
     );
 

--- a/libs/firebase/maple-functions/square-webhook/src/lib/square-webhook.ts
+++ b/libs/firebase/maple-functions/square-webhook/src/lib/square-webhook.ts
@@ -189,6 +189,7 @@ export async function handleCatalogUpdate(
               squareCatalogVersion: Number(catalogObject.version || 0),
               squareLocationId: square.locationId,
               sku: variationData?.sku ?? '',
+              variations: [{ variantId: 'var_compat', squareVariationId: variation.id!, sku: variationData?.sku ?? '' }],
             }
           );
           // Update image URL if available (create doesn't support imageUrl directly)
@@ -290,6 +291,7 @@ export async function handleCatalogUpdate(
         squareCatalogVersion: Number(catalogObject.version || 0),
         squareLocationId: square.locationId,
         sku: variationData?.sku ?? '',
+        variations: [{ variantId: 'var_compat', squareVariationId: variation.id!, sku: variationData?.sku ?? '' }],
       }
     );
 

--- a/libs/ts/domain/src/lib/etsy.ts
+++ b/libs/ts/domain/src/lib/etsy.ts
@@ -14,10 +14,6 @@
 export interface EtsyCache {
   title: string;
   description?: string;
-  /** Price in cents (e.g., 2500 = $25.00) */
-  priceCents: number;
-  /** Current inventory quantity */
-  quantity: number;
   /** Public Etsy listing URL */
   url?: string;
   /** Etsy taxonomy category ID */
@@ -28,6 +24,13 @@ export interface EtsyCache {
   state: 'active' | 'draft' | 'inactive';
   /** When this cache was last synced from Etsy */
   syncedAt: Date;
+
+  // --- Deprecated: per-variant data now lives on ProductVariant ---
+
+  /** @deprecated Use product.variants[].priceCents */
+  priceCents?: number;
+  /** @deprecated Use product.variants[].quantity */
+  quantity?: number;
 }
 
 /**

--- a/libs/ts/domain/src/lib/product.spec.ts
+++ b/libs/ts/domain/src/lib/product.spec.ts
@@ -1,13 +1,20 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   generateSku,
+  generateVariantId,
   isCacheStale,
   getEffectiveCommissionRate,
   formatPrice,
   toCents,
+  getTotalQuantity,
+  findVariant,
+  findVariantBySquareId,
+  findVariantByEtsyProductId,
+  isMultiVariant,
+  resolveVariants,
   CACHE_STALE_THRESHOLD_MS,
 } from './product';
-import type { Product } from './product';
+import type { Product, ProductVariant } from './product';
 
 describe('generateSku', () => {
   it('returns a string starting with prd_', () => {
@@ -36,6 +43,21 @@ describe('generateSku', () => {
   });
 });
 
+describe('generateVariantId', () => {
+  it('returns a string starting with var_', () => {
+    const id = generateVariantId();
+    expect(id).toMatch(/^var_/);
+  });
+
+  it('generates unique IDs', () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      ids.add(generateVariantId());
+    }
+    expect(ids.size).toBe(100);
+  });
+});
+
 describe('isCacheStale', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -52,9 +74,6 @@ describe('isCacheStale', () => {
     const product: Pick<Product, 'squareCache'> = {
       squareCache: {
         name: 'Test',
-        priceCents: 1000,
-        quantity: 5,
-        sku: 'prd_test123',
         syncedAt: now,
       },
     };
@@ -72,9 +91,6 @@ describe('isCacheStale', () => {
     const product: Pick<Product, 'squareCache'> = {
       squareCache: {
         name: 'Test',
-        priceCents: 1000,
-        quantity: 5,
-        sku: 'prd_test123',
         syncedAt,
       },
     };
@@ -92,9 +108,6 @@ describe('isCacheStale', () => {
     const product: Pick<Product, 'squareCache'> = {
       squareCache: {
         name: 'Test',
-        priceCents: 1000,
-        quantity: 5,
-        sku: 'prd_test123',
         syncedAt,
       },
     };
@@ -112,9 +125,6 @@ describe('isCacheStale', () => {
     const product: Pick<Product, 'squareCache'> = {
       squareCache: {
         name: 'Test',
-        priceCents: 1000,
-        quantity: 5,
-        sku: 'prd_test123',
         syncedAt,
       },
     };
@@ -215,5 +225,159 @@ describe('toCents', () => {
 describe('CACHE_STALE_THRESHOLD_MS', () => {
   it('is set to 5 minutes', () => {
     expect(CACHE_STALE_THRESHOLD_MS).toBe(5 * 60 * 1000);
+  });
+});
+
+// --- Variant helpers ---
+
+const makeVariant = (overrides?: Partial<ProductVariant>): ProductVariant => ({
+  id: 'var_abc12345',
+  label: 'Regular',
+  sku: 'prd_test1234',
+  priceCents: 2500,
+  quantity: 5,
+  ...overrides,
+});
+
+const makeProductWithVariants = (
+  variants: ProductVariant[]
+): Pick<Product, 'variants'> => ({ variants });
+
+describe('getTotalQuantity', () => {
+  it('returns quantity for single variant', () => {
+    const product = makeProductWithVariants([makeVariant({ quantity: 10 })]);
+    expect(getTotalQuantity(product)).toBe(10);
+  });
+
+  it('sums quantities across multiple variants', () => {
+    const product = makeProductWithVariants([
+      makeVariant({ id: 'v1', quantity: 3 }),
+      makeVariant({ id: 'v2', quantity: 7 }),
+      makeVariant({ id: 'v3', quantity: 2 }),
+    ]);
+    expect(getTotalQuantity(product)).toBe(12);
+  });
+
+  it('returns 0 when all variants are out of stock', () => {
+    const product = makeProductWithVariants([
+      makeVariant({ quantity: 0 }),
+      makeVariant({ id: 'v2', quantity: 0 }),
+    ]);
+    expect(getTotalQuantity(product)).toBe(0);
+  });
+});
+
+describe('findVariant', () => {
+  it('finds variant by ID', () => {
+    const target = makeVariant({ id: 'var_target', label: 'Large' });
+    const product = makeProductWithVariants([
+      makeVariant({ id: 'var_other' }),
+      target,
+    ]);
+    expect(findVariant(product, 'var_target')).toEqual(target);
+  });
+
+  it('returns undefined for unknown ID', () => {
+    const product = makeProductWithVariants([makeVariant()]);
+    expect(findVariant(product, 'var_nonexistent')).toBeUndefined();
+  });
+});
+
+describe('findVariantBySquareId', () => {
+  it('finds variant by Square variation ID', () => {
+    const target = makeVariant({
+      id: 'v1',
+      squareVariationId: 'SQ_VAR_123',
+    });
+    const product = makeProductWithVariants([
+      makeVariant({ id: 'v0', squareVariationId: 'SQ_VAR_000' }),
+      target,
+    ]);
+    expect(findVariantBySquareId(product, 'SQ_VAR_123')).toEqual(target);
+  });
+
+  it('returns undefined when no match', () => {
+    const product = makeProductWithVariants([
+      makeVariant({ squareVariationId: 'SQ_VAR_999' }),
+    ]);
+    expect(findVariantBySquareId(product, 'SQ_VAR_000')).toBeUndefined();
+  });
+});
+
+describe('findVariantByEtsyProductId', () => {
+  it('finds variant by Etsy product ID', () => {
+    const target = makeVariant({ id: 'v1', etsyProductId: 42 });
+    const product = makeProductWithVariants([
+      makeVariant({ id: 'v0', etsyProductId: 99 }),
+      target,
+    ]);
+    expect(findVariantByEtsyProductId(product, 42)).toEqual(target);
+  });
+
+  it('returns undefined when no match', () => {
+    const product = makeProductWithVariants([makeVariant()]);
+    expect(findVariantByEtsyProductId(product, 42)).toBeUndefined();
+  });
+});
+
+describe('isMultiVariant', () => {
+  it('returns false for single variant', () => {
+    const product = makeProductWithVariants([makeVariant()]);
+    expect(isMultiVariant(product)).toBe(false);
+  });
+
+  it('returns true for multiple variants', () => {
+    const product = makeProductWithVariants([
+      makeVariant({ id: 'v1' }),
+      makeVariant({ id: 'v2' }),
+    ]);
+    expect(isMultiVariant(product)).toBe(true);
+  });
+});
+
+describe('resolveVariants', () => {
+  it('returns provided variants when present', () => {
+    const variants = [
+      { label: 'Small', priceCents: 1000, quantity: 3 },
+      { label: 'Large', priceCents: 1500, quantity: 5 },
+    ];
+    const result = resolveVariants({ variants });
+    expect(result).toEqual(variants);
+  });
+
+  it('creates single Regular variant from legacy fields', () => {
+    const result = resolveVariants({ priceCents: 2500, quantity: 10 });
+    expect(result).toEqual([
+      { label: 'Regular', priceCents: 2500, quantity: 10 },
+    ]);
+  });
+
+  it('defaults to 0 price and quantity when legacy fields missing', () => {
+    const result = resolveVariants({});
+    expect(result).toEqual([
+      { label: 'Regular', priceCents: 0, quantity: 0 },
+    ]);
+  });
+
+  it('prefers variants over legacy fields', () => {
+    const result = resolveVariants({
+      variants: [{ label: 'Custom', priceCents: 500, quantity: 1 }],
+      priceCents: 9999,
+      quantity: 99,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].label).toBe('Custom');
+    expect(result[0].priceCents).toBe(500);
+  });
+
+  it('falls back to legacy when variants is empty array', () => {
+    const result = resolveVariants({
+      variants: [],
+      priceCents: 2500,
+      quantity: 10,
+    });
+    expect(result).toEqual([
+      { label: 'Regular', priceCents: 2500, quantity: 10 },
+    ]);
   });
 });

--- a/libs/ts/domain/src/lib/product.ts
+++ b/libs/ts/domain/src/lib/product.ts
@@ -9,9 +9,37 @@
  * Square owns: name, description, price, quantity, SKU, images
  * Firestore owns: artist relationship, commission rates, status
  *
+ * Products support multiple variants (e.g. size, color). Most products
+ * have a single "Regular" variant. Each variant maps 1:1 to a Square
+ * ITEM_VARIATION and an Etsy inventory product.
+ *
+ * @see ADR-010 for hybrid inventory architecture
  * @see ADR-011 for sync strategy details
  */
 import type { EtsyCache } from './etsy';
+
+/**
+ * A product variant (e.g. size, color).
+ *
+ * Most products have a single variant with label "Regular".
+ * Each variant maps to one Square ITEM_VARIATION and one Etsy inventory product.
+ */
+export interface ProductVariant {
+  /** Internal variant ID (auto-generated) */
+  id: string;
+  /** Display label: "Regular", "Small", "Blue", etc. */
+  label: string;
+  /** Product SKU for barcode scanning */
+  sku: string;
+  /** Price in cents (e.g., 2500 = $25.00) */
+  priceCents: number;
+  /** Current inventory quantity */
+  quantity: number;
+  /** Square item variation ID */
+  squareVariationId?: string;
+  /** Etsy per-variant product ID */
+  etsyProductId?: number;
+}
 
 /**
  * Cached data from Square for display without API calls.
@@ -21,20 +49,28 @@ import type { EtsyCache } from './etsy';
  * - Webhooks (real-time on sales/inventory changes)
  * - Lazy refresh (on product access if stale)
  * - Periodic sync (nightly safety net)
+ *
+ * Listing-level fields only. Per-variant data (price, quantity, SKU)
+ * lives on ProductVariant.
  */
 export interface SquareCache {
   name: string;
   description?: string;
-  /** Price in cents (e.g., 2500 = $25.00) */
-  priceCents: number;
-  /** Current inventory quantity */
-  quantity: number;
-  /** Product SKU for barcode scanning */
-  sku: string;
   /** Primary product image URL */
   imageUrl?: string;
   /** When this cache was last synced from Square */
   syncedAt: Date;
+
+  // --- Deprecated: per-variant data now lives on ProductVariant ---
+  // These fields are populated from variants[0] for backward compatibility.
+  // Consumers should migrate to reading from product.variants[].
+
+  /** @deprecated Use product.variants[].priceCents */
+  priceCents?: number;
+  /** @deprecated Use product.variants[].quantity */
+  quantity?: number;
+  /** @deprecated Use product.variants[].sku */
+  sku?: string;
 }
 
 /**
@@ -65,13 +101,27 @@ export interface Product {
   createdAt: Date;
   updatedAt: Date;
 
+  // === VARIANTS ===
+
+  /**
+   * Product variants (minimum 1). Most products have a single "Regular" variant.
+   * Each variant has its own SKU, price, quantity, and external system IDs.
+   */
+  variants: ProductVariant[];
+
+  /**
+   * Labels for what variants represent (e.g. ["Size"], ["Color", "Size"]).
+   * Empty or undefined for single-variant products.
+   */
+  variantProperties?: string[];
+
   // === EXTERNAL SYSTEM LINKS ===
 
   /** Square catalog item ID - Required, Square is catalog owner */
   squareItemId: string;
 
-  /** Square item variation ID (for inventory tracking) */
-  squareVariationId: string;
+  /** @deprecated Use product.variants[].squareVariationId */
+  squareVariationId?: string;
 
   /** Square catalog version for optimistic locking on updates */
   squareCatalogVersion?: number;
@@ -85,7 +135,7 @@ export interface Product {
   // === CACHED DATA (may be stale, for display only) ===
 
   /**
-   * Cached data from Square for fast reads.
+   * Cached listing-level data from Square for fast reads.
    * Check syncedAt to determine freshness.
    */
   squareCache: SquareCache;
@@ -113,6 +163,93 @@ export function isCacheStale(product: Pick<Product, 'squareCache'>): boolean {
 }
 
 /**
+ * Generate a unique variant ID
+ */
+export function generateVariantId(): string {
+  return `var_${Math.random().toString(36).substring(2, 10)}`;
+}
+
+/**
+ * Get total quantity across all variants
+ */
+export function getTotalQuantity(product: Pick<Product, 'variants'>): number {
+  return product.variants.reduce((sum, v) => sum + v.quantity, 0);
+}
+
+/**
+ * Find a variant by ID
+ */
+export function findVariant(
+  product: Pick<Product, 'variants'>,
+  variantId: string
+): ProductVariant | undefined {
+  return product.variants.find((v) => v.id === variantId);
+}
+
+/**
+ * Find a variant by Square variation ID
+ */
+export function findVariantBySquareId(
+  product: Pick<Product, 'variants'>,
+  squareVariationId: string
+): ProductVariant | undefined {
+  return product.variants.find(
+    (v) => v.squareVariationId === squareVariationId
+  );
+}
+
+/**
+ * Find a variant by Etsy product ID
+ */
+export function findVariantByEtsyProductId(
+  product: Pick<Product, 'variants'>,
+  etsyProductId: number
+): ProductVariant | undefined {
+  return product.variants.find((v) => v.etsyProductId === etsyProductId);
+}
+
+/**
+ * Check if a product has multiple variants (not just the default "Regular")
+ */
+export function isMultiVariant(product: Pick<Product, 'variants'>): boolean {
+  return product.variants.length > 1;
+}
+
+/**
+ * Resolve CreateProductInput to a normalized variants array.
+ * If variants[] is provided, use it. Otherwise, create a single "Regular"
+ * variant from the legacy priceCents/quantity fields.
+ */
+export function resolveVariants(
+  input: Pick<
+    CreateProductInput,
+    'variants' | 'priceCents' | 'quantity'
+  >
+): CreateVariantInput[] {
+  if (input.variants && input.variants.length > 0) {
+    return input.variants;
+  }
+  return [
+    {
+      label: 'Regular',
+      priceCents: input.priceCents ?? 0,
+      quantity: input.quantity ?? 0,
+    },
+  ];
+}
+
+/**
+ * Input for a product variant during creation
+ */
+export interface CreateVariantInput {
+  label: string;
+  priceCents: number;
+  quantity: number;
+  /** SKU is auto-generated if not provided */
+  sku?: string;
+}
+
+/**
  * Input for creating a new product
  *
  * Square IDs and cache are populated after Square API call.
@@ -129,10 +266,25 @@ export interface CreateProductInput {
   // Required - will be sent to Square to create catalog item
   name: string;
   description?: string;
-  /** Price in cents */
-  priceCents: number;
-  /** Initial inventory quantity */
-  quantity: number;
+
+  /**
+   * Product variants. If omitted, a single "Regular" variant is created
+   * from the top-level priceCents/quantity fields for backward compatibility.
+   */
+  variants?: CreateVariantInput[];
+
+  /**
+   * Labels for variant dimensions (e.g. ["Size"], ["Color"]).
+   * Only meaningful when variants has more than 1 entry.
+   */
+  variantProperties?: string[];
+
+  // === Legacy single-variant fields (used when variants is omitted) ===
+
+  /** Price in cents — used when variants is omitted */
+  priceCents?: number;
+  /** Initial inventory quantity — used when variants is omitted */
+  quantity?: number;
 }
 
 /**
@@ -153,11 +305,26 @@ export interface UpdateProductInput {
   // Square-owned (triggers Square API call)
   name?: string;
   description?: string;
-  /** Price in cents */
-  priceCents?: number;
 
-  // Inventory changes go through Inventory API
+  /** Updated variants (replaces all variants) */
+  variants?: CreateVariantInput[];
+  variantProperties?: string[];
+
+  // === Legacy single-variant fields ===
+  /** Price in cents — applies to first variant when variants is omitted */
+  priceCents?: number;
+  /** Quantity — applies to first variant when variants is omitted */
   quantity?: number;
+}
+
+/**
+ * Result of creating a single variation in Square
+ */
+export interface SquareVariationResult {
+  /** Internal variant ID (matches ProductVariant.id) */
+  variantId: string;
+  squareVariationId: string;
+  sku: string;
 }
 
 /**
@@ -165,9 +332,15 @@ export interface UpdateProductInput {
  */
 export interface SquareProductResult {
   squareItemId: string;
-  squareVariationId: string;
   squareCatalogVersion: number;
   squareLocationId: string;
+  /** Per-variation results */
+  variations: SquareVariationResult[];
+
+  // === Legacy fields for backward compatibility ===
+  /** @deprecated Use variations[0].squareVariationId */
+  squareVariationId: string;
+  /** @deprecated Use variations[0].sku */
   sku: string;
 }
 

--- a/libs/ts/validation/src/lib/product.validation.spec.ts
+++ b/libs/ts/validation/src/lib/product.validation.spec.ts
@@ -3,6 +3,7 @@ import { productValidation } from './product.validation';
 import type { CreateProductInput } from '@maple/ts/domain';
 
 describe('productValidation', () => {
+  // Legacy single-variant input (backward compatible)
   const validProduct: CreateProductInput = {
     artistId: 'artist-123',
     status: 'active',
@@ -11,8 +12,20 @@ describe('productValidation', () => {
     quantity: 5,
   };
 
+  // New variant-aware input
+  const validProductWithVariants: CreateProductInput = {
+    artistId: 'artist-123',
+    status: 'active',
+    name: 'Handmade Earrings',
+    variants: [
+      { label: 'Small', priceCents: 1500, quantity: 3 },
+      { label: 'Large', priceCents: 2500, quantity: 5 },
+    ],
+    variantProperties: ['Size'],
+  };
+
   describe('valid data', () => {
-    it('passes with all required fields', () => {
+    it('passes with all required fields (legacy)', () => {
       const result = productValidation(validProduct);
       expect(result.isValid()).toBe(true);
     });
@@ -23,6 +36,19 @@ describe('productValidation', () => {
         categoryId: 'cat-123',
         customCommissionRate: 0.25,
         description: 'A beautiful handmade bowl',
+      });
+      expect(result.isValid()).toBe(true);
+    });
+
+    it('passes with variants', () => {
+      const result = productValidation(validProductWithVariants);
+      expect(result.isValid()).toBe(true);
+    });
+
+    it('passes with single variant', () => {
+      const result = productValidation({
+        ...validProductWithVariants,
+        variants: [{ label: 'Regular', priceCents: 2500, quantity: 5 }],
       });
       expect(result.isValid()).toBe(true);
     });
@@ -142,7 +168,9 @@ describe('productValidation', () => {
     });
   });
 
-  describe('priceCents field', () => {
+  // --- Legacy single-variant fields ---
+
+  describe('priceCents field (legacy)', () => {
     it('fails when price is missing', () => {
       const result = productValidation({
         ...validProduct,
@@ -199,7 +227,7 @@ describe('productValidation', () => {
     });
   });
 
-  describe('quantity field', () => {
+  describe('quantity field (legacy)', () => {
     it('fails when quantity is missing', () => {
       const result = productValidation({
         ...validProduct,
@@ -244,6 +272,97 @@ describe('productValidation', () => {
         ...validProduct,
         quantity: 100,
       });
+      expect(result.hasErrors('quantity')).toBe(false);
+    });
+  });
+
+  // --- Variant validation ---
+
+  describe('variants validation', () => {
+    it('fails when a variant label is blank', () => {
+      const result = productValidation({
+        ...validProductWithVariants,
+        variants: [{ label: '', priceCents: 1000, quantity: 1 }],
+      });
+      expect(result.hasErrors('variants')).toBe(true);
+      expect(result.getErrors('variants')).toContain(
+        'Each variant must have a label'
+      );
+    });
+
+    it('fails when a variant price is 0', () => {
+      const result = productValidation({
+        ...validProductWithVariants,
+        variants: [{ label: 'Small', priceCents: 0, quantity: 1 }],
+      });
+      expect(result.hasErrors('variants')).toBe(true);
+      expect(result.getErrors('variants')).toContain(
+        'Each variant price must be greater than 0'
+      );
+    });
+
+    it('fails when a variant price exceeds $100,000', () => {
+      const result = productValidation({
+        ...validProductWithVariants,
+        variants: [{ label: 'Small', priceCents: 10000001, quantity: 1 }],
+      });
+      expect(result.hasErrors('variants')).toBe(true);
+      expect(result.getErrors('variants')).toContain(
+        'Each variant price cannot exceed $100,000'
+      );
+    });
+
+    it('fails when a variant quantity is negative', () => {
+      const result = productValidation({
+        ...validProductWithVariants,
+        variants: [{ label: 'Small', priceCents: 1000, quantity: -1 }],
+      });
+      expect(result.hasErrors('variants')).toBe(true);
+      expect(result.getErrors('variants')).toContain(
+        'Each variant quantity must be 0 or greater'
+      );
+    });
+
+    it('fails when a variant quantity is not a whole number', () => {
+      const result = productValidation({
+        ...validProductWithVariants,
+        variants: [{ label: 'Small', priceCents: 1000, quantity: 2.5 }],
+      });
+      expect(result.hasErrors('variants')).toBe(true);
+      expect(result.getErrors('variants')).toContain(
+        'Each variant quantity must be a whole number'
+      );
+    });
+
+    it('fails when variant labels are duplicated', () => {
+      const result = productValidation({
+        ...validProductWithVariants,
+        variants: [
+          { label: 'Small', priceCents: 1000, quantity: 1 },
+          { label: 'Small', priceCents: 1500, quantity: 2 },
+        ],
+      });
+      expect(result.hasErrors('variants')).toBe(true);
+      expect(result.getErrors('variants')).toContain(
+        'Variant labels must be unique'
+      );
+    });
+
+    it('passes with valid multi-variant input', () => {
+      const result = productValidation(validProductWithVariants);
+      expect(result.hasErrors('variants')).toBe(false);
+    });
+
+    it('does not validate legacy priceCents/quantity when variants are present', () => {
+      // variants present means legacy fields are ignored
+      const result = productValidation({
+        artistId: 'artist-123',
+        status: 'active',
+        name: 'Test',
+        variants: [{ label: 'Regular', priceCents: 1000, quantity: 1 }],
+        // Legacy fields deliberately omitted — should not cause errors
+      });
+      expect(result.hasErrors('priceCents')).toBe(false);
       expect(result.hasErrors('quantity')).toBe(false);
     });
   });

--- a/libs/ts/validation/src/lib/product.validation.ts
+++ b/libs/ts/validation/src/lib/product.validation.ts
@@ -15,24 +15,13 @@ import type { CreateProductInput } from '@maple/ts/domain';
  *
  * CreateProductInput contains:
  * - Firestore-owned: artistId, status, customCommissionRate
- * - Square-bound: name, description, priceCents, quantity
+ * - Square-bound: name, description, variants (or legacy priceCents/quantity)
  *
  * @param data - Partial product data to validate
  * @param field - Optional field(s) to validate (for single-field or
  *                partial-update validation). Pass a string for a single
  *                field, or an array of field names to validate only those
  *                fields (useful for partial updates).
- *
- * @example
- * // Full validation
- * const result = productValidation(formData);
- * if (result.isValid()) {
- *   // Submit form
- * }
- *
- * @example
- * // Partial update - only validate fields that were provided
- * const result = productValidation(patch, Object.keys(patch));
  */
 export const productValidation = staticSuite(
   (data: Partial<CreateProductInput>, field?: string | string[]) => {
@@ -76,37 +65,84 @@ export const productValidation = staticSuite(
       enforce(data.name).longerThanOrEquals(2);
     });
 
-    test('priceCents', 'Price is required', () => {
-      enforce(data.priceCents).isNotNullish();
-    });
+    // === Variant validation ===
 
-    test('priceCents', 'Price must be greater than 0', () => {
-      if (data.priceCents !== undefined) {
-        enforce(data.priceCents).greaterThan(0);
-      }
-    });
+    if (data.variants && data.variants.length > 0) {
+      // New variant-aware path
+      test('variants', 'At least one variant is required', () => {
+        enforce(data.variants).isNotEmpty();
+      });
 
-    test('priceCents', 'Price cannot exceed $100,000', () => {
-      if (data.priceCents !== undefined) {
-        // 100000 dollars = 10000000 cents
-        enforce(data.priceCents).lessThanOrEquals(10000000);
-      }
-    });
+      test('variants', 'Each variant must have a label', () => {
+        for (const v of data.variants!) {
+          enforce(v.label).isNotBlank();
+        }
+      });
 
-    test('quantity', 'Quantity is required', () => {
-      enforce(data.quantity).isNotNullish();
-    });
+      test('variants', 'Each variant price must be greater than 0', () => {
+        for (const v of data.variants!) {
+          enforce(v.priceCents).greaterThan(0);
+        }
+      });
 
-    test('quantity', 'Quantity must be 0 or greater', () => {
-      if (data.quantity !== undefined) {
-        enforce(data.quantity).greaterThanOrEquals(0);
-      }
-    });
+      test('variants', 'Each variant price cannot exceed $100,000', () => {
+        for (const v of data.variants!) {
+          enforce(v.priceCents).lessThanOrEquals(10000000);
+        }
+      });
 
-    test('quantity', 'Quantity must be a whole number', () => {
-      if (data.quantity !== undefined) {
-        enforce(data.quantity).condition((val) => Number.isInteger(val));
-      }
-    });
+      test('variants', 'Each variant quantity must be 0 or greater', () => {
+        for (const v of data.variants!) {
+          enforce(v.quantity).greaterThanOrEquals(0);
+        }
+      });
+
+      test('variants', 'Each variant quantity must be a whole number', () => {
+        for (const v of data.variants!) {
+          enforce(v.quantity).condition((val) => Number.isInteger(val));
+        }
+      });
+
+      test('variants', 'Variant labels must be unique', () => {
+        const labels = data.variants!.map((v) => v.label);
+        enforce(labels).condition(
+          (arr) => new Set(arr).size === arr.length
+        );
+      });
+    } else {
+      // Legacy single-variant path (priceCents/quantity at top level)
+      test('priceCents', 'Price is required', () => {
+        enforce(data.priceCents).isNotNullish();
+      });
+
+      test('priceCents', 'Price must be greater than 0', () => {
+        if (data.priceCents !== undefined) {
+          enforce(data.priceCents).greaterThan(0);
+        }
+      });
+
+      test('priceCents', 'Price cannot exceed $100,000', () => {
+        if (data.priceCents !== undefined) {
+          // 100000 dollars = 10000000 cents
+          enforce(data.priceCents).lessThanOrEquals(10000000);
+        }
+      });
+
+      test('quantity', 'Quantity is required', () => {
+        enforce(data.quantity).isNotNullish();
+      });
+
+      test('quantity', 'Quantity must be 0 or greater', () => {
+        if (data.quantity !== undefined) {
+          enforce(data.quantity).greaterThanOrEquals(0);
+        }
+      });
+
+      test('quantity', 'Quantity must be a whole number', () => {
+        if (data.quantity !== undefined) {
+          enforce(data.quantity).condition((val) => Number.isInteger(val));
+        }
+      });
+    }
   }
 );


### PR DESCRIPTION
## Summary

- Adds `ProductVariant` type with id, label, sku, priceCents, quantity, squareVariationId, etsyProductId
- Adds `variants[]` to Product (minimum 1 entry — most products have a single "Regular" variant)
- Adds 7 variant helper functions (getTotalQuantity, findVariant, findVariantBySquareId, isMultiVariant, resolveVariants, etc.)
- Updates validation suite with variant-aware rules alongside legacy single-variant path
- Updates repository with transparent migration (legacy Firestore docs auto-convert via `docToProduct()`)
- Keeps deprecated fields on SquareCache/EtsyCache/Product populated from `variants[0]` for backward compatibility

Foundation for Phase 5 multi-channel inventory sync (Square POS + Etsy). See `.claude/plans/wild-scribbling-stearns.md` for the full 9-PR plan.

Closes #305

## Test plan

- [x] 43 domain unit tests (product.spec.ts) — all variant helpers covered
- [x] 40 validation tests (product.validation.spec.ts) — variant rules + legacy path
- [x] 129 database tests (product.repository.spec.ts) — migration + create with variations
- [x] 886 total tests across 47 files passing
- [ ] CI build check

🤖 Generated with [Claude Code](https://claude.com/claude-code)