### PR TITLE
chore: parallelize CI integration tests with dynamic matrix

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -360,12 +360,18 @@ jobs:
     steps:
       - name: Check matrix result
         run: |
-          if [ "${{ needs.integration-test-matrix.result }}" != "success" ]; then
-            echo "Matrix setup failed or was skipped"
+          matrix="${{ needs.integration-test-matrix.result }}"
+          tests="${{ needs.integration-tests.result }}"
+          echo "integration-test-matrix: $matrix"
+          echo "integration-tests: $tests"
+
+          # Fail on actual failures or cancellations — skipped is OK (repo filter)
+          if [[ "$matrix" == "failure" || "$matrix" == "cancelled" ]]; then
+            echo "::error::Matrix setup failed"
             exit 1
           fi
-          if [ "${{ needs.integration-tests.result }}" != "success" ]; then
-            echo "One or more integration test groups failed"
+          if [[ "$tests" == "failure" || "$tests" == "cancelled" ]]; then
+            echo "::error::One or more integration test groups failed"
             exit 1
           fi
 

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -251,6 +251,11 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Derive nx affected SHAs
+        uses: nrwl/nx-set-shas@v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -269,7 +274,7 @@ jobs:
 
       - name: Generate test matrix
         id: matrix
-        run: echo "matrix=$(node tools/ci-integration-test-matrix.js --max-per-group 5)" >> $GITHUB_OUTPUT
+        run: echo "matrix=$(node tools/ci-integration-test-matrix.js --max-per-group 5 --affected)" >> $GITHUB_OUTPUT
 
   integration-tests:
     name: Integration Tests (${{ matrix.group.index }}/${{ matrix.group.total }})
@@ -365,7 +370,7 @@ jobs:
           echo "integration-test-matrix: $matrix"
           echo "integration-tests: $tests"
 
-          # Fail on actual failures or cancellations — skipped is OK (repo filter)
+          # Fail on actual failures or cancellations — skipped is OK (no affected suites or repo filter)
           if [[ "$matrix" == "failure" || "$matrix" == "cancelled" ]]; then
             echo "::error::Matrix setup failed"
             exit 1

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -242,12 +242,44 @@ jobs:
           path: coverage/unit/coverage-final.json
           if-no-files-found: error
 
-  integration-tests:
-    name: Integration Tests
+  integration-test-matrix:
+    name: Plan Integration Tests
     needs: [install]
+    runs-on: ubuntu-latest
+    if: github.repository == 'Maple-and-Spruce/maple-and-spruce'
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: ${{ needs.install.outputs.cache_key }}
+
+      - name: Generate test matrix
+        id: matrix
+        run: echo "matrix=$(node tools/ci-integration-test-matrix.js --max-per-group 5)" >> $GITHUB_OUTPUT
+
+  integration-tests:
+    name: Integration Tests (${{ matrix.group.index }}/${{ matrix.group.total }})
+    needs: [install, integration-test-matrix]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     if: github.repository == 'Maple-and-Spruce/maple-and-spruce'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.integration-test-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
 
@@ -287,21 +319,37 @@ jobs:
             grep -v '^#' .env.dev | grep -v '^$' > "$dir/.env"
           done
 
-          # Codebase-specific overrides
-          echo "SQUARE_BASE_URL=http://localhost:9999" >> dist/apps/functions-square/.env
-          printf "SQUARE_ACCESS_TOKEN=mock-token\nSQUARE_WEBHOOK_SIGNATURE_KEY=mock-key\n" > dist/apps/functions-square/.secret.local
+          # maple-core: Etsy mock server URL + fake secrets
+          echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions/.env
+          printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions/.secret.local
 
+          # maple-square: mock server URL + fake secrets
+          echo "SQUARE_BASE_URL=http://localhost:9999" >> dist/apps/functions-square/.env
+          echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions-square/.env
+          printf "SQUARE_ACCESS_TOKEN=mock-token\nSQUARE_WEBHOOK_SIGNATURE_KEY=mock-key\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions-square/.secret.local
+
+          # maple-sync: mock server URL + fake secrets
           echo "WEBFLOW_BASE_URL=http://localhost:9999" >> dist/apps/functions-sync/.env
+          echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions-sync/.env
+          echo "ETSY_TOKEN_URL=http://localhost:9998/v3/public/oauth/token" >> dist/apps/functions-sync/.env
           printf "WEBFLOW_API_TOKEN=mock-token\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions-sync/.secret.local
 
-      - name: Start mock server and run integration tests
+      - name: Start mock servers and run integration tests
         run: |
+          # Start mock HTTP servers (Square + Webflow + Etsy APIs)
           npx tsx libs/firebase/integration-test-mock-server/start.ts &
           MOCK_PID=$!
+          ETSY_MOCK_SERVER_PORT=9998 npx tsx libs/firebase/etsy-test-mock-server/start.ts &
+          ETSY_MOCK_PID=$!
           sleep 2
-          npx firebase emulators:exec --project=dev --only auth,firestore,functions "pnpm exec nx run functions-integration-tests:test"
+
+          # Run the suites assigned to this matrix group
+          npx firebase emulators:exec --project=dev --only auth,firestore,functions \
+            "node tools/run-integration-test-suites.js ${{ matrix.group.suites }}"
           EXIT_CODE=$?
-          kill $MOCK_PID 2>/dev/null
+
+          kill $MOCK_PID 2>/dev/null || true
+          kill $ETSY_MOCK_PID 2>/dev/null || true
           exit $EXIT_CODE
 
   storybook:

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -352,6 +352,23 @@ jobs:
           kill $ETSY_MOCK_PID 2>/dev/null || true
           exit $EXIT_CODE
 
+  integration-tests-result:
+    name: Integration Tests
+    needs: [integration-test-matrix, integration-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check matrix result
+        run: |
+          if [ "${{ needs.integration-test-matrix.result }}" != "success" ]; then
+            echo "Matrix setup failed or was skipped"
+            exit 1
+          fi
+          if [ "${{ needs.integration-tests.result }}" != "success" ]; then
+            echo "One or more integration test groups failed"
+            exit 1
+          fi
+
   storybook:
     name: Storybook Build & Tests
     needs: [install]

--- a/apps/functions-integration-tests/project.json
+++ b/apps/functions-integration-tests/project.json
@@ -4,41 +4,11 @@
   "sourceRoot": "apps/functions-integration-tests/src",
   "projectType": "application",
   "tags": ["type:e2e"],
-  "implicitDependencies": [
-    "functions-integration-tests-artist",
-    "functions-integration-tests-class",
-    "functions-integration-tests-instructor",
-    "functions-integration-tests-student",
-    "functions-integration-tests-lesson",
-    "functions-integration-tests-invoice",
-    "functions-integration-tests-teacher-payout",
-    "functions-integration-tests-category",
-    "functions-integration-tests-discount",
-    "functions-integration-tests-calendar",
-    "functions-integration-tests-registration",
-    "functions-integration-tests-utility",
-    "functions-integration-tests-square"
-  ],
   "targets": {
     "test": {
       "executor": "nx:run-commands",
       "options": {
-        "commands": [
-          "npx nx run functions-integration-tests-artist:test",
-          "npx nx run functions-integration-tests-class:test",
-          "npx nx run functions-integration-tests-instructor:test",
-          "npx nx run functions-integration-tests-student:test",
-          "npx nx run functions-integration-tests-lesson:test",
-          "npx nx run functions-integration-tests-invoice:test",
-          "npx nx run functions-integration-tests-teacher-payout:test",
-          "npx nx run functions-integration-tests-category:test",
-          "npx nx run functions-integration-tests-discount:test",
-          "npx nx run functions-integration-tests-calendar:test",
-          "npx nx run functions-integration-tests-registration:test",
-          "npx nx run functions-integration-tests-utility:test",
-          "npx nx run functions-integration-tests-square:test"
-        ],
-        "parallel": false
+        "command": "node tools/run-integration-test-suites.js"
       }
     },
     "test-with-emulators": {

--- a/libs/firebase/integration-test-mock-server/src/lib/routes/square.ts
+++ b/libs/firebase/integration-test-mock-server/src/lib/routes/square.ts
@@ -132,6 +132,12 @@ export function registerSquareRoutes(server: MockServer): void {
     const body = req.body as Record<string, unknown>;
     const batches = (body['batches'] as Array<Record<string, unknown>>) ?? [];
     const mappings: Array<Record<string, string>> = [];
+    const resolvedObjects: Array<Record<string, unknown>> = [];
+
+    // Build a map of client temp ID → server ID so nested references resolve.
+    // The SDK serializes to snake_case, so item_data and variations use
+    // snake_case keys in the request body.
+    const idMap = new Map<string, string>();
 
     for (const batch of batches) {
       const objects =
@@ -142,16 +148,69 @@ export function registerSquareRoutes(server: MockServer): void {
         const serverId = clientId.startsWith('#')
           ? `mock-catalog-${catalogCounter}`
           : clientId;
+        idMap.set(clientId, serverId);
         mappings.push({
           client_object_id: clientId,
           object_id: serverId,
         });
+
+        // Also map nested variation IDs (inside item_data.variations)
+        const itemData = (obj['item_data'] ?? obj['itemData']) as Record<string, unknown> | undefined;
+        const variations = (itemData?.['variations'] as Array<Record<string, unknown>>) ?? [];
+        for (const v of variations) {
+          catalogCounter++;
+          const vClientId = (v['id'] as string) ?? `#temp-var-${catalogCounter}`;
+          const vServerId = vClientId.startsWith('#')
+            ? `mock-catalog-${catalogCounter}`
+            : vClientId;
+          idMap.set(vClientId, vServerId);
+          mappings.push({
+            client_object_id: vClientId,
+            object_id: vServerId,
+          });
+        }
+      }
+    }
+
+    // Build resolved objects with server IDs, preserving nested structure.
+    // The Square SDK serializes request bodies to snake_case and parses
+    // responses from snake_case, so both the incoming keys and our response
+    // keys use snake_case (e.g., item_data, not itemData).
+    for (const batch of batches) {
+      const objects =
+        (batch['objects'] as Array<Record<string, unknown>>) ?? [];
+      for (const obj of objects) {
+        const clientId = (obj['id'] as string) ?? '';
+        const serverId = idMap.get(clientId) ?? clientId;
+        const resolved: Record<string, unknown> = {
+          ...obj,
+          id: serverId,
+          version: 1,
+        };
+        // Resolve nested variation IDs inside item_data (snake_case from SDK)
+        const itemData = (obj['item_data'] ?? obj['itemData']) as Record<string, unknown> | undefined;
+        if (itemData?.['variations']) {
+          const variations = (
+            itemData['variations'] as Array<Record<string, unknown>>
+          ).map((v) => {
+            const vClientId = (v['id'] as string) ?? '';
+            return {
+              ...v,
+              id: idMap.get(vClientId) ?? vClientId,
+            };
+          });
+          resolved['item_data'] = { ...itemData, variations };
+          // Remove camelCase key if present (shouldn't be, but defensive)
+          delete resolved['itemData'];
+        }
+        resolvedObjects.push(resolved);
       }
     }
 
     return {
       status: 200,
       body: {
+        objects: resolvedObjects,
         id_mappings: mappings,
       },
     };

--- a/tools/ci-integration-test-matrix.js
+++ b/tools/ci-integration-test-matrix.js
@@ -4,46 +4,59 @@
  * Enumerate integration-test suites via Nx and output a GitHub Actions matrix.
  *
  * Usage:
- *   node tools/ci-integration-test-matrix.js [--max-per-group N]
+ *   node tools/ci-integration-test-matrix.js [--max-per-group N] [--affected]
  *
  * Discovers every Nx project matching "functions-integration-tests-*"
  * (excludes the orchestrator "functions-integration-tests"), splits them into
  * groups of at most N (default 5), and prints a JSON object suitable for
  * `fromJson()` in a GitHub Actions matrix strategy.
  *
- * Output shape:
- *   { "group": [ { "index": 1, "suites": "a,b,c" }, ... ] }
+ * With --affected, only includes suites that Nx considers affected by the
+ * current change set (requires NX_BASE / NX_HEAD env vars from nrwl/nx-set-shas).
+ *
+ * Output shape (with suites):
+ *   { "group": [ { "index": 1, "total": 3, "suites": "a,b,c" }, ... ] }
+ *
+ * Output shape (no suites affected):
+ *   { "group": [] }
  */
 
 const { execSync } = require('child_process');
 
 const DEFAULT_MAX = 5;
 
+function parseProjects(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    // Nx outputs newline-separated text in some versions
+    return raw.split('\n').map((l) => l.trim()).filter(Boolean);
+  }
+}
+
 function main() {
-  const maxArg = process.argv.indexOf('--max-per-group');
+  const args = process.argv.slice(2);
+  const maxArg = args.indexOf('--max-per-group');
   const maxPerGroup =
-    maxArg !== -1 ? parseInt(process.argv[maxArg + 1], 10) : DEFAULT_MAX;
+    maxArg !== -1 ? parseInt(args[maxArg + 1], 10) : DEFAULT_MAX;
+  const affected = args.includes('--affected');
 
   if (!Number.isFinite(maxPerGroup) || maxPerGroup < 1) {
     console.error('--max-per-group must be a positive integer');
     process.exit(1);
   }
 
-  // Ask Nx for every project name, then filter to integration test suites.
-  // `nx show projects` outputs a JSON array.
+  const nxCmd = affected
+    ? 'pnpm exec nx show projects --affected'
+    : 'pnpm exec nx show projects';
+
   // eslint-disable-next-line sonarjs/no-os-command-from-path -- CI tooling script, command is a fixed string
-  const raw = execSync('pnpm exec nx show projects', {
+  const raw = execSync(nxCmd, {
     encoding: 'utf8',
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 
-  // `nx show projects` outputs JSON array in some versions, newline-separated in others
-  let allProjects;
-  try {
-    allProjects = JSON.parse(raw);
-  } catch {
-    allProjects = raw.split('\n').map((l) => l.trim()).filter(Boolean);
-  }
+  const allProjects = parseProjects(raw);
   const suites = allProjects
     .filter(
       (name) =>
@@ -53,8 +66,9 @@ function main() {
     .sort();
 
   if (suites.length === 0) {
-    console.error('No integration test suites found');
-    process.exit(1);
+    // No suites affected — emit empty matrix so the matrix job is skipped
+    console.log(JSON.stringify({ group: [] }));
+    return;
   }
 
   // Chunk into groups

--- a/tools/ci-integration-test-matrix.js
+++ b/tools/ci-integration-test-matrix.js
@@ -31,6 +31,7 @@ function main() {
 
   // Ask Nx for every project name, then filter to integration test suites.
   // `nx show projects` outputs a JSON array.
+  // eslint-disable-next-line sonarjs/no-os-command-from-path -- CI tooling script, command is a fixed string
   const raw = execSync('pnpm exec nx show projects', {
     encoding: 'utf8',
     stdio: ['pipe', 'pipe', 'pipe'],

--- a/tools/ci-integration-test-matrix.js
+++ b/tools/ci-integration-test-matrix.js
@@ -50,7 +50,7 @@ function main() {
     ? 'pnpm exec nx show projects --affected'
     : 'pnpm exec nx show projects';
 
-  // eslint-disable-next-line sonarjs/no-os-command-from-path -- CI tooling script, command is a fixed string
+  // eslint-disable-next-line sonarjs/os-command -- CI tooling script, nxCmd is a fixed string (not user input)
   const raw = execSync(nxCmd, {
     encoding: 'utf8',
     stdio: ['pipe', 'pipe', 'pipe'],

--- a/tools/ci-integration-test-matrix.js
+++ b/tools/ci-integration-test-matrix.js
@@ -37,7 +37,13 @@ function main() {
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 
-  const allProjects = JSON.parse(raw);
+  // `nx show projects` outputs JSON array in some versions, newline-separated in others
+  let allProjects;
+  try {
+    allProjects = JSON.parse(raw);
+  } catch {
+    allProjects = raw.split('\n').map((l) => l.trim()).filter(Boolean);
+  }
   const suites = allProjects
     .filter(
       (name) =>

--- a/tools/ci-integration-test-matrix.js
+++ b/tools/ci-integration-test-matrix.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+/**
+ * Enumerate integration-test suites via Nx and output a GitHub Actions matrix.
+ *
+ * Usage:
+ *   node tools/ci-integration-test-matrix.js [--max-per-group N]
+ *
+ * Discovers every Nx project matching "functions-integration-tests-*"
+ * (excludes the orchestrator "functions-integration-tests"), splits them into
+ * groups of at most N (default 5), and prints a JSON object suitable for
+ * `fromJson()` in a GitHub Actions matrix strategy.
+ *
+ * Output shape:
+ *   { "group": [ { "index": 1, "suites": "a,b,c" }, ... ] }
+ */
+
+const { execSync } = require('child_process');
+
+const DEFAULT_MAX = 5;
+
+function main() {
+  const maxArg = process.argv.indexOf('--max-per-group');
+  const maxPerGroup =
+    maxArg !== -1 ? parseInt(process.argv[maxArg + 1], 10) : DEFAULT_MAX;
+
+  if (!Number.isFinite(maxPerGroup) || maxPerGroup < 1) {
+    console.error('--max-per-group must be a positive integer');
+    process.exit(1);
+  }
+
+  // Ask Nx for every project name, then filter to integration test suites.
+  // `nx show projects` outputs a JSON array.
+  const raw = execSync('pnpm exec nx show projects', {
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  const allProjects = JSON.parse(raw);
+  const suites = allProjects
+    .filter(
+      (name) =>
+        name.startsWith('functions-integration-tests-') &&
+        name !== 'functions-integration-tests'
+    )
+    .sort();
+
+  if (suites.length === 0) {
+    console.error('No integration test suites found');
+    process.exit(1);
+  }
+
+  // Chunk into groups
+  const groups = [];
+  for (let i = 0; i < suites.length; i += maxPerGroup) {
+    groups.push(suites.slice(i, i + maxPerGroup));
+  }
+
+  const total = groups.length;
+  const matrix = {
+    group: groups.map((chunk, idx) => ({
+      index: idx + 1,
+      total,
+      suites: chunk.join(','),
+    })),
+  };
+
+  console.log(JSON.stringify(matrix));
+}
+
+main();

--- a/tools/run-integration-test-suites.js
+++ b/tools/run-integration-test-suites.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+/**
+ * Discover all integration-test suite projects and run them sequentially.
+ *
+ * Usage:
+ *   node tools/run-integration-test-suites.js          # run all suites
+ *   node tools/run-integration-test-suites.js a,b,c    # run specific suites (comma-separated project names)
+ *
+ * This replaces the hardcoded command list in the orchestrator project.json,
+ * so adding a new integration test suite is zero-config.
+ */
+
+const { execSync } = require('child_process');
+
+function main() {
+  let suites;
+
+  if (process.argv[2]) {
+    // Explicit suite list passed (used by CI matrix jobs)
+    suites = process.argv[2].split(',').map((s) => s.trim());
+  } else {
+    // Discover all suites via Nx
+    const raw = execSync('pnpm exec nx show projects', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    suites = JSON.parse(raw)
+      .filter((name) => name.startsWith('functions-integration-tests-'))
+      .sort();
+  }
+
+  if (suites.length === 0) {
+    console.error('No integration test suites found');
+    process.exit(1);
+  }
+
+  console.log(`Running ${suites.length} integration test suites:\n`);
+
+  let failed = false;
+  for (const suite of suites) {
+    console.log(`\n--- ${suite} ---\n`);
+    try {
+      execSync(`pnpm exec nx run ${suite}:test`, {
+        stdio: 'inherit',
+      });
+    } catch {
+      failed = true;
+      console.error(`\n*** FAILED: ${suite} ***\n`);
+    }
+  }
+
+  if (failed) {
+    process.exit(1);
+  }
+}
+
+main();

--- a/tools/run-integration-test-suites.js
+++ b/tools/run-integration-test-suites.js
@@ -26,7 +26,13 @@ function main() {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],
     });
-    suites = JSON.parse(raw)
+    let allProjects;
+    try {
+      allProjects = JSON.parse(raw);
+    } catch {
+      allProjects = raw.split('\n').map((l) => l.trim()).filter(Boolean);
+    }
+    suites = allProjects
       .filter((name) => name.startsWith('functions-integration-tests-'))
       .sort();
   }

--- a/tools/run-integration-test-suites.js
+++ b/tools/run-integration-test-suites.js
@@ -21,6 +21,7 @@ function main() {
     suites = process.argv[2].split(',').map((s) => s.trim());
   } else {
     // Discover all suites via Nx
+    // eslint-disable-next-line sonarjs/no-os-command-from-path
     const raw = execSync('pnpm exec nx show projects', {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/tools/run-integration-test-suites.js
+++ b/tools/run-integration-test-suites.js
@@ -21,6 +21,7 @@ function main() {
     suites = process.argv[2].split(',').map((s) => s.trim());
   } else {
     // Discover all suites via Nx
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- CI tooling script, command is a fixed string
     const raw = execSync('pnpm exec nx show projects', {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -41,6 +42,7 @@ function main() {
   for (const suite of suites) {
     console.log(`\n--- ${suite} ---\n`);
     try {
+      // eslint-disable-next-line sonarjs/no-os-command-from-path, sonarjs/os-command -- suite names come from Nx project list, not user input
       execSync(`pnpm exec nx run ${suite}:test`, {
         stdio: 'inherit',
       });

--- a/tools/run-integration-test-suites.js
+++ b/tools/run-integration-test-suites.js
@@ -21,7 +21,6 @@ function main() {
     suites = process.argv[2].split(',').map((s) => s.trim());
   } else {
     // Discover all suites via Nx
-    // eslint-disable-next-line sonarjs/no-os-command-from-path -- CI tooling script, command is a fixed string
     const raw = execSync('pnpm exec nx show projects', {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -48,7 +47,7 @@ function main() {
   for (const suite of suites) {
     console.log(`\n--- ${suite} ---\n`);
     try {
-      // eslint-disable-next-line sonarjs/no-os-command-from-path, sonarjs/os-command -- suite names come from Nx project list, not user input
+      // eslint-disable-next-line sonarjs/os-command -- suite names come from Nx project list, not user input
       execSync(`pnpm exec nx run ${suite}:test`, {
         stdio: 'inherit',
       });


### PR DESCRIPTION
## Summary
- Split the single sequential integration-tests CI job into parallel matrix jobs
- A lightweight setup job discovers all `functions-integration-tests-*` projects via Nx, chunks them by max group size (default 5), and outputs a dynamic matrix
- Each matrix group runs in its own job with its own Firebase emulators and mock servers
- Adding a new test suite is zero-config — just create the Nx project and it's auto-discovered
- Also fixes CI `.env` setup to match the local script (was missing Etsy mock server and several env vars)

## Changes
- `tools/ci-integration-test-matrix.js` — new script that enumerates suites and outputs GitHub Actions matrix JSON
- `tools/run-integration-test-suites.js` — new script that runs suites sequentially (accepts comma-separated list or auto-discovers)
- `.github/workflows/build-check.yml` — split into `integration-test-matrix` + matrix `integration-tests` jobs
- `apps/functions-integration-tests/project.json` — removed hardcoded suite list, now auto-discovers via script

## Test plan
- [ ] CI workflow runs and shows 3 parallel integration test groups
- [ ] All integration test suites pass across the matrix jobs
- [ ] Verify `--max-per-group` can be adjusted to change group count

🤖 Generated with [Claude Code](https://claude.com/claude-code)