### PR TITLE
feat: sale recording + inventory movement audit log

### DIFF
--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -147,3 +147,7 @@ export { saveEtsyArtistTemplate } from '@maple/firebase/maple-functions/save-ets
 
 // Etsy listing read (for import review UI — calls Etsy API, no Square dep)
 export { listEtsyListings } from '@maple/firebase/maple-functions/list-etsy-listings';
+
+// Phase 5: Sales tracking
+export { recordSale } from '@maple/firebase/maple-functions/record-sale';
+export { getSales } from '@maple/firebase/maple-functions/get-sales';

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -63,6 +63,8 @@
     "../../libs/firebase/maple-functions/save-etsy-category-template/**/*.ts",
     "../../libs/firebase/maple-functions/save-etsy-artist-template/**/*.ts",
     "../../libs/firebase/maple-functions/list-etsy-listings/**/*.ts",
+    "../../libs/firebase/maple-functions/record-sale/**/*.ts",
+    "../../libs/firebase/maple-functions/get-sales/**/*.ts",
     "../../libs/firebase/maple-functions/create-student/**/*.ts",
     "../../libs/firebase/maple-functions/delete-student/**/*.ts",
     "../../libs/firebase/maple-functions/get-student/**/*.ts",

--- a/docs/reference/deployed-functions.md
+++ b/docs/reference/deployed-functions.md
@@ -57,6 +57,10 @@ Core CRUD operations, auth, triggers, and admin functions. No heavy third-party 
 - `getCalendarEmbedConfig`, `updateCalendarEmbedConfig`, `addCalendarEmbedSource`, `removeCalendarEmbedSource`
 - `calendarEmbed` — HTTP: `/calendar/embed`
 
+### Sales (Phase 5)
+- `recordSale` — manually record a product sale with automatic commission calculation, inventory movement, and quantity decrement
+- `getSales` — retrieve sales with optional filters (artistId, source, date range)
+
 ### Auth
 - `checkAdminStatus`
 

--- a/libs/firebase/database/src/index.ts
+++ b/libs/firebase/database/src/index.ts
@@ -40,6 +40,16 @@ export {
 } from './lib/calendar-event.repository';
 export { CalendarEmbedConfigRepository } from './lib/calendar-embed-config.repository';
 
+// Phase 5: Sales & Inventory
+export {
+  SaleRepository,
+  type SaleFilters,
+} from './lib/sale.repository';
+export {
+  InventoryMovementRepository,
+  type InventoryMovementFilters,
+} from './lib/inventory-movement.repository';
+
 // Phase 5: Etsy
 export {
   FirestoreTokenStorage,

--- a/libs/firebase/database/src/lib/inventory-movement.repository.ts
+++ b/libs/firebase/database/src/lib/inventory-movement.repository.ts
@@ -1,0 +1,127 @@
+/**
+ * InventoryMovement Repository
+ *
+ * Immutable audit log of all inventory changes.
+ * Supports reconciliation by summing all movements for a product.
+ */
+import { db, toDate } from './utilities/database.config';
+import type {
+  InventoryMovement,
+  CreateInventoryMovementInput,
+  InventoryMovementType,
+  InventorySource,
+} from '@maple/ts/domain';
+import { calculateQuantityFromMovements } from '@maple/ts/domain';
+
+const COLLECTION = 'inventoryMovements';
+
+function docToMovement(
+  doc: FirebaseFirestore.DocumentSnapshot
+): InventoryMovement | undefined {
+  if (!doc.exists) {
+    return undefined;
+  }
+
+  const data = doc.data()!;
+
+  return {
+    id: doc.id,
+    productId: data.productId,
+    variantId: data.variantId,
+    type: data.type,
+    quantityChange: data.quantityChange,
+    quantityBefore: data.quantityBefore,
+    quantityAfter: data.quantityAfter,
+    source: data.source,
+    sourceReference: data.sourceReference,
+    saleId: data.saleId,
+    notes: data.notes,
+    performedBy: data.performedBy,
+    createdAt: toDate(data.createdAt),
+  };
+}
+
+export interface InventoryMovementFilters {
+  productId?: string;
+  type?: InventoryMovementType;
+  source?: InventorySource;
+}
+
+export const InventoryMovementRepository = {
+  async create(
+    input: CreateInventoryMovementInput
+  ): Promise<InventoryMovement> {
+    const docRef = db.collection(COLLECTION).doc();
+    const now = new Date();
+
+    const data = {
+      productId: input.productId,
+      variantId: input.variantId,
+      type: input.type,
+      quantityChange: input.quantityChange,
+      quantityBefore: input.quantityBefore,
+      quantityAfter: input.quantityAfter,
+      source: input.source,
+      sourceReference: input.sourceReference,
+      saleId: input.saleId,
+      notes: input.notes,
+      performedBy: input.performedBy,
+      createdAt: now,
+    };
+
+    await docRef.set(data);
+
+    return {
+      id: docRef.id,
+      ...data,
+      createdAt: now,
+    };
+  },
+
+  async findByProductId(productId: string): Promise<InventoryMovement[]> {
+    const snapshot = await db
+      .collection(COLLECTION)
+      .where('productId', '==', productId)
+      .orderBy('createdAt', 'desc')
+      .get();
+
+    return snapshot.docs
+      .map((doc) => docToMovement(doc))
+      .filter((m): m is InventoryMovement => m !== undefined);
+  },
+
+  async findAll(
+    filters: InventoryMovementFilters = {}
+  ): Promise<InventoryMovement[]> {
+    let query: FirebaseFirestore.Query = db.collection(COLLECTION);
+
+    if (filters.productId) {
+      query = query.where('productId', '==', filters.productId);
+    }
+    if (filters.type) {
+      query = query.where('type', '==', filters.type);
+    }
+    if (filters.source) {
+      query = query.where('source', '==', filters.source);
+    }
+
+    query = query.orderBy('createdAt', 'desc');
+
+    const snapshot = await query.get();
+    return snapshot.docs
+      .map((doc) => docToMovement(doc))
+      .filter((m): m is InventoryMovement => m !== undefined);
+  },
+
+  async reconcile(
+    productId: string
+  ): Promise<{
+    calculatedQuantity: number;
+    movements: InventoryMovement[];
+  }> {
+    const movements = await this.findByProductId(productId);
+    const calculatedQuantity = calculateQuantityFromMovements(movements);
+
+    return { calculatedQuantity, movements };
+  },
+};

--- a/libs/firebase/database/src/lib/sale.repository.ts
+++ b/libs/firebase/database/src/lib/sale.repository.ts
@@ -1,0 +1,145 @@
+/**
+ * Sale Repository
+ *
+ * Handles all Firestore operations for sales records.
+ * Each sale tracks commission split between store and artist.
+ */
+import { db, toDate } from './utilities/database.config';
+import type { Sale, CreateSaleInput, SaleSource } from '@maple/ts/domain';
+
+const COLLECTION = 'sales';
+
+function docToSale(
+  doc: FirebaseFirestore.DocumentSnapshot
+): Sale | undefined {
+  if (!doc.exists) {
+    return undefined;
+  }
+
+  const data = doc.data()!;
+
+  return {
+    id: doc.id,
+    productId: data.productId,
+    variantId: data.variantId,
+    artistId: data.artistId,
+    salePrice: data.salePrice,
+    quantitySold: data.quantitySold,
+    commission: data.commission,
+    artistEarnings: data.artistEarnings,
+    commissionRateApplied: data.commissionRateApplied,
+    source: data.source,
+    squareOrderId: data.squareOrderId,
+    squarePaymentId: data.squarePaymentId,
+    etsyOrderId: data.etsyOrderId,
+    etsyReceiptId: data.etsyReceiptId,
+    soldAt: toDate(data.soldAt),
+    createdAt: toDate(data.createdAt),
+    payoutId: data.payoutId,
+  };
+}
+
+export interface SaleFilters {
+  artistId?: string;
+  source?: SaleSource;
+  productId?: string;
+  dateFrom?: Date;
+  dateTo?: Date;
+}
+
+export const SaleRepository = {
+  async create(input: CreateSaleInput): Promise<Sale> {
+    const docRef = db.collection(COLLECTION).doc();
+    const now = new Date();
+
+    const data = {
+      productId: input.productId,
+      variantId: input.variantId,
+      artistId: input.artistId,
+      salePrice: input.salePrice,
+      quantitySold: input.quantitySold,
+      commission: input.commission,
+      artistEarnings: input.artistEarnings,
+      commissionRateApplied: input.commissionRateApplied,
+      source: input.source,
+      squareOrderId: input.squareOrderId,
+      squarePaymentId: input.squarePaymentId,
+      etsyOrderId: input.etsyOrderId,
+      etsyReceiptId: input.etsyReceiptId,
+      soldAt: input.soldAt,
+      createdAt: now,
+    };
+
+    await docRef.set(data);
+
+    return {
+      id: docRef.id,
+      ...data,
+      createdAt: now,
+    };
+  },
+
+  async findById(id: string): Promise<Sale | undefined> {
+    const doc = await db.collection(COLLECTION).doc(id).get();
+    return docToSale(doc);
+  },
+
+  async findAll(filters: SaleFilters = {}): Promise<Sale[]> {
+    let query: FirebaseFirestore.Query = db.collection(COLLECTION);
+
+    if (filters.artistId) {
+      query = query.where('artistId', '==', filters.artistId);
+    }
+    if (filters.source) {
+      query = query.where('source', '==', filters.source);
+    }
+    if (filters.productId) {
+      query = query.where('productId', '==', filters.productId);
+    }
+    if (filters.dateFrom) {
+      query = query.where('soldAt', '>=', filters.dateFrom);
+    }
+    if (filters.dateTo) {
+      query = query.where('soldAt', '<=', filters.dateTo);
+    }
+
+    query = query.orderBy('soldAt', 'desc');
+
+    const snapshot = await query.get();
+    return snapshot.docs
+      .map((doc) => docToSale(doc))
+      .filter((s): s is Sale => s !== undefined);
+  },
+
+  async findBySquareOrderId(
+    squareOrderId: string
+  ): Promise<Sale | undefined> {
+    const snapshot = await db
+      .collection(COLLECTION)
+      .where('squareOrderId', '==', squareOrderId)
+      .limit(1)
+      .get();
+
+    if (snapshot.empty) {
+      return undefined;
+    }
+
+    return docToSale(snapshot.docs[0]);
+  },
+
+  async findByEtsyReceiptId(
+    etsyReceiptId: string
+  ): Promise<Sale | undefined> {
+    const snapshot = await db
+      .collection(COLLECTION)
+      .where('etsyReceiptId', '==', etsyReceiptId)
+      .limit(1)
+      .get();
+
+    if (snapshot.empty) {
+      return undefined;
+    }
+
+    return docToSale(snapshot.docs[0]);
+  },
+};

--- a/libs/firebase/maple-functions/get-sales/project.json
+++ b/libs/firebase/maple-functions/get-sales/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-get-sales",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/get-sales/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/get-sales/src/index.ts
+++ b/libs/firebase/maple-functions/get-sales/src/index.ts
@@ -1,0 +1,1 @@
+export { getSales } from './lib/get-sales';

--- a/libs/firebase/maple-functions/get-sales/src/lib/get-sales.spec.ts
+++ b/libs/firebase/maple-functions/get-sales/src/lib/get-sales.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Unit tests for the getSales cloud function handler.
+ */
+
+const mocks = vi.hoisted(() => ({
+  saleFindAll: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/functions', () => ({
+  createAdminFunction: <TReq, TRes>(
+    handler: (data: TReq, ctx: unknown) => Promise<TRes>
+  ) => handler,
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  SaleRepository: { findAll: mocks.saleFindAll },
+}));
+
+import { getSales } from './get-sales';
+
+type Handler = (data: unknown, ctx?: unknown) => Promise<unknown>;
+const handler = getSales as unknown as Handler;
+
+const mockSales = [
+  {
+    id: 'sale-1',
+    productId: 'product-1',
+    artistId: 'artist-1',
+    salePrice: 25,
+    quantitySold: 1,
+    source: 'manual',
+    soldAt: new Date('2026-04-01'),
+    createdAt: new Date(),
+  },
+  {
+    id: 'sale-2',
+    productId: 'product-2',
+    artistId: 'artist-1',
+    salePrice: 30,
+    quantitySold: 1,
+    source: 'etsy',
+    soldAt: new Date('2026-04-05'),
+    createdAt: new Date(),
+  },
+];
+
+describe('getSales', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns all sales with no filters', async () => {
+    mocks.saleFindAll.mockResolvedValue(mockSales);
+
+    const result = (await handler({})) as { sales: unknown[] };
+
+    expect(result.sales).toHaveLength(2);
+    expect(mocks.saleFindAll).toHaveBeenCalledWith({
+      artistId: undefined,
+      source: undefined,
+      dateFrom: undefined,
+      dateTo: undefined,
+    });
+  });
+
+  it('passes artistId filter', async () => {
+    mocks.saleFindAll.mockResolvedValue([mockSales[0]]);
+
+    await handler({ artistId: 'artist-1' });
+
+    expect(mocks.saleFindAll).toHaveBeenCalledWith(
+      expect.objectContaining({ artistId: 'artist-1' })
+    );
+  });
+
+  it('passes source filter', async () => {
+    mocks.saleFindAll.mockResolvedValue([mockSales[1]]);
+
+    await handler({ source: 'etsy' });
+
+    expect(mocks.saleFindAll).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'etsy' })
+    );
+  });
+
+  it('converts date strings to Date objects', async () => {
+    mocks.saleFindAll.mockResolvedValue([]);
+
+    await handler({ from: '2026-04-01', to: '2026-04-30' });
+
+    const call = mocks.saleFindAll.mock.calls[0][0];
+    expect(call.dateFrom).toBeInstanceOf(Date);
+    expect(call.dateTo).toBeInstanceOf(Date);
+  });
+
+  it('returns empty array when no sales found', async () => {
+    mocks.saleFindAll.mockResolvedValue([]);
+
+    const result = (await handler({})) as { sales: unknown[] };
+
+    expect(result.sales).toHaveLength(0);
+  });
+});

--- a/libs/firebase/maple-functions/get-sales/src/lib/get-sales.ts
+++ b/libs/firebase/maple-functions/get-sales/src/lib/get-sales.ts
@@ -1,0 +1,26 @@
+/**
+ * Get Sales Cloud Function
+ *
+ * Retrieves sales with optional filters.
+ * Admin-only function.
+ */
+import { createAdminFunction } from '@maple/firebase/functions';
+import { SaleRepository } from '@maple/firebase/database';
+import type {
+  GetSalesRequest,
+  GetSalesResponse,
+} from '@maple/ts/firebase/api-types';
+
+export const getSales = createAdminFunction<
+  GetSalesRequest,
+  GetSalesResponse
+>(async (data) => {
+  const sales = await SaleRepository.findAll({
+    artistId: data.artistId,
+    source: data.source,
+    dateFrom: data.from ? new Date(data.from) : undefined,
+    dateTo: data.to ? new Date(data.to) : undefined,
+  });
+
+  return { sales };
+});

--- a/libs/firebase/maple-functions/get-sales/tsconfig.json
+++ b/libs/firebase/maple-functions/get-sales/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/get-sales/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/get-sales/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/get-sales/vitest.config.ts
+++ b/libs/firebase/maple-functions/get-sales/vitest.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  root: __dirname,
+  test: {
+    name: 'firebase-maple-functions-get-sales',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov', 'json-summary', 'json'],
+      reportsDirectory:
+        '../../../../coverage/libs/firebase/maple-functions/get-sales',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.spec.ts', 'src/index.ts'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@maple/ts/domain': resolve(__dirname, '../../../ts/domain/src/index.ts'),
+      '@maple/ts/firebase/api-types': resolve(
+        __dirname,
+        '../../../ts/firebase/api-types/src/index.ts'
+      ),
+      '@maple/firebase/database': resolve(
+        __dirname,
+        '../../../firebase/database/src/index.ts'
+      ),
+      '@maple/firebase/functions': resolve(
+        __dirname,
+        '../../../firebase/functions/src/index.ts'
+      ),
+    },
+  },
+});

--- a/libs/firebase/maple-functions/record-sale/project.json
+++ b/libs/firebase/maple-functions/record-sale/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-record-sale",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/record-sale/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/record-sale/src/index.ts
+++ b/libs/firebase/maple-functions/record-sale/src/index.ts
@@ -1,0 +1,1 @@
+export { recordSale } from './lib/record-sale';

--- a/libs/firebase/maple-functions/record-sale/src/lib/record-sale.spec.ts
+++ b/libs/firebase/maple-functions/record-sale/src/lib/record-sale.spec.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Unit tests for the recordSale cloud function handler.
+ *
+ * createAdminFunction is mocked to return the handler directly so we can
+ * invoke it like a plain function. Repositories are mocked; domain
+ * calculation functions are real.
+ */
+
+const mocks = vi.hoisted(() => ({
+  productFindById: vi.fn(),
+  artistFindById: vi.fn(),
+  saleCreate: vi.fn(),
+  inventoryMovementCreate: vi.fn(),
+  updateVariantQuantity: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/functions', () => ({
+  createAdminFunction: <TReq, TRes>(
+    handler: (data: TReq, ctx: unknown) => Promise<TRes>
+  ) => handler,
+  throwInvalidArgument: (msg: string) => {
+    throw new Error(msg);
+  },
+  throwNotFound: (entity: string, id: string) => {
+    throw new Error(`${entity} not found: ${id}`);
+  },
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  ProductRepository: {
+    findById: mocks.productFindById,
+    updateVariantQuantity: mocks.updateVariantQuantity,
+  },
+  ArtistRepository: { findById: mocks.artistFindById },
+  SaleRepository: { create: mocks.saleCreate },
+  InventoryMovementRepository: { create: mocks.inventoryMovementCreate },
+}));
+
+import { recordSale } from './record-sale';
+
+type Handler = (data: unknown, ctx?: unknown) => Promise<unknown>;
+const handler = recordSale as unknown as Handler;
+
+const mockProduct = {
+  id: 'product-1',
+  artistId: 'artist-1',
+  customCommissionRate: undefined,
+  variants: [
+    {
+      id: 'var-1',
+      label: 'Regular',
+      sku: 'SKU-001',
+      priceCents: 2500,
+      quantity: 10,
+    },
+  ],
+};
+
+const mockMultiVariantProduct = {
+  ...mockProduct,
+  id: 'product-2',
+  variants: [
+    { id: 'var-a', label: 'Small', sku: 'SKU-S', priceCents: 2000, quantity: 5 },
+    { id: 'var-b', label: 'Large', sku: 'SKU-L', priceCents: 3000, quantity: 3 },
+  ],
+};
+
+const mockArtist = {
+  id: 'artist-1',
+  name: 'Test Artist',
+  defaultCommissionRate: 0.4,
+};
+
+const mockSale = {
+  id: 'sale-1',
+  productId: 'product-1',
+  variantId: 'var-1',
+  artistId: 'artist-1',
+  salePrice: 25,
+  quantitySold: 1,
+  commission: 10,
+  artistEarnings: 15,
+  commissionRateApplied: 0.4,
+  source: 'manual' as const,
+  soldAt: new Date(),
+  createdAt: new Date(),
+};
+
+describe('recordSale', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('records a sale for a single-variant product', async () => {
+    mocks.productFindById.mockResolvedValue(mockProduct);
+    mocks.artistFindById.mockResolvedValue(mockArtist);
+    mocks.saleCreate.mockResolvedValue(mockSale);
+    mocks.inventoryMovementCreate.mockResolvedValue({ id: 'mov-1' });
+    mocks.updateVariantQuantity.mockResolvedValue(undefined);
+
+    const result = (await handler({ productId: 'product-1' })) as {
+      sale: { id: string };
+    };
+
+    expect(result.sale.id).toBe('sale-1');
+    expect(mocks.productFindById).toHaveBeenCalledWith('product-1');
+    expect(mocks.artistFindById).toHaveBeenCalledWith('artist-1');
+    expect(mocks.saleCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        productId: 'product-1',
+        variantId: 'var-1',
+        artistId: 'artist-1',
+        source: 'manual',
+      })
+    );
+    expect(mocks.inventoryMovementCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        productId: 'product-1',
+        variantId: 'var-1',
+        type: 'sale',
+        quantityChange: -1,
+        quantityBefore: 10,
+        quantityAfter: 9,
+      })
+    );
+    expect(mocks.updateVariantQuantity).toHaveBeenCalledWith(
+      'product-1',
+      'var-1',
+      9
+    );
+  });
+
+  it('uses custom sale price when provided', async () => {
+    mocks.productFindById.mockResolvedValue(mockProduct);
+    mocks.artistFindById.mockResolvedValue(mockArtist);
+    mocks.saleCreate.mockResolvedValue(mockSale);
+    mocks.inventoryMovementCreate.mockResolvedValue({ id: 'mov-1' });
+    mocks.updateVariantQuantity.mockResolvedValue(undefined);
+
+    await handler({ productId: 'product-1', salePriceCents: 2000 });
+
+    // salePrice = 2000 / 100 = $20
+    expect(mocks.saleCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        salePrice: 20,
+      })
+    );
+  });
+
+  it('handles multiple quantity sold', async () => {
+    mocks.productFindById.mockResolvedValue(mockProduct);
+    mocks.artistFindById.mockResolvedValue(mockArtist);
+    mocks.saleCreate.mockResolvedValue(mockSale);
+    mocks.inventoryMovementCreate.mockResolvedValue({ id: 'mov-1' });
+    mocks.updateVariantQuantity.mockResolvedValue(undefined);
+
+    await handler({ productId: 'product-1', quantitySold: 3 });
+
+    // salePrice = 2500 * 3 / 100 = $75
+    expect(mocks.saleCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        salePrice: 75,
+        quantitySold: 3,
+      })
+    );
+    expect(mocks.inventoryMovementCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        quantityChange: -3,
+        quantityBefore: 10,
+        quantityAfter: 7,
+      })
+    );
+    expect(mocks.updateVariantQuantity).toHaveBeenCalledWith(
+      'product-1',
+      'var-1',
+      7
+    );
+  });
+
+  it('requires variantId for multi-variant products', async () => {
+    mocks.productFindById.mockResolvedValue(mockMultiVariantProduct);
+
+    await expect(
+      handler({ productId: 'product-2' })
+    ).rejects.toThrow(/variantId is required/);
+
+    expect(mocks.saleCreate).not.toHaveBeenCalled();
+  });
+
+  it('records sale for specified variant of multi-variant product', async () => {
+    mocks.productFindById.mockResolvedValue(mockMultiVariantProduct);
+    mocks.artistFindById.mockResolvedValue(mockArtist);
+    mocks.saleCreate.mockResolvedValue(mockSale);
+    mocks.inventoryMovementCreate.mockResolvedValue({ id: 'mov-1' });
+    mocks.updateVariantQuantity.mockResolvedValue(undefined);
+
+    await handler({ productId: 'product-2', variantId: 'var-b' });
+
+    // var-b has priceCents: 3000
+    expect(mocks.saleCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variantId: 'var-b',
+        salePrice: 30,
+      })
+    );
+  });
+
+  it('throws when product is not found', async () => {
+    mocks.productFindById.mockResolvedValue(undefined);
+
+    await expect(
+      handler({ productId: 'missing' })
+    ).rejects.toThrow(/Product not found/);
+
+    expect(mocks.saleCreate).not.toHaveBeenCalled();
+  });
+
+  it('throws when artist is not found', async () => {
+    mocks.productFindById.mockResolvedValue(mockProduct);
+    mocks.artistFindById.mockResolvedValue(undefined);
+
+    await expect(
+      handler({ productId: 'product-1' })
+    ).rejects.toThrow(/Artist not found/);
+
+    expect(mocks.saleCreate).not.toHaveBeenCalled();
+  });
+
+  it('throws when productId is missing', async () => {
+    await expect(handler({})).rejects.toThrow(/Product ID is required/);
+  });
+
+  it('throws when quantity would go below zero', async () => {
+    const lowStockProduct = {
+      ...mockProduct,
+      variants: [{ ...mockProduct.variants[0], quantity: 1 }],
+    };
+    mocks.productFindById.mockResolvedValue(lowStockProduct);
+    mocks.artistFindById.mockResolvedValue(mockArtist);
+
+    await expect(
+      handler({ productId: 'product-1', quantitySold: 5 })
+    ).rejects.toThrow(/Cannot reduce quantity below 0/);
+
+    expect(mocks.saleCreate).not.toHaveBeenCalled();
+  });
+
+  it('uses product customCommissionRate when set', async () => {
+    const productWithCustomRate = {
+      ...mockProduct,
+      customCommissionRate: 0.3,
+    };
+    mocks.productFindById.mockResolvedValue(productWithCustomRate);
+    mocks.artistFindById.mockResolvedValue(mockArtist);
+    mocks.saleCreate.mockResolvedValue(mockSale);
+    mocks.inventoryMovementCreate.mockResolvedValue({ id: 'mov-1' });
+    mocks.updateVariantQuantity.mockResolvedValue(undefined);
+
+    await handler({ productId: 'product-1' });
+
+    expect(mocks.saleCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commissionRateApplied: 0.3,
+      })
+    );
+  });
+});

--- a/libs/firebase/maple-functions/record-sale/src/lib/record-sale.ts
+++ b/libs/firebase/maple-functions/record-sale/src/lib/record-sale.ts
@@ -1,0 +1,133 @@
+/**
+ * Record Sale Cloud Function
+ *
+ * Admin-only callable function for manually recording a product sale.
+ * Automatically:
+ * 1. Looks up product and artist for commission calculation
+ * 2. Creates a Sale record with commission split
+ * 3. Creates an InventoryMovement audit log entry
+ * 4. Decrements variant quantity on the product
+ */
+import {
+  createAdminFunction,
+  throwInvalidArgument,
+  throwNotFound,
+} from '@maple/firebase/functions';
+import {
+  ProductRepository,
+  ArtistRepository,
+  SaleRepository,
+  InventoryMovementRepository,
+} from '@maple/firebase/database';
+import {
+  calculateSaleAmounts,
+  getEffectiveCommissionRate,
+  findVariant,
+  validateInventoryMovement,
+} from '@maple/ts/domain';
+import type {
+  RecordProductSaleRequest,
+  RecordProductSaleResponse,
+} from '@maple/ts/firebase/api-types';
+
+export const recordSale = createAdminFunction<
+  RecordProductSaleRequest,
+  RecordProductSaleResponse
+>(async (data) => {
+  if (!data.productId) {
+    throwInvalidArgument('Product ID is required');
+  }
+
+  const quantitySold = data.quantitySold ?? 1;
+  if (quantitySold < 1) {
+    throwInvalidArgument('Quantity sold must be at least 1');
+  }
+
+  // 1. Fetch product
+  const product = await ProductRepository.findById(data.productId);
+  if (!product) {
+    throwNotFound('Product', data.productId);
+  }
+
+  // Determine which variant
+  let variantId = data.variantId;
+  if (!variantId && product.variants.length === 1) {
+    variantId = product.variants[0].id;
+  }
+  if (!variantId) {
+    throwInvalidArgument(
+      'variantId is required for multi-variant products'
+    );
+  }
+
+  const variant = findVariant(product, variantId);
+  if (!variant) {
+    throwNotFound('ProductVariant', variantId);
+  }
+
+  // 2. Fetch artist for commission rate
+  const artist = await ArtistRepository.findById(product.artistId);
+  if (!artist) {
+    throwNotFound('Artist', product.artistId);
+  }
+
+  // 3. Calculate commission
+  const commissionRate = getEffectiveCommissionRate(
+    product,
+    artist.defaultCommissionRate
+  );
+  const salePriceCents = data.salePriceCents ?? variant.priceCents;
+  const salePrice = (salePriceCents * quantitySold) / 100;
+  const { commission, artistEarnings } = calculateSaleAmounts(
+    salePrice,
+    commissionRate
+  );
+
+  // 4. Validate inventory
+  const inventoryCheck = validateInventoryMovement(
+    variant.quantity,
+    -quantitySold
+  );
+  if (!inventoryCheck.valid) {
+    throwInvalidArgument(inventoryCheck.error ?? 'Insufficient inventory');
+  }
+
+  // 5. Create sale record
+  const soldAt = data.soldAt ? new Date(data.soldAt) : new Date();
+  const sale = await SaleRepository.create({
+    productId: data.productId,
+    variantId,
+    artistId: product.artistId,
+    salePrice,
+    quantitySold,
+    commission,
+    artistEarnings,
+    commissionRateApplied: commissionRate,
+    source: data.source ?? 'manual',
+    etsyOrderId: data.etsyOrderId,
+    etsyReceiptId: data.etsyReceiptId,
+    soldAt,
+  });
+
+  // 6. Create inventory movement
+  await InventoryMovementRepository.create({
+    productId: data.productId,
+    variantId,
+    type: 'sale',
+    quantityChange: -quantitySold,
+    quantityBefore: variant.quantity,
+    quantityAfter: variant.quantity - quantitySold,
+    source: 'manual',
+    saleId: sale.id,
+    performedBy: 'admin',
+  });
+
+  // 7. Decrement variant quantity
+  await ProductRepository.updateVariantQuantity(
+    data.productId,
+    variantId,
+    variant.quantity - quantitySold
+  );
+
+  return { sale };
+});

--- a/libs/firebase/maple-functions/record-sale/tsconfig.json
+++ b/libs/firebase/maple-functions/record-sale/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/record-sale/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/record-sale/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/record-sale/vitest.config.ts
+++ b/libs/firebase/maple-functions/record-sale/vitest.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  root: __dirname,
+  test: {
+    name: 'firebase-maple-functions-record-sale',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov', 'json-summary', 'json'],
+      reportsDirectory:
+        '../../../../coverage/libs/firebase/maple-functions/record-sale',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.spec.ts', 'src/index.ts'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@maple/ts/domain': resolve(__dirname, '../../../ts/domain/src/index.ts'),
+      '@maple/ts/validation': resolve(
+        __dirname,
+        '../../../ts/validation/src/index.ts'
+      ),
+      '@maple/ts/firebase/api-types': resolve(
+        __dirname,
+        '../../../ts/firebase/api-types/src/index.ts'
+      ),
+      '@maple/firebase/database': resolve(
+        __dirname,
+        '../../../firebase/database/src/index.ts'
+      ),
+      '@maple/firebase/functions': resolve(
+        __dirname,
+        '../../../firebase/functions/src/index.ts'
+      ),
+    },
+  },
+});

--- a/libs/ts/domain/src/lib/inventory-movement.ts
+++ b/libs/ts/domain/src/lib/inventory-movement.ts
@@ -8,6 +8,8 @@
 export interface InventoryMovement {
   id: string;
   productId: string;
+  /** Optional variant ID when the product has multiple variants */
+  variantId?: string;
 
   type: InventoryMovementType;
   /** Change in quantity (+/- delta) */

--- a/libs/ts/domain/src/lib/sale.ts
+++ b/libs/ts/domain/src/lib/sale.ts
@@ -8,6 +8,8 @@
 export interface Sale {
   id: string;
   productId: string;
+  /** Optional variant ID when the product has multiple variants */
+  variantId?: string;
   artistId: string;
 
   /** The price the item sold for */

--- a/libs/ts/firebase/api-types/src/lib/sale.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/sale.types.ts
@@ -54,17 +54,22 @@ export interface RecordSaleResponse {
 // ============================================================================
 
 /**
- * Record a sale for an existing product.
- * The sale price defaults to the product price but can be overridden.
+ * Record a sale for an existing product (manual recording).
+ * Automatically looks up product/artist, calculates commission,
+ * creates a sale record, an inventory movement, and decrements quantity.
  */
 export interface RecordProductSaleRequest {
   productId: string;
-  /** Override the product price if different (e.g., discount) */
-  salePrice?: number;
-  source: SaleSource;
+  /** Optional variant ID — required for multi-variant products */
+  variantId?: string;
+  /** Quantity sold (defaults to 1) */
+  quantitySold?: number;
+  /** Override the product price if different (e.g., discount). In cents. */
+  salePriceCents?: number;
+  source?: SaleSource;
   etsyOrderId?: string;
   etsyReceiptId?: string;
-  soldAt: string;
+  soldAt?: string;
 }
 
 export interface RecordProductSaleResponse {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -335,6 +335,12 @@
       "@maple/firebase/maple-functions/import-etsy-listings": [
         "libs/firebase/maple-functions/import-etsy-listings/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/record-sale": [
+        "libs/firebase/maple-functions/record-sale/src/index.ts"
+      ],
+      "@maple/firebase/maple-functions/get-sales": [
+        "libs/firebase/maple-functions/get-sales/src/index.ts"
+      ],
       "@maple/firebase/integration-test-utils": [
         "libs/firebase/integration-test-utils/src/index.ts"
       ],


### PR DESCRIPTION
## Summary
- Add `SaleRepository` and `InventoryMovementRepository` to `@maple/firebase/database`
- Create `recordSale` Cloud Function for manual sale recording with automatic commission calculation, inventory movement tracking, and variant quantity decrement
- Create `getSales` Cloud Function for retrieving sales with optional filters (artistId, source, date range)
- Add `variantId` to `Sale` and `InventoryMovement` domain types to support multi-variant products (from PR 1 / #305)
- Update `RecordProductSaleRequest` API types for the manual recording flow

## Details

### Repositories
- **SaleRepository**: CRUD + `findBySquareOrderId` / `findByEtsyReceiptId` for dedup when webhook-driven recording is added later
- **InventoryMovementRepository**: Immutable audit log with `reconcile()` method that sums all movements for a product

### record-sale flow
1. Fetch product and resolve variant (auto-selects single variant, requires `variantId` for multi-variant)
2. Fetch artist for commission rate lookup
3. Calculate commission split via `calculateSaleAmounts()` + `getEffectiveCommissionRate()`
4. Validate inventory won't go negative
5. Create Sale record
6. Create InventoryMovement audit entry
7. Decrement variant quantity via `ProductRepository.updateVariantQuantity()`

### Not in scope
Square webhook extension for `order.completed` -- will be a follow-up PR once this foundation is solid.

## Test plan
- [x] 10 unit tests for record-sale (single-variant, multi-variant, custom price, quantity, error cases)
- [x] 5 unit tests for get-sales (filters, date conversion, empty results)
- [ ] Verify CI passes (Nx project discovery, tsconfig includes, esbuild)
- [ ] Integration tests can be added as a follow-up

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)