### PR TITLE
feat: Square multi-variation support

### DIFF
--- a/libs/firebase/maple-functions/create-product/src/lib/create-product.ts
+++ b/libs/firebase/maple-functions/create-product/src/lib/create-product.ts
@@ -3,8 +3,8 @@
  *
  * Creates a new product by:
  * 1. Validating input
- * 2. Creating catalog item in Square
- * 3. Setting initial inventory quantity in Square
+ * 2. Creating catalog item in Square (with one or more variations)
+ * 3. Setting initial inventory quantities in Square
  * 4. Creating linking record in Firestore
  *
  * Admin only.
@@ -17,6 +17,7 @@ import {
   SQUARE_STRING_NAMES,
 } from '@maple/firebase/square';
 import { productValidation } from '@maple/ts/validation';
+import { resolveVariants } from '@maple/ts/domain';
 import type {
   CreateProductRequest,
   CreateProductResponse,
@@ -32,6 +33,7 @@ export const createProduct = Functions.endpoint
         name: data.name,
         priceCents: data.priceCents,
         quantity: data.quantity,
+        variantCount: data.variants?.length,
       });
 
       // Validate input
@@ -54,35 +56,44 @@ export const createProduct = Functions.endpoint
 
       console.log('Square client initialized, creating catalog item...');
 
-      // 1. Create catalog item in Square
-      const priceCents = data.priceCents ?? 0;
-      const quantity = data.quantity ?? 0;
+      // Resolve variants from input (handles both single and multi-variant)
+      const resolvedVariants = resolveVariants(data);
 
+      // 1. Create catalog item in Square with all variations
       const catalogResult = await square.catalogService.createItem({
         name: data.name,
         description: data.description,
-        priceCents,
+        variants: resolvedVariants.map((v) => ({
+          label: v.label,
+          priceCents: v.priceCents,
+          sku: v.sku,
+        })),
       });
 
       console.log('Square catalog item created:', catalogResult);
 
-      // 2. Set initial inventory quantity
-      if (quantity > 0) {
-        await square.inventoryService.setQuantity({
-          squareVariationId: catalogResult.squareVariationId,
+      // 2. Set initial inventory quantities for each variation
+      const inventoryEntries = resolvedVariants
+        .map((v, i) => ({
+          squareVariationId: catalogResult.variations[i]?.squareVariationId ?? '',
           locationId: square.locationId,
-          quantity,
-        });
+          quantity: v.quantity,
+        }))
+        .filter((e) => e.quantity > 0 && e.squareVariationId);
+
+      if (inventoryEntries.length > 0) {
+        await square.inventoryService.setQuantities(inventoryEntries);
       }
 
       // 3. Create Firestore record with Square IDs
       const product = await ProductRepository.create(data, {
         squareItemId: catalogResult.squareItemId,
-        squareVariationId: catalogResult.squareVariationId,
         squareCatalogVersion: catalogResult.squareCatalogVersion,
         squareLocationId: square.locationId,
+        variations: catalogResult.variations,
+        // Legacy fields for backward compatibility
+        squareVariationId: catalogResult.squareVariationId,
         sku: catalogResult.sku,
-        variations: [{ variantId: 'var_compat', squareVariationId: catalogResult.squareVariationId, sku: catalogResult.sku }],
       });
 
       return { product };

--- a/libs/firebase/maple-functions/update-product/src/lib/update-product.ts
+++ b/libs/firebase/maple-functions/update-product/src/lib/update-product.ts
@@ -6,11 +6,15 @@
  * For Firestore-owned fields (artistId, status, customCommissionRate):
  * - Updates happen directly in Firestore
  *
- * For Square-owned fields (name, description, priceCents):
+ * For Square-owned fields (name, description):
  * - Updates Square Catalog API first, then updates Firestore cache
  *
- * For quantity changes:
- * - Updates Square Inventory API, then updates Firestore cache
+ * For variant price/quantity changes:
+ * - Updates Square Catalog API (prices) and Inventory API (quantities)
+ * - Then updates Firestore variants
+ *
+ * Supports both multi-variant (data.variants[]) and legacy single-variant
+ * (data.priceCents / data.quantity) update paths.
  */
 import {
   Functions,
@@ -24,6 +28,7 @@ import {
   SQUARE_SECRET_NAMES,
   SQUARE_STRING_NAMES,
 } from '@maple/firebase/square';
+import type { UpdateCatalogVariationInput } from '@maple/firebase/square';
 import { productValidation } from '@maple/ts/validation';
 import type {
   UpdateProductRequest,
@@ -41,7 +46,7 @@ export const updateProduct = Functions.endpoint
         throwNotFound('Product', data.id);
       }
 
-      // Validation must run before any Square writes — invalid data must
+      // Validation must run before any Square writes -- invalid data must
       // never reach Square and fail halfway through.
       const fields = Object.keys(data).filter((key) => key !== 'id');
       if (fields.length > 0) {
@@ -51,17 +56,34 @@ export const updateProduct = Functions.endpoint
         }
       }
 
-      // Check if any Square-owned fields are being updated
-      const hasCatalogUpdates =
-        data.name !== undefined ||
-        data.description !== undefined ||
-        data.priceCents !== undefined;
+      // Determine what kind of updates we have
+      const hasItemLevelUpdates =
+        data.name !== undefined || data.description !== undefined;
 
-      const hasInventoryUpdates = data.quantity !== undefined;
+      // Multi-variant path: data.variants[] contains per-variant updates
+      const hasVariantUpdates =
+        data.variants !== undefined && data.variants.length > 0;
 
-      // Handle Square updates if needed
-      if (hasCatalogUpdates || hasInventoryUpdates) {
-        // Initialize Square client
+      // Legacy single-variant path
+      const hasLegacyCatalogUpdate = data.priceCents !== undefined;
+      const hasLegacyInventoryUpdate = data.quantity !== undefined;
+
+      const needsSquare =
+        hasItemLevelUpdates ||
+        hasVariantUpdates ||
+        hasLegacyCatalogUpdate ||
+        hasLegacyInventoryUpdate;
+
+      if (needsSquare) {
+        if (
+          !existing.squareItemId ||
+          existing.squareCatalogVersion === undefined
+        ) {
+          throw new Error(
+            'Product missing Square IDs. Cannot update catalog fields.'
+          );
+        }
+
         const square = new Square(
           secrets as typeof secrets &
             Record<(typeof SQUARE_SECRET_NAMES)[number], string>,
@@ -69,49 +91,114 @@ export const updateProduct = Functions.endpoint
             Record<(typeof SQUARE_STRING_NAMES)[number], string>
         );
 
-        // Update catalog if needed
+        const locationId = existing.squareLocationId ?? square.locationId;
+
+        // --- Catalog update (item-level fields + per-variation prices) ---
+        const hasCatalogUpdates =
+          hasItemLevelUpdates || hasVariantUpdates || hasLegacyCatalogUpdate;
+
         if (hasCatalogUpdates) {
-          if (
-            !existing.squareItemId ||
-            !existing.squareVariationId ||
-            existing.squareCatalogVersion === undefined
-          ) {
-            throw new Error(
-              'Product missing Square IDs. Cannot update catalog fields.'
-            );
+          // Build variation-level updates
+          let variationUpdates: UpdateCatalogVariationInput[] | undefined;
+
+          if (hasVariantUpdates) {
+            // Map incoming variant data to existing variants by label match or index
+            variationUpdates = data.variants!
+              .map((v) => {
+                const match = existing.variants.find(
+                  (ev) => ev.label === v.label
+                );
+                if (!match?.squareVariationId) return null;
+                return {
+                  squareVariationId: match.squareVariationId,
+                  name: v.label,
+                  priceCents: v.priceCents,
+                  sku: v.sku,
+                };
+              })
+              .filter(
+                (u): u is UpdateCatalogVariationInput => u !== null
+              );
+          } else if (hasLegacyCatalogUpdate && existing.squareVariationId) {
+            variationUpdates = [
+              {
+                squareVariationId: existing.squareVariationId,
+                priceCents: data.priceCents,
+              },
+            ];
           }
 
           const catalogResult = await square.catalogService.updateItem({
             squareItemId: existing.squareItemId,
-            squareVariationId: existing.squareVariationId,
             squareCatalogVersion: existing.squareCatalogVersion,
             name: data.name,
             description: data.description,
-            priceCents: data.priceCents,
+            variations: variationUpdates,
           });
 
-          // Update cache with new values
+          // Update listing-level cache
           await ProductRepository.updateSquareCache(
             data.id,
             {
               name: data.name ?? existing.squareCache.name,
-              description: data.description ?? existing.squareCache.description,
-              priceCents: data.priceCents ?? existing.squareCache.priceCents,
+              description:
+                data.description ?? existing.squareCache.description,
             },
             catalogResult.squareCatalogVersion
           );
+
+          // Update variant prices in Firestore if variants were changed
+          if (hasVariantUpdates) {
+            const updatedVariants = existing.variants.map((ev) => {
+              const incoming = data.variants!.find(
+                (v) => v.label === ev.label
+              );
+              if (!incoming) return ev;
+              return {
+                ...ev,
+                priceCents: incoming.priceCents ?? ev.priceCents,
+                sku: incoming.sku ?? ev.sku,
+              };
+            });
+            await ProductRepository.updateVariants(data.id, updatedVariants);
+          }
         }
 
-        // Update inventory if needed
-        if (hasInventoryUpdates) {
+        // --- Inventory updates ---
+        if (hasVariantUpdates) {
+          // Set quantities for each variant that has a quantity field
+          const inventoryEntries = data.variants!
+            .filter((v) => v.quantity !== undefined && v.quantity !== null)
+            .map((v) => {
+              const match = existing.variants.find(
+                (ev) => ev.label === v.label
+              );
+              return {
+                squareVariationId: match?.squareVariationId ?? '',
+                locationId,
+                quantity: v.quantity,
+              };
+            })
+            .filter((e) => e.squareVariationId);
+
+          if (inventoryEntries.length > 0) {
+            await square.inventoryService.setQuantities(inventoryEntries);
+
+            // Update cached quantities per variant
+            for (const entry of inventoryEntries) {
+              await ProductRepository.updateCachedQuantity(
+                data.id,
+                entry.quantity,
+                entry.squareVariationId
+              );
+            }
+          }
+        } else if (hasLegacyInventoryUpdate) {
           if (!existing.squareVariationId) {
             throw new Error(
               'Product missing Square variation ID. Cannot update inventory.'
             );
           }
-
-          const locationId =
-            existing.squareLocationId ?? square.locationId;
 
           await square.inventoryService.setQuantity({
             squareVariationId: existing.squareVariationId,
@@ -119,8 +206,10 @@ export const updateProduct = Functions.endpoint
             quantity: data.quantity!,
           });
 
-          // Update cached quantity
-          await ProductRepository.updateCachedQuantity(data.id, data.quantity!);
+          await ProductRepository.updateCachedQuantity(
+            data.id,
+            data.quantity!
+          );
         }
       }
 

--- a/libs/firebase/maple-functions/update-product/src/lib/update-product.ts
+++ b/libs/firebase/maple-functions/update-product/src/lib/update-product.ts
@@ -103,22 +103,21 @@ export const updateProduct = Functions.endpoint
 
           if (hasVariantUpdates) {
             // Map incoming variant data to existing variants by label match or index
-            variationUpdates = data.variants!
-              .map((v) => {
-                const match = existing.variants.find(
-                  (ev) => ev.label === v.label
-                );
-                if (!match?.squareVariationId) return null;
-                return {
+            const mapped: UpdateCatalogVariationInput[] = [];
+            for (const v of data.variants!) {
+              const match = existing.variants.find(
+                (ev) => ev.label === v.label
+              );
+              if (match?.squareVariationId) {
+                mapped.push({
                   squareVariationId: match.squareVariationId,
                   name: v.label,
                   priceCents: v.priceCents,
                   sku: v.sku,
-                };
-              })
-              .filter(
-                (u): u is UpdateCatalogVariationInput => u !== null
-              );
+                });
+              }
+            }
+            variationUpdates = mapped.length > 0 ? mapped : undefined;
           } else if (hasLegacyCatalogUpdate && existing.squareVariationId) {
             variationUpdates = [
               {

--- a/libs/firebase/square/src/index.ts
+++ b/libs/firebase/square/src/index.ts
@@ -10,10 +10,12 @@ export {
 // Catalog service
 export {
   CatalogService,
+  type CatalogVariationInput,
   type CreateCatalogItemInput,
   type CreateCatalogItemResult,
   type UpdateCatalogItemInput,
   type UpdateCatalogItemResult,
+  type UpdateCatalogVariationInput,
   type UploadCatalogImageInput,
   type UploadCatalogImageResult,
 } from './lib/catalog.service';

--- a/libs/firebase/square/src/lib/catalog.service.spec.ts
+++ b/libs/firebase/square/src/lib/catalog.service.spec.ts
@@ -1,0 +1,423 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CatalogService } from './catalog.service';
+import type { SquareClient } from 'square';
+
+/**
+ * Unit tests for the Square CatalogService wrapper.
+ *
+ * Mocks the Square client at the method level and verifies
+ * catalog CRUD orchestration with single and multiple variations.
+ */
+
+interface MockClient {
+  catalog: {
+    batchUpsert: ReturnType<typeof vi.fn>;
+    object: {
+      get: ReturnType<typeof vi.fn>;
+      delete: ReturnType<typeof vi.fn>;
+    };
+    list: ReturnType<typeof vi.fn>;
+    images: {
+      create: ReturnType<typeof vi.fn>;
+    };
+  };
+}
+
+function makeMockClient(): MockClient {
+  return {
+    catalog: {
+      batchUpsert: vi.fn(),
+      object: {
+        get: vi.fn(),
+        delete: vi.fn(),
+      },
+      list: vi.fn(),
+      images: {
+        create: vi.fn(),
+      },
+    },
+  };
+}
+
+describe('CatalogService.createItem', () => {
+  let client: MockClient;
+  let service: CatalogService;
+
+  beforeEach(() => {
+    client = makeMockClient();
+    service = new CatalogService(client as unknown as SquareClient);
+  });
+
+  it('creates a single "Regular" variation when no variants provided', async () => {
+    client.catalog.batchUpsert.mockResolvedValue({
+      objects: [
+        {
+          type: 'ITEM',
+          id: 'SQ-ITEM-1',
+          version: 1n,
+          itemData: {
+            variations: [
+              {
+                type: 'ITEM_VARIATION',
+                id: 'SQ-VAR-1',
+                itemVariationData: { sku: 'prd_abc123' },
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const result = await service.createItem({
+      name: 'Handmade Mug',
+      description: 'A lovely mug',
+      priceCents: 2500,
+      sku: 'prd_abc123',
+    });
+
+    // Verify a single variation was sent to Square
+    const batchCall = client.catalog.batchUpsert.mock.calls[0][0];
+    const sentVariations =
+      batchCall.batches[0].objects[0].itemData.variations;
+    expect(sentVariations).toHaveLength(1);
+    expect(sentVariations[0].itemVariationData.name).toBe('Regular');
+    expect(sentVariations[0].itemVariationData.priceMoney.amount).toBe(
+      2500n
+    );
+
+    // Verify result
+    expect(result.squareItemId).toBe('SQ-ITEM-1');
+    expect(result.squareCatalogVersion).toBe(1);
+    expect(result.variations).toHaveLength(1);
+    expect(result.variations[0].squareVariationId).toBe('SQ-VAR-1');
+    expect(result.variations[0].sku).toBe('prd_abc123');
+
+    // Legacy fields
+    expect(result.squareVariationId).toBe('SQ-VAR-1');
+    expect(result.sku).toBe('prd_abc123');
+  });
+
+  it('creates multiple ITEM_VARIATIONs when variants array is provided', async () => {
+    client.catalog.batchUpsert.mockResolvedValue({
+      objects: [
+        {
+          type: 'ITEM',
+          id: 'SQ-ITEM-2',
+          version: 3n,
+          itemData: {
+            variations: [
+              {
+                type: 'ITEM_VARIATION',
+                id: 'SQ-VAR-SM',
+                itemVariationData: { sku: 'prd_sm' },
+              },
+              {
+                type: 'ITEM_VARIATION',
+                id: 'SQ-VAR-LG',
+                itemVariationData: { sku: 'prd_lg' },
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const result = await service.createItem({
+      name: 'Ceramic Bowl',
+      description: 'Available in two sizes',
+      variants: [
+        { label: 'Small', priceCents: 2000, sku: 'prd_sm', variantId: 'var_sm' },
+        { label: 'Large', priceCents: 3500, sku: 'prd_lg', variantId: 'var_lg' },
+      ],
+    });
+
+    // Verify two variations sent to Square
+    const batchCall = client.catalog.batchUpsert.mock.calls[0][0];
+    const sentVariations =
+      batchCall.batches[0].objects[0].itemData.variations;
+    expect(sentVariations).toHaveLength(2);
+    expect(sentVariations[0].itemVariationData.name).toBe('Small');
+    expect(sentVariations[0].itemVariationData.priceMoney.amount).toBe(
+      2000n
+    );
+    expect(sentVariations[1].itemVariationData.name).toBe('Large');
+    expect(sentVariations[1].itemVariationData.priceMoney.amount).toBe(
+      3500n
+    );
+
+    // Verify result maps back correctly
+    expect(result.squareItemId).toBe('SQ-ITEM-2');
+    expect(result.squareCatalogVersion).toBe(3);
+    expect(result.variations).toHaveLength(2);
+
+    expect(result.variations[0]).toEqual({
+      variantId: 'var_sm',
+      squareVariationId: 'SQ-VAR-SM',
+      sku: 'prd_sm',
+    });
+    expect(result.variations[1]).toEqual({
+      variantId: 'var_lg',
+      squareVariationId: 'SQ-VAR-LG',
+      sku: 'prd_lg',
+    });
+
+    // Legacy fields point at first variation
+    expect(result.squareVariationId).toBe('SQ-VAR-SM');
+    expect(result.sku).toBe('prd_sm');
+  });
+
+  it('throws when Square returns errors', async () => {
+    client.catalog.batchUpsert.mockResolvedValue({
+      errors: [{ code: 'INVALID_REQUEST', detail: 'bad data' }],
+    });
+
+    await expect(
+      service.createItem({ name: 'Fail', priceCents: 100 })
+    ).rejects.toThrow(/Square API error.*bad data/);
+  });
+
+  it('throws when no ITEM object in response', async () => {
+    client.catalog.batchUpsert.mockResolvedValue({ objects: [] });
+
+    await expect(
+      service.createItem({ name: 'Missing', priceCents: 100 })
+    ).rejects.toThrow(/no ITEM in response/);
+  });
+
+  it('throws when no variations in response', async () => {
+    client.catalog.batchUpsert.mockResolvedValue({
+      objects: [
+        {
+          type: 'ITEM',
+          id: 'SQ-ITEM-3',
+          version: 1,
+          itemData: { variations: [] },
+        },
+      ],
+    });
+
+    await expect(
+      service.createItem({ name: 'NoVar', priceCents: 100 })
+    ).rejects.toThrow(/no variations in ITEM response/);
+  });
+
+  it('generates SKU when not provided', async () => {
+    client.catalog.batchUpsert.mockResolvedValue({
+      objects: [
+        {
+          type: 'ITEM',
+          id: 'SQ-ITEM-4',
+          version: 1n,
+          itemData: {
+            variations: [
+              {
+                type: 'ITEM_VARIATION',
+                id: 'SQ-VAR-4',
+                itemVariationData: { sku: 'prd_generated' },
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    // The generated SKU won't match the response sku, but the result
+    // should still use the input sku we generated (not the response one)
+    const result = await service.createItem({
+      name: 'Auto SKU',
+      priceCents: 500,
+    });
+
+    // Should have a SKU starting with 'prd_'
+    expect(result.sku).toMatch(/^prd_/);
+    expect(result.variations).toHaveLength(1);
+  });
+});
+
+describe('CatalogService.updateItem', () => {
+  let client: MockClient;
+  let service: CatalogService;
+
+  beforeEach(() => {
+    client = makeMockClient();
+    service = new CatalogService(client as unknown as SquareClient);
+  });
+
+  function mockCurrentItem(variations: Array<{ id: string; sku: string; price: number }>) {
+    const nestedVariations = variations.map((v) => ({
+      type: 'ITEM_VARIATION',
+      id: v.id,
+      version: 1n,
+      itemVariationData: {
+        sku: v.sku,
+        priceMoney: { amount: BigInt(v.price), currency: 'USD' },
+      },
+    }));
+
+    client.catalog.object.get.mockResolvedValue({
+      object: {
+        type: 'ITEM',
+        id: 'SQ-ITEM-1',
+        version: 5n,
+        itemData: {
+          name: 'Original Name',
+          description: 'Original Description',
+          variations: nestedVariations,
+        },
+      },
+      relatedObjects: [],
+    });
+
+    client.catalog.batchUpsert.mockResolvedValue({
+      objects: [
+        {
+          type: 'ITEM',
+          id: 'SQ-ITEM-1',
+          version: 6n,
+        },
+      ],
+    });
+  }
+
+  it('updates a single variation via legacy fields', async () => {
+    mockCurrentItem([{ id: 'SQ-VAR-1', sku: 'prd_abc', price: 2500 }]);
+
+    const result = await service.updateItem({
+      squareItemId: 'SQ-ITEM-1',
+      squareCatalogVersion: 5,
+      squareVariationId: 'SQ-VAR-1',
+      priceCents: 3000,
+    });
+
+    expect(result.squareCatalogVersion).toBe(6);
+
+    const batchCall = client.catalog.batchUpsert.mock.calls[0][0];
+    const sentVariations =
+      batchCall.batches[0].objects[0].itemData.variations;
+    expect(sentVariations).toHaveLength(1);
+    expect(sentVariations[0].itemVariationData.priceMoney.amount).toBe(
+      3000n
+    );
+  });
+
+  it('updates multiple variations via variations array', async () => {
+    mockCurrentItem([
+      { id: 'SQ-VAR-SM', sku: 'prd_sm', price: 2000 },
+      { id: 'SQ-VAR-LG', sku: 'prd_lg', price: 3500 },
+    ]);
+
+    const result = await service.updateItem({
+      squareItemId: 'SQ-ITEM-1',
+      squareCatalogVersion: 5,
+      name: 'Updated Bowl',
+      variations: [
+        { squareVariationId: 'SQ-VAR-SM', priceCents: 2200 },
+        { squareVariationId: 'SQ-VAR-LG', priceCents: 3800 },
+      ],
+    });
+
+    expect(result.squareCatalogVersion).toBe(6);
+
+    const batchCall = client.catalog.batchUpsert.mock.calls[0][0];
+    const itemData = batchCall.batches[0].objects[0].itemData;
+    expect(itemData.name).toBe('Updated Bowl');
+    expect(itemData.variations).toHaveLength(2);
+    expect(
+      itemData.variations[0].itemVariationData.priceMoney.amount
+    ).toBe(2200n);
+    expect(
+      itemData.variations[1].itemVariationData.priceMoney.amount
+    ).toBe(3800n);
+  });
+
+  it('updates item-level fields only (no variation changes)', async () => {
+    mockCurrentItem([{ id: 'SQ-VAR-1', sku: 'prd_abc', price: 2500 }]);
+
+    const result = await service.updateItem({
+      squareItemId: 'SQ-ITEM-1',
+      squareCatalogVersion: 5,
+      name: 'New Name',
+      description: 'New Desc',
+    });
+
+    expect(result.squareCatalogVersion).toBe(6);
+
+    const batchCall = client.catalog.batchUpsert.mock.calls[0][0];
+    const itemData = batchCall.batches[0].objects[0].itemData;
+    expect(itemData.name).toBe('New Name');
+    expect(itemData.description).toBe('New Desc');
+    // No variation updates when none specified
+    expect(itemData.variations).toHaveLength(0);
+  });
+
+  it('throws on version mismatch', async () => {
+    client.catalog.object.get.mockResolvedValue({
+      object: {
+        type: 'ITEM',
+        id: 'SQ-ITEM-1',
+        version: 10n,
+        itemData: { variations: [] },
+      },
+    });
+
+    await expect(
+      service.updateItem({
+        squareItemId: 'SQ-ITEM-1',
+        squareCatalogVersion: 5,
+        name: 'Conflict',
+      })
+    ).rejects.toThrow(/version mismatch/);
+  });
+
+  it('throws when variation not found', async () => {
+    mockCurrentItem([{ id: 'SQ-VAR-1', sku: 'prd_abc', price: 2500 }]);
+
+    await expect(
+      service.updateItem({
+        squareItemId: 'SQ-ITEM-1',
+        squareCatalogVersion: 5,
+        variations: [
+          { squareVariationId: 'SQ-VAR-MISSING', priceCents: 999 },
+        ],
+      })
+    ).rejects.toThrow(/variation not found.*SQ-VAR-MISSING/);
+  });
+
+  it('finds variation in relatedObjects when not nested', async () => {
+    client.catalog.object.get.mockResolvedValue({
+      object: {
+        type: 'ITEM',
+        id: 'SQ-ITEM-1',
+        version: 5n,
+        itemData: {
+          name: 'Bowl',
+          variations: [],
+        },
+      },
+      relatedObjects: [
+        {
+          type: 'ITEM_VARIATION',
+          id: 'SQ-VAR-REL',
+          version: 1n,
+          itemVariationData: {
+            sku: 'prd_rel',
+            priceMoney: { amount: 1000n, currency: 'USD' },
+          },
+        },
+      ],
+    });
+
+    client.catalog.batchUpsert.mockResolvedValue({
+      objects: [{ type: 'ITEM', id: 'SQ-ITEM-1', version: 6n }],
+    });
+
+    const result = await service.updateItem({
+      squareItemId: 'SQ-ITEM-1',
+      squareCatalogVersion: 5,
+      squareVariationId: 'SQ-VAR-REL',
+      priceCents: 1200,
+    });
+
+    expect(result.squareCatalogVersion).toBe(6);
+  });
+});

--- a/libs/firebase/square/src/lib/catalog.service.ts
+++ b/libs/firebase/square/src/lib/catalog.service.ts
@@ -254,7 +254,9 @@ export class CatalogService {
     // Match response variations to input variants by SKU
     const variations: SquareVariationResult[] = variantInputs.map((v) => {
       const matched = responseVariations.find(
-        (rv) => rv.itemVariationData?.sku === v.sku
+        (rv) =>
+          (rv as { itemVariationData?: { sku?: string } }).itemVariationData
+            ?.sku === v.sku
       );
       return {
         variantId: v.variantId,
@@ -324,7 +326,8 @@ export class CatalogService {
           );
         }
 
-        const currentData = existing.itemVariationData;
+        const existingTyped = existing as { itemVariationData?: Square.CatalogItemVariation };
+        const currentData = existingTyped.itemVariationData;
         const updatedData: Square.CatalogItemVariation = {
           ...currentData,
           itemId: input.squareItemId,

--- a/libs/firebase/square/src/lib/catalog.service.ts
+++ b/libs/firebase/square/src/lib/catalog.service.ts
@@ -7,7 +7,8 @@
  * @see https://developer.squareup.com/docs/catalog-api/what-it-does
  */
 import { SquareClient, Square } from 'square';
-import { generateSku } from '@maple/ts/domain';
+import { generateSku, generateVariantId } from '@maple/ts/domain';
+import type { SquareVariationResult } from '@maple/ts/domain';
 
 /**
  * Input for uploading a catalog image
@@ -38,6 +39,20 @@ export interface UploadCatalogImageResult {
 }
 
 /**
+ * Input for a single catalog item variation
+ */
+export interface CatalogVariationInput {
+  /** Variant label (used as variation name in Square) */
+  label: string;
+  /** Price in cents (e.g., 2500 = $25.00) */
+  priceCents: number;
+  /** SKU - if not provided, one will be generated */
+  sku?: string;
+  /** Internal variant ID - if not provided, one will be generated */
+  variantId?: string;
+}
+
+/**
  * Input for creating a catalog item
  */
 export interface CreateCatalogItemInput {
@@ -45,12 +60,17 @@ export interface CreateCatalogItemInput {
   name: string;
   /** Product description */
   description?: string;
-  /** Price in cents (e.g., 2500 = $25.00) */
-  priceCents: number;
+  /** Price in cents (e.g., 2500 = $25.00) — used when variants is omitted */
+  priceCents?: number;
   /** Initial quantity (optional, set via Inventory API) */
   quantity?: number;
-  /** SKU - if not provided, one will be generated */
+  /** SKU - if not provided, one will be generated — used when variants is omitted */
   sku?: string;
+  /**
+   * Multiple variations. If provided, priceCents/sku at the top level are ignored.
+   * If omitted, a single "Regular" variation is created from priceCents/sku.
+   */
+  variants?: CatalogVariationInput[];
 }
 
 /**
@@ -59,12 +79,30 @@ export interface CreateCatalogItemInput {
 export interface CreateCatalogItemResult {
   /** Square catalog item ID */
   squareItemId: string;
-  /** Square item variation ID (for inventory tracking) */
-  squareVariationId: string;
   /** Square catalog version (for optimistic locking) */
   squareCatalogVersion: number;
-  /** The generated or provided SKU */
+  /** Per-variation results */
+  variations: SquareVariationResult[];
+
+  // --- Legacy fields for backward compatibility ---
+  /** @deprecated Use variations[0].squareVariationId */
+  squareVariationId: string;
+  /** @deprecated Use variations[0].sku */
   sku: string;
+}
+
+/**
+ * Input for updating a single variation within a catalog item
+ */
+export interface UpdateCatalogVariationInput {
+  /** Square variation ID to update */
+  squareVariationId: string;
+  /** Updated variation name/label (optional) */
+  name?: string;
+  /** Updated price in cents (optional) */
+  priceCents?: number;
+  /** Updated SKU (optional) */
+  sku?: string;
 }
 
 /**
@@ -73,17 +111,25 @@ export interface CreateCatalogItemResult {
 export interface UpdateCatalogItemInput {
   /** Square catalog item ID */
   squareItemId: string;
-  /** Square item variation ID */
-  squareVariationId: string;
   /** Current catalog version (for optimistic locking) */
   squareCatalogVersion: number;
   /** Updated name (optional) */
   name?: string;
   /** Updated description (optional) */
   description?: string;
-  /** Updated price in cents (optional) */
+
+  /**
+   * Multiple variation updates. If provided, the legacy squareVariationId/priceCents/sku
+   * fields are ignored.
+   */
+  variations?: UpdateCatalogVariationInput[];
+
+  // --- Legacy single-variation fields ---
+  /** @deprecated Use variations[] instead */
+  squareVariationId?: string;
+  /** @deprecated Use variations[] instead */
   priceCents?: number;
-  /** Updated SKU (optional) */
+  /** @deprecated Use variations[] instead */
   sku?: string;
 }
 
@@ -102,21 +148,54 @@ export class CatalogService {
   constructor(private readonly client: SquareClient) {}
 
   /**
-   * Create a new catalog item with a single variation
+   * Create a new catalog item with one or more variations
    *
    * Square uses a hierarchical model:
    * - CatalogItem: The product (name, description)
    * - CatalogItemVariation: The purchasable unit (price, SKU)
    *
-   * For our consignment model, each product has exactly one variation.
+   * If `variants` is provided, each entry becomes an ITEM_VARIATION.
+   * If omitted, a single "Regular" variation is created from the
+   * top-level priceCents/sku fields (backward compatible).
    */
   async createItem(input: CreateCatalogItemInput): Promise<CreateCatalogItemResult> {
-    const sku = input.sku || generateSku();
-    const idempotencyKey = `create-${sku}-${Date.now()}`;
+    // Normalize to a variants array
+    const variantInputs: Array<{ label: string; priceCents: number; sku: string; variantId: string }> =
+      input.variants && input.variants.length > 0
+        ? input.variants.map((v) => ({
+            label: v.label,
+            priceCents: v.priceCents,
+            sku: v.sku || generateSku(),
+            variantId: v.variantId || generateVariantId(),
+          }))
+        : [
+            {
+              label: 'Regular',
+              priceCents: input.priceCents ?? 0,
+              sku: input.sku || generateSku(),
+              variantId: generateVariantId(),
+            },
+          ];
 
-    // Generate temporary IDs for the batch upsert
-    const itemId = `#item-${sku}`;
-    const variationId = `#variation-${sku}`;
+    const firstSku = variantInputs[0].sku;
+    const idempotencyKey = `create-${firstSku}-${Date.now()}`;
+    const itemId = `#item-${firstSku}`;
+
+    // Build one ITEM_VARIATION per variant
+    const variationObjects: Square.CatalogObject[] = variantInputs.map((v) => ({
+      type: 'ITEM_VARIATION',
+      id: `#variation-${v.sku}`,
+      itemVariationData: {
+        name: v.label,
+        sku: v.sku,
+        pricingType: 'FIXED_PRICING',
+        priceMoney: {
+          amount: BigInt(v.priceCents),
+          currency: 'USD',
+        },
+        trackInventory: true,
+      },
+    }));
 
     const response = await this.client.catalog.batchUpsert({
       idempotencyKey,
@@ -129,22 +208,7 @@ export class CatalogService {
               itemData: {
                 name: input.name,
                 description: input.description,
-                variations: [
-                  {
-                    type: 'ITEM_VARIATION',
-                    id: variationId,
-                    itemVariationData: {
-                      name: 'Regular',
-                      sku: sku,
-                      pricingType: 'FIXED_PRICING',
-                      priceMoney: {
-                        amount: BigInt(input.priceCents),
-                        currency: 'USD',
-                      },
-                      trackInventory: true,
-                    },
-                  },
-                ],
+                variations: variationObjects,
               },
             },
           ],
@@ -174,25 +238,38 @@ export class CatalogService {
       throw new Error('Failed to create catalog item: no ITEM in response');
     }
 
-    // The variation is nested inside the item's itemData.variations array
-    const variations = itemObject.itemData?.variations || [];
-    const variationObject = variations[0];
+    // Map response variations back to our result structure
+    const responseVariations = itemObject.itemData?.variations || [];
 
-    if (!variationObject) {
+    if (responseVariations.length === 0) {
       console.error(
         'Square batchUpsert itemObject:',
         JSON.stringify(itemObject, null, 2)
       );
       throw new Error(
-        'Failed to create catalog item: no variation in ITEM response'
+        'Failed to create catalog item: no variations in ITEM response'
       );
     }
 
+    // Match response variations to input variants by SKU
+    const variations: SquareVariationResult[] = variantInputs.map((v) => {
+      const matched = responseVariations.find(
+        (rv) => rv.itemVariationData?.sku === v.sku
+      );
+      return {
+        variantId: v.variantId,
+        squareVariationId: matched?.id ?? '',
+        sku: v.sku,
+      };
+    });
+
     return {
       squareItemId: itemObject.id!,
-      squareVariationId: variationObject.id!,
       squareCatalogVersion: Number(itemObject.version || 0),
-      sku,
+      variations,
+      // Legacy fields for backward compatibility
+      squareVariationId: variations[0]?.squareVariationId ?? '',
+      sku: variations[0]?.sku ?? '',
     };
   }
 
@@ -200,6 +277,8 @@ export class CatalogService {
    * Update an existing catalog item
    *
    * Uses optimistic locking via catalog version to prevent conflicts.
+   * Supports updating multiple variations via the `variations` array,
+   * or a single variation via the legacy `squareVariationId`/`priceCents`/`sku` fields.
    */
   async updateItem(input: UpdateCatalogItemInput): Promise<UpdateCatalogItemResult> {
     // First, retrieve the current item to get its full structure
@@ -220,53 +299,58 @@ export class CatalogService {
       );
     }
 
-    // Find the variation - could be in relatedObjects OR nested in itemData.variations
+    // Resolve which variations to update
+    const variationUpdates = this.resolveVariationUpdates(input);
+
+    // Collect all existing variations from the response
     const relatedObjects = currentResponse.relatedObjects || [];
-    let variation = relatedObjects.find(
-      (obj: Square.CatalogObject) => obj.id === input.squareVariationId
+    const nestedVariations = currentItem.itemData?.variations || [];
+
+    // Helper to find an existing variation by ID
+    const findVariation = (variationId: string): Square.CatalogObject | undefined => {
+      return (
+        relatedObjects.find((obj: Square.CatalogObject) => obj.id === variationId) ||
+        (nestedVariations.find((v) => v.id === variationId) as Square.CatalogObject | undefined)
+      );
+    };
+
+    // Build updated variation objects
+    const updatedVariations: Square.CatalogObject[] = variationUpdates.map(
+      (update) => {
+        const existing = findVariation(update.squareVariationId);
+        if (!existing || existing.type !== 'ITEM_VARIATION') {
+          throw new Error(
+            `Catalog variation not found: ${update.squareVariationId}`
+          );
+        }
+
+        const currentData = existing.itemVariationData;
+        const updatedData: Square.CatalogItemVariation = {
+          ...currentData,
+          itemId: input.squareItemId,
+          name: update.name ?? currentData?.name,
+          sku: update.sku ?? currentData?.sku,
+          priceMoney:
+            update.priceCents !== undefined
+              ? { amount: BigInt(update.priceCents), currency: 'USD' }
+              : currentData?.priceMoney,
+        };
+
+        return {
+          type: 'ITEM_VARIATION' as const,
+          id: update.squareVariationId,
+          version: existing.version,
+          itemVariationData: updatedData,
+        };
+      }
     );
 
-    // If not in relatedObjects, check the nested variations array
-    if (!variation) {
-      const nestedVariations = currentItem.itemData?.variations || [];
-      variation = nestedVariations.find(
-        (v) => v.id === input.squareVariationId
-      ) as Square.CatalogObject | undefined;
-    }
-
-    if (!variation || variation.type !== 'ITEM_VARIATION') {
-      throw new Error(`Catalog variation not found: ${input.squareVariationId}`);
-    }
-
-    // Build updated variation data
-    const currentVariationData = variation.itemVariationData;
-    const updatedVariationData: Square.CatalogItemVariation = {
-      ...currentVariationData,
-      itemId: input.squareItemId,
-      sku: input.sku ?? currentVariationData?.sku,
-      priceMoney: input.priceCents !== undefined
-        ? {
-            amount: BigInt(input.priceCents),
-            currency: 'USD',
-          }
-        : currentVariationData?.priceMoney,
-    };
-
-    // Build the updated variation object to nest inside the item
-    const updatedVariation: Square.CatalogObject = {
-      type: 'ITEM_VARIATION',
-      id: input.squareVariationId,
-      version: variation.version,
-      itemVariationData: updatedVariationData,
-    };
-
-    // Build updated item data with the variation nested inside
-    // Square expects variations to be nested in the item, not as separate batch objects
+    // Build updated item data
     const updatedItemData: Square.CatalogItem = {
       ...currentItem.itemData,
       name: input.name ?? currentItem.itemData?.name,
       description: input.description ?? currentItem.itemData?.description,
-      variations: [updatedVariation],
+      variations: updatedVariations,
     };
 
     const idempotencyKey = `update-${input.squareItemId}-${Date.now()}`;
@@ -294,6 +378,33 @@ export class CatalogService {
     return {
       squareCatalogVersion: Number(updatedItem?.version || 0),
     };
+  }
+
+  /**
+   * Normalize update input into an array of variation updates.
+   * If `variations` array is provided, use it directly.
+   * Otherwise, build a single-element array from the legacy fields.
+   */
+  private resolveVariationUpdates(
+    input: UpdateCatalogItemInput
+  ): UpdateCatalogVariationInput[] {
+    if (input.variations && input.variations.length > 0) {
+      return input.variations;
+    }
+
+    // Legacy single-variation path
+    if (input.squareVariationId) {
+      return [
+        {
+          squareVariationId: input.squareVariationId,
+          priceCents: input.priceCents,
+          sku: input.sku,
+        },
+      ];
+    }
+
+    // No variation updates
+    return [];
   }
 
   /**

--- a/libs/firebase/square/src/lib/inventory.service.spec.ts
+++ b/libs/firebase/square/src/lib/inventory.service.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { InventoryService } from './inventory.service';
+import type { SquareClient } from 'square';
+
+/**
+ * Unit tests for the Square InventoryService wrapper.
+ *
+ * Mocks the Square client at the method level and verifies
+ * inventory set/adjust operations including batch setQuantities.
+ */
+
+interface MockClient {
+  inventory: {
+    batchCreateChanges: ReturnType<typeof vi.fn>;
+    batchGetCounts: ReturnType<typeof vi.fn>;
+  };
+  locations: {
+    list: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeMockClient(): MockClient {
+  return {
+    inventory: {
+      batchCreateChanges: vi.fn().mockResolvedValue({}),
+      batchGetCounts: vi.fn().mockResolvedValue({ data: [] }),
+    },
+    locations: {
+      list: vi.fn(),
+    },
+  };
+}
+
+describe('InventoryService.setQuantities', () => {
+  let client: MockClient;
+  let service: InventoryService;
+
+  beforeEach(() => {
+    client = makeMockClient();
+    service = new InventoryService(client as unknown as SquareClient);
+  });
+
+  it('sends a single batchCreateChanges call with all entries', async () => {
+    await service.setQuantities([
+      { squareVariationId: 'SQ-VAR-SM', locationId: 'LOC-1', quantity: 5 },
+      { squareVariationId: 'SQ-VAR-LG', locationId: 'LOC-1', quantity: 3 },
+    ]);
+
+    expect(client.inventory.batchCreateChanges).toHaveBeenCalledTimes(1);
+    const call = client.inventory.batchCreateChanges.mock.calls[0][0];
+    expect(call.changes).toHaveLength(2);
+
+    expect(call.changes[0].type).toBe('PHYSICAL_COUNT');
+    expect(call.changes[0].physicalCount.catalogObjectId).toBe('SQ-VAR-SM');
+    expect(call.changes[0].physicalCount.quantity).toBe('5');
+    expect(call.changes[0].physicalCount.state).toBe('IN_STOCK');
+
+    expect(call.changes[1].physicalCount.catalogObjectId).toBe('SQ-VAR-LG');
+    expect(call.changes[1].physicalCount.quantity).toBe('3');
+  });
+
+  it('is a no-op when entries array is empty', async () => {
+    await service.setQuantities([]);
+    expect(client.inventory.batchCreateChanges).not.toHaveBeenCalled();
+  });
+
+  it('handles a single entry', async () => {
+    await service.setQuantities([
+      { squareVariationId: 'SQ-VAR-1', locationId: 'LOC-1', quantity: 10 },
+    ]);
+
+    expect(client.inventory.batchCreateChanges).toHaveBeenCalledTimes(1);
+    const call = client.inventory.batchCreateChanges.mock.calls[0][0];
+    expect(call.changes).toHaveLength(1);
+    expect(call.changes[0].physicalCount.quantity).toBe('10');
+  });
+});
+
+describe('InventoryService.setQuantity', () => {
+  let client: MockClient;
+  let service: InventoryService;
+
+  beforeEach(() => {
+    client = makeMockClient();
+    service = new InventoryService(client as unknown as SquareClient);
+  });
+
+  it('sends a PHYSICAL_COUNT change', async () => {
+    await service.setQuantity({
+      squareVariationId: 'SQ-VAR-1',
+      locationId: 'LOC-1',
+      quantity: 7,
+    });
+
+    expect(client.inventory.batchCreateChanges).toHaveBeenCalledTimes(1);
+    const call = client.inventory.batchCreateChanges.mock.calls[0][0];
+    expect(call.changes).toHaveLength(1);
+    expect(call.changes[0].type).toBe('PHYSICAL_COUNT');
+    expect(call.changes[0].physicalCount.catalogObjectId).toBe('SQ-VAR-1');
+    expect(call.changes[0].physicalCount.quantity).toBe('7');
+  });
+});

--- a/libs/firebase/square/src/lib/inventory.service.ts
+++ b/libs/firebase/square/src/lib/inventory.service.ts
@@ -100,6 +100,37 @@ export class InventoryService {
   }
 
   /**
+   * Batch set inventory quantities for multiple variations.
+   *
+   * Each entry becomes a separate PHYSICAL_COUNT change within
+   * a single batchCreateChanges call.
+   */
+  async setQuantities(
+    entries: Array<{ squareVariationId: string; locationId: string; quantity: number }>
+  ): Promise<void> {
+    if (entries.length === 0) {
+      return;
+    }
+
+    const idempotencyKey = `set-batch-${Date.now()}`;
+    const occurredAt = new Date().toISOString();
+
+    await this.client.inventory.batchCreateChanges({
+      idempotencyKey,
+      changes: entries.map((entry) => ({
+        type: 'PHYSICAL_COUNT',
+        physicalCount: {
+          catalogObjectId: entry.squareVariationId,
+          locationId: entry.locationId,
+          quantity: String(entry.quantity),
+          state: 'IN_STOCK',
+          occurredAt,
+        },
+      })),
+    });
+  }
+
+  /**
    * Adjust inventory quantity by a delta
    *
    * Use positive numbers to add inventory, negative to remove.

--- a/libs/firebase/square/vitest.config.ts
+++ b/libs/firebase/square/vitest.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
 
 export default defineConfig({
   root: __dirname,
+  resolve: {
+    alias: {
+      '@maple/ts/domain': resolve(__dirname, '../../ts/domain/src/index.ts'),
+    },
+  },
   test: {
     name: 'square',
     globals: true,


### PR DESCRIPTION
## Summary

- Update `CatalogService.createItem()` to accept an optional `variants` array, creating one ITEM_VARIATION per variant in Square (falls back to single "Regular" variation for backward compatibility)
- Update `CatalogService.updateItem()` to accept a `variations[]` array for updating multiple variation prices/SKUs in a single batch upsert
- Add `InventoryService.setQuantities()` for batch-setting inventory quantities across multiple variations in one API call
- Update `create-product` cloud function to use `resolveVariants()` and pass per-variant data to Square catalog and inventory APIs
- Update `update-product` cloud function to handle both multi-variant (`data.variants[]`) and legacy single-variant update paths
- Add unit tests for CatalogService (12 tests) and InventoryService (4 tests) covering single/multi-variation create, update, error paths, and batch inventory

Closes #306

## Test plan

- [x] CatalogService tests pass (12 new tests covering create/update with single and multiple variations)
- [x] InventoryService tests pass (4 new tests covering setQuantities batch and setQuantity)
- [x] All existing square service tests continue to pass (57 tests)
- [ ] Integration tests with Firebase emulators (CI)
- [ ] Verify backward compatibility: single-variant products still work via legacy fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)