### PR TITLE
feat: Push-to-Etsy Cloud Functions

### DIFF
--- a/apps/functions-sync/src/index.ts
+++ b/apps/functions-sync/src/index.ts
@@ -22,3 +22,7 @@ export { etsyAuthUrl } from '@maple/firebase/maple-functions/etsy-auth-url';
 export { etsyAuthCallback } from '@maple/firebase/maple-functions/etsy-auth-callback';
 export { getEtsyConnectionStatus } from '@maple/firebase/maple-functions/get-etsy-connection-status';
 export { refreshEtsyShopId } from '@maple/firebase/maple-functions/refresh-etsy-shop-id';
+
+// Etsy push (catalog → Etsy)
+export { pushProductToEtsy } from '@maple/firebase/maple-functions/push-product-to-etsy';
+export { updateEtsyListing } from '@maple/firebase/maple-functions/update-etsy-listing';

--- a/apps/functions-sync/tsconfig.app.json
+++ b/apps/functions-sync/tsconfig.app.json
@@ -14,6 +14,8 @@
     "../../libs/firebase/maple-functions/etsy-auth-callback/**/*.ts",
     "../../libs/firebase/maple-functions/get-etsy-connection-status/**/*.ts",
     "../../libs/firebase/maple-functions/refresh-etsy-shop-id/**/*.ts",
+    "../../libs/firebase/maple-functions/push-product-to-etsy/**/*.ts",
+    "../../libs/firebase/maple-functions/update-etsy-listing/**/*.ts",
     "../../libs/firebase/etsy/src/**/*.ts",
     "../../libs/firebase/database/src/**/*.ts",
     "../../libs/firebase/functions/src/**/*.ts",

--- a/docs/reference/deployed-functions.md
+++ b/docs/reference/deployed-functions.md
@@ -106,3 +106,13 @@ Webflow CMS synchronization. Isolates `webflow-api`.
 - `syncArtistToWebflow` — Firestore trigger: syncs artist data to Webflow CMS
 - `syncClassToWebflow` — Firestore trigger: syncs class data to Webflow CMS
 - `syncRegistrationCount` — Firestore trigger: re-syncs class to Webflow when registrations change (spots remaining)
+
+### Etsy OAuth
+- `etsyAuthUrl` — generates OAuth authorization URL for Etsy
+- `etsyAuthCallback` — exchanges authorization code for tokens
+- `getEtsyConnectionStatus` — checks if Etsy OAuth tokens are valid
+- `refreshEtsyShopId` — re-resolves the Etsy shop ID from the API
+
+### Etsy Push (catalog to Etsy)
+- `pushProductToEtsy` — creates a draft Etsy listing from a Firestore Product, uploads image, sets variant inventory
+- `updateEtsyListing` — syncs current product data to an existing Etsy listing (title, description, prices, quantities)

--- a/function-codebases.json
+++ b/function-codebases.json
@@ -30,7 +30,9 @@
     "firebase-maple-functions-get-etsy-connection-status": "maple-sync",
     "firebase-maple-functions-refresh-etsy-shop-id": "maple-sync",
     "firebase-maple-functions-list-etsy-listings": "maple-core",
-    "firebase-maple-functions-import-etsy-listings": "maple-square"
+    "firebase-maple-functions-import-etsy-listings": "maple-square",
+    "firebase-maple-functions-push-product-to-etsy": "maple-sync",
+    "firebase-maple-functions-update-etsy-listing": "maple-sync"
   },
   "defaultCodebase": "maple-core"
 }

--- a/libs/firebase/maple-functions/push-product-to-etsy/project.json
+++ b/libs/firebase/maple-functions/push-product-to-etsy/project.json
@@ -1,0 +1,15 @@
+{
+  "name": "firebase-maple-functions-push-product-to-etsy",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/push-product-to-etsy/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {
+    "test": {
+      "executor": "@nx/vitest:test",
+      "options": {
+        "config": "libs/firebase/maple-functions/push-product-to-etsy/vitest.config.ts"
+      }
+    }
+  }
+}

--- a/libs/firebase/maple-functions/push-product-to-etsy/src/index.ts
+++ b/libs/firebase/maple-functions/push-product-to-etsy/src/index.ts
@@ -1,0 +1,1 @@
+export { pushProductToEtsy } from './lib/push-product-to-etsy';

--- a/libs/firebase/maple-functions/push-product-to-etsy/src/lib/push-product-to-etsy.spec.ts
+++ b/libs/firebase/maple-functions/push-product-to-etsy/src/lib/push-product-to-etsy.spec.ts
@@ -1,0 +1,357 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Tests for pushProductToEtsy Cloud Function
+ *
+ * Validates: input validation, draft listing creation, image upload,
+ * multi-variant inventory, Firestore updates, and activation.
+ */
+
+const mocks = vi.hoisted(() => {
+  return {
+    findById: vi.fn(),
+    updateEtsyCache: vi.fn(),
+    updateVariants: vi.fn(),
+    getCategoryTemplate: vi.fn(),
+    getArtistTemplate: vi.fn(),
+    createDraftListing: vi.fn(),
+    uploadListingImage: vi.fn(),
+    activateListing: vi.fn(),
+    updateInventory: vi.fn(),
+    capturedHandler: null as ((...args: unknown[]) => Promise<unknown>) | null,
+  };
+});
+
+vi.mock('@maple/firebase/database', () => ({
+  FirestoreTokenStorage: { getTokens: vi.fn() },
+  ProductRepository: {
+    findById: mocks.findById,
+    updateEtsyCache: mocks.updateEtsyCache,
+    updateVariants: mocks.updateVariants,
+  },
+  EtsyTemplateRepository: {
+    getCategoryTemplate: mocks.getCategoryTemplate,
+    getArtistTemplate: mocks.getArtistTemplate,
+  },
+}));
+
+vi.mock('@maple/firebase/etsy', () => ({
+  EtsyClient: class {
+    listings = {
+      createDraftListing: mocks.createDraftListing,
+      uploadListingImage: mocks.uploadListingImage,
+      activateListing: mocks.activateListing,
+    };
+    inventory = {
+      updateInventory: mocks.updateInventory,
+    };
+  },
+}));
+
+vi.mock('@maple/firebase/functions', () => ({
+  Functions: {
+    endpoint: {
+      usingSecrets: vi.fn().mockReturnThis(),
+      usingStrings: vi.fn().mockReturnThis(),
+      requiringRole: vi.fn().mockReturnThis(),
+      handle: vi.fn((handler: (...args: unknown[]) => Promise<unknown>) => {
+        mocks.capturedHandler = handler;
+        return 'mock-function';
+      }),
+    },
+  },
+  Role: { Admin: 'admin' },
+}));
+
+import './push-product-to-etsy';
+
+const secrets = { ETSY_API_KEY: 'key', ETSY_SHARED_SECRET: 'secret' };
+const strings = { ETSY_REDIRECT_URI: 'https://example.com/callback' };
+const context = { uid: 'admin-1' };
+
+function makeProduct(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'prod-1',
+    artistId: 'artist-1',
+    categoryId: 'cat-1',
+    status: 'active',
+    variants: [
+      {
+        id: 'var-1',
+        label: 'Regular',
+        sku: 'prd_abc123',
+        priceCents: 2500,
+        quantity: 5,
+      },
+    ],
+    squareCache: {
+      name: 'Handmade Bowl',
+      description: 'A lovely handmade ceramic bowl',
+      imageUrl: 'https://images.example.com/bowl.jpg',
+      syncedAt: new Date(),
+    },
+    etsyListingId: undefined,
+    ...overrides,
+  };
+}
+
+function makeEtsyListing(overrides: Record<string, unknown> = {}) {
+  return {
+    listing_id: 98765,
+    title: 'Handmade Bowl',
+    description: 'A lovely handmade ceramic bowl',
+    url: 'https://www.etsy.com/listing/98765',
+    taxonomy_id: 1234,
+    tags: ['handmade', 'ceramic'],
+    state: 'draft',
+    ...overrides,
+  };
+}
+
+describe('pushProductToEtsy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns error when productId is missing', async () => {
+    const result = (await mocks.capturedHandler!(
+      {},
+      context,
+      secrets,
+      strings
+    )) as { success: boolean; error: string };
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('productId is required');
+  });
+
+  it('returns error when product not found', async () => {
+    mocks.findById.mockResolvedValue(undefined);
+
+    const result = (await mocks.capturedHandler!(
+      { productId: 'missing' },
+      context,
+      secrets,
+      strings
+    )) as { success: boolean; error: string };
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('not found');
+  });
+
+  it('returns error when product has no variants', async () => {
+    mocks.findById.mockResolvedValue(makeProduct({ variants: [] }));
+
+    const result = (await mocks.capturedHandler!(
+      { productId: 'prod-1' },
+      context,
+      secrets,
+      strings
+    )) as { success: boolean; error: string };
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('at least one variant');
+  });
+
+  it('returns error when product already has an Etsy listing', async () => {
+    mocks.findById.mockResolvedValue(
+      makeProduct({ etsyListingId: '12345' })
+    );
+
+    const result = (await mocks.capturedHandler!(
+      { productId: 'prod-1' },
+      context,
+      secrets,
+      strings
+    )) as { success: boolean; error: string };
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('already linked');
+  });
+
+  it('returns error when no taxonomy_id is available', async () => {
+    mocks.findById.mockResolvedValue(makeProduct());
+    mocks.getCategoryTemplate.mockResolvedValue(undefined);
+    mocks.getArtistTemplate.mockResolvedValue(undefined);
+
+    const result = (await mocks.capturedHandler!(
+      { productId: 'prod-1' },
+      context,
+      secrets,
+      strings
+    )) as { success: boolean; error: string };
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('taxonomy_id');
+  });
+
+  it('creates a draft listing and updates Firestore on success', async () => {
+    const product = makeProduct();
+    mocks.findById.mockResolvedValue(product);
+    mocks.getCategoryTemplate.mockResolvedValue({
+      taxonomyId: 1234,
+      tags: ['handmade'],
+      whoMade: 'someone_else',
+      whenMade: 'made_to_order',
+    });
+    mocks.getArtistTemplate.mockResolvedValue(undefined);
+
+    const listing = makeEtsyListing();
+    mocks.createDraftListing.mockResolvedValue(listing);
+
+    // Mock the refetch after updates
+    mocks.findById.mockResolvedValueOnce(product).mockResolvedValueOnce({
+      ...product,
+      etsyListingId: '98765',
+    });
+
+    const result = (await mocks.capturedHandler!(
+      { productId: 'prod-1' },
+      context,
+      secrets,
+      strings
+    )) as { success: boolean; etsyListingId: string };
+
+    expect(result.success).toBe(true);
+    expect(result.etsyListingId).toBe('98765');
+
+    // Verify createDraftListing was called with correct data
+    expect(mocks.createDraftListing).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Handmade Bowl',
+        price: 25,
+        quantity: 5,
+        taxonomy_id: 1234,
+        who_made: 'someone_else',
+        when_made: 'made_to_order',
+      })
+    );
+
+    // Verify Firestore was updated
+    expect(mocks.updateEtsyCache).toHaveBeenCalledWith(
+      'prod-1',
+      '98765',
+      expect.objectContaining({
+        title: 'Handmade Bowl',
+        state: 'draft',
+      })
+    );
+  });
+
+  it('handles multi-variant products with inventory update', async () => {
+    const product = makeProduct({
+      variants: [
+        { id: 'var-1', label: 'Small', sku: 'sku-sm', priceCents: 2000, quantity: 3 },
+        { id: 'var-2', label: 'Large', sku: 'sku-lg', priceCents: 3000, quantity: 2 },
+      ],
+      variantProperties: ['Size'],
+    });
+    mocks.findById.mockResolvedValue(product);
+    mocks.getCategoryTemplate.mockResolvedValue({ taxonomyId: 1234 });
+    mocks.getArtistTemplate.mockResolvedValue(undefined);
+
+    const listing = makeEtsyListing();
+    mocks.createDraftListing.mockResolvedValue(listing);
+    mocks.updateInventory.mockResolvedValue({
+      products: [
+        { product_id: 501, sku: 'sku-sm', offerings: [], property_values: [] },
+        { product_id: 502, sku: 'sku-lg', offerings: [], property_values: [] },
+      ],
+    });
+
+    // Refetch
+    mocks.findById
+      .mockResolvedValueOnce(product)
+      .mockResolvedValueOnce({ ...product, etsyListingId: '98765' });
+
+    const result = (await mocks.capturedHandler!(
+      { productId: 'prod-1' },
+      context,
+      secrets,
+      strings
+    )) as { success: boolean };
+
+    expect(result.success).toBe(true);
+
+    // Total quantity should be 3 + 2 = 5
+    expect(mocks.createDraftListing).toHaveBeenCalledWith(
+      expect.objectContaining({ quantity: 5 })
+    );
+
+    // Inventory should be updated with variant data
+    expect(mocks.updateInventory).toHaveBeenCalledWith(
+      98765,
+      expect.objectContaining({
+        products: expect.arrayContaining([
+          expect.objectContaining({ sku: 'sku-sm' }),
+          expect.objectContaining({ sku: 'sku-lg' }),
+        ]),
+      })
+    );
+
+    // Variant etsyProductId mappings should be saved
+    expect(mocks.updateVariants).toHaveBeenCalledWith(
+      'prod-1',
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'var-1', etsyProductId: 501 }),
+        expect.objectContaining({ id: 'var-2', etsyProductId: 502 }),
+      ])
+    );
+  });
+
+  it('activates the listing when activateAfterPush is true', async () => {
+    const product = makeProduct();
+    mocks.findById.mockResolvedValue(product);
+    mocks.getCategoryTemplate.mockResolvedValue({ taxonomyId: 1234 });
+    mocks.getArtistTemplate.mockResolvedValue(undefined);
+    mocks.createDraftListing.mockResolvedValue(makeEtsyListing());
+    mocks.activateListing.mockResolvedValue({
+      ...makeEtsyListing(),
+      state: 'active',
+    });
+
+    mocks.findById
+      .mockResolvedValueOnce(product)
+      .mockResolvedValueOnce({ ...product, etsyListingId: '98765' });
+
+    const result = (await mocks.capturedHandler!(
+      { productId: 'prod-1', activateAfterPush: true },
+      context,
+      secrets,
+      strings
+    )) as { success: boolean };
+
+    expect(result.success).toBe(true);
+    expect(mocks.activateListing).toHaveBeenCalledWith(98765);
+
+    // Should update cache with active state
+    expect(mocks.updateEtsyCache).toHaveBeenCalledWith(
+      'prod-1',
+      '98765',
+      expect.objectContaining({ state: 'active' })
+    );
+  });
+
+  it('succeeds even if image upload fails (best-effort)', async () => {
+    const product = makeProduct();
+    mocks.findById.mockResolvedValue(product);
+    mocks.getCategoryTemplate.mockResolvedValue({ taxonomyId: 1234 });
+    mocks.getArtistTemplate.mockResolvedValue(undefined);
+    mocks.createDraftListing.mockResolvedValue(makeEtsyListing());
+
+    // Image download will fail because fetch is not mocked to return success.
+    // The function should still succeed.
+    mocks.findById
+      .mockResolvedValueOnce(product)
+      .mockResolvedValueOnce({ ...product, etsyListingId: '98765' });
+
+    const result = (await mocks.capturedHandler!(
+      { productId: 'prod-1' },
+      context,
+      secrets,
+      strings
+    )) as { success: boolean };
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/libs/firebase/maple-functions/push-product-to-etsy/src/lib/push-product-to-etsy.ts
+++ b/libs/firebase/maple-functions/push-product-to-etsy/src/lib/push-product-to-etsy.ts
@@ -1,0 +1,307 @@
+/**
+ * Push Product to Etsy Cloud Function
+ *
+ * Creates a native Etsy listing from an existing Firestore Product.
+ * Handles the full flow: create draft listing, upload image, set
+ * variant inventory, and optionally activate the listing.
+ *
+ * Admin only. Lives in the maple-sync codebase (Etsy API dependency).
+ */
+import { Functions, Role } from '@maple/firebase/functions';
+import {
+  FirestoreTokenStorage,
+  ProductRepository,
+  EtsyTemplateRepository,
+} from '@maple/firebase/database';
+import {
+  EtsyClient,
+  type CreateDraftListingInput,
+  type EtsyWhoMade,
+  type EtsyWhenMade,
+} from '@maple/firebase/etsy';
+import { mergeEtsyTemplates, getTotalQuantity } from '@maple/ts/domain';
+import type { Product, ProductVariant } from '@maple/ts/domain';
+import type {
+  PushProductToEtsyRequest,
+  PushProductToEtsyResponse,
+} from '@maple/ts/firebase/api-types';
+import type {
+  UpdateInventoryProduct,
+  UpdateInventoryOffering,
+  UpdateInventoryPropertyValue,
+} from '@maple/firebase/etsy';
+
+const ETSY_SECRET_NAMES = ['ETSY_API_KEY', 'ETSY_SHARED_SECRET'] as const;
+const ETSY_STRING_NAMES = ['ETSY_REDIRECT_URI'] as const;
+
+/**
+ * Download an image URL and return it as a Buffer with content type.
+ * Returns undefined on failure (best-effort).
+ */
+async function downloadImage(
+  imageUrl: string
+): Promise<{ buffer: Buffer; contentType: string } | undefined> {
+  try {
+    const response = await fetch(imageUrl);
+    if (!response.ok) {
+      console.warn(
+        `Failed to download image (${response.status}): ${imageUrl}`
+      );
+      return undefined;
+    }
+    const arrayBuffer = await response.arrayBuffer();
+    const contentType = response.headers.get('content-type') ?? 'image/jpeg';
+    return { buffer: Buffer.from(arrayBuffer), contentType };
+  } catch (err) {
+    console.warn('Failed to download image:', err);
+    return undefined;
+  }
+}
+
+/**
+ * Build the Etsy inventory products array for multi-variant listings.
+ *
+ * Each ProductVariant becomes an Etsy inventory product with its own
+ * price, quantity, and property values. The variant label is used as
+ * the property value (e.g. "Small", "Large").
+ */
+function buildInventoryProducts(
+  variants: ProductVariant[],
+  variantProperties?: string[]
+): {
+  products: UpdateInventoryProduct[];
+  priceOnProperty: number[];
+  quantityOnProperty: number[];
+  skuOnProperty: number[];
+} {
+  // Etsy property IDs: 513 = "Primary color", 514 = "Secondary color",
+  // 100 = custom property 1, 200 = custom property 2.
+  // Using 100 for the first variant dimension.
+  const propertyId = 100;
+  const propertyName = variantProperties?.[0] ?? 'Variation';
+
+  const products: UpdateInventoryProduct[] = variants.map((v) => ({
+    sku: v.sku,
+    offerings: [
+      {
+        price: v.priceCents / 100,
+        quantity: v.quantity,
+        is_enabled: true,
+      } as UpdateInventoryOffering,
+    ],
+    property_values: [
+      {
+        property_id: propertyId,
+        property_name: propertyName,
+        value_ids: [0],
+        values: [v.label],
+      } as UpdateInventoryPropertyValue,
+    ],
+  }));
+
+  return {
+    products,
+    priceOnProperty: [propertyId],
+    quantityOnProperty: [propertyId],
+    skuOnProperty: [propertyId],
+  };
+}
+
+export const pushProductToEtsy = Functions.endpoint
+  .usingSecrets(...ETSY_SECRET_NAMES)
+  .usingStrings(...ETSY_STRING_NAMES)
+  .requiringRole(Role.Admin)
+  .handle<PushProductToEtsyRequest, PushProductToEtsyResponse>(
+    async (data, _context, secrets, strings) => {
+      const { productId, activateAfterPush } = data;
+
+      if (!productId) {
+        return { success: false, error: 'productId is required' };
+      }
+
+      // 1. Fetch product from Firestore
+      const product = await ProductRepository.findById(productId);
+      if (!product) {
+        return { success: false, error: `Product ${productId} not found` };
+      }
+
+      // 2. Validate: must have variants, must not already be on Etsy
+      if (!product.variants || product.variants.length === 0) {
+        return {
+          success: false,
+          error: 'Product must have at least one variant',
+        };
+      }
+      if (product.etsyListingId) {
+        return {
+          success: false,
+          error: `Product is already linked to Etsy listing ${product.etsyListingId}`,
+        };
+      }
+
+      // 3. Resolve Etsy template defaults
+      const [categoryTemplate, artistTemplate] = await Promise.all([
+        product.categoryId
+          ? EtsyTemplateRepository.getCategoryTemplate(product.categoryId)
+          : Promise.resolve(undefined),
+        product.artistId
+          ? EtsyTemplateRepository.getArtistTemplate(product.artistId)
+          : Promise.resolve(undefined),
+      ]);
+
+      const defaults = mergeEtsyTemplates(categoryTemplate, artistTemplate);
+
+      // 4. Map Product -> CreateDraftListingInput
+      const firstVariant = product.variants[0];
+      const totalQuantity = getTotalQuantity(product);
+
+      if (!defaults.taxonomyId) {
+        return {
+          success: false,
+          error:
+            'No taxonomy_id available. Set a category or artist Etsy template with a taxonomy ID before pushing.',
+        };
+      }
+
+      const listingInput: CreateDraftListingInput = {
+        title: (product.squareCache.name ?? '').substring(0, 140),
+        description: product.squareCache.description ?? '',
+        price: firstVariant.priceCents / 100,
+        quantity: totalQuantity,
+        taxonomy_id: defaults.taxonomyId,
+        who_made: (defaults.whoMade as EtsyWhoMade) ?? 'someone_else',
+        when_made: (defaults.whenMade as EtsyWhenMade) ?? 'made_to_order',
+        is_supply: defaults.isSupply ?? false,
+        shipping_profile_id: defaults.shippingProfileId,
+        shop_section_id: defaults.shopSectionId,
+        tags: defaults.tags,
+        materials: defaults.materials,
+      };
+
+      // 5. Create the Etsy client and push the listing
+      const client = new EtsyClient({
+        apiKey: secrets.ETSY_API_KEY,
+        sharedSecret: secrets.ETSY_SHARED_SECRET,
+        tokenStorage: FirestoreTokenStorage,
+        redirectUri: strings.ETSY_REDIRECT_URI,
+      });
+
+      const listing = await client.listings.createDraftListing(listingInput);
+      const etsyListingId = String(listing.listing_id);
+
+      // 6. Upload image if available (best-effort)
+      const imageUrl = product.squareCache.imageUrl;
+      if (imageUrl) {
+        const downloaded = await downloadImage(imageUrl);
+        if (downloaded) {
+          try {
+            const ext =
+              downloaded.contentType.split('/')[1]?.split(';')[0] ?? 'jpg';
+            await client.listings.uploadListingImage(
+              listing.listing_id,
+              downloaded.buffer,
+              `product.${ext}`,
+              downloaded.contentType
+            );
+          } catch (err) {
+            console.warn('Failed to upload image to Etsy:', err);
+          }
+        }
+      }
+
+      // 7. Set variant inventory for multi-variant products
+      const isMultiVariant = product.variants.length > 1;
+      let variantEtsyProductIds: Map<string, number> | undefined;
+
+      if (isMultiVariant) {
+        try {
+          const inventoryData = buildInventoryProducts(
+            product.variants,
+            product.variantProperties
+          );
+
+          const updatedInventory = await client.inventory.updateInventory(
+            listing.listing_id,
+            {
+              products: inventoryData.products,
+              price_on_property: inventoryData.priceOnProperty,
+              quantity_on_property: inventoryData.quantityOnProperty,
+              sku_on_property: inventoryData.skuOnProperty,
+            }
+          );
+
+          // Map Etsy product_ids back to our variant IDs by SKU match
+          variantEtsyProductIds = new Map<string, number>();
+          for (const etsyProduct of updatedInventory.products) {
+            const matchingVariant = product.variants.find(
+              (v) => v.sku === etsyProduct.sku
+            );
+            if (matchingVariant) {
+              variantEtsyProductIds.set(
+                matchingVariant.id,
+                etsyProduct.product_id
+              );
+            }
+          }
+        } catch (err) {
+          console.warn('Failed to set variant inventory on Etsy:', err);
+        }
+      }
+
+      // 8. Update Firestore with Etsy data
+      await ProductRepository.updateEtsyCache(productId, etsyListingId, {
+        title: listing.title,
+        description: listing.description,
+        url: listing.url,
+        taxonomyId: listing.taxonomy_id,
+        tags: listing.tags,
+        state: 'draft',
+        syncedAt: new Date(),
+      });
+
+      // Update variant etsyProductId mappings if we have them
+      if (variantEtsyProductIds && variantEtsyProductIds.size > 0) {
+        const updatedVariants: ProductVariant[] = product.variants.map((v) => ({
+          ...v,
+          etsyProductId: variantEtsyProductIds!.get(v.id) ?? v.etsyProductId,
+        }));
+        await ProductRepository.updateVariants(productId, updatedVariants);
+      }
+
+      // 9. Activate if requested
+      let finalState: 'draft' | 'active' = 'draft';
+      if (activateAfterPush) {
+        try {
+          await client.listings.activateListing(listing.listing_id);
+          finalState = 'active';
+
+          // Update the cache state to active
+          await ProductRepository.updateEtsyCache(productId, etsyListingId, {
+            title: listing.title,
+            description: listing.description,
+            url: listing.url,
+            taxonomyId: listing.taxonomy_id,
+            tags: listing.tags,
+            state: 'active',
+            syncedAt: new Date(),
+          });
+        } catch (err) {
+          console.warn(
+            'Failed to activate listing (may need image/shipping profile):',
+            err
+          );
+        }
+      }
+
+      // Refetch the product to return the updated version
+      const refreshed = (await ProductRepository.findById(
+        productId
+      )) as Product;
+
+      return {
+        success: true,
+        etsyListingId,
+        product: refreshed,
+      };
+    }
+  );

--- a/libs/firebase/maple-functions/push-product-to-etsy/tsconfig.json
+++ b/libs/firebase/maple-functions/push-product-to-etsy/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/push-product-to-etsy/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/push-product-to-etsy/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/push-product-to-etsy/vitest.config.ts
+++ b/libs/firebase/maple-functions/push-product-to-etsy/vitest.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  root: __dirname,
+  test: {
+    name: 'firebase-maple-functions-push-product-to-etsy',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov', 'json-summary', 'json'],
+      reportsDirectory: '../../../../coverage/libs/firebase/maple-functions/push-product-to-etsy',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.spec.ts', 'src/index.ts'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@maple/ts/domain': resolve(__dirname, '../../../ts/domain/src/index.ts'),
+      '@maple/ts/firebase/api-types': resolve(__dirname, '../../../ts/firebase/api-types/src/index.ts'),
+      '@maple/firebase/database': resolve(__dirname, '../../../firebase/database/src/index.ts'),
+      '@maple/firebase/etsy': resolve(__dirname, '../../../firebase/etsy/src/index.ts'),
+      '@maple/firebase/functions': resolve(__dirname, '../../../firebase/functions/src/index.ts'),
+    },
+  },
+});

--- a/libs/firebase/maple-functions/update-etsy-listing/project.json
+++ b/libs/firebase/maple-functions/update-etsy-listing/project.json
@@ -1,0 +1,15 @@
+{
+  "name": "firebase-maple-functions-update-etsy-listing",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/update-etsy-listing/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {
+    "test": {
+      "executor": "@nx/vitest:test",
+      "options": {
+        "config": "libs/firebase/maple-functions/update-etsy-listing/vitest.config.ts"
+      }
+    }
+  }
+}

--- a/libs/firebase/maple-functions/update-etsy-listing/src/index.ts
+++ b/libs/firebase/maple-functions/update-etsy-listing/src/index.ts
@@ -1,0 +1,1 @@
+export { updateEtsyListing } from './lib/update-etsy-listing';

--- a/libs/firebase/maple-functions/update-etsy-listing/src/lib/update-etsy-listing.spec.ts
+++ b/libs/firebase/maple-functions/update-etsy-listing/src/lib/update-etsy-listing.spec.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Tests for updateEtsyListing Cloud Function
+ *
+ * Validates: input validation, listing update, inventory sync,
+ * and Firestore cache updates.
+ */
+
+const mocks = vi.hoisted(() => {
+  return {
+    findById: vi.fn(),
+    updateEtsyCache: vi.fn(),
+    updateVariants: vi.fn(),
+    getCategoryTemplate: vi.fn(),
+    getArtistTemplate: vi.fn(),
+    updateListing: vi.fn(),
+    updateInventory: vi.fn(),
+    setQuantity: vi.fn(),
+    capturedHandler: null as ((...args: unknown[]) => Promise<unknown>) | null,
+  };
+});
+
+vi.mock('@maple/firebase/database', () => ({
+  FirestoreTokenStorage: { getTokens: vi.fn() },
+  ProductRepository: {
+    findById: mocks.findById,
+    updateEtsyCache: mocks.updateEtsyCache,
+    updateVariants: mocks.updateVariants,
+  },
+  EtsyTemplateRepository: {
+    getCategoryTemplate: mocks.getCategoryTemplate,
+    getArtistTemplate: mocks.getArtistTemplate,
+  },
+}));
+
+vi.mock('@maple/firebase/etsy', () => ({
+  EtsyClient: class {
+    listings = {
+      updateListing: mocks.updateListing,
+    };
+    inventory = {
+      updateInventory: mocks.updateInventory,
+      setQuantity: mocks.setQuantity,
+    };
+  },
+}));
+
+vi.mock('@maple/firebase/functions', () => ({
+  Functions: {
+    endpoint: {
+      usingSecrets: vi.fn().mockReturnThis(),
+      usingStrings: vi.fn().mockReturnThis(),
+      requiringRole: vi.fn().mockReturnThis(),
+      handle: vi.fn((handler: (...args: unknown[]) => Promise<unknown>) => {
+        mocks.capturedHandler = handler;
+        return 'mock-function';
+      }),
+    },
+  },
+  Role: { Admin: 'admin' },
+}));
+
+import './update-etsy-listing';
+
+const secrets = { ETSY_API_KEY: 'key', ETSY_SHARED_SECRET: 'secret' };
+const strings = { ETSY_REDIRECT_URI: 'https://example.com/callback' };
+const context = { uid: 'admin-1' };
+
+function makeProduct(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'prod-1',
+    artistId: 'artist-1',
+    categoryId: 'cat-1',
+    status: 'active',
+    etsyListingId: '98765',
+    variants: [
+      {
+        id: 'var-1',
+        label: 'Regular',
+        sku: 'prd_abc123',
+        priceCents: 2500,
+        quantity: 5,
+      },
+    ],
+    squareCache: {
+      name: 'Handmade Bowl',
+      description: 'A lovely handmade ceramic bowl',
+      syncedAt: new Date(),
+    },
+    ...overrides,
+  };
+}
+
+function makeEtsyListing(overrides: Record<string, unknown> = {}) {
+  return {
+    listing_id: 98765,
+    title: 'Handmade Bowl',
+    description: 'A lovely handmade ceramic bowl',
+    url: 'https://www.etsy.com/listing/98765',
+    taxonomy_id: 1234,
+    tags: ['handmade', 'ceramic'],
+    state: 'active',
+    ...overrides,
+  };
+}
+
+describe('updateEtsyListing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns error when productId is missing', async () => {
+    const result = (await mocks.capturedHandler!(
+      {},
+      context,
+      secrets,
+      strings
+    )) as { success: boolean; error: string };
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('productId is required');
+  });
+
+  it('returns error when product not found', async () => {
+    mocks.findById.mockResolvedValue(undefined);
+
+    const result = (await mocks.capturedHandler!(
+      { productId: 'missing' },
+      context,
+      secrets,
+      strings
+    )) as { success: boolean; error: string };
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('not found');
+  });
+
+  it('returns error when product has no etsyListingId', async () => {
+    mocks.findById.mockResolvedValue(
+      makeProduct({ etsyListingId: undefined })
+    );
+
+    const result = (await mocks.capturedHandler!(
+      { productId: 'prod-1' },
+      context,
+      secrets,
+      strings
+    )) as { success: boolean; error: string };
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('does not have an Etsy listing');
+  });
+
+  it('updates listing and single-variant quantity on success', async () => {
+    const product = makeProduct();
+    mocks.findById.mockResolvedValue(product);
+    mocks.getCategoryTemplate.mockResolvedValue({
+      taxonomyId: 1234,
+      tags: ['handmade'],
+    });
+    mocks.getArtistTemplate.mockResolvedValue(undefined);
+
+    const updatedListing = makeEtsyListing();
+    mocks.updateListing.mockResolvedValue(updatedListing);
+    mocks.setQuantity.mockResolvedValue({
+      products: [],
+    });
+
+    // Refetch
+    mocks.findById
+      .mockResolvedValueOnce(product)
+      .mockResolvedValueOnce(product);
+
+    const result = (await mocks.capturedHandler!(
+      { productId: 'prod-1' },
+      context,
+      secrets,
+      strings
+    )) as { success: boolean; product: unknown };
+
+    expect(result.success).toBe(true);
+
+    expect(mocks.updateListing).toHaveBeenCalledWith(
+      98765,
+      expect.objectContaining({
+        title: 'Handmade Bowl',
+        price: 25,
+        quantity: 5,
+      })
+    );
+
+    // Single variant uses setQuantity
+    expect(mocks.setQuantity).toHaveBeenCalledWith(98765, 5);
+
+    // Firestore cache updated
+    expect(mocks.updateEtsyCache).toHaveBeenCalledWith(
+      'prod-1',
+      '98765',
+      expect.objectContaining({
+        title: 'Handmade Bowl',
+        state: 'active',
+      })
+    );
+  });
+
+  it('updates multi-variant inventory', async () => {
+    const product = makeProduct({
+      variants: [
+        { id: 'var-1', label: 'Small', sku: 'sku-sm', priceCents: 2000, quantity: 3 },
+        { id: 'var-2', label: 'Large', sku: 'sku-lg', priceCents: 3000, quantity: 2 },
+      ],
+      variantProperties: ['Size'],
+    });
+    mocks.findById.mockResolvedValue(product);
+    mocks.getCategoryTemplate.mockResolvedValue({ taxonomyId: 1234 });
+    mocks.getArtistTemplate.mockResolvedValue(undefined);
+    mocks.updateListing.mockResolvedValue(makeEtsyListing());
+    mocks.updateInventory.mockResolvedValue({
+      products: [
+        { product_id: 501, sku: 'sku-sm', offerings: [], property_values: [] },
+        { product_id: 502, sku: 'sku-lg', offerings: [], property_values: [] },
+      ],
+    });
+
+    mocks.findById
+      .mockResolvedValueOnce(product)
+      .mockResolvedValueOnce(product);
+
+    const result = (await mocks.capturedHandler!(
+      { productId: 'prod-1' },
+      context,
+      secrets,
+      strings
+    )) as { success: boolean };
+
+    expect(result.success).toBe(true);
+
+    // Should use updateInventory (not setQuantity) for multi-variant
+    expect(mocks.updateInventory).toHaveBeenCalledWith(
+      98765,
+      expect.objectContaining({
+        products: expect.arrayContaining([
+          expect.objectContaining({ sku: 'sku-sm' }),
+          expect.objectContaining({ sku: 'sku-lg' }),
+        ]),
+      })
+    );
+    expect(mocks.setQuantity).not.toHaveBeenCalled();
+
+    // Variant etsyProductId mappings saved
+    expect(mocks.updateVariants).toHaveBeenCalledWith(
+      'prod-1',
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'var-1', etsyProductId: 501 }),
+        expect.objectContaining({ id: 'var-2', etsyProductId: 502 }),
+      ])
+    );
+  });
+
+  it('succeeds even if inventory update fails (best-effort)', async () => {
+    const product = makeProduct();
+    mocks.findById.mockResolvedValue(product);
+    mocks.getCategoryTemplate.mockResolvedValue({ taxonomyId: 1234 });
+    mocks.getArtistTemplate.mockResolvedValue(undefined);
+    mocks.updateListing.mockResolvedValue(makeEtsyListing());
+    mocks.setQuantity.mockRejectedValue(new Error('Etsy API error'));
+
+    mocks.findById
+      .mockResolvedValueOnce(product)
+      .mockResolvedValueOnce(product);
+
+    const result = (await mocks.capturedHandler!(
+      { productId: 'prod-1' },
+      context,
+      secrets,
+      strings
+    )) as { success: boolean };
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/libs/firebase/maple-functions/update-etsy-listing/src/lib/update-etsy-listing.ts
+++ b/libs/firebase/maple-functions/update-etsy-listing/src/lib/update-etsy-listing.ts
@@ -1,0 +1,218 @@
+/**
+ * Update Etsy Listing Cloud Function
+ *
+ * Syncs current product data from Firestore to an existing Etsy listing.
+ * Updates listing fields (title, description, tags) and variant inventory
+ * (prices, quantities).
+ *
+ * Admin only. Lives in the maple-sync codebase (Etsy API dependency).
+ */
+import { Functions, Role } from '@maple/firebase/functions';
+import {
+  FirestoreTokenStorage,
+  ProductRepository,
+  EtsyTemplateRepository,
+} from '@maple/firebase/database';
+import {
+  EtsyClient,
+  type UpdateListingInput,
+  type EtsyWhoMade,
+  type EtsyWhenMade,
+} from '@maple/firebase/etsy';
+import { mergeEtsyTemplates, getTotalQuantity } from '@maple/ts/domain';
+import type { Product, ProductVariant } from '@maple/ts/domain';
+import type {
+  UpdateEtsyListingRequest,
+  UpdateEtsyListingResponse,
+} from '@maple/ts/firebase/api-types';
+import type {
+  UpdateInventoryProduct,
+  UpdateInventoryOffering,
+  UpdateInventoryPropertyValue,
+} from '@maple/firebase/etsy';
+
+const ETSY_SECRET_NAMES = ['ETSY_API_KEY', 'ETSY_SHARED_SECRET'] as const;
+const ETSY_STRING_NAMES = ['ETSY_REDIRECT_URI'] as const;
+
+export const updateEtsyListing = Functions.endpoint
+  .usingSecrets(...ETSY_SECRET_NAMES)
+  .usingStrings(...ETSY_STRING_NAMES)
+  .requiringRole(Role.Admin)
+  .handle<UpdateEtsyListingRequest, UpdateEtsyListingResponse>(
+    async (data, _context, secrets, strings) => {
+      const { productId } = data;
+
+      if (!productId) {
+        return { success: false, error: 'productId is required' };
+      }
+
+      // 1. Fetch product from Firestore
+      const product = await ProductRepository.findById(productId);
+      if (!product) {
+        return { success: false, error: `Product ${productId} not found` };
+      }
+
+      if (!product.etsyListingId) {
+        return {
+          success: false,
+          error:
+            'Product does not have an Etsy listing. Use pushProductToEtsy first.',
+        };
+      }
+
+      const etsyListingId = Number(product.etsyListingId);
+
+      // 2. Resolve template defaults for tags/materials/taxonomy
+      const [categoryTemplate, artistTemplate] = await Promise.all([
+        product.categoryId
+          ? EtsyTemplateRepository.getCategoryTemplate(product.categoryId)
+          : Promise.resolve(undefined),
+        product.artistId
+          ? EtsyTemplateRepository.getArtistTemplate(product.artistId)
+          : Promise.resolve(undefined),
+      ]);
+
+      const defaults = mergeEtsyTemplates(categoryTemplate, artistTemplate);
+
+      // 3. Build the update payload
+      const firstVariant = product.variants[0];
+      const totalQuantity = getTotalQuantity(product);
+
+      const updateInput: UpdateListingInput = {
+        title: (product.squareCache.name ?? '').substring(0, 140),
+        description: product.squareCache.description,
+        price: firstVariant.priceCents / 100,
+        quantity: totalQuantity,
+        tags: defaults.tags,
+        materials: defaults.materials,
+      };
+
+      if (defaults.taxonomyId) {
+        updateInput.taxonomy_id = defaults.taxonomyId;
+      }
+      if (defaults.whoMade) {
+        updateInput.who_made = defaults.whoMade as EtsyWhoMade;
+      }
+      if (defaults.whenMade) {
+        updateInput.when_made = defaults.whenMade as EtsyWhenMade;
+      }
+
+      // 4. Create Etsy client and update the listing
+      const client = new EtsyClient({
+        apiKey: secrets.ETSY_API_KEY,
+        sharedSecret: secrets.ETSY_SHARED_SECRET,
+        tokenStorage: FirestoreTokenStorage,
+        redirectUri: strings.ETSY_REDIRECT_URI,
+      });
+
+      const updatedListing = await client.listings.updateListing(
+        etsyListingId,
+        updateInput
+      );
+
+      // 5. Update variant inventory
+      const isMultiVariant = product.variants.length > 1;
+      let variantEtsyProductIds: Map<string, number> | undefined;
+
+      if (isMultiVariant) {
+        try {
+          const propertyId = 100;
+          const propertyName = product.variantProperties?.[0] ?? 'Variation';
+
+          const inventoryProducts: UpdateInventoryProduct[] =
+            product.variants.map((v) => ({
+              sku: v.sku,
+              offerings: [
+                {
+                  price: v.priceCents / 100,
+                  quantity: v.quantity,
+                  is_enabled: true,
+                } as UpdateInventoryOffering,
+              ],
+              property_values: [
+                {
+                  property_id: propertyId,
+                  property_name: propertyName,
+                  value_ids: [0],
+                  values: [v.label],
+                } as UpdateInventoryPropertyValue,
+              ],
+            }));
+
+          const updatedInventory = await client.inventory.updateInventory(
+            etsyListingId,
+            {
+              products: inventoryProducts,
+              price_on_property: [propertyId],
+              quantity_on_property: [propertyId],
+              sku_on_property: [propertyId],
+            }
+          );
+
+          // Map Etsy product_ids back to our variant IDs by SKU match
+          variantEtsyProductIds = new Map<string, number>();
+          for (const etsyProduct of updatedInventory.products) {
+            const matchingVariant = product.variants.find(
+              (v) => v.sku === etsyProduct.sku
+            );
+            if (matchingVariant) {
+              variantEtsyProductIds.set(
+                matchingVariant.id,
+                etsyProduct.product_id
+              );
+            }
+          }
+        } catch (err) {
+          console.warn('Failed to update variant inventory on Etsy:', err);
+        }
+      } else {
+        // Single variant: use setQuantity for simplicity
+        try {
+          await client.inventory.setQuantity(
+            etsyListingId,
+            firstVariant.quantity
+          );
+        } catch (err) {
+          console.warn('Failed to update quantity on Etsy:', err);
+        }
+      }
+
+      // 6. Update etsyCache in Firestore
+      await ProductRepository.updateEtsyCache(
+        productId,
+        product.etsyListingId,
+        {
+          title: updatedListing.title,
+          description: updatedListing.description,
+          url: updatedListing.url,
+          taxonomyId: updatedListing.taxonomy_id,
+          tags: updatedListing.tags,
+          state:
+            updatedListing.state === 'active' ||
+            updatedListing.state === 'draft'
+              ? updatedListing.state
+              : 'inactive',
+          syncedAt: new Date(),
+        }
+      );
+
+      // Update variant etsyProductId mappings if we have them
+      if (variantEtsyProductIds && variantEtsyProductIds.size > 0) {
+        const updatedVariants: ProductVariant[] = product.variants.map((v) => ({
+          ...v,
+          etsyProductId: variantEtsyProductIds!.get(v.id) ?? v.etsyProductId,
+        }));
+        await ProductRepository.updateVariants(productId, updatedVariants);
+      }
+
+      // Refetch the product to return the updated version
+      const refreshed = (await ProductRepository.findById(
+        productId
+      )) as Product;
+
+      return {
+        success: true,
+        product: refreshed,
+      };
+    }
+  );

--- a/libs/firebase/maple-functions/update-etsy-listing/tsconfig.json
+++ b/libs/firebase/maple-functions/update-etsy-listing/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/update-etsy-listing/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/update-etsy-listing/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/update-etsy-listing/vitest.config.ts
+++ b/libs/firebase/maple-functions/update-etsy-listing/vitest.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  root: __dirname,
+  test: {
+    name: 'firebase-maple-functions-update-etsy-listing',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov', 'json-summary', 'json'],
+      reportsDirectory: '../../../../coverage/libs/firebase/maple-functions/update-etsy-listing',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.spec.ts', 'src/index.ts'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@maple/ts/domain': resolve(__dirname, '../../../ts/domain/src/index.ts'),
+      '@maple/ts/firebase/api-types': resolve(__dirname, '../../../ts/firebase/api-types/src/index.ts'),
+      '@maple/firebase/database': resolve(__dirname, '../../../firebase/database/src/index.ts'),
+      '@maple/firebase/etsy': resolve(__dirname, '../../../firebase/etsy/src/index.ts'),
+      '@maple/firebase/functions': resolve(__dirname, '../../../firebase/functions/src/index.ts'),
+    },
+  },
+});

--- a/libs/ts/firebase/api-types/src/lib/etsy-push.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/etsy-push.types.ts
@@ -1,0 +1,46 @@
+/**
+ * Etsy push/update API request/response types
+ *
+ * Types for pushing products from our catalog to Etsy as native listings.
+ */
+import type { Product } from '@maple/ts/domain';
+
+// ============================================================================
+// Push Product to Etsy (create draft listing)
+// ============================================================================
+
+export interface PushProductToEtsyRequest {
+  /** Firestore Product ID to push to Etsy */
+  productId: string;
+  /** If true, activate the listing after push (requires image + shipping profile) */
+  activateAfterPush?: boolean;
+}
+
+export interface PushProductToEtsyResponse {
+  /** Whether the push succeeded */
+  success: boolean;
+  /** Etsy listing ID on success */
+  etsyListingId?: string;
+  /** Updated product with Etsy data populated */
+  product?: Product;
+  /** Error message on failure */
+  error?: string;
+}
+
+// ============================================================================
+// Update Etsy Listing (sync current product data to existing listing)
+// ============================================================================
+
+export interface UpdateEtsyListingRequest {
+  /** Firestore Product ID whose Etsy listing should be updated */
+  productId: string;
+}
+
+export interface UpdateEtsyListingResponse {
+  /** Whether the update succeeded */
+  success: boolean;
+  /** Updated product */
+  product?: Product;
+  /** Error message on failure */
+  error?: string;
+}

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -319,3 +319,11 @@ export type {
   ImportEtsyListingsResponse,
   ImportEtsyListingResult,
 } from './etsy-import.types';
+
+// Etsy Push types (push products from our catalog to Etsy)
+export type {
+  PushProductToEtsyRequest,
+  PushProductToEtsyResponse,
+  UpdateEtsyListingRequest,
+  UpdateEtsyListingResponse,
+} from './etsy-push.types';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -335,6 +335,12 @@
       "@maple/firebase/maple-functions/import-etsy-listings": [
         "libs/firebase/maple-functions/import-etsy-listings/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/push-product-to-etsy": [
+        "libs/firebase/maple-functions/push-product-to-etsy/src/index.ts"
+      ],
+      "@maple/firebase/maple-functions/update-etsy-listing": [
+        "libs/firebase/maple-functions/update-etsy-listing/src/index.ts"
+      ],
       "@maple/firebase/integration-test-utils": [
         "libs/firebase/integration-test-utils/src/index.ts"
       ],

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -16,5 +16,7 @@ export default defineWorkspace([
   'libs/firebase/maple-functions/calendar-embed/vitest.config.ts',
   'libs/react/classes/vitest.config.ts',
   'libs/react/signals/vitest.config.ts',
+  'libs/firebase/maple-functions/push-product-to-etsy/vitest.config.ts',
+  'libs/firebase/maple-functions/update-etsy-listing/vitest.config.ts',
   'vitest.storybook.config.ts',
 ]);


### PR DESCRIPTION
## Summary

- Adds `pushProductToEtsy` Cloud Function: creates a draft Etsy listing from a Firestore Product, downloads and uploads the product image, sets multi-variant inventory with property_values/offerings, updates Firestore with etsyListingId and per-variant etsyProductId mappings, and optionally activates the listing
- Adds `updateEtsyListing` Cloud Function: syncs current product data (title, description, price, quantity, tags) to an existing Etsy listing and updates variant inventory
- Adds shared API types (`PushProductToEtsyRequest/Response`, `UpdateEtsyListingRequest/Response`) in `etsy-push.types.ts`
- Both functions wired into `maple-sync` codebase with proper tsconfig includes, function-codebases.json mappings, and tsconfig.base.json path aliases
- 15 unit tests across both functions using `vi.mock()` pattern

## Key design decisions

- Template resolution uses `mergeEtsyTemplates()` (category base + artist overrides) for taxonomy_id, tags, materials, shipping profile, etc.
- Image upload is best-effort: failure does not block listing creation
- Multi-variant inventory uses Etsy property_id 100 (custom property) with variant labels as values
- Variant etsyProductId mappings are persisted back to Firestore by SKU match after inventory update

## Test plan

- [x] `pushProductToEtsy` validates missing productId, missing product, no variants, existing etsyListingId, missing taxonomy_id
- [x] `pushProductToEtsy` creates draft listing with correct price/quantity/taxonomy
- [x] `pushProductToEtsy` handles multi-variant products with inventory update and SKU-based product ID mapping
- [x] `pushProductToEtsy` activates listing when activateAfterPush=true
- [x] `pushProductToEtsy` succeeds when image download fails (best-effort)
- [x] `updateEtsyListing` validates missing productId, missing product, missing etsyListingId
- [x] `updateEtsyListing` updates listing and single-variant quantity
- [x] `updateEtsyListing` updates multi-variant inventory
- [x] `updateEtsyListing` succeeds when inventory update fails (best-effort)

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)