### PR TITLE
feat: public agreement signing page & email template (#320)

### DIFF
--- a/apps/maple-spruce/src/app/sign/[token]/page.tsx
+++ b/apps/maple-spruce/src/app/sign/[token]/page.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useParams, useSearchParams } from 'next/navigation';
+import {
+  Box,
+  Typography,
+  Container,
+  CircularProgress,
+  Alert,
+} from '@mui/material';
+import { httpsCallable } from 'firebase/functions';
+import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
+import { SigningForm } from '@maple/react/agreements';
+import type {
+  GetAgreementForSigningRequest,
+  GetAgreementForSigningResponse,
+  SubmitSignedAgreementRequest,
+  SubmitSignedAgreementResponse,
+} from '@maple/ts/firebase/api-types';
+import type { AgreementSection, MediaReleaseChoice } from '@maple/ts/domain';
+
+interface AgreementData {
+  templateName: string;
+  sections: AgreementSection[];
+  supportsMinor: boolean;
+  signerName: string;
+  signerEmail: string;
+  className?: string;
+}
+
+export default function SignAgreementPage() {
+  const params = useParams();
+  const searchParams = useSearchParams();
+  const token = params.token as string;
+  const kioskMode = searchParams.get('kiosk') === 'true';
+
+  const [agreement, setAgreement] = useState<AgreementData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token) return;
+
+    const fetchAgreement = async (): Promise<void> => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const functions = getMapleFunctions();
+        const getAgreement = httpsCallable<
+          GetAgreementForSigningRequest,
+          GetAgreementForSigningResponse
+        >(functions, 'getAgreementForSigning');
+
+        const result = await getAgreement({ token });
+        setAgreement(result.data);
+      } catch (err) {
+        console.error('Failed to fetch agreement:', err);
+        const message =
+          err instanceof Error ? err.message : 'Unable to load agreement.';
+        setError(message);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchAgreement();
+  }, [token]);
+
+  const handleSubmit = useCallback(
+    async (data: {
+      signatureData: string;
+      printedName: string;
+      mediaReleaseChoice?: MediaReleaseChoice;
+      isMinor: boolean;
+      minorName?: string;
+      guardianName?: string;
+      guardianSignatureData?: string;
+    }): Promise<void> => {
+      const functions = getMapleFunctions();
+      const submitSigned = httpsCallable<
+        SubmitSignedAgreementRequest,
+        SubmitSignedAgreementResponse
+      >(functions, 'submitSignedAgreement');
+
+      await submitSigned({
+        token,
+        signatureData: data.signatureData,
+        printedName: data.printedName,
+        mediaReleaseChoice: data.mediaReleaseChoice,
+        isMinor: data.isMinor,
+        minorName: data.minorName,
+        guardianName: data.guardianName,
+        guardianSignatureData: data.guardianSignatureData,
+      });
+    },
+    [token]
+  );
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <Box
+        sx={{
+          minHeight: '100vh',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          bgcolor: 'background.default',
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  // Error state
+  if (error || !agreement) {
+    return (
+      <Box
+        sx={{
+          minHeight: '100vh',
+          bgcolor: 'background.default',
+          py: 4,
+        }}
+      >
+        <Container maxWidth="md">
+          <Box sx={{ textAlign: 'center', py: 8 }}>
+            <Typography variant="h5" gutterBottom>
+              Unable to Load Agreement
+            </Typography>
+            <Alert severity="error" sx={{ mt: 2, textAlign: 'left' }}>
+              {error || 'Agreement not found'}
+            </Alert>
+          </Box>
+        </Container>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        minHeight: '100vh',
+        bgcolor: 'background.default',
+        py: 4,
+      }}
+    >
+      <Container maxWidth="md">
+        {/* Maple & Spruce header */}
+        <Box sx={{ textAlign: 'center', mb: 4 }}>
+          <Typography
+            variant="h6"
+            sx={{
+              fontStyle: 'italic',
+              color: 'text.secondary',
+              letterSpacing: 1,
+            }}
+          >
+            Maple & Spruce Folk Arts Collective LLC
+          </Typography>
+        </Box>
+
+        <SigningForm
+          templateName={agreement.templateName}
+          sections={agreement.sections}
+          supportsMinor={agreement.supportsMinor}
+          signerName={agreement.signerName}
+          signerEmail={agreement.signerEmail}
+          className={agreement.className}
+          onSubmit={handleSubmit}
+          kioskMode={kioskMode}
+        />
+      </Container>
+    </Box>
+  );
+}

--- a/apps/maple-spruce/src/config/public-routes.ts
+++ b/apps/maple-spruce/src/config/public-routes.ts
@@ -2,4 +2,4 @@
  * Routes that don't require authentication.
  * Supports route params like /public/:id
  */
-export const publicRoutes = ['/login', '/register', '/register/:classId', '/register/:classId/confirm'];
+export const publicRoutes = ['/login', '/register', '/register/:classId', '/register/:classId/confirm', '/sign/:token'];

--- a/libs/firebase/maple-functions/resend-agreement-request/src/lib/resend-agreement-request.ts
+++ b/libs/firebase/maple-functions/resend-agreement-request/src/lib/resend-agreement-request.ts
@@ -5,57 +5,73 @@
  * Admin-only endpoint.
  * Deployed to us-east4 via CI/CD pipeline.
  */
+import { Functions } from '@maple/firebase/functions';
+import { Role } from '@maple/firebase/functions';
 import {
-  createAdminFunction,
   throwInvalidArgument,
   throwNotFound,
 } from '@maple/firebase/functions';
 import {
   AgreementRequestRepository,
   AgreementTemplateRepository,
+  getDb,
 } from '@maple/firebase/database';
-import { getDb } from '@maple/firebase/database';
 import type {
   ResendAgreementRequestRequest,
   ResendAgreementRequestResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const resendAgreementRequest = createAdminFunction<
-  ResendAgreementRequestRequest,
-  ResendAgreementRequestResponse
->(async (data) => {
-  if (!data.id) throwInvalidArgument('Request ID is required');
+/**
+ * Extract the first HTTPS origin from ALLOWED_ORIGINS for signing URLs.
+ */
+function getAppUrl(allowedOrigins: string): string {
+  const origins = allowedOrigins.split(',').map((o) => o.trim());
+  const httpsOrigin = origins.find((o) => o.startsWith('https://'));
+  return httpsOrigin ?? origins[0] ?? 'http://localhost:3000';
+}
 
-  const request = await AgreementRequestRepository.findById(data.id);
-  if (!request) throwNotFound('Agreement request', data.id);
+export const resendAgreementRequest = Functions.endpoint
+  .usingStrings('ALLOWED_ORIGINS')
+  .requiringRole(Role.Admin)
+  .handle<ResendAgreementRequestRequest, ResendAgreementRequestResponse>(
+    async (data, _context, _secrets, strings) => {
+      if (!data.id) throwInvalidArgument('Request ID is required');
 
-  if (request!.status !== 'pending') {
-    throwInvalidArgument('Can only resend emails for pending requests');
-  }
+      const request = await AgreementRequestRepository.findById(data.id);
+      if (!request) throwNotFound('Agreement request', data.id);
 
-  if (new Date() >= request!.expiresAt) {
-    throwInvalidArgument('This signing request has expired');
-  }
+      if (request!.status !== 'pending') {
+        throwInvalidArgument('Can only resend emails for pending requests');
+      }
 
-  const template = await AgreementTemplateRepository.findById(
-    request!.templateId
+      if (new Date() >= request!.expiresAt) {
+        throwInvalidArgument('This signing request has expired');
+      }
+
+      const template = await AgreementTemplateRepository.findById(
+        request!.templateId
+      );
+
+      // Build the full signing URL
+      const appUrl = getAppUrl(strings.ALLOWED_ORIGINS);
+      const signingUrl = `${appUrl}/sign/${request!.signingToken}`;
+
+      // Queue signing email
+      const db = getDb();
+      await db.collection('mail').add({
+        to: request!.signerEmail,
+        template: {
+          name: 'agreement-signing-request',
+          data: {
+            signerName: request!.signerName,
+            templateName: template?.name ?? 'Agreement',
+            signingUrl,
+          },
+        },
+      });
+
+      await AgreementRequestRepository.markEmailSent(request!.id);
+
+      return { request: { ...request!, emailSentAt: new Date() } };
+    }
   );
-
-  // Queue signing email
-  const db = getDb();
-  await db.collection('mail').add({
-    to: request!.signerEmail,
-    template: {
-      name: 'agreement-signing-request',
-      data: {
-        signerName: request!.signerName,
-        templateName: template?.name ?? 'Agreement',
-        signingToken: request!.signingToken,
-      },
-    },
-  });
-
-  await AgreementRequestRepository.markEmailSent(request!.id);
-
-  return { request: { ...request!, emailSentAt: new Date() } };
-});

--- a/libs/firebase/maple-functions/send-agreement-request/src/lib/send-agreement-request.ts
+++ b/libs/firebase/maple-functions/send-agreement-request/src/lib/send-agreement-request.ts
@@ -8,16 +8,17 @@
  * Deployed to us-east4 via CI/CD pipeline.
  */
 import { randomBytes } from 'crypto';
-import {
-  createAdminFunction,
-  throwInvalidArgument,
-  throwNotFound,
-} from '@maple/firebase/functions';
+import { Functions } from '@maple/firebase/functions';
+import { Role } from '@maple/firebase/functions';
 import {
   AgreementTemplateRepository,
   AgreementRequestRepository,
+  getDb,
 } from '@maple/firebase/database';
-import { getDb } from '@maple/firebase/database';
+import {
+  throwInvalidArgument,
+  throwNotFound,
+} from '@maple/firebase/functions';
 import type {
   SendAgreementRequestRequest,
   SendAgreementRequestResponse,
@@ -27,53 +28,72 @@ import type { AgreementDeliveryMethod } from '@maple/ts/domain';
 /** Default expiry: 30 days from now */
 const DEFAULT_EXPIRY_DAYS = 30;
 
-export const sendAgreementRequest = createAdminFunction<
-  SendAgreementRequestRequest,
-  SendAgreementRequestResponse
->(async (data) => {
-  if (!data.templateId) throwInvalidArgument('Template ID is required');
-  if (!data.signerEmail) throwInvalidArgument('Signer email is required');
-  if (!data.signerName) throwInvalidArgument('Signer name is required');
+/**
+ * Extract the first HTTPS origin from ALLOWED_ORIGINS for signing URLs.
+ * Falls back to the first origin if no HTTPS origin exists.
+ */
+function getAppUrl(allowedOrigins: string): string {
+  const origins = allowedOrigins.split(',').map((o) => o.trim());
+  const httpsOrigin = origins.find((o) => o.startsWith('https://'));
+  return httpsOrigin ?? origins[0] ?? 'http://localhost:3000';
+}
 
-  const template = await AgreementTemplateRepository.findById(data.templateId);
-  if (!template) throwNotFound('Agreement template', data.templateId);
-  if (template!.status !== 'active') {
-    throwInvalidArgument('Cannot send requests for archived templates');
-  }
+export const sendAgreementRequest = Functions.endpoint
+  .usingStrings('ALLOWED_ORIGINS')
+  .requiringRole(Role.Admin)
+  .handle<SendAgreementRequestRequest, SendAgreementRequestResponse>(
+    async (data, _context, _secrets, strings) => {
+      if (!data.templateId) throwInvalidArgument('Template ID is required');
+      if (!data.signerEmail) throwInvalidArgument('Signer email is required');
+      if (!data.signerName) throwInvalidArgument('Signer name is required');
 
-  const signingToken = randomBytes(32).toString('hex');
-  const expiresAt = new Date();
-  expiresAt.setDate(expiresAt.getDate() + DEFAULT_EXPIRY_DAYS);
+      const template = await AgreementTemplateRepository.findById(
+        data.templateId
+      );
+      if (!template) throwNotFound('Agreement template', data.templateId);
+      if (template!.status !== 'active') {
+        throwInvalidArgument('Cannot send requests for archived templates');
+      }
 
-  const request = await AgreementRequestRepository.create({
-    templateId: data.templateId,
-    templateVersion: template!.version,
-    signerEmail: data.signerEmail,
-    signerName: data.signerName,
-    signerPhone: data.signerPhone,
-    deliveryMethod: (data.deliveryMethod || 'email') as AgreementDeliveryMethod,
-    classId: data.classId,
-    studentId: data.studentId,
-    signingToken,
-    expiresAt,
-    status: 'pending',
-  });
+      const signingToken = randomBytes(32).toString('hex');
+      const expiresAt = new Date();
+      expiresAt.setDate(expiresAt.getDate() + DEFAULT_EXPIRY_DAYS);
 
-  // Queue signing email
-  const db = getDb();
-  await db.collection('mail').add({
-    to: data.signerEmail,
-    template: {
-      name: 'agreement-signing-request',
-      data: {
+      const request = await AgreementRequestRepository.create({
+        templateId: data.templateId,
+        templateVersion: template!.version,
+        signerEmail: data.signerEmail,
         signerName: data.signerName,
-        templateName: template!.name,
+        signerPhone: data.signerPhone,
+        deliveryMethod: (data.deliveryMethod ||
+          'email') as AgreementDeliveryMethod,
+        classId: data.classId,
+        studentId: data.studentId,
         signingToken,
-      },
-    },
-  });
+        expiresAt,
+        status: 'pending',
+      });
 
-  await AgreementRequestRepository.markEmailSent(request.id);
+      // Build the full signing URL
+      const appUrl = getAppUrl(strings.ALLOWED_ORIGINS);
+      const signingUrl = `${appUrl}/sign/${signingToken}`;
 
-  return { request: { ...request, emailSentAt: new Date() } };
-});
+      // Queue signing email
+      const db = getDb();
+      await db.collection('mail').add({
+        to: data.signerEmail,
+        template: {
+          name: 'agreement-signing-request',
+          data: {
+            signerName: data.signerName,
+            templateName: template!.name,
+            signingUrl,
+          },
+        },
+      });
+
+      await AgreementRequestRepository.markEmailSent(request.id);
+
+      return { request: { ...request, emailSentAt: new Date() } };
+    }
+  );

--- a/libs/react/agreements/project.json
+++ b/libs/react/agreements/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "react-agreements",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/react/agreements/src",
+  "projectType": "library",
+  "tags": ["scope:react", "type:feature"],
+  "targets": {}
+}

--- a/libs/react/agreements/src/index.ts
+++ b/libs/react/agreements/src/index.ts
@@ -1,0 +1,2 @@
+export { SignatureCanvas, type SignatureCanvasHandle } from './lib/SignatureCanvas';
+export { SigningForm, type SigningFormProps } from './lib/SigningForm';

--- a/libs/react/agreements/src/lib/SignatureCanvas.tsx
+++ b/libs/react/agreements/src/lib/SignatureCanvas.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useRef, useEffect, useCallback, forwardRef, useImperativeHandle } from 'react';
+import { Box, Button, Typography, Stack } from '@mui/material';
+import SignaturePad from 'signature_pad';
+
+export interface SignatureCanvasHandle {
+  /** Returns base64 PNG data URL, or empty string if blank */
+  toDataURL: () => string;
+  /** Returns true if the pad has no strokes */
+  isEmpty: () => boolean;
+  /** Clear the canvas */
+  clear: () => void;
+}
+
+interface SignatureCanvasProps {
+  label?: string;
+  /** Height in pixels (default: 200) */
+  height?: number;
+  /** Whether to show an error state */
+  error?: boolean;
+  /** Error helper text */
+  helperText?: string;
+}
+
+export const SignatureCanvas = forwardRef<SignatureCanvasHandle, SignatureCanvasProps>(
+  function SignatureCanvas({ label = 'Signature', height = 200, error, helperText }, ref) {
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    const padRef = useRef<SignaturePad | null>(null);
+
+    // Initialize signature_pad and handle resize
+    useEffect(() => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+
+      // Handle high-DPI displays
+      const ratio = Math.max(window.devicePixelRatio || 1, 1);
+      const rect = canvas.getBoundingClientRect();
+      canvas.width = rect.width * ratio;
+      canvas.height = rect.height * ratio;
+      const ctx = canvas.getContext('2d');
+      if (ctx) {
+        ctx.scale(ratio, ratio);
+      }
+
+      padRef.current = new SignaturePad(canvas, {
+        backgroundColor: 'rgb(255, 255, 255)',
+        penColor: 'rgb(0, 0, 0)',
+      });
+
+      return () => {
+        padRef.current?.off();
+        padRef.current = null;
+      };
+    }, []);
+
+    // Handle window resize
+    useEffect(() => {
+      const handleResize = (): void => {
+        const canvas = canvasRef.current;
+        const pad = padRef.current;
+        if (!canvas || !pad) return;
+
+        const data = pad.toData();
+        const ratio = Math.max(window.devicePixelRatio || 1, 1);
+        const rect = canvas.getBoundingClientRect();
+        canvas.width = rect.width * ratio;
+        canvas.height = rect.height * ratio;
+        const ctx = canvas.getContext('2d');
+        if (ctx) {
+          ctx.scale(ratio, ratio);
+        }
+        pad.clear();
+        pad.fromData(data);
+      };
+
+      window.addEventListener('resize', handleResize);
+      return () => window.removeEventListener('resize', handleResize);
+    }, []);
+
+    const handleClear = useCallback(() => {
+      padRef.current?.clear();
+    }, []);
+
+    useImperativeHandle(ref, () => ({
+      toDataURL: () => {
+        if (!padRef.current || padRef.current.isEmpty()) return '';
+        return padRef.current.toDataURL('image/png');
+      },
+      isEmpty: () => padRef.current?.isEmpty() ?? true,
+      clear: () => padRef.current?.clear(),
+    }));
+
+    return (
+      <Box>
+        <Typography
+          variant="subtitle2"
+          sx={{ mb: 1, color: error ? 'error.main' : 'text.secondary' }}
+        >
+          {label}
+        </Typography>
+        <Box
+          sx={{
+            border: 1,
+            borderColor: error ? 'error.main' : 'divider',
+            borderRadius: 1,
+            overflow: 'hidden',
+            bgcolor: 'white',
+          }}
+        >
+          <canvas
+            ref={canvasRef}
+            style={{
+              width: '100%',
+              height: `${height}px`,
+              display: 'block',
+              touchAction: 'none',
+            }}
+          />
+        </Box>
+        <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mt: 0.5 }}>
+          <Typography variant="caption" color={error ? 'error' : 'text.secondary'}>
+            {helperText || 'Draw your signature above'}
+          </Typography>
+          <Button size="small" onClick={handleClear}>
+            Clear
+          </Button>
+        </Stack>
+      </Box>
+    );
+  }
+);

--- a/libs/react/agreements/src/lib/SigningForm.tsx
+++ b/libs/react/agreements/src/lib/SigningForm.tsx
@@ -1,0 +1,404 @@
+'use client';
+
+import React, { useRef, useCallback } from 'react';
+import {
+  Box,
+  Typography,
+  TextField,
+  Button,
+  Alert,
+  CircularProgress,
+  Divider,
+  Paper,
+  Radio,
+  RadioGroup,
+  FormControlLabel,
+  FormControl,
+  FormLabel,
+  FormHelperText,
+  Switch,
+} from '@mui/material';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import {
+  useSignal,
+  useComputed,
+  useSignals,
+} from '@maple/react/signals';
+import { SignatureCanvas, type SignatureCanvasHandle } from './SignatureCanvas';
+import type { AgreementSection, MediaReleaseChoice } from '@maple/ts/domain';
+
+interface FirebaseError {
+  code?: string;
+  message?: string;
+}
+
+const GENERIC_ERROR_CODES = new Set(['internal', 'INTERNAL', 'unknown', 'UNKNOWN']);
+
+function extractErrorMessage(error: unknown): string {
+  const fallback = 'Something went wrong. Please try again.';
+  if (!error) return fallback;
+  const fbError = error as FirebaseError;
+  if (fbError.message && !GENERIC_ERROR_CODES.has(fbError.message)) {
+    return fbError.message;
+  }
+  if (error instanceof Error && !GENERIC_ERROR_CODES.has(error.message)) {
+    return error.message;
+  }
+  return fallback;
+}
+
+export interface SigningFormProps {
+  templateName: string;
+  sections: AgreementSection[];
+  supportsMinor: boolean;
+  signerName: string;
+  signerEmail: string;
+  className?: string;
+  onSubmit: (data: {
+    signatureData: string;
+    printedName: string;
+    mediaReleaseChoice?: MediaReleaseChoice;
+    isMinor: boolean;
+    minorName?: string;
+    guardianName?: string;
+    guardianSignatureData?: string;
+  }) => Promise<void>;
+  /** If true, resets the form after successful submission (kiosk mode) */
+  kioskMode?: boolean;
+}
+
+export function SigningForm({
+  templateName,
+  sections,
+  supportsMinor,
+  signerName,
+  signerEmail,
+  className,
+  onSubmit,
+  kioskMode = false,
+}: SigningFormProps): React.JSX.Element {
+  useSignals();
+
+  const signatureRef = useRef<SignatureCanvasHandle>(null);
+  const guardianSignatureRef = useRef<SignatureCanvasHandle>(null);
+
+  const printedName = useSignal(signerName);
+  const mediaReleaseChoice = useSignal<MediaReleaseChoice | ''>('');
+  const isMinor = useSignal(false);
+  const minorName = useSignal('');
+  const guardianName = useSignal('');
+
+  const isSubmitting = useSignal(false);
+  const submitError = useSignal('');
+  const isComplete = useSignal(false);
+  const showValidation = useSignal(false);
+
+  const hasMediaRelease = useComputed(() =>
+    sections.some((s) => s.responseType === 'media-release')
+  );
+
+  const validationErrors = useComputed(() => {
+    if (!showValidation.value) return {} as Record<string, string>;
+    const errors: Record<string, string> = {};
+
+    if (!printedName.value.trim()) {
+      errors.printedName = 'Printed name is required';
+    }
+
+    if (hasMediaRelease.value && !mediaReleaseChoice.value) {
+      errors.mediaReleaseChoice = 'Please select a photo/media release option';
+    }
+
+    if (isMinor.value) {
+      if (!minorName.value.trim()) {
+        errors.minorName = "Minor's name is required";
+      }
+      if (!guardianName.value.trim()) {
+        errors.guardianName = 'Parent/guardian name is required';
+      }
+    }
+
+    return errors;
+  });
+
+  const handleSubmit = useCallback(async () => {
+    showValidation.value = true;
+
+    // Check signature
+    if (signatureRef.current?.isEmpty()) {
+      submitError.value = 'Please sign the agreement before submitting.';
+      return;
+    }
+
+    // Check guardian signature for minors
+    if (isMinor.value && guardianSignatureRef.current?.isEmpty()) {
+      submitError.value = 'Parent/guardian signature is required.';
+      return;
+    }
+
+    // Check validation errors
+    const errors = validationErrors.peek();
+    if (Object.keys(errors).length > 0) {
+      submitError.value = '';
+      return;
+    }
+
+    // Prevent double-submit
+    if (isSubmitting.value) return;
+    isSubmitting.value = true;
+    submitError.value = '';
+
+    try {
+      await onSubmit({
+        signatureData: signatureRef.current!.toDataURL(),
+        printedName: printedName.value.trim(),
+        mediaReleaseChoice: mediaReleaseChoice.value as MediaReleaseChoice || undefined,
+        isMinor: isMinor.value,
+        minorName: isMinor.value ? minorName.value.trim() : undefined,
+        guardianName: isMinor.value ? guardianName.value.trim() : undefined,
+        guardianSignatureData: isMinor.value
+          ? guardianSignatureRef.current?.toDataURL()
+          : undefined,
+      });
+
+      isComplete.value = true;
+
+      if (kioskMode) {
+        // Reset form after 5 seconds in kiosk mode
+        setTimeout(() => {
+          printedName.value = '';
+          mediaReleaseChoice.value = '';
+          isMinor.value = false;
+          minorName.value = '';
+          guardianName.value = '';
+          showValidation.value = false;
+          isComplete.value = false;
+          signatureRef.current?.clear();
+          guardianSignatureRef.current?.clear();
+        }, 5000);
+      }
+    } catch (err) {
+      submitError.value = extractErrorMessage(err);
+    } finally {
+      isSubmitting.value = false;
+    }
+  }, [
+    onSubmit,
+    kioskMode,
+    printedName,
+    mediaReleaseChoice,
+    isMinor,
+    minorName,
+    guardianName,
+    isSubmitting,
+    submitError,
+    isComplete,
+    showValidation,
+    validationErrors,
+  ]);
+
+  // Success state
+  if (isComplete.value) {
+    return (
+      <Box sx={{ textAlign: 'center', py: 6 }}>
+        <CheckCircleOutlineIcon
+          sx={{ fontSize: 64, color: 'success.main', mb: 2 }}
+        />
+        <Typography variant="h5" gutterBottom>
+          Agreement Signed Successfully
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          Thank you, {printedName.value}. Your signed agreement has been recorded.
+        </Typography>
+        {kioskMode && (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 2 }}>
+            This form will reset shortly for the next person.
+          </Typography>
+        )}
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      {/* Header */}
+      <Box sx={{ mb: 3 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          {templateName}
+        </Typography>
+        {className && (
+          <Typography variant="subtitle1" color="text.secondary">
+            For: {className}
+          </Typography>
+        )}
+        <Typography variant="body2" color="text.secondary">
+          {signerEmail}
+        </Typography>
+      </Box>
+
+      {/* Agreement Sections */}
+      {sections.map((section) => (
+        <Paper key={section.id} sx={{ p: 3, mb: 2 }}>
+          <Typography variant="h6" gutterBottom>
+            {section.title}
+          </Typography>
+          <Box
+            sx={{ '& p': { mb: 1.5 }, '& ul': { pl: 3 }, '& li': { mb: 0.5 } }}
+            dangerouslySetInnerHTML={{ __html: section.content }}
+          />
+
+          {/* Media Release Radio Buttons */}
+          {section.responseType === 'media-release' && (
+            <FormControl
+              sx={{ mt: 2 }}
+              error={!!validationErrors.value.mediaReleaseChoice}
+            >
+              <FormLabel>Select one:</FormLabel>
+              <RadioGroup
+                value={mediaReleaseChoice.value}
+                onChange={(e) => {
+                  mediaReleaseChoice.value = e.target.value as MediaReleaseChoice;
+                }}
+              >
+                <FormControlLabel
+                  value="grant"
+                  control={<Radio />}
+                  label="I grant permission for this photo and media release."
+                />
+                <FormControlLabel
+                  value="grant-without-name"
+                  control={<Radio />}
+                  label="I grant permission for this photo and media release, but request that my (or my child's) name not be attached to any images or media used."
+                />
+                <FormControlLabel
+                  value="deny"
+                  control={<Radio />}
+                  label="I do not grant this release. I request that my image (or my child's image) not be used in Maple & Spruce promotional materials."
+                />
+              </RadioGroup>
+              {validationErrors.value.mediaReleaseChoice && (
+                <FormHelperText>
+                  {validationErrors.value.mediaReleaseChoice}
+                </FormHelperText>
+              )}
+            </FormControl>
+          )}
+        </Paper>
+      ))}
+
+      <Divider sx={{ my: 3 }} />
+
+      {/* Minor Toggle */}
+      {supportsMinor && (
+        <Box sx={{ mb: 3 }}>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={isMinor.value}
+                onChange={(e) => {
+                  isMinor.value = e.target.checked;
+                }}
+              />
+            }
+            label="I am signing on behalf of a minor (under 18)"
+          />
+
+          {isMinor.value && (
+            <Box sx={{ mt: 2, pl: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
+              <TextField
+                label="Minor's Full Name"
+                value={minorName.value}
+                onChange={(e) => {
+                  minorName.value = e.target.value;
+                }}
+                error={!!validationErrors.value.minorName}
+                helperText={validationErrors.value.minorName}
+                fullWidth
+              />
+              <TextField
+                label="Parent/Guardian Full Name"
+                value={guardianName.value}
+                onChange={(e) => {
+                  guardianName.value = e.target.value;
+                }}
+                error={!!validationErrors.value.guardianName}
+                helperText={validationErrors.value.guardianName}
+                fullWidth
+              />
+              <SignatureCanvas
+                ref={guardianSignatureRef}
+                label="Parent/Guardian Signature"
+                height={150}
+              />
+            </Box>
+          )}
+        </Box>
+      )}
+
+      {/* Signature Section */}
+      <Paper sx={{ p: 3, mb: 3 }}>
+        <Typography variant="h6" gutterBottom>
+          Acknowledgment & Agreement
+        </Typography>
+        <Typography variant="body2" sx={{ mb: 3 }}>
+          By signing below, I acknowledge that I have read and understand this
+          entire agreement. I agree to be bound by all terms and conditions
+          contained herein.
+        </Typography>
+
+        <SignatureCanvas
+          ref={signatureRef}
+          label="Your Signature"
+          height={kioskMode ? 250 : 200}
+        />
+
+        <TextField
+          label="Print Your Full Name"
+          value={printedName.value}
+          onChange={(e) => {
+            printedName.value = e.target.value;
+          }}
+          error={!!validationErrors.value.printedName}
+          helperText={validationErrors.value.printedName}
+          fullWidth
+          sx={{ mt: 2 }}
+        />
+
+        <TextField
+          label="Date"
+          value={new Date().toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+          })}
+          disabled
+          fullWidth
+          sx={{ mt: 2 }}
+        />
+      </Paper>
+
+      {/* Error */}
+      {submitError.value && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {submitError.value}
+        </Alert>
+      )}
+
+      {/* Submit */}
+      <Button
+        variant="contained"
+        size="large"
+        fullWidth
+        onClick={handleSubmit}
+        disabled={isSubmitting.value}
+        sx={{ py: 1.5 }}
+      >
+        {isSubmitting.value ? (
+          <CircularProgress size={24} color="inherit" />
+        ) : (
+          'Sign Agreement'
+        )}
+      </Button>
+    </Box>
+  );
+}

--- a/libs/react/agreements/tsconfig.json
+++ b/libs/react/agreements/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "strict": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/react/agreements/tsconfig.lib.json
+++ b/libs/react/agreements/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts", "src/**/*.stories.tsx"]
+}

--- a/libs/react/agreements/tsconfig.spec.json
+++ b/libs/react/agreements/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "types": ["vitest/globals", "node"]
+  },
+  "include": [
+    "vitest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.d.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "pdf-lib": "^1.17.1",
     "react": "19.0.0",
     "react-dom": "19.0.0",
+    "signature_pad": "^5.1.3",
     "square": "^43.2.1",
     "vest": "^5.4.6",
     "webflow-api": "^3.3.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       react-dom:
         specifier: 19.0.0
         version: 19.0.0(react@19.0.0)
+      signature_pad:
+        specifier: ^5.1.3
+        version: 5.1.3
       square:
         specifier: ^43.2.1
         version: 43.2.1(encoding@0.1.13)
@@ -9799,6 +9802,9 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  signature_pad@5.1.3:
+    resolution: {integrity: sha512-zyxW5vuJVnQdGcU+kAj9FYl7WaAunY3kA5S7mPg0xJiujL9+sPAWfSQHS5tXaJXDUa4FuZeKhfdCDQ6K3wfkpQ==}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -22073,6 +22079,8 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  signature_pad@5.1.3: {}
 
   sirv@3.0.2:
     dependencies:

--- a/tools/seed-email-templates.ts
+++ b/tools/seed-email-templates.ts
@@ -210,6 +210,59 @@ const registrationCancelledHtml = `<!DOCTYPE html>
 </html>`;
 
 // ---------------------------------------------------------------------------
+// Template: agreement-signing-request
+// ---------------------------------------------------------------------------
+
+const agreementSigningRequestSubject =
+  'Action Required: Please sign your {{templateName}}';
+
+const agreementSigningRequestHtml = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Agreement Signing Request</title>
+<style>${styles}</style>
+</head>
+<body>
+<div class="wrapper">
+  <div class="header">
+    <h1>Maple &amp; Spruce Folk Arts</h1>
+  </div>
+  <div class="content">
+    <h2>Please Sign Your Agreement</h2>
+    <p>Hi {{signerName}},</p>
+    <p>We need you to review and sign the <strong>{{templateName}}</strong> before your visit.</p>
+
+    <div class="highlight-box">
+      <strong style="color: #4A3728;">Sign Your Agreement</strong><br>
+      <p>Please click the link below to review and sign your agreement. You'll need to provide your signature electronically.</p>
+      <p style="text-align: center; margin: 16px 0;">
+        <a href="{{signingUrl}}" style="display: inline-block; background-color: #6B7B5E; color: #ffffff; padding: 12px 32px; text-decoration: none; border-radius: 4px; font-weight: bold;">Review &amp; Sign Agreement</a>
+      </p>
+    </div>
+
+    <p style="font-size: 14px; color: #999;">
+      This link will expire in 30 days. If you have trouble with the link, copy and paste this URL into your browser:<br>
+      <a href="{{signingUrl}}" style="color: #6B7B5E; word-break: break-all;">{{signingUrl}}</a>
+    </p>
+
+    <p>If you have any questions, please reach out at
+      <a href="mailto:katie@mapleandsprucefolkarts.com" style="color: #6B7B5E;">katie@mapleandsprucefolkarts.com</a>,
+      call us at <a href="tel:+13043144506" style="color: #6B7B5E;">304-314-4506</a>,
+      or visit our <a href="https://mapleandsprucefolkarts.com/contact" style="color: #6B7B5E;">contact page</a>.</p>
+  </div>
+  <div class="footer">
+    <strong style="color: #4A3728;">Maple &amp; Spruce Folk Arts</strong><br>
+    Morgantown, WV<br>
+    <a href="mailto:katie@mapleandsprucefolkarts.com">katie@mapleandsprucefolkarts.com</a> | <a href="tel:+13043144506">304-314-4506</a><br>
+    <a href="https://mapleandsprucefolkarts.com">mapleandsprucefolkarts.com</a>
+  </div>
+</div>
+</body>
+</html>`;
+
+// ---------------------------------------------------------------------------
 // Seed to Firestore
 // ---------------------------------------------------------------------------
 
@@ -226,6 +279,10 @@ const templates: Record<string, EmailTemplate> = {
   'registration-cancelled': {
     subject: registrationCancelledSubject,
     html: registrationCancelledHtml,
+  },
+  'agreement-signing-request': {
+    subject: agreementSigningRequestSubject,
+    html: agreementSigningRequestHtml,
   },
 };
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -292,6 +292,7 @@
       "@maple/react/classes": ["libs/react/classes/src/index.ts"],
       "@maple/react/discounts": ["libs/react/discounts/src/index.ts"],
       "@maple/react/registrations": ["libs/react/registrations/src/index.ts"],
+      "@maple/react/agreements": ["libs/react/agreements/src/index.ts"],
       "@maple/react/events": ["libs/react/events/src/index.ts"],
       "@maple/firebase/maple-functions/get-calendar-embed-config": [
         "libs/firebase/maple-functions/get-calendar-embed-config/src/index.ts"


### PR DESCRIPTION
## Summary

- Add `signature_pad` dependency for canvas-based signature capture (zero monthly cost)
- Create `SignatureCanvas` and `SigningForm` React components in new `libs/react/agreements/` library
- Add public `/sign/[token]` page route for signing agreements without authentication
- Add `agreement-signing-request` Handlebars email template with branded signing button
- Update `sendAgreementRequest` and `resendAgreementRequest` to construct full signing URLs from `ALLOWED_ORIGINS`

## Details

**SignatureCanvas** — Wraps `signature_pad` with MUI styling, handles high-DPI displays and window resize, provides clear button and imperative API (`toDataURL()`, `isEmpty()`, `clear()`)

**SigningForm** — Full signing form with:
- Rendered agreement sections (HTML content via `dangerouslySetInnerHTML`)
- Photo/media release radio buttons (grant / grant-without-name / deny)
- Minor toggle with guardian name + co-signature fields
- Signature canvas, printed name, auto-populated date
- Preact Signals for form state (matches existing pattern)
- Kiosk mode support (`?kiosk=true` auto-resets form after 5s)

**Email template** — Branded HTML email matching existing M&S style with prominent "Review & Sign Agreement" CTA button

## Test plan

- [x] `npx tsc --noEmit` passes for functions app, agreements lib, and maple-spruce app
- [ ] Manual: create template in Firestore, send request via function, open signing link, sign on desktop
- [ ] Manual: test kiosk mode (`/sign/{token}?kiosk=true`) on iPad
- [ ] Manual: seed email template and verify email renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)