### PR TITLE
feat: auto-attach waivers during class registration (#320)

### DIFF
--- a/libs/firebase/maple-functions/create-registration/src/lib/create-registration.ts
+++ b/libs/firebase/maple-functions/create-registration/src/lib/create-registration.ts
@@ -11,8 +11,9 @@
  * 6. Create Square Order with tax line item
  * 7. Process Square payment against the order
  * 8. Create registration record
- * 9. Write to `mail` collection for confirmation email
- * 10. Return registration + confirmation number
+ * 9. Auto-attach agreement/waiver requests for matching class category
+ * 10. Write to `mail` collection for confirmation email (with waiver link if applicable)
+ * 11. Return registration + confirmation number
  *
  * Deployed to us-east4 via CI/CD pipeline.
  */
@@ -21,6 +22,8 @@ import {
   ClassRepository,
   DiscountRepository,
   RegistrationRepository,
+  AgreementTemplateRepository,
+  AgreementRequestRepository,
   getDb,
 } from '@maple/firebase/database';
 import {
@@ -57,9 +60,18 @@ function generateConfirmationNumber(): string {
   return `MS-${code}`;
 }
 
+/**
+ * Extract the first HTTPS origin from ALLOWED_ORIGINS for signing URLs.
+ */
+function getAppUrl(allowedOrigins: string): string {
+  const origins = allowedOrigins.split(',').map((o) => o.trim());
+  const httpsOrigin = origins.find((o) => o.startsWith('https://'));
+  return httpsOrigin ?? origins[0] ?? 'http://localhost:3000';
+}
+
 export const createRegistration = Functions.endpoint
   .usingSecrets(...SQUARE_SECRET_NAMES)
-  .usingStrings(...SQUARE_STRING_NAMES)
+  .usingStrings(...SQUARE_STRING_NAMES, 'ALLOWED_ORIGINS')
   .handle<CreateRegistrationRequest, CreateRegistrationResponse>(
     async (data, _context, secrets, strings) => {
       // 1. Validate input
@@ -250,7 +262,53 @@ export const createRegistration = Functions.endpoint
         );
       }
 
-      // 8. Write to mail collection for confirmation email
+      // 8. Auto-attach agreement/waiver requests for this class category
+      let waiverUrl: string | undefined;
+      try {
+        if (classEntity.categoryId) {
+          const templates =
+            await AgreementTemplateRepository.findAutoAttachForCategory(
+              classEntity.categoryId
+            );
+
+          if (templates.length > 0) {
+            const appUrl = getAppUrl(strings.ALLOWED_ORIGINS);
+
+            for (const template of templates) {
+              const signingToken = randomBytes(32).toString('hex');
+              const expiresAt = new Date();
+              expiresAt.setDate(expiresAt.getDate() + 30);
+
+              await AgreementRequestRepository.create({
+                templateId: template.id,
+                templateVersion: template.version,
+                signerEmail: data.customerEmail,
+                signerName: data.customerName,
+                signerPhone: data.customerPhone,
+                deliveryMethod: 'registration',
+                registrationId: registrationDocRef.id,
+                classId: data.classId,
+                signingToken,
+                expiresAt,
+                status: 'pending',
+              });
+
+              // Use the first template's signing URL for the confirmation email
+              if (!waiverUrl) {
+                waiverUrl = `${appUrl}/sign/${signingToken}`;
+              }
+            }
+          }
+        }
+      } catch (agreementError) {
+        // Don't fail the registration if agreement creation fails
+        console.error(
+          'Failed to create agreement requests:',
+          agreementError
+        );
+      }
+
+      // 9. Write to mail collection for confirmation email
       try {
         const formatCurrency = (cents: number): string =>
           `$${(cents / 100).toFixed(2)}`;
@@ -287,6 +345,7 @@ export const createRegistration = Functions.endpoint
                 : squareReceiptUrl,
               materialsIncluded: classEntity.materialsIncluded,
               whatToBring: classEntity.whatToBring,
+              waiverUrl,
             },
           },
         });
@@ -295,7 +354,7 @@ export const createRegistration = Functions.endpoint
         console.error('Failed to queue confirmation email:', emailError);
       }
 
-      // 9. Fetch and return the final registration
+      // 11. Fetch and return the final registration
       const registration = await RegistrationRepository.findById(
         registrationDocRef.id
       );

--- a/tools/seed-email-templates.ts
+++ b/tools/seed-email-templates.ts
@@ -124,6 +124,16 @@ const registrationConfirmationHtml = `<!DOCTYPE html>
     </div>
     {{/if}}
 
+    {{#if waiverUrl}}
+    <div class="highlight-box">
+      <strong style="color: #4A3728;">Action Required: Sign Your Waiver</strong><br>
+      <p>Please review and sign your class waiver before attending. This is required for participation.</p>
+      <p style="text-align: center; margin: 12px 0 4px;">
+        <a href="{{waiverUrl}}" style="display: inline-block; background-color: #6B7B5E; color: #ffffff; padding: 10px 28px; text-decoration: none; border-radius: 4px; font-weight: bold;">Sign Waiver</a>
+      </p>
+    </div>
+    {{/if}}
+
     <p>If you have any questions, please reach out at
       <a href="mailto:katie@mapleandsprucefolkarts.com" style="color: #6B7B5E;">katie@mapleandsprucefolkarts.com</a>,
       call us at <a href="tel:+13043144506" style="color: #6B7B5E;">304-314-4506</a>,


### PR DESCRIPTION
## Summary

- Modify `createRegistration` to auto-create agreement signing requests when a class's category has auto-attach templates
- Add waiver signing URL to the registration confirmation email with a branded "Sign Waiver" CTA button

## Changes

**`create-registration.ts`** — New step 9 after registration is confirmed:
1. Looks up the class's `categoryId`
2. Queries `AgreementTemplateRepository.findAutoAttachForCategory()` for active templates with `autoAttach: true`
3. Creates an `AgreementRequest` for each matching template with `deliveryMethod: 'registration'`
4. Passes the first template's signing URL as `waiverUrl` to the confirmation email

This step is wrapped in try/catch so agreement failures never block the registration itself.

**`seed-email-templates.ts`** — Adds `{{#if waiverUrl}}` block to the registration confirmation email with a green "Sign Waiver" button matching the existing brand styling.

## How it works end-to-end

1. Admin creates an agreement template (e.g., "Stained Glass Liability Waiver") and sets `autoAttach: true` with `classCategoryIds: ["glass-arts-category-id"]`
2. Customer registers for a stained glass class
3. Registration is confirmed, payment processed
4. System auto-creates an agreement request linked to the registration
5. Confirmation email includes "Sign Waiver" button linking to `/sign/{token}`
6. Customer clicks link, signs on the public signing page

## Test plan

- [x] `npx tsc --noEmit` passes for functions app
- [ ] Integration test: register for a class with auto-attach template, verify agreement request created
- [ ] Manual: verify confirmation email renders waiver link correctly
- [ ] Manual: verify registration still succeeds when no templates match (no waiverUrl in email)

🤖 Generated with [Claude Code](https://claude.com/claude-code)