### PR TITLE
fix: guard syncRegistrationCount against trigger feedback loop

### DIFF
--- a/apps/functions-integration-tests-registration/project.json
+++ b/apps/functions-integration-tests-registration/project.json
@@ -6,6 +6,7 @@
   "tags": ["type:e2e"],
   "implicitDependencies": [
     "firebase-maple-functions-calculate-registration-cost",
+    "firebase-maple-functions-sync-registration-count",
     "firebase-maple-functions-update-registration",
     "firebase-integration-test-utils"
   ],

--- a/libs/firebase/maple-functions/sync-registration-count/src/index.ts
+++ b/libs/firebase/maple-functions/sync-registration-count/src/index.ts
@@ -1,1 +1,5 @@
-export { syncRegistrationCount } from './lib/sync-registration-count';
+export {
+  syncRegistrationCount,
+  isCountRelevantChange,
+  extractClassId,
+} from './lib/sync-registration-count';

--- a/libs/firebase/maple-functions/sync-registration-count/src/lib/sync-registration-count.spec.ts
+++ b/libs/firebase/maple-functions/sync-registration-count/src/lib/sync-registration-count.spec.ts
@@ -81,6 +81,7 @@ vi.mock('firebase-functions/params', () => ({
 // Import after mocks
 import {
   extractClassId,
+  isCountRelevantChange,
   syncRegistrationCount,
 } from './sync-registration-count';
 
@@ -164,6 +165,166 @@ describe('Sync Registration Count', () => {
       );
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('isCountRelevantChange', () => {
+    it('returns true for create (no before snapshot)', () => {
+      const before = makeSnapshot(false) as import('firebase-functions/v2/firestore').DocumentSnapshot;
+      const after = makeSnapshot(true, {
+        classId: 'class-001',
+        status: 'confirmed',
+        quantity: 1,
+      }) as import('firebase-functions/v2/firestore').DocumentSnapshot;
+
+      expect(isCountRelevantChange(before, after)).toBe(true);
+    });
+
+    it('returns true for delete (no after snapshot)', () => {
+      const before = makeSnapshot(true, {
+        classId: 'class-001',
+        status: 'confirmed',
+        quantity: 1,
+      }) as import('firebase-functions/v2/firestore').DocumentSnapshot;
+      const after = makeSnapshot(false) as import('firebase-functions/v2/firestore').DocumentSnapshot;
+
+      expect(isCountRelevantChange(before, after)).toBe(true);
+    });
+
+    it('returns true when status changes', () => {
+      const before = makeSnapshot(true, {
+        classId: 'class-001',
+        status: 'pending',
+        quantity: 1,
+      }) as import('firebase-functions/v2/firestore').DocumentSnapshot;
+      const after = makeSnapshot(true, {
+        classId: 'class-001',
+        status: 'cancelled',
+        quantity: 1,
+      }) as import('firebase-functions/v2/firestore').DocumentSnapshot;
+
+      expect(isCountRelevantChange(before, after)).toBe(true);
+    });
+
+    it('returns true when quantity changes', () => {
+      const before = makeSnapshot(true, {
+        classId: 'class-001',
+        status: 'confirmed',
+        quantity: 1,
+      }) as import('firebase-functions/v2/firestore').DocumentSnapshot;
+      const after = makeSnapshot(true, {
+        classId: 'class-001',
+        status: 'confirmed',
+        quantity: 2,
+      }) as import('firebase-functions/v2/firestore').DocumentSnapshot;
+
+      expect(isCountRelevantChange(before, after)).toBe(true);
+    });
+
+    it('returns true when classId changes', () => {
+      const before = makeSnapshot(true, {
+        classId: 'class-001',
+        status: 'confirmed',
+        quantity: 1,
+      }) as import('firebase-functions/v2/firestore').DocumentSnapshot;
+      const after = makeSnapshot(true, {
+        classId: 'class-002',
+        status: 'confirmed',
+        quantity: 1,
+      }) as import('firebase-functions/v2/firestore').DocumentSnapshot;
+
+      expect(isCountRelevantChange(before, after)).toBe(true);
+    });
+
+    it('returns false when only non-count fields change (e.g. squarePaymentId)', () => {
+      const before = makeSnapshot(true, {
+        classId: 'class-001',
+        status: 'confirmed',
+        quantity: 1,
+        squarePaymentId: null,
+      }) as import('firebase-functions/v2/firestore').DocumentSnapshot;
+      const after = makeSnapshot(true, {
+        classId: 'class-001',
+        status: 'confirmed',
+        quantity: 1,
+        squarePaymentId: 'sq-pay-123',
+      }) as import('firebase-functions/v2/firestore').DocumentSnapshot;
+
+      expect(isCountRelevantChange(before, after)).toBe(false);
+    });
+
+    it('returns false when only updatedAt changes', () => {
+      const before = makeSnapshot(true, {
+        classId: 'class-001',
+        status: 'confirmed',
+        quantity: 1,
+        updatedAt: new Date('2026-01-01'),
+      }) as import('firebase-functions/v2/firestore').DocumentSnapshot;
+      const after = makeSnapshot(true, {
+        classId: 'class-001',
+        status: 'confirmed',
+        quantity: 1,
+        updatedAt: new Date('2026-01-02'),
+      }) as import('firebase-functions/v2/firestore').DocumentSnapshot;
+
+      expect(isCountRelevantChange(before, after)).toBe(false);
+    });
+  });
+
+  describe('handler — feedback loop guard', () => {
+    it('skips sync when only non-count fields change on update', async () => {
+      await handler({
+        params: { registrationId: 'reg-loop' },
+        data: {
+          after: makeSnapshot(true, {
+            classId: 'class-001',
+            status: 'confirmed',
+            quantity: 1,
+            squarePaymentId: 'sq-pay-123',
+            updatedAt: new Date(),
+          }),
+          before: makeSnapshot(true, {
+            classId: 'class-001',
+            status: 'confirmed',
+            quantity: 1,
+            squarePaymentId: null,
+            updatedAt: new Date('2026-01-01'),
+          }),
+        },
+      });
+
+      expect(mocks.classFindById).not.toHaveBeenCalled();
+      expect(mocks.syncClass).not.toHaveBeenCalled();
+    });
+
+    it('proceeds with sync when status changes from pending to confirmed', async () => {
+      const classEntity = createMockClass();
+      mocks.classFindById.mockResolvedValue(classEntity);
+      mocks.registrationCountByClassId.mockResolvedValue(1);
+      mocks.syncClass.mockResolvedValue({
+        success: true,
+        webflowItemId: 'wf-1',
+        isNew: false,
+      });
+
+      await handler({
+        params: { registrationId: 'reg-status-change' },
+        data: {
+          after: makeSnapshot(true, {
+            classId: 'class-001',
+            status: 'confirmed',
+            quantity: 1,
+          }),
+          before: makeSnapshot(true, {
+            classId: 'class-001',
+            status: 'pending',
+            quantity: 1,
+          }),
+        },
+      });
+
+      expect(mocks.classFindById).toHaveBeenCalledWith('class-001');
+      expect(mocks.syncClass).toHaveBeenCalled();
     });
   });
 

--- a/libs/firebase/maple-functions/sync-registration-count/src/lib/sync-registration-count.ts
+++ b/libs/firebase/maple-functions/sync-registration-count/src/lib/sync-registration-count.ts
@@ -52,6 +52,46 @@ export function extractClassId(
 }
 
 /**
+ * Fields on the registration document that affect the registration count.
+ * If none of these changed, syncing would produce the same result and we
+ * can skip the (expensive) Webflow call — preventing a trigger feedback
+ * loop where an unrelated field update re-fires this function endlessly.
+ */
+const COUNT_RELEVANT_FIELDS = ['classId', 'status', 'quantity'] as const;
+
+/**
+ * Check whether a write event actually changes the registration count.
+ *
+ * - Create (no before) or delete (no after): always relevant.
+ * - Update: relevant only when classId, status, or quantity changed.
+ */
+export function isCountRelevantChange(
+  before: DocumentSnapshot | undefined,
+  after: DocumentSnapshot | undefined
+): boolean {
+  const beforeExists = before?.exists ?? false;
+  const afterExists = after?.exists ?? false;
+
+  // Create or delete — always relevant
+  if (!beforeExists || !afterExists) {
+    return true;
+  }
+
+  const beforeData = before!.data();
+  const afterData = after!.data();
+
+  // If either snapshot has no data, treat as relevant (defensive)
+  if (!beforeData || !afterData) {
+    return true;
+  }
+
+  // Check if any count-relevant field changed
+  return COUNT_RELEVANT_FIELDS.some(
+    (field) => beforeData[field] !== afterData[field]
+  );
+}
+
+/**
  * Sync Registration Count to Webflow CMS
  *
  * Firestore trigger on the registrations collection.
@@ -66,6 +106,17 @@ export const syncRegistrationCount = onDocumentWritten(
   },
   async (event) => {
     const change: Change<DocumentSnapshot> = event.data!;
+
+    // Guard: skip if the write didn't change any count-relevant fields.
+    // This prevents a trigger feedback loop where an unrelated update
+    // (e.g. squarePaymentId, updatedAt) re-fires this function and
+    // causes it to loop dozens of times in the emulator.
+    if (!isCountRelevantChange(change.before, change.after)) {
+      console.log(
+        'Registration write did not change count-relevant fields, skipping sync'
+      );
+      return;
+    }
 
     // Get classId from before or after snapshot (covers create, update, delete)
     const classId =


### PR DESCRIPTION
## Summary

- Add `isCountRelevantChange()` guard to `syncRegistrationCount` that checks whether `classId`, `status`, or `quantity` changed between before/after snapshots
- On creates/deletes, always proceed (count always changes)
- On updates, skip the Webflow sync if only non-count fields changed (e.g., `squarePaymentId`, `squareOrderId`, `updatedAt`)
- This prevents the emulator from firing the trigger dozens of times during the registration payment flow, which was causing CI integration test failures

## Test plan

- [x] Unit tests for `isCountRelevantChange()` (7 cases: create, delete, status/quantity/classId change, non-count-only changes)
- [x] Handler test: skips sync when only `squarePaymentId` + `updatedAt` change
- [x] Handler test: proceeds with sync when status changes from `pending` to `confirmed`
- [x] All 24 tests pass (`nx test firebase-maple-functions-sync-registration-count`)

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)