### PR TITLE
feat: agreement admin UI — template list, request list, send dialog (#320)

### DIFF
--- a/apps/maple-spruce/src/app/agreements/page.tsx
+++ b/apps/maple-spruce/src/app/agreements/page.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  Tabs,
+  Tab,
+} from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import type { AgreementTemplate } from '@maple/ts/domain';
+import { DeleteConfirmDialog } from '@maple/react/ui';
+import {
+  AgreementTemplateList,
+  AgreementRequestList,
+  SendAgreementDialog,
+} from '@maple/react/agreements';
+import { AppShell } from '../../components/layout';
+import { useAgreementTemplates, useAgreementRequests } from '../../hooks';
+
+export default function AgreementsPage() {
+  const [tab, setTab] = useState(0);
+
+  const {
+    templatesState,
+    deleteTemplate: deleteTemplateApi,
+  } = useAgreementTemplates();
+
+  const {
+    requestsState,
+    sendRequest,
+    resendRequest,
+  } = useAgreementRequests();
+
+  // Send dialog state
+  const [isSendOpen, setIsSendOpen] = useState(false);
+  const [isSending, setIsSending] = useState(false);
+
+  // Delete dialog state
+  const [templateToDelete, setTemplateToDelete] =
+    useState<AgreementTemplate | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  // Resend state
+  const [isResending, setIsResending] = useState(false);
+
+  const handleSendWaiver = useCallback(
+    async (data: {
+      templateId: string;
+      signerEmail: string;
+      signerName: string;
+      signerPhone?: string;
+    }) => {
+      setIsSending(true);
+      try {
+        await sendRequest({
+          ...data,
+          deliveryMethod: 'email',
+        });
+      } finally {
+        setIsSending(false);
+      }
+    },
+    [sendRequest]
+  );
+
+  const handleResend = useCallback(
+    async (id: string) => {
+      setIsResending(true);
+      try {
+        await resendRequest(id);
+      } catch (error) {
+        console.error('Failed to resend:', error);
+      } finally {
+        setIsResending(false);
+      }
+    },
+    [resendRequest]
+  );
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!templateToDelete) return;
+    setIsDeleting(true);
+    try {
+      await deleteTemplateApi(templateToDelete.id);
+      setTemplateToDelete(null);
+    } catch (error) {
+      console.error('Failed to delete template:', error);
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [templateToDelete, deleteTemplateApi]);
+
+  const handleEditTemplate = useCallback((_template: AgreementTemplate) => {
+    // TODO: Open template editor dialog (Phase 4 enhancement)
+    console.log('Edit template:', _template.id);
+  }, []);
+
+  const templates =
+    templatesState.status === 'success' ? templatesState.data : [];
+
+  return (
+    <AppShell>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mb: 3,
+        }}
+      >
+        <Typography variant="h4" component="h1">
+          Agreements & Waivers
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Button
+            variant="outlined"
+            startIcon={<SendIcon />}
+            onClick={() => setIsSendOpen(true)}
+          >
+            Send Waiver
+          </Button>
+        </Box>
+      </Box>
+
+      <Tabs
+        value={tab}
+        onChange={(_e, v) => setTab(v)}
+        sx={{ mb: 1 }}
+      >
+        <Tab label="Templates" />
+        <Tab label="Requests" />
+      </Tabs>
+
+      {tab === 0 && (
+        <AgreementTemplateList
+          templatesState={templatesState}
+          onEdit={handleEditTemplate}
+          onDelete={setTemplateToDelete}
+        />
+      )}
+
+      {tab === 1 && (
+        <AgreementRequestList
+          requestsState={requestsState}
+          onResend={handleResend}
+          isResending={isResending}
+        />
+      )}
+
+      <SendAgreementDialog
+        open={isSendOpen}
+        onClose={() => setIsSendOpen(false)}
+        onSend={handleSendWaiver}
+        templates={templates}
+        isSending={isSending}
+      />
+
+      <DeleteConfirmDialog
+        open={!!templateToDelete}
+        onClose={() => setTemplateToDelete(null)}
+        onConfirm={handleConfirmDelete}
+        isDeleting={isDeleting}
+        title="Archive Template?"
+        itemName={templateToDelete?.name ?? ''}
+      />
+    </AppShell>
+  );
+}

--- a/apps/maple-spruce/src/components/layout/AppShellWrapper.tsx
+++ b/apps/maple-spruce/src/components/layout/AppShellWrapper.tsx
@@ -16,6 +16,7 @@ import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
 import SettingsIcon from '@mui/icons-material/Settings';
 import LocalOfferIcon from '@mui/icons-material/LocalOffer';
 import HowToRegIcon from '@mui/icons-material/HowToReg';
+import GavelIcon from '@mui/icons-material/Gavel';
 import { AppShell, type NavGroup } from '@maple/react/layout';
 import { useSyncConflictSummary } from '@maple/react/data';
 
@@ -88,6 +89,11 @@ export function AppShellWrapper({
             label: 'Registrations',
             href: '/registrations',
             icon: <HowToRegIcon />,
+          },
+          {
+            label: 'Agreements',
+            href: '/agreements',
+            icon: <GavelIcon />,
           },
         ],
       },

--- a/apps/maple-spruce/src/hooks/index.ts
+++ b/apps/maple-spruce/src/hooks/index.ts
@@ -14,5 +14,7 @@ export {
   useRegistrations,
   useCalendarEvents,
   useArtistPayouts,
+  useAgreementTemplates,
+  useAgreementRequests,
 } from '@maple/react/data';
 export { useAuth } from '@maple/react/auth';

--- a/libs/react/agreements/src/index.ts
+++ b/libs/react/agreements/src/index.ts
@@ -1,2 +1,5 @@
 export { SignatureCanvas, type SignatureCanvasHandle } from './lib/SignatureCanvas';
 export { SigningForm, type SigningFormProps } from './lib/SigningForm';
+export { AgreementTemplateList } from './lib/AgreementTemplateList';
+export { AgreementRequestList } from './lib/AgreementRequestList';
+export { SendAgreementDialog } from './lib/SendAgreementDialog';

--- a/libs/react/agreements/src/lib/AgreementRequestList.tsx
+++ b/libs/react/agreements/src/lib/AgreementRequestList.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import {
+  Box,
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Chip,
+  IconButton,
+  Skeleton,
+  Alert,
+  Tooltip,
+} from '@mui/material';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import type { AgreementRequest, RequestState } from '@maple/ts/domain';
+
+function formatDate(date: Date): string {
+  return new Date(date).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+const statusColors: Record<
+  string,
+  'warning' | 'success' | 'error' | 'default'
+> = {
+  pending: 'warning',
+  signed: 'success',
+  expired: 'error',
+  cancelled: 'default',
+};
+
+interface AgreementRequestListProps {
+  requestsState: RequestState<AgreementRequest[]>;
+  onResend: (id: string) => void;
+  isResending?: boolean;
+}
+
+export function AgreementRequestList({
+  requestsState,
+  onResend,
+  isResending,
+}: AgreementRequestListProps) {
+  if (
+    requestsState.status === 'loading' ||
+    requestsState.status === 'idle'
+  ) {
+    return (
+      <Box sx={{ mt: 2 }}>
+        {[1, 2, 3].map((i) => (
+          <Skeleton key={i} height={60} sx={{ mb: 1 }} />
+        ))}
+      </Box>
+    );
+  }
+
+  if (requestsState.status === 'error') {
+    return (
+      <Alert severity="error" sx={{ mt: 2 }}>
+        Failed to load requests: {requestsState.error}
+      </Alert>
+    );
+  }
+
+  const requests = requestsState.data;
+
+  if (requests.length === 0) {
+    return (
+      <Box sx={{ textAlign: 'center', py: 8, color: 'text.secondary' }}>
+        <Typography variant="h6">No agreement requests yet</Typography>
+        <Typography variant="body2" sx={{ mt: 1 }}>
+          Requests are created when you send a waiver or when a customer
+          registers for a class with an auto-attach template.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <TableContainer component={Paper} sx={{ mt: 2 }}>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Signer</TableCell>
+            <TableCell>Method</TableCell>
+            <TableCell>Status</TableCell>
+            <TableCell>Created</TableCell>
+            <TableCell>Expires</TableCell>
+            <TableCell align="right">Actions</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {requests.map((request) => (
+            <TableRow key={request.id} hover>
+              <TableCell>
+                <Typography variant="body2" fontWeight={600}>
+                  {request.signerName}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {request.signerEmail}
+                </Typography>
+              </TableCell>
+              <TableCell>
+                <Chip
+                  label={request.deliveryMethod}
+                  size="small"
+                  variant="outlined"
+                />
+              </TableCell>
+              <TableCell>
+                <Chip
+                  label={request.status}
+                  size="small"
+                  color={statusColors[request.status] ?? 'default'}
+                />
+              </TableCell>
+              <TableCell>{formatDate(request.createdAt)}</TableCell>
+              <TableCell>{formatDate(request.expiresAt)}</TableCell>
+              <TableCell align="right">
+                {request.status === 'pending' && (
+                  <Tooltip title="Resend signing email">
+                    <IconButton
+                      size="small"
+                      onClick={() => onResend(request.id)}
+                      disabled={isResending}
+                    >
+                      <RefreshIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/libs/react/agreements/src/lib/AgreementTemplateList.tsx
+++ b/libs/react/agreements/src/lib/AgreementTemplateList.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import {
+  Box,
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Chip,
+  IconButton,
+  Skeleton,
+  Alert,
+} from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import type { AgreementTemplate, RequestState } from '@maple/ts/domain';
+
+interface AgreementTemplateListProps {
+  templatesState: RequestState<AgreementTemplate[]>;
+  onEdit: (template: AgreementTemplate) => void;
+  onDelete: (template: AgreementTemplate) => void;
+}
+
+export function AgreementTemplateList({
+  templatesState,
+  onEdit,
+  onDelete,
+}: AgreementTemplateListProps) {
+  if (
+    templatesState.status === 'loading' ||
+    templatesState.status === 'idle'
+  ) {
+    return (
+      <Box sx={{ mt: 2 }}>
+        {[1, 2, 3].map((i) => (
+          <Skeleton key={i} height={60} sx={{ mb: 1 }} />
+        ))}
+      </Box>
+    );
+  }
+
+  if (templatesState.status === 'error') {
+    return (
+      <Alert severity="error" sx={{ mt: 2 }}>
+        Failed to load templates: {templatesState.error}
+      </Alert>
+    );
+  }
+
+  const templates = templatesState.data;
+
+  if (templates.length === 0) {
+    return (
+      <Box sx={{ textAlign: 'center', py: 8, color: 'text.secondary' }}>
+        <Typography variant="h6">No agreement templates yet</Typography>
+        <Typography variant="body2" sx={{ mt: 1 }}>
+          Create a template to start collecting waivers and agreements.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <TableContainer component={Paper} sx={{ mt: 2 }}>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Name</TableCell>
+            <TableCell>Sections</TableCell>
+            <TableCell>Auto-Attach</TableCell>
+            <TableCell>Version</TableCell>
+            <TableCell>Status</TableCell>
+            <TableCell align="right">Actions</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {templates.map((template) => (
+            <TableRow key={template.id} hover>
+              <TableCell>
+                <Typography variant="body2" fontWeight={600}>
+                  {template.name}
+                </Typography>
+                {template.description && (
+                  <Typography variant="caption" color="text.secondary">
+                    {template.description}
+                  </Typography>
+                )}
+              </TableCell>
+              <TableCell>{template.sections.length}</TableCell>
+              <TableCell>
+                {template.autoAttach ? (
+                  <Chip label="Auto" size="small" color="primary" />
+                ) : (
+                  <Chip label="Manual" size="small" variant="outlined" />
+                )}
+              </TableCell>
+              <TableCell>v{template.version}</TableCell>
+              <TableCell>
+                <Chip
+                  label={template.status}
+                  size="small"
+                  color={
+                    template.status === 'active' ? 'success' : 'default'
+                  }
+                />
+              </TableCell>
+              <TableCell align="right">
+                <IconButton size="small" onClick={() => onEdit(template)}>
+                  <EditIcon fontSize="small" />
+                </IconButton>
+                <IconButton size="small" onClick={() => onDelete(template)}>
+                  <DeleteIcon fontSize="small" />
+                </IconButton>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/libs/react/agreements/src/lib/SendAgreementDialog.tsx
+++ b/libs/react/agreements/src/lib/SendAgreementDialog.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+  CircularProgress,
+  Alert,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+} from '@mui/material';
+import {
+  useSignal,
+  useSignals,
+} from '@maple/react/signals';
+import type { AgreementTemplate } from '@maple/ts/domain';
+
+interface SendAgreementDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSend: (data: {
+    templateId: string;
+    signerEmail: string;
+    signerName: string;
+    signerPhone?: string;
+  }) => Promise<void>;
+  templates: AgreementTemplate[];
+  isSending: boolean;
+}
+
+export function SendAgreementDialog({
+  open,
+  onClose,
+  onSend,
+  templates,
+  isSending,
+}: SendAgreementDialogProps) {
+  useSignals();
+
+  const templateId = useSignal('');
+  const signerName = useSignal('');
+  const signerEmail = useSignal('');
+  const signerPhone = useSignal('');
+  const error = useSignal('');
+
+  const handleClose = () => {
+    templateId.value = '';
+    signerName.value = '';
+    signerEmail.value = '';
+    signerPhone.value = '';
+    error.value = '';
+    onClose();
+  };
+
+  const handleSend = async () => {
+    if (!templateId.value) {
+      error.value = 'Please select a template';
+      return;
+    }
+    if (!signerName.value.trim()) {
+      error.value = 'Name is required';
+      return;
+    }
+    if (!signerEmail.value.trim()) {
+      error.value = 'Email is required';
+      return;
+    }
+
+    error.value = '';
+    try {
+      await onSend({
+        templateId: templateId.value,
+        signerEmail: signerEmail.value.trim(),
+        signerName: signerName.value.trim(),
+        signerPhone: signerPhone.value.trim() || undefined,
+      });
+      handleClose();
+    } catch (err) {
+      error.value =
+        err instanceof Error ? err.message : 'Failed to send waiver';
+    }
+  };
+
+  const activeTemplates = templates.filter((t) => t.status === 'active');
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Send Waiver</DialogTitle>
+      <DialogContent>
+        {error.value && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error.value}
+          </Alert>
+        )}
+
+        <FormControl fullWidth sx={{ mt: 1 }}>
+          <InputLabel>Template</InputLabel>
+          <Select
+            value={templateId.value}
+            label="Template"
+            onChange={(e) => {
+              templateId.value = e.target.value;
+            }}
+          >
+            {activeTemplates.map((t) => (
+              <MenuItem key={t.id} value={t.id}>
+                {t.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <TextField
+          label="Recipient Name"
+          value={signerName.value}
+          onChange={(e) => {
+            signerName.value = e.target.value;
+          }}
+          fullWidth
+          sx={{ mt: 2 }}
+        />
+
+        <TextField
+          label="Recipient Email"
+          type="email"
+          value={signerEmail.value}
+          onChange={(e) => {
+            signerEmail.value = e.target.value;
+          }}
+          fullWidth
+          sx={{ mt: 2 }}
+        />
+
+        <TextField
+          label="Phone (optional)"
+          value={signerPhone.value}
+          onChange={(e) => {
+            signerPhone.value = e.target.value;
+          }}
+          fullWidth
+          sx={{ mt: 2 }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          onClick={handleSend}
+          disabled={isSending}
+        >
+          {isSending ? <CircularProgress size={20} /> : 'Send'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/libs/react/data/src/index.ts
+++ b/libs/react/data/src/index.ts
@@ -39,6 +39,16 @@ export {
   type UseArtistPayoutsOptions,
 } from './lib/useArtistPayouts';
 
+// Agreements & Waivers
+export {
+  useAgreementTemplates,
+  type UseAgreementTemplatesFilters,
+} from './lib/useAgreementTemplates';
+export {
+  useAgreementRequests,
+  type UseAgreementRequestsFilters,
+} from './lib/useAgreementRequests';
+
 // Phase 3c: Registration & Discounts
 export {
   useDiscounts,

--- a/libs/react/data/src/lib/useAgreementRequests.ts
+++ b/libs/react/data/src/lib/useAgreementRequests.ts
@@ -1,0 +1,114 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { httpsCallable } from 'firebase/functions';
+import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
+import type {
+  AgreementRequest,
+  AgreementRequestStatus,
+  RequestState,
+} from '@maple/ts/domain';
+import type {
+  GetAgreementRequestsRequest,
+  GetAgreementRequestsResponse,
+  SendAgreementRequestRequest,
+  SendAgreementRequestResponse,
+  ResendAgreementRequestRequest,
+  ResendAgreementRequestResponse,
+} from '@maple/ts/firebase/api-types';
+import type { AgreementDeliveryMethod } from '@maple/ts/domain';
+
+export interface UseAgreementRequestsFilters {
+  status?: AgreementRequestStatus;
+  signerEmail?: string;
+}
+
+export function useAgreementRequests(
+  filters?: UseAgreementRequestsFilters
+) {
+  const [requestsState, setRequestsState] = useState<
+    RequestState<AgreementRequest[]>
+  >({ status: 'idle' });
+
+  const fetchRequests = useCallback(async () => {
+    setRequestsState({ status: 'loading' });
+    try {
+      const functions = getMapleFunctions();
+      const getRequests = httpsCallable<
+        GetAgreementRequestsRequest,
+        GetAgreementRequestsResponse
+      >(functions, 'getAgreementRequests');
+      const result = await getRequests({
+        status: filters?.status,
+        signerEmail: filters?.signerEmail,
+      });
+      setRequestsState({ status: 'success', data: result.data.requests });
+    } catch (error) {
+      console.error('Failed to fetch agreement requests:', error);
+      setRequestsState({
+        status: 'error',
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to fetch requests',
+      });
+    }
+  }, [filters?.status, filters?.signerEmail]);
+
+  const sendRequest = useCallback(
+    async (input: {
+      templateId: string;
+      signerEmail: string;
+      signerName: string;
+      signerPhone?: string;
+      deliveryMethod: AgreementDeliveryMethod;
+      classId?: string;
+      studentId?: string;
+    }): Promise<AgreementRequest> => {
+      const functions = getMapleFunctions();
+      const send = httpsCallable<
+        SendAgreementRequestRequest,
+        SendAgreementRequestResponse
+      >(functions, 'sendAgreementRequest');
+      const result = await send(input);
+      setRequestsState((prev) => {
+        if (prev.status !== 'success') return prev;
+        return { ...prev, data: [result.data.request, ...prev.data] };
+      });
+      return result.data.request;
+    },
+    []
+  );
+
+  const resendRequest = useCallback(
+    async (id: string): Promise<void> => {
+      const functions = getMapleFunctions();
+      const resend = httpsCallable<
+        ResendAgreementRequestRequest,
+        ResendAgreementRequestResponse
+      >(functions, 'resendAgreementRequest');
+      const result = await resend({ id });
+      setRequestsState((prev) => {
+        if (prev.status !== 'success') return prev;
+        return {
+          ...prev,
+          data: prev.data.map((r) =>
+            r.id === id ? result.data.request : r
+          ),
+        };
+      });
+    },
+    []
+  );
+
+  useEffect(() => {
+    fetchRequests();
+  }, [fetchRequests]);
+
+  return {
+    requestsState,
+    fetchRequests,
+    sendRequest,
+    resendRequest,
+  };
+}

--- a/libs/react/data/src/lib/useAgreementTemplates.ts
+++ b/libs/react/data/src/lib/useAgreementTemplates.ts
@@ -1,0 +1,122 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { httpsCallable } from 'firebase/functions';
+import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
+import type {
+  AgreementTemplate,
+  AgreementTemplateStatus,
+  RequestState,
+} from '@maple/ts/domain';
+import type {
+  GetAgreementTemplatesRequest,
+  GetAgreementTemplatesResponse,
+  CreateAgreementTemplateRequest,
+  CreateAgreementTemplateResponse,
+  UpdateAgreementTemplateRequest,
+  UpdateAgreementTemplateResponse,
+  DeleteAgreementTemplateRequest,
+  DeleteAgreementTemplateResponse,
+} from '@maple/ts/firebase/api-types';
+
+export interface UseAgreementTemplatesFilters {
+  status?: AgreementTemplateStatus;
+}
+
+export function useAgreementTemplates(
+  filters?: UseAgreementTemplatesFilters
+) {
+  const [templatesState, setTemplatesState] = useState<
+    RequestState<AgreementTemplate[]>
+  >({ status: 'idle' });
+
+  const fetchTemplates = useCallback(async () => {
+    setTemplatesState({ status: 'loading' });
+    try {
+      const functions = getMapleFunctions();
+      const getTemplates = httpsCallable<
+        GetAgreementTemplatesRequest,
+        GetAgreementTemplatesResponse
+      >(functions, 'getAgreementTemplates');
+      const result = await getTemplates({ status: filters?.status });
+      setTemplatesState({ status: 'success', data: result.data.templates });
+    } catch (error) {
+      console.error('Failed to fetch agreement templates:', error);
+      setTemplatesState({
+        status: 'error',
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to fetch templates',
+      });
+    }
+  }, [filters?.status]);
+
+  const createTemplate = useCallback(
+    async (
+      input: CreateAgreementTemplateRequest
+    ): Promise<AgreementTemplate> => {
+      const functions = getMapleFunctions();
+      const create = httpsCallable<
+        CreateAgreementTemplateRequest,
+        CreateAgreementTemplateResponse
+      >(functions, 'createAgreementTemplate');
+      const result = await create(input);
+      setTemplatesState((prev) => {
+        if (prev.status !== 'success') return prev;
+        return { ...prev, data: [...prev.data, result.data.template] };
+      });
+      return result.data.template;
+    },
+    []
+  );
+
+  const updateTemplate = useCallback(
+    async (
+      input: UpdateAgreementTemplateRequest
+    ): Promise<AgreementTemplate> => {
+      const functions = getMapleFunctions();
+      const update = httpsCallable<
+        UpdateAgreementTemplateRequest,
+        UpdateAgreementTemplateResponse
+      >(functions, 'updateAgreementTemplate');
+      const result = await update(input);
+      setTemplatesState((prev) => {
+        if (prev.status !== 'success') return prev;
+        return {
+          ...prev,
+          data: prev.data.map((t) =>
+            t.id === result.data.template.id ? result.data.template : t
+          ),
+        };
+      });
+      return result.data.template;
+    },
+    []
+  );
+
+  const deleteTemplate = useCallback(async (id: string): Promise<void> => {
+    const functions = getMapleFunctions();
+    const del = httpsCallable<
+      DeleteAgreementTemplateRequest,
+      DeleteAgreementTemplateResponse
+    >(functions, 'deleteAgreementTemplate');
+    await del({ id });
+    setTemplatesState((prev) => {
+      if (prev.status !== 'success') return prev;
+      return { ...prev, data: prev.data.filter((t) => t.id !== id) };
+    });
+  }, []);
+
+  useEffect(() => {
+    fetchTemplates();
+  }, [fetchTemplates]);
+
+  return {
+    templatesState,
+    fetchTemplates,
+    createTemplate,
+    updateTemplate,
+    deleteTemplate,
+  };
+}


### PR DESCRIPTION
## Summary

- Add `/agreements` admin page with tabbed view (Templates, Requests)
- Add "Send Waiver" dialog so Katie can send waivers to anyone's email (music lessons, one-offs)
- Add resend capability for pending agreement requests
- Add sidebar nav entry under Classes group

## Components

**Data hooks** (`libs/react/data/`):
- `useAgreementTemplates` — CRUD with optimistic updates, follows existing `useDiscounts` pattern
- `useAgreementRequests` — list, send, resend with optimistic updates

**Admin components** (`libs/react/agreements/`):
- `AgreementTemplateList` — Table showing name, section count, auto-attach status, version, status
- `AgreementRequestList` — Table showing signer, delivery method, status, dates, resend button
- `SendAgreementDialog` — Dialog to pick template, enter recipient email/name/phone, send

**Page** (`apps/maple-spruce/src/app/agreements/page.tsx`):
- Two tabs: Templates and Requests
- "Send Waiver" button in header opens the send dialog
- Template archive (soft-delete) via DeleteConfirmDialog

## Test plan

- [x] TypeScript compiles clean (agreements lib + app)
- [ ] Manual: navigate to /agreements, verify template list loads
- [ ] Manual: click "Send Waiver", fill form, verify email sent
- [ ] Manual: verify resend button works for pending requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)