### PR TITLE
fix: handle empty integration test matrix without failing CI

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -281,7 +281,7 @@ jobs:
     needs: [install, integration-test-matrix]
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: github.repository == 'Maple-and-Spruce/maple-and-spruce'
+    if: github.repository == 'Maple-and-Spruce/maple-and-spruce' && fromJson(needs.integration-test-matrix.outputs.matrix).group[0] != null
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.integration-test-matrix.outputs.matrix) }}
@@ -374,6 +374,12 @@ jobs:
           if [[ "$matrix" == "failure" || "$matrix" == "cancelled" ]]; then
             echo "::error::Matrix setup failed"
             exit 1
+          fi
+          # When no integration test suites are affected, the matrix emits {"group": []}
+          # which causes zero shard jobs. GitHub reports this as "skipped" — that's fine.
+          if [[ "$tests" == "skipped" ]]; then
+            echo "No integration test suites affected — skipping"
+            exit 0
           fi
           if [[ "$tests" == "failure" || "$tests" == "cancelled" ]]; then
             echo "::error::One or more integration test groups failed"


### PR DESCRIPTION
## Summary

- Skip integration test shard job when matrix has no entries (no affected suites)
- Treat "skipped" result as success in the result aggregation job
- Fixes false CI failures on PRs that don't affect integration test suites

## Test plan

- [x] PRs touching only non-function code should see Integration Tests pass (skipped)
- [ ] PRs touching function code should still run the affected integration test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)