### PR TITLE
feat: scheduled expiry cleanup for agreement requests (#334)

### DIFF
--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -160,6 +160,9 @@ export { getSignedAgreement } from '@maple/firebase/maple-functions/get-signed-a
 export { getAgreementForSigning } from '@maple/firebase/maple-functions/get-agreement-for-signing';
 export { submitSignedAgreement } from '@maple/firebase/maple-functions/submit-signed-agreement';
 
+// Agreement scheduled functions
+export { expireAgreementRequests } from '@maple/firebase/maple-functions/expire-agreement-requests';
+
 // Etsy template functions (read/write Firestore only — no Etsy API dep)
 export { getEtsyTemplates } from '@maple/firebase/maple-functions/get-etsy-templates';
 export { saveEtsyCategoryTemplate } from '@maple/firebase/maple-functions/save-etsy-category-template';

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -96,6 +96,7 @@
     "../../libs/firebase/maple-functions/get-signed-agreement/**/*.ts",
     "../../libs/firebase/maple-functions/get-agreement-for-signing/**/*.ts",
     "../../libs/firebase/maple-functions/submit-signed-agreement/**/*.ts",
+    "../../libs/firebase/maple-functions/expire-agreement-requests/**/*.ts",
     "../../libs/firebase/database/src/**/*.ts",
     "../../libs/firebase/functions/src/**/*.ts",
     "../../libs/ts/domain/src/**/*.ts",

--- a/libs/firebase/maple-functions/expire-agreement-requests/project.json
+++ b/libs/firebase/maple-functions/expire-agreement-requests/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-expire-agreement-requests",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/expire-agreement-requests/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/expire-agreement-requests/src/index.ts
+++ b/libs/firebase/maple-functions/expire-agreement-requests/src/index.ts
@@ -1,0 +1,1 @@
+export { expireAgreementRequests } from './lib/expire-agreement-requests';

--- a/libs/firebase/maple-functions/expire-agreement-requests/src/lib/expire-agreement-requests.ts
+++ b/libs/firebase/maple-functions/expire-agreement-requests/src/lib/expire-agreement-requests.ts
@@ -1,0 +1,49 @@
+/**
+ * Expire Agreement Requests Scheduled Function
+ *
+ * Runs daily at 3:00 AM ET to mark pending agreement requests
+ * that have passed their expiresAt date as 'expired'.
+ *
+ * Deployed to us-east4 via CI/CD pipeline.
+ */
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+import { getFirestore } from 'firebase-admin/firestore';
+import admin from 'firebase-admin';
+
+export const expireAgreementRequests = onSchedule(
+  {
+    schedule: '0 3 * * *', // 3:00 AM every day
+    timeZone: 'America/New_York',
+    region: 'us-east4',
+  },
+  async () => {
+    if (admin.apps.length === 0) {
+      admin.initializeApp();
+    }
+
+    const db = getFirestore();
+    const now = new Date();
+
+    const snapshot = await db
+      .collection('agreementRequests')
+      .where('status', '==', 'pending')
+      .where('expiresAt', '<', now)
+      .get();
+
+    if (snapshot.empty) {
+      console.log('No expired agreement requests found.');
+      return;
+    }
+
+    const batch = db.batch();
+    for (const doc of snapshot.docs) {
+      batch.update(doc.ref, {
+        status: 'expired',
+        updatedAt: now,
+      });
+    }
+
+    await batch.commit();
+    console.log(`Marked ${snapshot.size} agreement request(s) as expired.`);
+  }
+);

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -357,6 +357,9 @@
       "@maple/firebase/maple-functions/get-payouts": [
         "libs/firebase/maple-functions/get-payouts/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/expire-agreement-requests": [
+        "libs/firebase/maple-functions/expire-agreement-requests/src/index.ts"
+      ],
       "@maple/firebase/integration-test-utils": [
         "libs/firebase/integration-test-utils/src/index.ts"
       ],


### PR DESCRIPTION
## Summary

- Add `expireAgreementRequests` scheduled Cloud Function that runs daily at 3:00 AM ET
- Queries `agreementRequests` where `status == 'pending'` and `expiresAt < now`
- Batch-updates matching documents to `status: 'expired'`
- Deployed in `maple-core` codebase

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] Deploy to dev, verify Cloud Scheduler job appears in Firebase console
- [ ] Create a test request with past expiresAt, trigger function manually, verify status updates

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)