### PR TITLE
feat: agreement template editor dialog (#333)

### DIFF
--- a/apps/maple-spruce/src/app/agreements/page.tsx
+++ b/apps/maple-spruce/src/app/agreements/page.tsx
@@ -8,22 +8,34 @@ import {
   Tabs,
   Tab,
 } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
 import SendIcon from '@mui/icons-material/Send';
-import type { AgreementTemplate } from '@maple/ts/domain';
+import type {
+  AgreementTemplate,
+  AgreementSection,
+  CreateAgreementTemplateInput,
+} from '@maple/ts/domain';
 import { DeleteConfirmDialog } from '@maple/react/ui';
 import {
   AgreementTemplateList,
+  AgreementTemplateForm,
   AgreementRequestList,
   SendAgreementDialog,
 } from '@maple/react/agreements';
 import { AppShell } from '../../components/layout';
-import { useAgreementTemplates, useAgreementRequests } from '../../hooks';
+import {
+  useAgreementTemplates,
+  useAgreementRequests,
+  useClassCategories,
+} from '../../hooks';
 
 export default function AgreementsPage() {
   const [tab, setTab] = useState(0);
 
   const {
     templatesState,
+    createTemplate,
+    updateTemplate,
     deleteTemplate: deleteTemplateApi,
   } = useAgreementTemplates();
 
@@ -32,6 +44,15 @@ export default function AgreementsPage() {
     sendRequest,
     resendRequest,
   } = useAgreementRequests();
+
+  const { categoriesState: classCategoriesState } = useClassCategories();
+
+  // Template form dialog state
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editingTemplate, setEditingTemplate] = useState<
+    AgreementTemplate | undefined
+  >();
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   // Send dialog state
   const [isSendOpen, setIsSendOpen] = useState(false);
@@ -44,6 +65,43 @@ export default function AgreementsPage() {
 
   // Resend state
   const [isResending, setIsResending] = useState(false);
+
+  const handleOpenForm = useCallback((template?: AgreementTemplate) => {
+    setEditingTemplate(template);
+    setIsFormOpen(true);
+  }, []);
+
+  const handleCloseForm = useCallback(() => {
+    setIsFormOpen(false);
+    setEditingTemplate(undefined);
+  }, []);
+
+  const handleSubmitForm = useCallback(
+    async (data: {
+      name: string;
+      description?: string;
+      sections: AgreementSection[];
+      classCategoryIds: string[];
+      autoAttach: boolean;
+      supportsMinor: boolean;
+    }) => {
+      setIsSubmitting(true);
+      try {
+        if (editingTemplate) {
+          await updateTemplate({ id: editingTemplate.id, ...data });
+        } else {
+          await createTemplate(data as CreateAgreementTemplateInput);
+        }
+        handleCloseForm();
+      } catch (error) {
+        console.error('Failed to save template:', error);
+        throw error;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [editingTemplate, handleCloseForm, createTemplate, updateTemplate]
+  );
 
   const handleSendWaiver = useCallback(
     async (data: {
@@ -92,13 +150,12 @@ export default function AgreementsPage() {
     }
   }, [templateToDelete, deleteTemplateApi]);
 
-  const handleEditTemplate = useCallback((_template: AgreementTemplate) => {
-    // TODO: Open template editor dialog (Phase 4 enhancement)
-    console.log('Edit template:', _template.id);
-  }, []);
-
   const templates =
     templatesState.status === 'success' ? templatesState.data : [];
+  const classCategories =
+    classCategoriesState.status === 'success'
+      ? classCategoriesState.data
+      : [];
 
   return (
     <AppShell>
@@ -114,6 +171,15 @@ export default function AgreementsPage() {
           Agreements & Waivers
         </Typography>
         <Box sx={{ display: 'flex', gap: 1 }}>
+          {tab === 0 && (
+            <Button
+              variant="contained"
+              startIcon={<AddIcon />}
+              onClick={() => handleOpenForm()}
+            >
+              New Template
+            </Button>
+          )}
           <Button
             variant="outlined"
             startIcon={<SendIcon />}
@@ -136,7 +202,7 @@ export default function AgreementsPage() {
       {tab === 0 && (
         <AgreementTemplateList
           templatesState={templatesState}
-          onEdit={handleEditTemplate}
+          onEdit={handleOpenForm}
           onDelete={setTemplateToDelete}
         />
       )}
@@ -148,6 +214,15 @@ export default function AgreementsPage() {
           isResending={isResending}
         />
       )}
+
+      <AgreementTemplateForm
+        open={isFormOpen}
+        onClose={handleCloseForm}
+        onSubmit={handleSubmitForm}
+        template={editingTemplate}
+        classCategories={classCategories}
+        isSubmitting={isSubmitting}
+      />
 
       <SendAgreementDialog
         open={isSendOpen}

--- a/libs/react/agreements/src/index.ts
+++ b/libs/react/agreements/src/index.ts
@@ -1,5 +1,6 @@
 export { SignatureCanvas, type SignatureCanvasHandle } from './lib/SignatureCanvas';
 export { SigningForm, type SigningFormProps } from './lib/SigningForm';
 export { AgreementTemplateList } from './lib/AgreementTemplateList';
+export { AgreementTemplateForm } from './lib/AgreementTemplateForm';
 export { AgreementRequestList } from './lib/AgreementRequestList';
 export { SendAgreementDialog } from './lib/SendAgreementDialog';

--- a/libs/react/agreements/src/lib/AgreementTemplateForm.tsx
+++ b/libs/react/agreements/src/lib/AgreementTemplateForm.tsx
@@ -1,0 +1,390 @@
+'use client';
+
+import { useCallback, useEffect } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  FormControlLabel,
+  Switch,
+  Alert,
+  IconButton,
+  Typography,
+  Paper,
+  Divider,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Chip,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import type {
+  AgreementTemplate,
+  AgreementSection,
+  AgreementSectionResponseType,
+  ClassCategory,
+} from '@maple/ts/domain';
+import {
+  useSignal,
+  useComputed,
+  batch,
+  useSignals,
+} from '@maple/react/signals';
+
+interface SectionFormData {
+  id: string;
+  title: string;
+  content: string;
+  responseType: AgreementSectionResponseType | '';
+}
+
+interface AgreementTemplateFormProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (data: {
+    name: string;
+    description?: string;
+    sections: AgreementSection[];
+    classCategoryIds: string[];
+    autoAttach: boolean;
+    supportsMinor: boolean;
+  }) => Promise<void>;
+  template?: AgreementTemplate;
+  classCategories: ClassCategory[];
+  isSubmitting?: boolean;
+}
+
+let sectionCounter = 0;
+function generateSectionId(): string {
+  sectionCounter += 1;
+  return `section-${Date.now()}-${sectionCounter}`;
+}
+
+export function AgreementTemplateForm({
+  open,
+  onClose,
+  onSubmit,
+  template,
+  classCategories,
+  isSubmitting = false,
+}: AgreementTemplateFormProps) {
+  useSignals();
+
+  const name = useSignal('');
+  const description = useSignal('');
+  const autoAttach = useSignal(false);
+  const supportsMinor = useSignal(false);
+  const classCategoryIds = useSignal<string[]>([]);
+  const sections = useSignal<SectionFormData[]>([]);
+
+  const showValidationErrors = useSignal(false);
+  const submitError = useSignal<string | null>(null);
+
+  const validationErrors = useComputed(() => {
+    if (!showValidationErrors.value) return {} as Record<string, string>;
+    const errors: Record<string, string> = {};
+    if (!name.value.trim()) errors.name = 'Name is required';
+    if (sections.value.length === 0) errors.sections = 'At least one section is required';
+    for (let i = 0; i < sections.value.length; i++) {
+      const s = sections.value[i];
+      if (!s.title.trim()) errors[`section-${i}-title`] = 'Title is required';
+      if (!s.content.trim()) errors[`section-${i}-content`] = 'Content is required';
+    }
+    return errors;
+  });
+
+  // Initialize form when opening
+  useEffect(() => {
+    if (!open) return;
+
+    if (template) {
+      batch(() => {
+        name.value = template.name;
+        description.value = template.description ?? '';
+        autoAttach.value = template.autoAttach;
+        supportsMinor.value = template.supportsMinor;
+        classCategoryIds.value = [...template.classCategoryIds];
+        sections.value = template.sections.map((s) => ({
+          id: s.id,
+          title: s.title,
+          content: s.content,
+          responseType: s.responseType ?? '',
+        }));
+        showValidationErrors.value = false;
+        submitError.value = null;
+      });
+    } else {
+      batch(() => {
+        name.value = '';
+        description.value = '';
+        autoAttach.value = false;
+        supportsMinor.value = false;
+        classCategoryIds.value = [];
+        sections.value = [];
+        showValidationErrors.value = false;
+        submitError.value = null;
+      });
+    }
+  }, [open, template]);
+
+  const addSection = useCallback(() => {
+    sections.value = [
+      ...sections.value,
+      { id: generateSectionId(), title: '', content: '', responseType: '' },
+    ];
+  }, [sections]);
+
+  const removeSection = useCallback(
+    (index: number) => {
+      sections.value = sections.value.filter((_, i) => i !== index);
+    },
+    [sections]
+  );
+
+  const moveSection = useCallback(
+    (index: number, direction: -1 | 1) => {
+      const newIndex = index + direction;
+      if (newIndex < 0 || newIndex >= sections.value.length) return;
+      const arr = [...sections.value];
+      [arr[index], arr[newIndex]] = [arr[newIndex], arr[index]];
+      sections.value = arr;
+    },
+    [sections]
+  );
+
+  const updateSection = useCallback(
+    (index: number, field: keyof SectionFormData, value: string) => {
+      sections.value = sections.value.map((s, i) =>
+        i === index ? { ...s, [field]: value } : s
+      );
+    },
+    [sections]
+  );
+
+  const handleSubmit = useCallback(async () => {
+    showValidationErrors.value = true;
+
+    const errors = validationErrors.peek();
+    if (Object.keys(errors).length > 0) return;
+
+    submitError.value = null;
+
+    try {
+      await onSubmit({
+        name: name.value.trim(),
+        description: description.value.trim() || undefined,
+        sections: sections.value.map((s) => ({
+          id: s.id,
+          title: s.title.trim(),
+          content: s.content.trim(),
+          responseType: (s.responseType || undefined) as AgreementSectionResponseType | undefined,
+        })),
+        classCategoryIds: classCategoryIds.value,
+        autoAttach: autoAttach.value,
+        supportsMinor: supportsMinor.value,
+      });
+    } catch (error: unknown) {
+      submitError.value =
+        error instanceof Error ? error.message : 'Failed to save template';
+    }
+  }, [onSubmit, name, description, sections, classCategoryIds, autoAttach, supportsMinor, validationErrors]);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>
+        {template ? 'Edit Template' : 'Create Agreement Template'}
+      </DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          {submitError.value && (
+            <Alert severity="error" onClose={() => (submitError.value = null)}>
+              {submitError.value}
+            </Alert>
+          )}
+
+          <TextField
+            label="Template Name"
+            value={name.value}
+            onChange={(e) => (name.value = e.target.value)}
+            error={!!validationErrors.value.name}
+            helperText={validationErrors.value.name || 'e.g., "Stained Glass Liability Waiver"'}
+            required
+            fullWidth
+          />
+
+          <TextField
+            label="Description (internal)"
+            value={description.value}
+            onChange={(e) => (description.value = e.target.value)}
+            fullWidth
+            placeholder="Optional admin notes about this template"
+          />
+
+          <Box sx={{ display: 'flex', gap: 2 }}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={autoAttach.value}
+                  onChange={(e) => (autoAttach.value = e.target.checked)}
+                />
+              }
+              label="Auto-attach to registrations"
+            />
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={supportsMinor.value}
+                  onChange={(e) => (supportsMinor.value = e.target.checked)}
+                />
+              }
+              label="Supports minor/guardian"
+            />
+          </Box>
+
+          {autoAttach.value && (
+            <FormControl fullWidth>
+              <InputLabel>Class Categories</InputLabel>
+              <Select
+                multiple
+                value={classCategoryIds.value}
+                label="Class Categories"
+                onChange={(e) => {
+                  classCategoryIds.value = e.target.value as string[];
+                }}
+                renderValue={(selected) => (
+                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                    {selected.map((id) => {
+                      const cat = classCategories.find((c) => c.id === id);
+                      return (
+                        <Chip key={id} label={cat?.name ?? id} size="small" />
+                      );
+                    })}
+                  </Box>
+                )}
+              >
+                {classCategories.map((cat) => (
+                  <MenuItem key={cat.id} value={cat.id}>
+                    {cat.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+
+          <Divider />
+
+          {/* Sections */}
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <Typography variant="h6">Sections</Typography>
+            <Button startIcon={<AddIcon />} onClick={addSection} size="small">
+              Add Section
+            </Button>
+          </Box>
+
+          {validationErrors.value.sections && (
+            <Alert severity="error">{validationErrors.value.sections}</Alert>
+          )}
+
+          {sections.value.map((section, index) => (
+            <Paper key={section.id} variant="outlined" sx={{ p: 2 }}>
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+                <Typography variant="subtitle2" color="text.secondary">
+                  Section {index + 1}
+                </Typography>
+                <Box>
+                  <IconButton
+                    size="small"
+                    onClick={() => moveSection(index, -1)}
+                    disabled={index === 0}
+                  >
+                    <ArrowUpwardIcon fontSize="small" />
+                  </IconButton>
+                  <IconButton
+                    size="small"
+                    onClick={() => moveSection(index, 1)}
+                    disabled={index === sections.value.length - 1}
+                  >
+                    <ArrowDownwardIcon fontSize="small" />
+                  </IconButton>
+                  <IconButton
+                    size="small"
+                    onClick={() => removeSection(index)}
+                    color="error"
+                  >
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
+                </Box>
+              </Box>
+
+              <TextField
+                label="Section Title"
+                value={section.title}
+                onChange={(e) => updateSection(index, 'title', e.target.value)}
+                error={!!validationErrors.value[`section-${index}-title`]}
+                helperText={validationErrors.value[`section-${index}-title`]}
+                required
+                fullWidth
+                size="small"
+                sx={{ mb: 1.5 }}
+              />
+
+              <TextField
+                label="Content (HTML)"
+                value={section.content}
+                onChange={(e) => updateSection(index, 'content', e.target.value)}
+                error={!!validationErrors.value[`section-${index}-content`]}
+                helperText={validationErrors.value[`section-${index}-content`] || 'HTML content for this section'}
+                required
+                fullWidth
+                multiline
+                minRows={4}
+                maxRows={12}
+                size="small"
+                sx={{ mb: 1.5 }}
+              />
+
+              <FormControl fullWidth size="small">
+                <InputLabel>Response Type (optional)</InputLabel>
+                <Select
+                  value={section.responseType}
+                  label="Response Type (optional)"
+                  onChange={(e) =>
+                    updateSection(index, 'responseType', e.target.value)
+                  }
+                >
+                  <MenuItem value="">None</MenuItem>
+                  <MenuItem value="acknowledgment">Acknowledgment (checkbox)</MenuItem>
+                  <MenuItem value="media-release">Media Release (3 radio options)</MenuItem>
+                </Select>
+              </FormControl>
+            </Paper>
+          ))}
+
+          {sections.value.length === 0 && (
+            <Box sx={{ textAlign: 'center', py: 4, color: 'text.secondary' }}>
+              <Typography variant="body2">
+                No sections yet. Click "Add Section" to start building the agreement.
+              </Typography>
+            </Box>
+          )}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={isSubmitting}>
+          Cancel
+        </Button>
+        <Button onClick={handleSubmit} variant="contained" disabled={isSubmitting}>
+          {isSubmitting ? 'Saving...' : template ? 'Update' : 'Create'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary

- Add `AgreementTemplateForm` dialog for creating and editing agreement templates in the admin UI
- Wire into `/agreements` page with "New Template" button and edit action on existing templates
- Load class categories for auto-attach targeting

## Template Editor Features

- **Name & description** — template metadata
- **Auto-attach toggle** — when enabled, shows class category multi-select so templates auto-attach to matching registrations
- **Supports minor toggle** — enables guardian co-signature fields on the signing page
- **Section management**:
  - Add/remove sections with title, HTML content (multiline textarea), and optional response type
  - Reorder sections with up/down arrows
  - Response type options: none, acknowledgment (checkbox), media-release (3 radio options)
- **Validation** — name required, at least one section, each section needs title and content
- **Edit mode** — pre-populates all fields from existing template

## Test plan

- [x] TypeScript compiles clean
- [ ] Manual: click "New Template", add sections, save — verify template appears in list
- [ ] Manual: click edit on existing template, modify sections, save — verify version bumps
- [ ] Manual: enable auto-attach, select categories, save — verify classCategoryIds stored
- [ ] Manual: create template with media-release section, send to email, verify radio buttons on signing page

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)