### PR TITLE
fix: redirect stderr in Nx affected detection (#345)

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -62,7 +62,7 @@ jobs:
           # Compute affected projects once — shared by both the functions
           # deploy and the webflow components publish below.
           if [ "$DEPLOY_ALL" != "true" ]; then
-            ALL_AFFECTED=$(pnpm exec nx show projects --affected --base=${{ steps.base.outputs.commit }})
+            ALL_AFFECTED=$(pnpm exec nx show projects --affected --base=${{ steps.base.outputs.commit }} 2>/dev/null)
             echo "Affected projects:"
             echo "$ALL_AFFECTED"
           fi

--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -159,6 +159,7 @@ export { getSignedAgreement } from '@maple/firebase/maple-functions/get-signed-a
 // Public signing functions (no auth required)
 export { getAgreementForSigning } from '@maple/firebase/maple-functions/get-agreement-for-signing';
 export { submitSignedAgreement } from '@maple/firebase/maple-functions/submit-signed-agreement';
+export { getRequiredAgreementsForClass } from '@maple/firebase/maple-functions/get-required-agreements-for-class';
 
 // Agreement scheduled functions
 export { expireAgreementRequests } from '@maple/firebase/maple-functions/expire-agreement-requests';

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -96,6 +96,7 @@
     "../../libs/firebase/maple-functions/get-signed-agreement/**/*.ts",
     "../../libs/firebase/maple-functions/get-agreement-for-signing/**/*.ts",
     "../../libs/firebase/maple-functions/submit-signed-agreement/**/*.ts",
+    "../../libs/firebase/maple-functions/get-required-agreements-for-class/**/*.ts",
     "../../libs/firebase/maple-functions/expire-agreement-requests/**/*.ts",
     "../../libs/firebase/database/src/**/*.ts",
     "../../libs/firebase/functions/src/**/*.ts",

--- a/apps/webflow-components/src/RegistrationWidget.tsx
+++ b/apps/webflow-components/src/RegistrationWidget.tsx
@@ -21,6 +21,7 @@ import PrintIcon from '@mui/icons-material/Print';
 import { httpsCallable } from 'firebase/functions';
 import { theme } from '@maple/react/theme';
 import { RegistrationCheckoutForm } from '@maple/react/registrations';
+import type { RequiredAgreementTemplate } from '@maple/react/registrations';
 import type { PublicClass } from '@maple/ts/domain';
 import type {
   GetPublicClassRequest,
@@ -29,6 +30,9 @@ import type {
   CalculateRegistrationCostResponse,
   CreateRegistrationRequest,
   CreateRegistrationResponse,
+  GetRequiredAgreementsForClassRequest,
+  GetRequiredAgreementsForClassResponse,
+  InlineAgreementSigningData,
 } from '@maple/ts/firebase/api-types';
 import { getWidgetFunctions } from './firebase-init';
 
@@ -140,7 +144,7 @@ interface RegistrationWidgetProps {
 type WidgetState =
   | { status: 'loading' }
   | { status: 'error'; message: string }
-  | { status: 'ready'; publicClass: PublicClass }
+  | { status: 'ready'; publicClass: PublicClass; requiredAgreements: RequiredAgreementTemplate[] }
   | {
       status: 'confirmed';
       confirmationNumber: string;
@@ -154,6 +158,7 @@ type WidgetState =
       classDurationMinutes: number;
       skillLevel: string;
       location?: string;
+      agreementsSigned?: boolean;
     };
 
 export function RegistrationWidget({
@@ -181,8 +186,24 @@ export function RegistrationWidget({
           GetPublicClassResponse
         >(functions, 'getPublicClass');
 
-        const result = await getPublicClass({ id: classId });
-        setState({ status: 'ready', publicClass: result.data.class });
+        const getRequiredAgreements = httpsCallable<
+          GetRequiredAgreementsForClassRequest,
+          GetRequiredAgreementsForClassResponse
+        >(functions, 'getRequiredAgreementsForClass');
+
+        // Fetch class and required agreements in parallel
+        const [classResult, agreementsResult] = await Promise.all([
+          getPublicClass({ id: classId }),
+          getRequiredAgreements({ classId }).catch(() => ({
+            data: { agreements: [] as GetRequiredAgreementsForClassResponse['agreements'] },
+          })),
+        ]);
+
+        setState({
+          status: 'ready',
+          publicClass: classResult.data.class,
+          requiredAgreements: agreementsResult.data.agreements,
+        });
       } catch (err) {
         console.error('Failed to fetch class:', err);
         setState({
@@ -226,6 +247,7 @@ export function RegistrationWidget({
       discountCode?: string;
       notes?: string;
       paymentNonce: string;
+      agreements?: InlineAgreementSigningData[];
     }): Promise<CreateRegistrationResponse> => {
       const createRegistration = httpsCallable<
         CreateRegistrationRequest,
@@ -245,6 +267,7 @@ export function RegistrationWidget({
       customerEmail: string;
       pricePaidCents: number;
       quantity: number;
+      agreementsSigned?: boolean;
     }) => {
       if (state.status !== 'ready') return;
 
@@ -297,6 +320,7 @@ export function RegistrationWidget({
         classDurationMinutes: pc.durationMinutes,
         skillLevel: pc.skillLevel,
         location: pc.location,
+        agreementsSigned: details.agreementsSigned,
       });
     },
     [state]
@@ -343,6 +367,7 @@ export function RegistrationWidget({
                   squareApplicationId={squareAppId}
                   squareLocationId={squareLocationId}
                   env={env}
+                  requiredAgreements={state.requiredAgreements}
                   onCalculateCost={handleCalculateCost}
                   onSubmit={handleSubmit}
                   onSuccess={handleSuccess}
@@ -388,6 +413,17 @@ export function RegistrationWidget({
                 ${(state.pricePaidCents / 100).toFixed(2)} paid
               </Typography>
             </Box>
+
+            {/* Waiver signed indicator */}
+            {state.agreementsSigned && (
+              <Alert
+                severity="success"
+                icon={<CheckCircleOutlineIcon />}
+                sx={{ mb: 2, textAlign: 'left' }}
+              >
+                Waiver signed — no further action needed.
+              </Alert>
+            )}
 
             {/* Confirmation number — de-emphasized */}
             <Typography

--- a/docs/reference/deployed-functions.md
+++ b/docs/reference/deployed-functions.md
@@ -66,6 +66,15 @@ Core CRUD operations, auth, triggers, and admin functions. No heavy third-party 
 - `markPayoutPaid` — marks a pending payout as paid with payment method and optional reference
 - `getPayouts` — retrieves artist payouts with optional filters (artistId, status)
 
+### Agreements & Waivers
+- `getAgreementTemplates`, `getAgreementTemplate`, `createAgreementTemplate`, `updateAgreementTemplate`, `deleteAgreementTemplate`
+- `getAgreementRequests`, `sendAgreementRequest`, `resendAgreementRequest`
+- `getSignedAgreements`, `getSignedAgreement`
+- `getAgreementForSigning` _(public, token-based)_
+- `submitSignedAgreement` _(public, token-based, 120s timeout)_
+- `getRequiredAgreementsForClass` _(public — returns required-at-checkout templates for a class)_
+- `expireAgreementRequests` _(scheduled — marks expired requests)_
+
 ### Auth
 - `checkAdminStatus`
 

--- a/docs/reference/implementation-status.md
+++ b/docs/reference/implementation-status.md
@@ -364,6 +364,50 @@ Square foundation is complete. Ready for Product Management integration.
 | Vercel deployment | Pending | `storybook.maple-and-spruce.com` |
 | Chromatic project token | Pending | Add `CHROMATIC_PROJECT_TOKEN` to GitHub secrets |
 
+## Agreement & Waiver System - Epic #320
+
+### Phase 1: Foundation (Complete, #321)
+
+| Feature | Status | Location |
+|---------|--------|----------|
+| Domain types (template, request, signed agreement) | **Complete** | `libs/ts/domain/src/lib/agreement-*.ts` |
+| Repositories (3 collections) | **Complete** | `libs/firebase/database/src/lib/agreement-*.repository.ts` |
+| Validation suites (template + signing) | **Complete** | `libs/ts/validation/src/lib/agreement-*.validation.ts` |
+| 12 Cloud Functions (CRUD, signing, admin) | **Complete** | `libs/firebase/maple-functions/*-agreement-*/` |
+| Auto-attach agreements during registration | **Complete** | `libs/firebase/maple-functions/create-registration/` |
+| Agreement request expiry cleanup | **Complete** | `libs/firebase/maple-functions/expire-agreement-requests/` |
+
+### Phase 2: Signing Flow (Complete)
+
+| Feature | Status | Location |
+|---------|--------|----------|
+| SigningForm component (signature_pad) | **Complete** | `libs/react/agreements/src/lib/SigningForm.tsx` |
+| SignatureCanvas component | **Complete** | `libs/react/agreements/src/lib/SignatureCanvas.tsx` |
+| Public signing page `/sign/:token` | **Complete** | `apps/maple-spruce/src/app/sign/[token]/page.tsx` |
+| Kiosk mode support | **Complete** | `?kiosk=true` query param |
+| Agreement template editor dialog | **Complete** | `libs/react/agreements/src/lib/AgreementTemplateForm.tsx` (#333) |
+
+### Phase 3: Registration Integration (PR #343)
+
+| Feature | Status | Location |
+|---------|--------|----------|
+| `signingRequirement` field on templates | **Complete** | `libs/ts/domain/src/lib/agreement-template.ts` |
+| `getRequiredAgreementsForClass` Cloud Function | **Complete** | `libs/firebase/maple-functions/get-required-agreements-for-class/` |
+| Required agreement validation before payment | **Complete** | `libs/firebase/maple-functions/create-registration/` |
+| Inline signing step in checkout form | **Complete** | `libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx` |
+| Webflow widget agreement integration | **Complete** | `apps/webflow-components/src/RegistrationWidget.tsx` |
+| Signing requirement admin UI | **Complete** | Radio group in `AgreementTemplateForm.tsx` |
+| Confirmation email: signed vs deferred states | **Complete** | `tools/seed-email-templates.ts` |
+
+### Phase 4: Enhancements (Not Started)
+
+| Feature | Status | Issue |
+|---------|--------|-------|
+| SMS delivery via Twilio | Not Started | #335 |
+| Kiosk mode improvements | Not Started | — |
+| Bulk re-send | Not Started | — |
+| PDF export | Not Started | — |
+
 ## External Dependencies
 
 - [x] Firebase projects created (`maple-and-spruce` prod, `maple-and-spruce-dev` dev)

--- a/libs/firebase/database/src/lib/agreement-template.repository.ts
+++ b/libs/firebase/database/src/lib/agreement-template.repository.ts
@@ -8,6 +8,7 @@ import { db, toDate } from './utilities/database.config';
 import type {
   AgreementTemplate,
   AgreementTemplateStatus,
+  SigningRequirement,
   CreateAgreementTemplateInput,
   UpdateAgreementTemplateInput,
 } from '@maple/ts/domain';
@@ -29,6 +30,7 @@ function docToAgreementTemplate(
     sections: data.sections ?? [],
     classCategoryIds: data.classCategoryIds ?? [],
     autoAttach: data.autoAttach ?? false,
+    signingRequirement: (data.signingRequirement as SigningRequirement) ?? 'deferred',
     supportsMinor: data.supportsMinor ?? false,
     version: data.version ?? 1,
     status: data.status as AgreementTemplateStatus,
@@ -41,6 +43,7 @@ export interface AgreementTemplateFilters {
   status?: AgreementTemplateStatus;
   classCategoryId?: string;
   autoAttach?: boolean;
+  signingRequirement?: SigningRequirement;
 }
 
 export const AgreementTemplateRepository = {
@@ -55,6 +58,14 @@ export const AgreementTemplateRepository = {
 
     if (filters?.autoAttach !== undefined) {
       query = query.where('autoAttach', '==', filters.autoAttach);
+    }
+
+    if (filters?.signingRequirement) {
+      query = query.where(
+        'signingRequirement',
+        '==',
+        filters.signingRequirement
+      );
     }
 
     if (filters?.classCategoryId) {
@@ -88,6 +99,20 @@ export const AgreementTemplateRepository = {
       status: 'active',
       autoAttach: true,
       classCategoryId,
+    });
+  },
+
+  /**
+   * Find active required-at-checkout templates for a given class category
+   */
+  async findRequiredForCategory(
+    classCategoryId: string
+  ): Promise<AgreementTemplate[]> {
+    return this.findAll({
+      status: 'active',
+      autoAttach: true,
+      classCategoryId,
+      signingRequirement: 'required',
     });
   },
 

--- a/libs/firebase/maple-functions/create-registration/src/lib/create-registration.ts
+++ b/libs/firebase/maple-functions/create-registration/src/lib/create-registration.ts
@@ -11,9 +11,11 @@
  * 6. Create Square Order with tax line item
  * 7. Process Square payment against the order
  * 8. Create registration record
- * 9. Auto-attach agreement/waiver requests for matching class category
- * 10. Write to `mail` collection for confirmation email (with waiver link if applicable)
- * 11. Return registration + confirmation number
+ * 9. Validate required agreement signatures (if any) — before payment
+ * 10. Process required agreements (upload signatures, create records) — after payment
+ * 11. Auto-attach deferred agreement/waiver requests for matching class category
+ * 12. Write to `mail` collection for confirmation email (with waiver link if applicable)
+ * 13. Return registration + confirmation number
  *
  * Deployed to us-east4 via CI/CD pipeline.
  */
@@ -24,6 +26,7 @@ import {
   RegistrationRepository,
   AgreementTemplateRepository,
   AgreementRequestRepository,
+  SignedAgreementRepository,
   getDb,
 } from '@maple/firebase/database';
 import {
@@ -43,7 +46,10 @@ import { registrationValidation } from '@maple/ts/validation';
 import type {
   CreateRegistrationRequest,
   CreateRegistrationResponse,
+  InlineAgreementSigningData,
 } from '@maple/ts/firebase/api-types';
+import type { AgreementTemplate, MediaReleaseChoice } from '@maple/ts/domain';
+import { getStorage } from 'firebase-admin/storage';
 import { randomBytes } from 'crypto';
 
 /**
@@ -69,6 +75,103 @@ function getAppUrl(allowedOrigins: string): string {
   return httpsOrigin ?? origins[0] ?? 'http://localhost:3000';
 }
 
+/**
+ * Upload a base64 PNG to Firebase Storage and return the file path.
+ */
+async function uploadSignature(
+  signedAgreementId: string,
+  filename: string,
+  base64Data: string
+): Promise<string> {
+  const bucket = getStorage().bucket();
+  const filePath = `agreements/${signedAgreementId}/${filename}`;
+  const file = bucket.file(filePath);
+
+  const raw = base64Data.includes(',')
+    ? base64Data.split(',')[1]
+    : base64Data;
+  const buffer = Buffer.from(raw, 'base64');
+
+  await file.save(buffer, {
+    metadata: { contentType: 'image/png' },
+  });
+
+  return filePath;
+}
+
+/**
+ * Render agreement sections into an HTML snapshot for the legal record.
+ */
+function renderAgreementHtml(
+  templateName: string,
+  sections: Array<{ title: string; content: string }>
+): string {
+  const sectionHtml = sections
+    .map(
+      (s) =>
+        `<section><h2>${s.title}</h2><div>${s.content}</div></section>`
+    )
+    .join('\n');
+
+  return `<!DOCTYPE html>
+<html>
+<head><title>${templateName}</title></head>
+<body>
+<h1>${templateName}</h1>
+${sectionHtml}
+</body>
+</html>`;
+}
+
+/**
+ * Validate that all required agreement templates have matching signature data.
+ */
+function validateRequiredAgreements(
+  requiredTemplates: AgreementTemplate[],
+  agreements: InlineAgreementSigningData[] | undefined
+): void {
+  if (requiredTemplates.length === 0) return;
+
+  if (!agreements || agreements.length === 0) {
+    throw new Error(
+      'Required agreements must be signed before checkout can complete'
+    );
+  }
+
+  const submittedIds = new Set(agreements.map((a) => a.templateId));
+  const missingTemplates = requiredTemplates.filter(
+    (t) => !submittedIds.has(t.id)
+  );
+
+  if (missingTemplates.length > 0) {
+    const names = missingTemplates.map((t) => t.name).join(', ');
+    throw new Error(
+      `The following agreements must be signed before checkout: ${names}`
+    );
+  }
+
+  // Validate each submitted agreement has required fields
+  for (const agreement of agreements) {
+    if (!agreement.signatureData) {
+      throw new Error('Signature is required for all agreements');
+    }
+    if (!agreement.printedName?.trim()) {
+      throw new Error('Printed name is required for all agreements');
+    }
+    if (agreement.isMinor) {
+      if (!agreement.minorName?.trim()) {
+        throw new Error("Minor's name is required");
+      }
+      if (!agreement.guardianName?.trim()) {
+        throw new Error('Parent/guardian name is required');
+      }
+      if (!agreement.guardianSignatureData) {
+        throw new Error('Parent/guardian signature is required');
+      }
+    }
+  }
+}
+
 export const createRegistration = Functions.endpoint
   .usingSecrets(...SQUARE_SECRET_NAMES)
   .usingStrings(...SQUARE_STRING_NAMES, 'ALLOWED_ORIGINS')
@@ -92,6 +195,17 @@ export const createRegistration = Functions.endpoint
 
       if (!isClassRegistrationOpen(classEntity)) {
         throw new Error('This class is not currently open for registration');
+      }
+
+      // 2b. Check for required agreements and validate signatures before payment
+      const requiredTemplates = classEntity.categoryId
+        ? await AgreementTemplateRepository.findRequiredForCategory(
+            classEntity.categoryId
+          )
+        : [];
+
+      if (requiredTemplates.length > 0) {
+        validateRequiredAgreements(requiredTemplates, data.agreements);
       }
 
       // 3. Calculate cost (with optional discount)
@@ -262,19 +376,125 @@ export const createRegistration = Functions.endpoint
         );
       }
 
-      // 8. Auto-attach agreement/waiver requests for this class category
+      // 8. Process required agreements (signed at checkout)
+      let agreementsSigned = false;
+      try {
+        if (requiredTemplates.length > 0 && data.agreements) {
+          const templateMap = new Map(
+            requiredTemplates.map((t) => [t.id, t])
+          );
+
+          for (const agreementData of data.agreements) {
+            const template = templateMap.get(agreementData.templateId);
+            if (!template) continue;
+
+            const tempId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+            // Upload signature images
+            const signatureImagePath = await uploadSignature(
+              tempId,
+              'signature.png',
+              agreementData.signatureData
+            );
+
+            let guardianSignatureImagePath: string | undefined;
+            if (agreementData.isMinor && agreementData.guardianSignatureData) {
+              guardianSignatureImagePath = await uploadSignature(
+                tempId,
+                'guardian-signature.png',
+                agreementData.guardianSignatureData
+              );
+            }
+
+            // Create agreement request (already signed)
+            const signingToken = randomBytes(32).toString('hex');
+            const request = await AgreementRequestRepository.create({
+              templateId: template.id,
+              templateVersion: template.version,
+              signerEmail: data.customerEmail,
+              signerName: data.customerName,
+              signerPhone: data.customerPhone,
+              deliveryMethod: 'registration',
+              registrationId: registrationDocRef.id,
+              classId: data.classId,
+              signingToken,
+              expiresAt: new Date(), // Already signed, expiry irrelevant
+              status: 'pending', // Will be marked signed immediately
+            });
+
+            // Create signed agreement record
+            const agreementHtmlSnapshot = renderAgreementHtml(
+              template.name,
+              template.sections
+            );
+
+            const signedAgreement = await SignedAgreementRepository.create({
+              requestId: request.id,
+              templateId: template.id,
+              templateVersion: template.version,
+              agreementHtmlSnapshot,
+              signerEmail: data.customerEmail,
+              printedName: agreementData.printedName.trim(),
+              signatureImagePath,
+              mediaReleaseChoice: agreementData.mediaReleaseChoice as
+                | MediaReleaseChoice
+                | undefined,
+              isMinor: agreementData.isMinor ?? false,
+              minorName: agreementData.minorName,
+              guardianName: agreementData.guardianName,
+              guardianSignatureImagePath,
+              signedAt: new Date(),
+              ipAddress: 'inline-checkout',
+              userAgent: 'inline-checkout',
+            });
+
+            // Rename storage files to use the actual signed agreement ID
+            const bucket = getStorage().bucket();
+            const newSignaturePath = `agreements/${signedAgreement.id}/signature.png`;
+            await bucket.file(signatureImagePath).move(newSignaturePath);
+
+            if (guardianSignatureImagePath) {
+              const newGuardianPath = `agreements/${signedAgreement.id}/guardian-signature.png`;
+              await bucket
+                .file(guardianSignatureImagePath)
+                .move(newGuardianPath);
+            }
+
+            // Mark request as signed
+            await AgreementRequestRepository.markSigned(
+              request.id,
+              signedAgreement.id
+            );
+          }
+
+          agreementsSigned = true;
+        }
+      } catch (requiredAgreementError) {
+        // Log but don't fail — payment already processed
+        console.error(
+          'Failed to process required agreements after payment:',
+          requiredAgreementError
+        );
+      }
+
+      // 9. Auto-attach deferred agreement requests for this class category
       let waiverUrl: string | undefined;
       try {
         if (classEntity.categoryId) {
-          const templates =
+          const allTemplates =
             await AgreementTemplateRepository.findAutoAttachForCategory(
               classEntity.categoryId
             );
 
-          if (templates.length > 0) {
+          // Only create pending requests for deferred templates
+          const deferredTemplates = allTemplates.filter(
+            (t) => (t.signingRequirement ?? 'deferred') === 'deferred'
+          );
+
+          if (deferredTemplates.length > 0) {
             const appUrl = getAppUrl(strings.ALLOWED_ORIGINS);
 
-            for (const template of templates) {
+            for (const template of deferredTemplates) {
               const signingToken = randomBytes(32).toString('hex');
               const expiresAt = new Date();
               expiresAt.setDate(expiresAt.getDate() + 30);
@@ -301,14 +521,14 @@ export const createRegistration = Functions.endpoint
           }
         }
       } catch (agreementError) {
-        // Don't fail the registration if agreement creation fails
+        // Don't fail the registration if deferred agreement creation fails
         console.error(
-          'Failed to create agreement requests:',
+          'Failed to create deferred agreement requests:',
           agreementError
         );
       }
 
-      // 9. Write to mail collection for confirmation email
+      // 10. Write to mail collection for confirmation email
       try {
         const formatCurrency = (cents: number): string =>
           `$${(cents / 100).toFixed(2)}`;
@@ -345,6 +565,7 @@ export const createRegistration = Functions.endpoint
                 : squareReceiptUrl,
               materialsIncluded: classEntity.materialsIncluded,
               whatToBring: classEntity.whatToBring,
+              agreementsSigned: agreementsSigned || undefined,
               waiverUrl,
             },
           },
@@ -366,6 +587,8 @@ export const createRegistration = Functions.endpoint
       return {
         registration,
         confirmationNumber,
+        waiverUrl,
+        agreementsSigned: agreementsSigned || undefined,
       };
     }
   );

--- a/libs/firebase/maple-functions/get-required-agreements-for-class/project.json
+++ b/libs/firebase/maple-functions/get-required-agreements-for-class/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-get-required-agreements-for-class",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/get-required-agreements-for-class/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/get-required-agreements-for-class/src/index.ts
+++ b/libs/firebase/maple-functions/get-required-agreements-for-class/src/index.ts
@@ -1,0 +1,1 @@
+export { getRequiredAgreementsForClass } from './lib/get-required-agreements-for-class';

--- a/libs/firebase/maple-functions/get-required-agreements-for-class/src/lib/get-required-agreements-for-class.spec.ts
+++ b/libs/firebase/maple-functions/get-required-agreements-for-class/src/lib/get-required-agreements-for-class.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Tests for getRequiredAgreementsForClass
+ *
+ * Verifies the public function correctly returns required-at-checkout
+ * agreement templates for a given class's category.
+ */
+
+const mocks = vi.hoisted(() => ({
+  classFindById: vi.fn(),
+  findRequiredForCategory: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  ClassRepository: {
+    findById: mocks.classFindById,
+  },
+  AgreementTemplateRepository: {
+    findRequiredForCategory: mocks.findRequiredForCategory,
+  },
+}));
+
+// Mock firebase/functions to extract the handler
+vi.mock('@maple/firebase/functions', () => ({
+  createPublicFunction: (handler: (data: unknown) => unknown) => handler,
+}));
+
+import { getRequiredAgreementsForClass } from './get-required-agreements-for-class';
+
+// The export is the handler function itself (createPublicFunction mock returns it)
+const handler = getRequiredAgreementsForClass as unknown as (
+  data: { classId?: string }
+) => Promise<{ agreements: unknown[] }>;
+
+describe('getRequiredAgreementsForClass', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws if classId is not provided', async () => {
+    await expect(handler({})).rejects.toThrow('Class ID is required');
+  });
+
+  it('throws if class is not found', async () => {
+    mocks.classFindById.mockResolvedValue(undefined);
+    await expect(handler({ classId: 'nonexistent' })).rejects.toThrow(
+      'Class not found'
+    );
+  });
+
+  it('returns empty array if class has no categoryId', async () => {
+    mocks.classFindById.mockResolvedValue({ id: 'c1', name: 'Test Class' });
+
+    const result = await handler({ classId: 'c1' });
+
+    expect(result.agreements).toEqual([]);
+    expect(mocks.findRequiredForCategory).not.toHaveBeenCalled();
+  });
+
+  it('returns empty array if no required templates match', async () => {
+    mocks.classFindById.mockResolvedValue({
+      id: 'c1',
+      name: 'Test Class',
+      categoryId: 'cat1',
+    });
+    mocks.findRequiredForCategory.mockResolvedValue([]);
+
+    const result = await handler({ classId: 'c1' });
+
+    expect(result.agreements).toEqual([]);
+    expect(mocks.findRequiredForCategory).toHaveBeenCalledWith('cat1');
+  });
+
+  it('returns template summaries for required templates', async () => {
+    mocks.classFindById.mockResolvedValue({
+      id: 'c1',
+      name: 'Stained Glass',
+      categoryId: 'cat1',
+    });
+    mocks.findRequiredForCategory.mockResolvedValue([
+      {
+        id: 't1',
+        name: 'Safety Waiver',
+        sections: [{ id: 's1', title: 'Liability', content: '<p>Terms</p>' }],
+        supportsMinor: true,
+        // Extra fields should not leak through
+        version: 3,
+        status: 'active',
+        classCategoryIds: ['cat1'],
+      },
+    ]);
+
+    const result = await handler({ classId: 'c1' });
+
+    expect(result.agreements).toEqual([
+      {
+        templateId: 't1',
+        templateName: 'Safety Waiver',
+        sections: [{ id: 's1', title: 'Liability', content: '<p>Terms</p>' }],
+        supportsMinor: true,
+      },
+    ]);
+  });
+});

--- a/libs/firebase/maple-functions/get-required-agreements-for-class/src/lib/get-required-agreements-for-class.ts
+++ b/libs/firebase/maple-functions/get-required-agreements-for-class/src/lib/get-required-agreements-for-class.ts
@@ -1,0 +1,48 @@
+/**
+ * Get Required Agreements for Class Cloud Function
+ *
+ * Public endpoint (no auth required) — returns template content
+ * for required-at-checkout agreements matching a class's category.
+ * Used by the Webflow registration widget to show inline signing.
+ * Deployed to us-east4 via CI/CD pipeline.
+ */
+import { createPublicFunction } from '@maple/firebase/functions';
+import {
+  ClassRepository,
+  AgreementTemplateRepository,
+} from '@maple/firebase/database';
+import type {
+  GetRequiredAgreementsForClassRequest,
+  GetRequiredAgreementsForClassResponse,
+} from '@maple/ts/firebase/api-types';
+
+export const getRequiredAgreementsForClass = createPublicFunction<
+  GetRequiredAgreementsForClassRequest,
+  GetRequiredAgreementsForClassResponse
+>(async (data) => {
+  if (!data.classId) {
+    throw new Error('Class ID is required');
+  }
+
+  const classEntity = await ClassRepository.findById(data.classId);
+  if (!classEntity) {
+    throw new Error(`Class not found: ${data.classId}`);
+  }
+
+  if (!classEntity.categoryId) {
+    return { agreements: [] };
+  }
+
+  const templates = await AgreementTemplateRepository.findRequiredForCategory(
+    classEntity.categoryId
+  );
+
+  return {
+    agreements: templates.map((template) => ({
+      templateId: template.id,
+      templateName: template.name,
+      sections: template.sections,
+      supportsMinor: template.supportsMinor,
+    })),
+  };
+});

--- a/libs/react/agreements/src/lib/AgreementTemplateForm.tsx
+++ b/libs/react/agreements/src/lib/AgreementTemplateForm.tsx
@@ -21,6 +21,9 @@ import {
   Select,
   MenuItem,
   Chip,
+  Radio,
+  RadioGroup,
+  FormLabel,
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -30,6 +33,7 @@ import type {
   AgreementTemplate,
   AgreementSection,
   AgreementSectionResponseType,
+  SigningRequirement,
   ClassCategory,
 } from '@maple/ts/domain';
 import {
@@ -55,6 +59,7 @@ interface AgreementTemplateFormProps {
     sections: AgreementSection[];
     classCategoryIds: string[];
     autoAttach: boolean;
+    signingRequirement: SigningRequirement;
     supportsMinor: boolean;
   }) => Promise<void>;
   template?: AgreementTemplate;
@@ -81,6 +86,7 @@ export function AgreementTemplateForm({
   const name = useSignal('');
   const description = useSignal('');
   const autoAttach = useSignal(false);
+  const signingRequirement = useSignal<SigningRequirement>('deferred');
   const supportsMinor = useSignal(false);
   const classCategoryIds = useSignal<string[]>([]);
   const sections = useSignal<SectionFormData[]>([]);
@@ -110,6 +116,7 @@ export function AgreementTemplateForm({
         name.value = template.name;
         description.value = template.description ?? '';
         autoAttach.value = template.autoAttach;
+        signingRequirement.value = template.signingRequirement ?? 'deferred';
         supportsMinor.value = template.supportsMinor;
         classCategoryIds.value = [...template.classCategoryIds];
         sections.value = template.sections.map((s) => ({
@@ -126,6 +133,7 @@ export function AgreementTemplateForm({
         name.value = '';
         description.value = '';
         autoAttach.value = false;
+        signingRequirement.value = 'deferred';
         supportsMinor.value = false;
         classCategoryIds.value = [];
         sections.value = [];
@@ -189,6 +197,7 @@ export function AgreementTemplateForm({
         })),
         classCategoryIds: classCategoryIds.value,
         autoAttach: autoAttach.value,
+        signingRequirement: signingRequirement.value,
         supportsMinor: supportsMinor.value,
       });
     } catch (error: unknown) {
@@ -250,33 +259,56 @@ export function AgreementTemplateForm({
           </Box>
 
           {autoAttach.value && (
-            <FormControl fullWidth>
-              <InputLabel>Class Categories</InputLabel>
-              <Select
-                multiple
-                value={classCategoryIds.value}
-                label="Class Categories"
-                onChange={(e) => {
-                  classCategoryIds.value = e.target.value as string[];
-                }}
-                renderValue={(selected) => (
-                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-                    {selected.map((id) => {
-                      const cat = classCategories.find((c) => c.id === id);
-                      return (
-                        <Chip key={id} label={cat?.name ?? id} size="small" />
-                      );
-                    })}
-                  </Box>
-                )}
-              >
-                {classCategories.map((cat) => (
-                  <MenuItem key={cat.id} value={cat.id}>
-                    {cat.name}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
+            <>
+              <FormControl fullWidth>
+                <InputLabel>Class Categories</InputLabel>
+                <Select
+                  multiple
+                  value={classCategoryIds.value}
+                  label="Class Categories"
+                  onChange={(e) => {
+                    classCategoryIds.value = e.target.value as string[];
+                  }}
+                  renderValue={(selected) => (
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                      {selected.map((id) => {
+                        const cat = classCategories.find((c) => c.id === id);
+                        return (
+                          <Chip key={id} label={cat?.name ?? id} size="small" />
+                        );
+                      })}
+                    </Box>
+                  )}
+                >
+                  {classCategories.map((cat) => (
+                    <MenuItem key={cat.id} value={cat.id}>
+                      {cat.name}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+
+              <FormControl>
+                <FormLabel>Signing Requirement</FormLabel>
+                <RadioGroup
+                  value={signingRequirement.value}
+                  onChange={(e) => {
+                    signingRequirement.value = e.target.value as SigningRequirement;
+                  }}
+                >
+                  <FormControlLabel
+                    value="required"
+                    control={<Radio size="small" />}
+                    label="Required at checkout — must sign before payment"
+                  />
+                  <FormControlLabel
+                    value="deferred"
+                    control={<Radio size="small" />}
+                    label="Deferred — sign later via emailed link"
+                  />
+                </RadioGroup>
+              </FormControl>
+            </>
           )}
 
           <Divider />

--- a/libs/react/registrations/src/index.ts
+++ b/libs/react/registrations/src/index.ts
@@ -2,5 +2,6 @@ export { RegistrationList } from './lib/RegistrationList';
 export { RegistrationDetailDialog } from './lib/RegistrationDetailDialog';
 export { PublicClassCard } from './lib/PublicClassCard';
 export { RegistrationCheckoutForm } from './lib/RegistrationCheckoutForm';
+export type { RequiredAgreementTemplate } from './lib/RegistrationCheckoutForm';
 export { CostSummary } from './lib/CostSummary';
 export { SquareCardForm } from './lib/SquareCardForm';

--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.spec.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.spec.tsx
@@ -17,6 +17,12 @@ import type {
   CreateRegistrationResponse,
 } from '@maple/ts/firebase/api-types';
 
+// Mock @maple/react/agreements — SigningForm depends on signature_pad
+// which isn't available in jsdom.
+vi.mock('@maple/react/agreements', () => ({
+  SigningForm: () => <div data-testid="mock-signing-form">Mock Signing Form</div>,
+}));
+
 // Mock SquareCardForm — the real one loads Square's Web Payments SDK
 // from a CDN, which isn't available in jsdom. We emulate the minimum
 // surface the parent depends on: signalling ready, exposing a tokenize

--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
@@ -19,7 +19,7 @@ import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { SquareCardForm } from './SquareCardForm';
 import { CostSummary } from './CostSummary';
 import { SigningForm } from '@maple/react/agreements';
-import type { PublicClass, AgreementSection, MediaReleaseChoice } from '@maple/ts/domain';
+import type { PublicClass, AgreementSection } from '@maple/ts/domain';
 import type {
   CalculateRegistrationCostResponse,
   CreateRegistrationResponse,

--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
@@ -15,15 +15,26 @@ import {
   useSignals,
   batch,
 } from '@maple/react/signals';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { SquareCardForm } from './SquareCardForm';
 import { CostSummary } from './CostSummary';
-import type { PublicClass } from '@maple/ts/domain';
+import { SigningForm } from '@maple/react/agreements';
+import type { PublicClass, AgreementSection, MediaReleaseChoice } from '@maple/ts/domain';
 import type {
   CalculateRegistrationCostResponse,
   CreateRegistrationResponse,
+  InlineAgreementSigningData,
 } from '@maple/ts/firebase/api-types';
 import { registrationValidation } from '@maple/ts/validation';
 import { formatPhoneNumber } from './formatPhoneNumber';
+
+/** Template summary returned by getRequiredAgreementsForClass */
+export interface RequiredAgreementTemplate {
+  templateId: string;
+  templateName: string;
+  sections: AgreementSection[];
+  supportsMinor: boolean;
+}
 
 /**
  * Firebase callable errors have a `code` and `message` property.
@@ -70,6 +81,8 @@ interface RegistrationCheckoutFormProps {
   squareLocationId: string;
   /** Square environment — passed through to SquareCardForm */
   env?: string;
+  /** Required agreements that must be signed before checkout */
+  requiredAgreements?: RequiredAgreementTemplate[];
   onCalculateCost: (
     classId: string,
     quantity: number,
@@ -84,6 +97,7 @@ interface RegistrationCheckoutFormProps {
     discountCode?: string;
     notes?: string;
     paymentNonce: string;
+    agreements?: InlineAgreementSigningData[];
   }) => Promise<CreateRegistrationResponse>;
   onSuccess: (details: {
     confirmationNumber: string;
@@ -91,6 +105,7 @@ interface RegistrationCheckoutFormProps {
     customerEmail: string;
     pricePaidCents: number;
     quantity: number;
+    agreementsSigned?: boolean;
   }) => void;
 }
 
@@ -99,6 +114,7 @@ export function RegistrationCheckoutForm({
   squareApplicationId,
   squareLocationId,
   env,
+  requiredAgreements = [],
   onCalculateCost,
   onSubmit,
   onSuccess,
@@ -132,6 +148,20 @@ export function RegistrationCheckoutForm({
   // the ClassForm/ArtistForm pattern so users aren't yelled at mid-typing.
   const showValidationErrors = useSignal(false);
 
+  // Agreement signing state — tracks completed inline signatures
+  const signedAgreements = useSignal<Map<string, InlineAgreementSigningData>>(
+    new Map()
+  );
+  const currentAgreementIndex = useSignal(0);
+  const hasRequiredAgreements = requiredAgreements.length > 0;
+  const allAgreementsSigned = useComputed(
+    () =>
+      !hasRequiredAgreements ||
+      requiredAgreements.every((a) =>
+        signedAgreements.value.has(a.templateId)
+      )
+  );
+
   // Derived state — guaranteed in sync with its inputs.
   const isFull = useComputed(() => publicClass.spotsRemaining <= 0);
   const maxQuantity = useComputed(() =>
@@ -141,7 +171,11 @@ export function RegistrationCheckoutForm({
     () => (costBreakdown.value?.discountAmountCents ?? 0) > 0
   );
   const isButtonDisabled = useComputed(
-    () => isSubmitting.value || !isCardReady.value || isFull.value
+    () =>
+      isSubmitting.value ||
+      !isCardReady.value ||
+      isFull.value ||
+      !allAgreementsSigned.value
   );
 
   // ============================================================
@@ -252,6 +286,11 @@ export function RegistrationCheckoutForm({
 
       const nonce = await tokenizeRef.current();
 
+      // Collect signed agreement data if any
+      const agreementsData = hasRequiredAgreements
+        ? Array.from(signedAgreements.value.values())
+        : undefined;
+
       const result = await onSubmit({
         classId: publicClass.id,
         customerEmail: customerEmail.value.trim(),
@@ -261,6 +300,7 @@ export function RegistrationCheckoutForm({
         discountCode: discountCode.value.trim() || undefined,
         notes: notes.value.trim() || undefined,
         paymentNonce: nonce,
+        agreements: agreementsData,
       });
 
       onSuccess({
@@ -269,6 +309,7 @@ export function RegistrationCheckoutForm({
         customerEmail: customerEmail.value.trim(),
         pricePaidCents: result.registration.pricePaidCents,
         quantity: quantity.value,
+        agreementsSigned: result.agreementsSigned,
       });
     } catch (error) {
       submitError.value = extractErrorMessage(error);
@@ -424,6 +465,88 @@ export function RegistrationCheckoutForm({
           quantity={quantity.value}
           pricePerItemCents={publicClass.priceCents}
         />
+      )}
+
+      {/* Required Agreements Section */}
+      {hasRequiredAgreements && (
+        <Box>
+          <Typography variant="h6" gutterBottom>
+            {requiredAgreements.length === 1
+              ? 'Sign Waiver'
+              : `Sign Waivers (${signedAgreements.value.size}/${requiredAgreements.length})`}
+          </Typography>
+
+          {requiredAgreements.map((agreement, index) => {
+            const isSigned = signedAgreements.value.has(agreement.templateId);
+            const isActive = currentAgreementIndex.value === index;
+
+            if (isSigned) {
+              return (
+                <Alert
+                  key={agreement.templateId}
+                  severity="success"
+                  icon={<CheckCircleOutlineIcon />}
+                  sx={{ mb: 2 }}
+                >
+                  {agreement.templateName} — Signed
+                </Alert>
+              );
+            }
+
+            if (!isActive) {
+              return (
+                <Alert
+                  key={agreement.templateId}
+                  severity="info"
+                  sx={{ mb: 2 }}
+                >
+                  {agreement.templateName} — Pending
+                </Alert>
+              );
+            }
+
+            return (
+              <Box key={agreement.templateId} sx={{ mb: 2 }}>
+                <SigningForm
+                  templateName={agreement.templateName}
+                  sections={agreement.sections}
+                  supportsMinor={agreement.supportsMinor}
+                  signerName={customerName.value}
+                  signerEmail={customerEmail.value}
+                  className={publicClass.name}
+                  onSubmit={async (signingData) => {
+                    const newMap = new Map(signedAgreements.value);
+                    newMap.set(agreement.templateId, {
+                      templateId: agreement.templateId,
+                      signatureData: signingData.signatureData,
+                      printedName: signingData.printedName,
+                      mediaReleaseChoice: signingData.mediaReleaseChoice,
+                      isMinor: signingData.isMinor,
+                      minorName: signingData.minorName,
+                      guardianName: signingData.guardianName,
+                      guardianSignatureData: signingData.guardianSignatureData,
+                    });
+                    signedAgreements.value = newMap;
+
+                    // Advance to next unsigned agreement
+                    const nextIndex = requiredAgreements.findIndex(
+                      (a, i) => i > index && !newMap.has(a.templateId)
+                    );
+                    if (nextIndex !== -1) {
+                      currentAgreementIndex.value = nextIndex;
+                    }
+                  }}
+                />
+              </Box>
+            );
+          })}
+
+          {!allAgreementsSigned.value && !customerName.value.trim() && (
+            <Alert severity="info" sx={{ mb: 2 }}>
+              Please fill in your name and email above before signing.
+            </Alert>
+          )}
+        </Box>
       )}
 
       {/* Payment Section */}

--- a/libs/ts/domain/src/lib/agreement-template.ts
+++ b/libs/ts/domain/src/lib/agreement-template.ts
@@ -38,6 +38,13 @@ export interface AgreementSection {
 
 export type AgreementTemplateStatus = 'active' | 'archived';
 
+/**
+ * Controls when the agreement must be signed relative to checkout.
+ * - 'required': Must be signed before payment is processed (inline during checkout)
+ * - 'deferred': Signing link sent after payment via confirmation email
+ */
+export type SigningRequirement = 'required' | 'deferred';
+
 export const AGREEMENT_TEMPLATE_STATUSES: AgreementTemplateStatus[] = [
   'active',
   'archived',
@@ -58,6 +65,8 @@ export interface AgreementTemplate {
   classCategoryIds: string[];
   /** Whether to auto-create agreement requests on registration for matching categories */
   autoAttach: boolean;
+  /** When the agreement must be signed relative to checkout (default: deferred) */
+  signingRequirement: SigningRequirement;
   /** Whether this template includes minor/guardian co-signature fields */
   supportsMinor: boolean;
   /** Version number, incremented on each edit */
@@ -74,6 +83,7 @@ export type CreateAgreementTemplateInput = {
   sections: AgreementSection[];
   classCategoryIds: string[];
   autoAttach: boolean;
+  signingRequirement: SigningRequirement;
   supportsMinor: boolean;
 };
 
@@ -85,6 +95,7 @@ export type UpdateAgreementTemplateInput = {
   sections?: AgreementSection[];
   classCategoryIds?: string[];
   autoAttach?: boolean;
+  signingRequirement?: SigningRequirement;
   supportsMinor?: boolean;
   status?: AgreementTemplateStatus;
 };

--- a/libs/ts/firebase/api-types/src/lib/agreement.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/agreement.types.ts
@@ -11,6 +11,7 @@ import type {
   AgreementRequestStatus,
   AgreementDeliveryMethod,
   SignedAgreement,
+  SigningRequirement,
   MediaReleaseChoice,
   AgreementSection,
 } from '@maple/ts/domain';
@@ -41,6 +42,7 @@ export interface CreateAgreementTemplateRequest {
   sections: AgreementSection[];
   classCategoryIds: string[];
   autoAttach: boolean;
+  signingRequirement: SigningRequirement;
   supportsMinor: boolean;
 }
 
@@ -55,6 +57,7 @@ export interface UpdateAgreementTemplateRequest {
   sections?: AgreementSection[];
   classCategoryIds?: string[];
   autoAttach?: boolean;
+  signingRequirement?: SigningRequirement;
   supportsMinor?: boolean;
   status?: AgreementTemplateStatus;
 }
@@ -171,4 +174,39 @@ export interface SubmitSignedAgreementRequest {
 
 export interface SubmitSignedAgreementResponse {
   signedAgreement: SignedAgreement;
+}
+
+// ============================================================================
+// Required Agreements for Class (Public - for checkout form)
+// ============================================================================
+
+export interface GetRequiredAgreementsForClassRequest {
+  classId: string;
+}
+
+export interface GetRequiredAgreementsForClassResponse {
+  agreements: Array<{
+    templateId: string;
+    templateName: string;
+    sections: AgreementSection[];
+    supportsMinor: boolean;
+  }>;
+}
+
+// ============================================================================
+// Inline Agreement Signing Data (used in CreateRegistrationRequest)
+// ============================================================================
+
+/** Signature data submitted inline during checkout for required agreements */
+export interface InlineAgreementSigningData {
+  templateId: string;
+  /** Base64-encoded PNG of the signature canvas */
+  signatureData: string;
+  printedName: string;
+  mediaReleaseChoice?: MediaReleaseChoice;
+  isMinor: boolean;
+  minorName?: string;
+  guardianName?: string;
+  /** Base64-encoded PNG of guardian signature */
+  guardianSignatureData?: string;
 }

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -335,6 +335,9 @@ export type {
   GetAgreementForSigningResponse,
   SubmitSignedAgreementRequest,
   SubmitSignedAgreementResponse,
+  GetRequiredAgreementsForClassRequest,
+  GetRequiredAgreementsForClassResponse,
+  InlineAgreementSigningData,
 } from './agreement.types';
 
 // Etsy Import types (read-only pull from Etsy into our catalog)

--- a/libs/ts/firebase/api-types/src/lib/registration.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/registration.types.ts
@@ -9,6 +9,7 @@ import type {
   UpdateRegistrationInput,
   RegistrationStatus,
 } from '@maple/ts/domain';
+import type { InlineAgreementSigningData } from './agreement.types';
 
 // ============================================================================
 // Get Registrations (Admin)
@@ -106,9 +107,15 @@ export interface CreateRegistrationRequest {
   notes?: string;
   /** Nonce from Square Web Payments SDK (card tokenization) */
   paymentNonce: string;
+  /** Signed agreement data for required-at-checkout agreements */
+  agreements?: InlineAgreementSigningData[];
 }
 
 export interface CreateRegistrationResponse {
   registration: Registration;
   confirmationNumber: string;
+  /** Signing URL for deferred agreements (included in email too) */
+  waiverUrl?: string;
+  /** True if all agreements were signed at checkout */
+  agreementsSigned?: boolean;
 }

--- a/libs/ts/validation/src/lib/agreement-template.validation.ts
+++ b/libs/ts/validation/src/lib/agreement-template.validation.ts
@@ -19,6 +19,7 @@ export interface AgreementTemplateValidationInput {
   }>;
   classCategoryIds?: string[];
   autoAttach?: boolean;
+  signingRequirement?: string;
   supportsMinor?: boolean;
 }
 
@@ -80,5 +81,15 @@ export const agreementTemplateValidation = staticSuite(
         enforce(ids.length).equals(new Set(ids).size);
       }
     });
+
+    test(
+      'signingRequirement',
+      'Signing requirement must be required or deferred',
+      () => {
+        if (data.signingRequirement) {
+          enforce(data.signingRequirement).inside(['required', 'deferred']);
+        }
+      }
+    );
   }
 );

--- a/tools/seed-email-templates.ts
+++ b/tools/seed-email-templates.ts
@@ -124,6 +124,13 @@ const registrationConfirmationHtml = `<!DOCTYPE html>
     </div>
     {{/if}}
 
+    {{#if agreementsSigned}}
+    <div class="highlight-box">
+      <strong style="color: #4A3728;">Waiver Signed &#10003;</strong><br>
+      <p>Your class waiver has been signed and recorded. No further action is needed.</p>
+    </div>
+    {{/if}}
+
     {{#if waiverUrl}}
     <div class="highlight-box">
       <strong style="color: #4A3728;">Action Required: Sign Your Waiver</strong><br>

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -408,6 +408,9 @@
       "@maple/firebase/maple-functions/submit-signed-agreement": [
         "libs/firebase/maple-functions/submit-signed-agreement/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/get-required-agreements-for-class": [
+        "libs/firebase/maple-functions/get-required-agreements-for-class/src/index.ts"
+      ],
       "@maple/firebase/square-test-mock-server": [
         "libs/firebase/square-test-mock-server/src/index.ts"
       ],


### PR DESCRIPTION
## Summary

- Adds `2>/dev/null` to the `nx show projects --affected` command in the merge workflow to prevent stderr warnings from corrupting the JSON output
- This caused the `publish_webflow_components` job to be skipped on PR #343 merge despite webflow-components being in the affected graph

## Changes

One-line fix in `.github/workflows/firebase-functions-merge.yml` — redirect stderr when capturing Nx affected output.

## Test plan
- [x] Verified locally that `nx show projects --affected` with `2>/dev/null` correctly outputs clean JSON
- [x] Verified `jq` parsing succeeds on the clean output
- [ ] Next merge touching webflow-components should trigger the publish job

Fixes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)