### PR TITLE
fix: correct timezone conversion for calendar ICS event times

### DIFF
--- a/libs/ts/calendar/src/lib/generate-ics-feed.spec.ts
+++ b/libs/ts/calendar/src/lib/generate-ics-feed.spec.ts
@@ -150,4 +150,22 @@ describe('generateIcsFeed', () => {
     expect(ics).toContain('PRODID:');
     expect(ics).toContain('Maple & Spruce');
   });
+
+  it('converts UTC dates to Eastern time in DTSTART/DTEND', () => {
+    // 2030-06-14T23:00:00Z = 7:00 PM ET (EDT, UTC-4)
+    const event = makeEvent({
+      startDateTime: new Date('2030-06-14T23:00:00Z'),
+      endDateTime: new Date('2030-06-15T01:00:00Z'),
+    });
+
+    const ics = generateIcsFeed([event], 'Test');
+    const veventBlock = ics.split('BEGIN:VEVENT')[1]?.split('END:VEVENT')[0] ?? '';
+
+    // DTSTART should reflect 7:00 PM ET (190000), not 11:00 PM UTC (230000)
+    expect(veventBlock).toContain('T190000');
+    expect(veventBlock).not.toContain('T230000');
+
+    // DTEND should reflect 9:00 PM ET (210000), not 1:00 AM UTC (010000)
+    expect(veventBlock).toContain('T210000');
+  });
 });

--- a/libs/ts/calendar/src/lib/generate-ics-feed.ts
+++ b/libs/ts/calendar/src/lib/generate-ics-feed.ts
@@ -11,6 +11,18 @@ import type { CalendarEvent } from '@maple/ts/domain';
 const TIMEZONE = 'America/New_York';
 
 /**
+ * Convert a UTC Date to a Date whose local-time getters (getHours, etc.)
+ * return values in the target timezone.
+ *
+ * ical-generator extracts time components via local getters and labels them
+ * with TZID. Without this conversion, UTC values get mislabeled as Eastern,
+ * shifting events by 4-5 hours.
+ */
+function toTimezoneDate(utcDate: Date, timezone: string): Date {
+  return new Date(utcDate.toLocaleString('en-US', { timeZone: timezone }));
+}
+
+/**
  * Parse an RFC 5545 RRULE string into ical-generator repeating options.
  *
  * Supports common patterns:
@@ -62,8 +74,8 @@ export function generateIcsFeed(
 
     const icalEvent = calendar.createEvent({
       id: event.id,
-      start: startDate,
-      end: endDate,
+      start: toTimezoneDate(startDate, TIMEZONE),
+      end: toTimezoneDate(endDate, TIMEZONE),
       timezone: TIMEZONE,
       summary: event.title,
       description: event.description || undefined,


### PR DESCRIPTION
## Summary

- **Bug**: ICS calendar feed events were shifted 4-5 hours from their correct times. `ical-generator` extracts time components via local getters (`getHours()`, etc.) and labels them with `TZID=America/New_York`. Since Cloud Functions run in UTC, a class at 7:00 PM ET (stored as 23:00 UTC) was output as `DTSTART;TZID=America/New_York:...T230000` — interpreted as 11:00 PM ET.
- **Fix**: Added a `toTimezoneDate()` helper that converts UTC Date objects to "fake" Dates whose local-time getters return Eastern time values. Applied to `startDate` and `endDate` before passing to `createEvent()`.
- **Test**: Added a test verifying that UTC dates `23:00Z` and `01:00Z` produce `T190000` and `T210000` (7 PM and 9 PM ET) in the ICS output.

## Test plan

- [x] All 14 existing + new unit tests pass
- [ ] Verify ICS feed output in a calendar client after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)