### PR TITLE
feat: add signed agreement detail view in admin portal

### DIFF
--- a/apps/maple-spruce/src/app/agreements/page.tsx
+++ b/apps/maple-spruce/src/app/agreements/page.tsx
@@ -13,6 +13,7 @@ import SendIcon from '@mui/icons-material/Send';
 import type {
   AgreementTemplate,
   AgreementSection,
+  AgreementRequest,
   CreateAgreementTemplateInput,
 } from '@maple/ts/domain';
 import { DeleteConfirmDialog } from '@maple/react/ui';
@@ -21,12 +22,14 @@ import {
   AgreementTemplateForm,
   AgreementRequestList,
   SendAgreementDialog,
+  SignedAgreementDetailDialog,
 } from '@maple/react/agreements';
 import { AppShell } from '../../components/layout';
 import {
   useAgreementTemplates,
   useAgreementRequests,
   useClassCategories,
+  useSignedAgreement,
 } from '../../hooks';
 
 export default function AgreementsPage() {
@@ -47,6 +50,12 @@ export default function AgreementsPage() {
 
   const { categoriesState: classCategoriesState } = useClassCategories();
 
+  const {
+    detailState: signedAgreementState,
+    fetchSignedAgreement,
+    clearDetail: clearSignedAgreement,
+  } = useSignedAgreement();
+
   // Template form dialog state
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [editingTemplate, setEditingTemplate] = useState<
@@ -65,6 +74,10 @@ export default function AgreementsPage() {
 
   // Resend state
   const [isResending, setIsResending] = useState(false);
+
+  // Signed agreement detail state
+  const [viewingSignerName, setViewingSignerName] = useState<string>();
+  const [isDetailOpen, setIsDetailOpen] = useState(false);
 
   const handleOpenForm = useCallback((template?: AgreementTemplate) => {
     setEditingTemplate(template);
@@ -136,6 +149,22 @@ export default function AgreementsPage() {
     },
     [resendRequest]
   );
+
+  const handleViewSigned = useCallback(
+    (request: AgreementRequest) => {
+      if (!request.signedAgreementId) return;
+      setViewingSignerName(request.signerName);
+      setIsDetailOpen(true);
+      fetchSignedAgreement(request.signedAgreementId);
+    },
+    [fetchSignedAgreement]
+  );
+
+  const handleCloseDetail = useCallback(() => {
+    setIsDetailOpen(false);
+    setViewingSignerName(undefined);
+    clearSignedAgreement();
+  }, [clearSignedAgreement]);
 
   const handleConfirmDelete = useCallback(async () => {
     if (!templateToDelete) return;
@@ -211,6 +240,7 @@ export default function AgreementsPage() {
         <AgreementRequestList
           requestsState={requestsState}
           onResend={handleResend}
+          onViewSigned={handleViewSigned}
           isResending={isResending}
         />
       )}
@@ -230,6 +260,13 @@ export default function AgreementsPage() {
         onSend={handleSendWaiver}
         templates={templates}
         isSending={isSending}
+      />
+
+      <SignedAgreementDetailDialog
+        open={isDetailOpen}
+        onClose={handleCloseDetail}
+        detailState={signedAgreementState}
+        signerName={viewingSignerName}
       />
 
       <DeleteConfirmDialog

--- a/apps/maple-spruce/src/hooks/index.ts
+++ b/apps/maple-spruce/src/hooks/index.ts
@@ -16,5 +16,6 @@ export {
   useArtistPayouts,
   useAgreementTemplates,
   useAgreementRequests,
+  useSignedAgreement,
 } from '@maple/react/data';
 export { useAuth } from '@maple/react/auth';

--- a/libs/react/agreements/src/index.ts
+++ b/libs/react/agreements/src/index.ts
@@ -4,3 +4,4 @@ export { AgreementTemplateList } from './lib/AgreementTemplateList';
 export { AgreementTemplateForm } from './lib/AgreementTemplateForm';
 export { AgreementRequestList } from './lib/AgreementRequestList';
 export { SendAgreementDialog } from './lib/SendAgreementDialog';
+export { SignedAgreementDetailDialog } from './lib/SignedAgreementDetailDialog';

--- a/libs/react/agreements/src/lib/AgreementRequestList.tsx
+++ b/libs/react/agreements/src/lib/AgreementRequestList.tsx
@@ -17,6 +17,7 @@ import {
   Tooltip,
 } from '@mui/material';
 import RefreshIcon from '@mui/icons-material/Refresh';
+import VisibilityIcon from '@mui/icons-material/Visibility';
 import type { AgreementRequest, RequestState } from '@maple/ts/domain';
 
 function formatDate(date: Date): string {
@@ -40,12 +41,14 @@ const statusColors: Record<
 interface AgreementRequestListProps {
   requestsState: RequestState<AgreementRequest[]>;
   onResend: (id: string) => void;
+  onViewSigned: (request: AgreementRequest) => void;
   isResending?: boolean;
 }
 
 export function AgreementRequestList({
   requestsState,
   onResend,
+  onViewSigned,
   isResending,
 }: AgreementRequestListProps) {
   if (
@@ -124,6 +127,16 @@ export function AgreementRequestList({
               <TableCell>{formatDate(request.createdAt)}</TableCell>
               <TableCell>{formatDate(request.expiresAt)}</TableCell>
               <TableCell align="right">
+                {request.status === 'signed' && request.signedAgreementId && (
+                  <Tooltip title="View signed agreement">
+                    <IconButton
+                      size="small"
+                      onClick={() => onViewSigned(request)}
+                    >
+                      <VisibilityIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                )}
                 {request.status === 'pending' && (
                   <Tooltip title="Resend signing email">
                     <IconButton

--- a/libs/react/agreements/src/lib/SignedAgreementDetailDialog.tsx
+++ b/libs/react/agreements/src/lib/SignedAgreementDetailDialog.tsx
@@ -1,0 +1,271 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Typography,
+  Chip,
+  Divider,
+  Alert,
+  Skeleton,
+  Tabs,
+  Tab,
+} from '@mui/material';
+import type { RequestState } from '@maple/ts/domain';
+import type { SignedAgreementDetail } from '@maple/react/data';
+
+function formatDate(date: Date | string): string {
+  return new Date(date).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function formatMediaRelease(choice: string): { label: string; color: 'success' | 'warning' | 'error' } {
+  switch (choice) {
+    case 'grant':
+      return { label: 'Granted', color: 'success' };
+    case 'grant-without-name':
+      return { label: 'Granted (no name)', color: 'warning' };
+    case 'deny':
+      return { label: 'Denied', color: 'error' };
+    default:
+      return { label: choice, color: 'warning' };
+  }
+}
+
+interface SignedAgreementDetailDialogProps {
+  open: boolean;
+  onClose: () => void;
+  detailState: RequestState<SignedAgreementDetail>;
+  signerName?: string;
+}
+
+export function SignedAgreementDetailDialog({
+  open,
+  onClose,
+  detailState,
+  signerName,
+}: SignedAgreementDetailDialogProps) {
+  const [tab, setTab] = useState(0);
+
+  const handleClose = () => {
+    setTab(0);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        Signed Agreement{signerName ? ` — ${signerName}` : ''}
+      </DialogTitle>
+      <DialogContent>
+        {detailState.status === 'loading' || detailState.status === 'idle' ? (
+          <Box sx={{ mt: 1 }}>
+            {[1, 2, 3, 4].map((i) => (
+              <Skeleton key={i} height={40} sx={{ mb: 1 }} />
+            ))}
+          </Box>
+        ) : detailState.status === 'error' ? (
+          <Alert severity="error" sx={{ mt: 1 }}>
+            {detailState.error}
+          </Alert>
+        ) : (
+          <SignedAgreementContent
+            detail={detailState.data}
+            tab={tab}
+            onTabChange={setTab}
+          />
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+function SignedAgreementContent({
+  detail,
+  tab,
+  onTabChange,
+}: {
+  detail: SignedAgreementDetail;
+  tab: number;
+  onTabChange: (tab: number) => void;
+}) {
+  const { agreement, signatureImageUrl, guardianSignatureImageUrl } = detail;
+  const mediaRelease = agreement.mediaReleaseChoice
+    ? formatMediaRelease(agreement.mediaReleaseChoice)
+    : null;
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+      <Tabs value={tab} onChange={(_e, v) => onTabChange(v)}>
+        <Tab label="Details" />
+        <Tab label="Agreement" />
+      </Tabs>
+
+      {tab === 0 && (
+        <>
+          {/* Signer Info */}
+          <Typography variant="subtitle2" color="text.secondary">
+            Signer
+          </Typography>
+          <Box sx={{ pl: 1 }}>
+            <Typography variant="body1" fontWeight={500}>
+              {agreement.printedName}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {agreement.signerEmail}
+            </Typography>
+          </Box>
+
+          <Divider />
+
+          {/* Signed Date */}
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+            }}
+          >
+            <Typography variant="subtitle2" color="text.secondary">
+              Signed
+            </Typography>
+            <Typography variant="body2">
+              {formatDate(agreement.signedAt)}
+            </Typography>
+          </Box>
+
+          <Divider />
+
+          {/* Media Release */}
+          {mediaRelease && (
+            <>
+              <Box
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                }}
+              >
+                <Typography variant="subtitle2" color="text.secondary">
+                  Photo / Media Release
+                </Typography>
+                <Chip
+                  label={mediaRelease.label}
+                  size="small"
+                  color={mediaRelease.color}
+                />
+              </Box>
+              <Divider />
+            </>
+          )}
+
+          {/* Minor Info */}
+          {agreement.isMinor && (
+            <>
+              <Typography variant="subtitle2" color="text.secondary">
+                Minor
+              </Typography>
+              <Box sx={{ pl: 1 }}>
+                <Typography variant="body2">
+                  Minor: {agreement.minorName}
+                </Typography>
+                <Typography variant="body2">
+                  Guardian: {agreement.guardianName}
+                </Typography>
+              </Box>
+              <Divider />
+            </>
+          )}
+
+          {/* Signature */}
+          <Typography variant="subtitle2" color="text.secondary">
+            Signature
+          </Typography>
+          <Box
+            sx={{
+              pl: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 2,
+            }}
+          >
+            <Box
+              component="img"
+              src={signatureImageUrl}
+              alt={`Signature of ${agreement.printedName}`}
+              sx={{
+                maxWidth: '100%',
+                maxHeight: 120,
+                objectFit: 'contain',
+                border: 1,
+                borderColor: 'divider',
+                borderRadius: 1,
+                p: 1,
+                backgroundColor: 'grey.50',
+              }}
+            />
+            {guardianSignatureImageUrl && (
+              <>
+                <Typography variant="caption" color="text.secondary">
+                  Guardian Signature
+                </Typography>
+                <Box
+                  component="img"
+                  src={guardianSignatureImageUrl}
+                  alt={`Guardian signature of ${agreement.guardianName}`}
+                  sx={{
+                    maxWidth: '100%',
+                    maxHeight: 120,
+                    objectFit: 'contain',
+                    border: 1,
+                    borderColor: 'divider',
+                    borderRadius: 1,
+                    p: 1,
+                    backgroundColor: 'grey.50',
+                  }}
+                />
+              </>
+            )}
+          </Box>
+        </>
+      )}
+
+      {tab === 1 && (
+        <Box
+          sx={{
+            border: 1,
+            borderColor: 'divider',
+            borderRadius: 1,
+            p: 2,
+            maxHeight: 400,
+            overflow: 'auto',
+            '& h1, & h2, & h3': {
+              fontSize: '1rem',
+              fontWeight: 600,
+              mt: 2,
+              mb: 1,
+            },
+            '& p': { mb: 1 },
+            '& ul, & ol': { pl: 3, mb: 1 },
+          }}
+          dangerouslySetInnerHTML={{
+            __html: agreement.agreementHtmlSnapshot,
+          }}
+        />
+      )}
+    </Box>
+  );
+}

--- a/libs/react/data/src/index.ts
+++ b/libs/react/data/src/index.ts
@@ -48,6 +48,10 @@ export {
   useAgreementRequests,
   type UseAgreementRequestsFilters,
 } from './lib/useAgreementRequests';
+export {
+  useSignedAgreement,
+  type SignedAgreementDetail,
+} from './lib/useSignedAgreement';
 
 // Feature Flags
 export { useFeatureFlags } from './lib/useFeatureFlags';

--- a/libs/react/data/src/lib/useSignedAgreement.ts
+++ b/libs/react/data/src/lib/useSignedAgreement.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { httpsCallable } from 'firebase/functions';
+import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
+import type { SignedAgreement, RequestState } from '@maple/ts/domain';
+import type {
+  GetSignedAgreementRequest,
+  GetSignedAgreementResponse,
+} from '@maple/ts/firebase/api-types';
+
+export interface SignedAgreementDetail {
+  agreement: SignedAgreement;
+  signatureImageUrl: string;
+  guardianSignatureImageUrl?: string;
+}
+
+export function useSignedAgreement() {
+  const [detailState, setDetailState] = useState<
+    RequestState<SignedAgreementDetail>
+  >({ status: 'idle' });
+
+  const fetchSignedAgreement = useCallback(async (id: string) => {
+    setDetailState({ status: 'loading' });
+    try {
+      const functions = getMapleFunctions();
+      const getAgreement = httpsCallable<
+        GetSignedAgreementRequest,
+        GetSignedAgreementResponse
+      >(functions, 'getSignedAgreement');
+      const result = await getAgreement({ id });
+      setDetailState({ status: 'success', data: result.data });
+    } catch (error) {
+      console.error('Failed to fetch signed agreement:', error);
+      setDetailState({
+        status: 'error',
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to fetch signed agreement',
+      });
+    }
+  }, []);
+
+  const clearDetail = useCallback(() => {
+    setDetailState({ status: 'idle' });
+  }, []);
+
+  return {
+    detailState,
+    fetchSignedAgreement,
+    clearDetail,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a detail dialog for viewing signed agreements from the Requests tab
- Admins can click the eye icon on signed requests to see: signer info, media release choice (granted/denied/no-name), signature images, signed date, and the full agreement HTML snapshot
- New `useSignedAgreement` data hook calls the existing `getSignedAgreement` cloud function

## Changes
- **New:** `SignedAgreementDetailDialog` component with Details + Agreement tabs
- **New:** `useSignedAgreement` hook for fetching signed agreement detail + signature URLs
- **Updated:** `AgreementRequestList` — added view icon button for signed requests
- **Updated:** Agreements page — wired up detail dialog state and callbacks

## Testing
- [ ] Send a test agreement, sign it, then click the eye icon on the signed request
- [ ] Verify signer name, email, signed date display correctly
- [ ] Verify media release choice shows with correct color chip
- [ ] Verify signature image loads in the detail dialog
- [ ] Switch to "Agreement" tab and verify HTML snapshot renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)