### PR TITLE
fix: update Firestore record with final signature storage paths

### DIFF
--- a/libs/firebase/database/src/lib/signed-agreement.repository.ts
+++ b/libs/firebase/database/src/lib/signed-agreement.repository.ts
@@ -82,6 +82,22 @@ export const SignedAgreementRepository = {
     return docToSignedAgreement(doc);
   },
 
+  async updateStoragePaths(
+    id: string,
+    paths: {
+      signatureImagePath: string;
+      guardianSignatureImagePath?: string;
+    }
+  ): Promise<void> {
+    const update: Record<string, string> = {
+      signatureImagePath: paths.signatureImagePath,
+    };
+    if (paths.guardianSignatureImagePath) {
+      update.guardianSignatureImagePath = paths.guardianSignatureImagePath;
+    }
+    await db.collection(COLLECTION).doc(id).update(update);
+  },
+
   async create(
     input: CreateSignedAgreementInput
   ): Promise<SignedAgreement> {

--- a/libs/firebase/maple-functions/submit-signed-agreement/src/lib/submit-signed-agreement.ts
+++ b/libs/firebase/maple-functions/submit-signed-agreement/src/lib/submit-signed-agreement.ts
@@ -166,6 +166,12 @@ export const submitSignedAgreement = Functions.endpoint
         await bucket.file(guardianSignatureImagePath).move(newGuardianPath);
       }
 
+      // Update Firestore record with final storage paths
+      await SignedAgreementRepository.updateStoragePaths(signedAgreement.id, {
+        signatureImagePath: newSignaturePath,
+        guardianSignatureImagePath: newGuardianPath,
+      });
+
       // Mark request as signed
       await AgreementRequestRepository.markSigned(
         request.id,


### PR DESCRIPTION
## Summary
- After moving signature images from temp path to final path (`agreements/{id}/signature.png`), the Firestore record was not being updated with the new path
- This caused `getSignedAgreement` to generate signed URLs pointing to the old temp path, resulting in 404s when loading signature images in the admin detail view

## Changes
- Added `updateStoragePaths` method to `SignedAgreementRepository`
- Call it in `submitSignedAgreement` after moving files to their final locations

## Testing
- [ ] Send and sign a new test agreement
- [ ] View the signed agreement detail — signature image should load
- [ ] Test with a minor agreement to verify guardian signature path also updates

**Note:** Existing signed agreements in prod have stale paths. You'll need to re-sign a test agreement after this deploys to verify the fix. The existing test agreement can be manually fixed in Firestore by updating `signatureImagePath` to the correct path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)