### PR TITLE
feat: wire Apple Pay checkout URL to Webflow component

### DIFF
--- a/apps/webflow-components/src/RegistrationWidget.tsx
+++ b/apps/webflow-components/src/RegistrationWidget.tsx
@@ -139,6 +139,7 @@ interface RegistrationWidgetProps {
   squareAppId: string;
   squareLocationId: string;
   env: string;
+  applePayCheckoutUrl?: string;
 }
 
 type WidgetState =
@@ -166,6 +167,7 @@ export function RegistrationWidget({
   squareAppId,
   squareLocationId,
   env,
+  applePayCheckoutUrl,
 }: RegistrationWidgetProps) {
   const [state, setState] = useState<WidgetState>({ status: 'loading' });
 
@@ -367,6 +369,7 @@ export function RegistrationWidget({
                   squareApplicationId={squareAppId}
                   squareLocationId={squareLocationId}
                   env={env}
+                  applePayCheckoutUrl={applePayCheckoutUrl}
                   requiredAgreements={state.requiredAgreements}
                   onCalculateCost={handleCalculateCost}
                   onSubmit={handleSubmit}

--- a/apps/webflow-components/src/registration.webflow.tsx
+++ b/apps/webflow-components/src/registration.webflow.tsx
@@ -32,5 +32,9 @@ export default declareComponent(RegistrationWidget, {
       options: ['dev', 'prod'],
       defaultValue: 'prod',
     }),
+    applePayCheckoutUrl: props.Text({
+      name: 'Apple Pay Checkout URL',
+      defaultValue: 'https://business.mapleandsprucefolkarts.com/apple-pay-checkout',
+    }),
   },
 });


### PR DESCRIPTION
## Summary
- Adds `applePayCheckoutUrl` prop to `RegistrationWidget` and passes it through to `RegistrationCheckoutForm`
- Exposes it in the Webflow Designer as "Apple Pay Checkout URL" with default `https://business.mapleandsprucefolkarts.com/apple-pay-checkout`
- This was missing from #338 — the Apple Pay popup page existed but was never wired to the Webflow component

## After merge
- Republish Webflow component: `npx webflow library share --manifest apps/webflow-components/webflow.json --skip-update-check`
- Test Apple Pay in Safari on the registration page

## Test plan
- [ ] Verify Apple Pay button appears in Safari/iOS on the registration page
- [ ] Verify Apple Pay popup opens and returns token
- [ ] Verify Google Pay and card payment still work
- [ ] Verify the prop is configurable in Webflow Designer

🤖 Generated with [Claude Code](https://claude.com/claude-code)