### PR TITLE
fix: digital wallets toggle and wallet payment validation

### DIFF
--- a/apps/maple-spruce/src/config/public-routes.ts
+++ b/apps/maple-spruce/src/config/public-routes.ts
@@ -2,4 +2,4 @@
  * Routes that don't require authentication.
  * Supports route params like /public/:id
  */
-export const publicRoutes = ['/login', '/register', '/register/:classId', '/register/:classId/confirm', '/sign/:token'];
+export const publicRoutes = ['/login', '/register', '/register/:classId', '/register/:classId/confirm', '/sign/:token', '/apple-pay-checkout'];

--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
@@ -336,9 +336,17 @@ export function RegistrationCheckoutForm({
 
   const handleDigitalWalletToken = useCallback(
     (token: string) => {
+      // Validate before submitting — if invalid, show errors and surface
+      // a message so the user knows why nothing happened after wallet auth.
+      showValidationErrors.value = true;
+      if (!isValid.value || !allAgreementsSigned.value) {
+        submitError.value =
+          'Please complete all required fields and agreements before paying.';
+        return;
+      }
       submitWithNonce(token);
     },
-    [submitWithNonce]
+    [submitWithNonce, showValidationErrors, isValid, allAgreementsSigned, submitError]
   );
 
 
@@ -383,6 +391,11 @@ export function RegistrationCheckoutForm({
   const handleApplePayClick = useCallback((): void => {
     if (!applePayCheckoutUrl || !costBreakdown.value) return;
 
+    // Validate customer info before opening popup
+    showValidationErrors.value = true;
+    if (!isValid.value) return;
+    if (!allAgreementsSigned.value) return;
+
     const totalCents = costBreakdown.value.totalCents;
     const params = new URLSearchParams({
       amount: String(totalCents),
@@ -409,6 +422,9 @@ export function RegistrationCheckoutForm({
     squareApplicationId,
     squareLocationId,
     publicClass.name,
+    showValidationErrors,
+    isValid,
+    allAgreementsSigned,
   ]);
 
   // Listen for Apple Pay token messages from the popup window

--- a/libs/react/registrations/src/lib/SquareCardForm.tsx
+++ b/libs/react/registrations/src/lib/SquareCardForm.tsx
@@ -218,13 +218,6 @@ export function SquareCardForm({
     document.head.appendChild(script);
   }, [applicationId, locationId, env]);
 
-  // Initialize payments once SDK is ready AND we have a valid amount
-  useEffect(() => {
-    if (!sdkReady || initializedRef.current || !totalCents) return;
-    initializedRef.current = true;
-    initializePayments();
-  }, [sdkReady, totalCents, initializePayments]);
-
   const initializePayments = useCallback(async () => {
     try {
       if (!window.Square) {
@@ -393,6 +386,13 @@ export function SquareCardForm({
       setIsLoading(false);
     }
   }, [applicationId, locationId, totalCents, showDigitalWallets, onReady, onTokenizeRef]);
+
+  // Initialize payments once SDK is ready AND we have a valid amount
+  useEffect(() => {
+    if (!sdkReady || initializedRef.current || !totalCents) return;
+    initializedRef.current = true;
+    initializePayments();
+  }, [sdkReady, totalCents, initializePayments]);
 
   const showDivider = (hasApplePay || hasGooglePay) && !isLoading;
 

--- a/libs/react/registrations/src/lib/SquareCardForm.tsx
+++ b/libs/react/registrations/src/lib/SquareCardForm.tsx
@@ -218,6 +218,13 @@ export function SquareCardForm({
     document.head.appendChild(script);
   }, [applicationId, locationId, env]);
 
+  // Initialize payments once SDK is ready AND we have a valid amount
+  useEffect(() => {
+    if (!sdkReady || initializedRef.current || !totalCents) return;
+    initializedRef.current = true;
+    initializePayments();
+  }, [sdkReady, totalCents, initializePayments]);
+
   const initializePayments = useCallback(async () => {
     try {
       if (!window.Square) {
@@ -386,13 +393,6 @@ export function SquareCardForm({
       setIsLoading(false);
     }
   }, [applicationId, locationId, totalCents, showDigitalWallets, onReady, onTokenizeRef]);
-
-  // Initialize payments once SDK is ready AND we have a valid amount
-  useEffect(() => {
-    if (!sdkReady || initializedRef.current || !totalCents) return;
-    initializedRef.current = true;
-    initializePayments();
-  }, [sdkReady, totalCents, initializePayments]);
 
   const showDivider = (hasApplePay || hasGooglePay) && !isLoading;
 


### PR DESCRIPTION
## Summary
- Adds `showDigitalWallets` prop to `SquareCardForm` and `RegistrationCheckoutForm` — when `false` (default), Apple Pay/Google Pay SDK initialization is skipped entirely, so only the card form renders
- Validates customer info (name, email, agreements) before opening the Apple Pay popup — prevents the user from authenticating then silently failing
- Validates before Google Pay submission — shows an error banner if form is incomplete after wallet auth

Companion to #353 which added the Webflow Designer toggle (defaulted to "hide") and the Apple Pay hydration fix.

## Test plan
- [ ] Deploy Webflow component with Digital Wallets set to "hide" — verify only card form shows
- [ ] Flip to "show" — verify Apple Pay and Google Pay buttons appear
- [ ] With wallets shown, leave name/email empty and click Apple Pay — verify popup doesn't open and field errors appear
- [ ] With wallets shown, complete Google Pay auth with empty fields — verify error banner appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)