### PR TITLE
perf: cache calendarEmbed redirect for 5 minutes (#355)

### DIFF
--- a/libs/firebase/maple-functions/calendar-embed/src/lib/calendar-embed.spec.ts
+++ b/libs/firebase/maple-functions/calendar-embed/src/lib/calendar-embed.spec.ts
@@ -19,15 +19,18 @@ import {
 
 function makeResponse(): {
   res: CalendarEmbedResponse;
+  set: ReturnType<typeof vi.fn>;
   redirect: ReturnType<typeof vi.fn>;
   status: ReturnType<typeof vi.fn>;
   json: ReturnType<typeof vi.fn>;
 } {
+  const set = vi.fn();
   const redirect = vi.fn();
   const json = vi.fn();
   const status = vi.fn().mockReturnValue({ json });
   return {
-    res: { redirect, status } as CalendarEmbedResponse,
+    res: { set, redirect, status } as CalendarEmbedResponse,
+    set,
     redirect,
     status,
     json,
@@ -235,6 +238,21 @@ describe('handleCalendarEmbedRequest', () => {
     expect(params.has('timezone')).toBe(false);
     expect(params.has('title')).toBe(false);
     expect(params.has('css_url')).toBe(false);
+  });
+
+  it('sets Cache-Control headers on the redirect response', async () => {
+    mocks.get.mockResolvedValue(baseConfig);
+    const { res, set } = makeResponse();
+
+    await handleCalendarEmbedRequest(
+      { hostname: 'maple-and-spruce-api.web.app', protocol: 'https' },
+      res
+    );
+
+    expect(set).toHaveBeenCalledWith(
+      'Cache-Control',
+      'public, max-age=300, s-maxage=300, stale-while-revalidate=600'
+    );
   });
 
   it('returns 500 JSON when the repository throws', async () => {

--- a/libs/firebase/maple-functions/calendar-embed/src/lib/calendar-embed.ts
+++ b/libs/firebase/maple-functions/calendar-embed/src/lib/calendar-embed.ts
@@ -59,6 +59,7 @@ export interface CalendarEmbedRequest {
 }
 
 export interface CalendarEmbedResponse {
+  set(header: string, value: string): void;
   redirect(status: number, url: string): void;
   status(code: number): { json(body: unknown): void };
 }
@@ -100,6 +101,13 @@ export async function handleCalendarEmbedRequest(
     }
 
     const owcUrl = `${config.owcBaseUrl}/calendar.html?${params.toString()}`;
+
+    // Cache the redirect for 5 minutes so repeat visits skip this
+    // Cloud Function entirely and go straight to the OWC URL.
+    response.set(
+      'Cache-Control',
+      'public, max-age=300, s-maxage=300, stale-while-revalidate=600'
+    );
     response.redirect(302, owcUrl);
   } catch (error) {
     console.error('Error generating calendar embed redirect:', error);


### PR DESCRIPTION
## Summary
- Add `Cache-Control: public, max-age=300, s-maxage=300, stale-while-revalidate=600` to the `calendarEmbed` 302 redirect response
- Add `set()` to the `CalendarEmbedResponse` interface and update test helper
- Add test verifying cache headers are set on redirect

## Why
The calendar page iframe loads via `calendarEmbed` → 302 redirect → Open Web Calendar. Without cache headers on the redirect, every page visit cold-starts the Cloud Function and reads Firestore before even reaching the OWC instance. This adds unnecessary latency to an already slow loading chain (~22s total).

Companion PR: david-shortman/open-web-calendar#2 (edge caching on the OWC side)

## Testing
- [x] Unit tests pass (13/13)
- [ ] Verify redirect response includes `Cache-Control` header in emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)