### PR TITLE
feat: class & category image gallery data + admin UI

### DIFF
--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -99,6 +99,7 @@ export { createClass } from '@maple/firebase/maple-functions/create-class';
 export { updateClass } from '@maple/firebase/maple-functions/update-class';
 export { deleteClass } from '@maple/firebase/maple-functions/delete-class';
 export { uploadClassImage } from '@maple/firebase/maple-functions/upload-class-image';
+export { uploadClassGalleryImage } from '@maple/firebase/maple-functions/upload-class-gallery-image';
 export { migrateClassSessions } from '@maple/firebase/maple-functions/migrate-class-sessions';
 
 // Public class API (no auth required - for Webflow integration)
@@ -111,6 +112,7 @@ export { createClassCategory } from '@maple/firebase/maple-functions/create-clas
 export { updateClassCategory } from '@maple/firebase/maple-functions/update-class-category';
 export { deleteClassCategory } from '@maple/firebase/maple-functions/delete-class-category';
 export { reorderClassCategories } from '@maple/firebase/maple-functions/reorder-class-categories';
+export { uploadCategoryGalleryImage } from '@maple/firebase/maple-functions/upload-category-gallery-image';
 
 // Discount functions
 export { getDiscounts } from '@maple/firebase/maple-functions/get-discounts';

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -36,6 +36,8 @@
     "../../libs/firebase/maple-functions/update-class/**/*.ts",
     "../../libs/firebase/maple-functions/delete-class/**/*.ts",
     "../../libs/firebase/maple-functions/upload-class-image/**/*.ts",
+    "../../libs/firebase/maple-functions/upload-class-gallery-image/**/*.ts",
+    "../../libs/firebase/maple-functions/upload-category-gallery-image/**/*.ts",
     "../../libs/firebase/maple-functions/get-public-classes/**/*.ts",
     "../../libs/firebase/maple-functions/get-public-class/**/*.ts",
     "../../libs/firebase/maple-functions/get-class-categories/**/*.ts",

--- a/apps/maple-spruce/.storybook/fixtures/classes.ts
+++ b/apps/maple-spruce/.storybook/fixtures/classes.ts
@@ -1,4 +1,4 @@
-import type { Class, ClassCategory } from '@maple/ts/domain';
+import type { Class, ClassCategory, GalleryImage } from '@maple/ts/domain';
 
 /**
  * Mock class data for Storybook stories
@@ -219,6 +219,60 @@ export const mockClassCategory3: ClassCategory = {
 
 export const mockClassCategories: ClassCategory[] = [
   mockClassCategory,
+  mockClassCategory2,
+  mockClassCategory3,
+];
+
+/**
+ * Reusable gallery image fixtures (3 images).
+ */
+export const mockGalleryImages: GalleryImage[] = [
+  {
+    url: 'https://picsum.photos/seed/gallery-1/600/400',
+    alt: 'Hands shaping wet clay on a wheel',
+  },
+  {
+    url: 'https://picsum.photos/seed/gallery-2/600/400',
+    alt: 'A row of finished bowls cooling on a shelf',
+  },
+  {
+    url: 'https://picsum.photos/seed/gallery-3/600/400',
+    alt: 'Studio bench with tools laid out before class',
+  },
+];
+
+/**
+ * Class with a gallery (3 images) used to demo the supplementary
+ * gallery rendering on top of the existing primary `imageUrl`.
+ */
+export const mockClassWithGallery: Class = {
+  ...mockClass,
+  id: 'class-with-gallery',
+  galleryImages: mockGalleryImages,
+};
+
+/**
+ * Class category whose pool has 5 reusable images shared with the
+ * fiber-arts class above.
+ */
+export const mockClassCategoryWithPool: ClassCategory = {
+  ...mockClassCategory,
+  galleryImages: [
+    ...mockGalleryImages,
+    {
+      url: 'https://picsum.photos/seed/gallery-4/600/400',
+      alt: 'Close-up of yarn skeins in earthy tones',
+    },
+    {
+      url: 'https://picsum.photos/seed/gallery-5/600/400',
+      alt: 'Loom warped and ready for a new tapestry',
+    },
+  ],
+};
+
+/** Categories list with the fiber-arts category swapped for the pool variant. */
+export const mockClassCategoriesWithPool: ClassCategory[] = [
+  mockClassCategoryWithPool,
   mockClassCategory2,
   mockClassCategory3,
 ];

--- a/apps/maple-spruce/src/components/class-categories/ClassCategoryForm.tsx
+++ b/apps/maple-spruce/src/components/class-categories/ClassCategoryForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import {
   Box,
   Button,
@@ -11,14 +11,37 @@ import {
   TextField,
   Alert,
 } from '@mui/material';
-import type { ClassCategory, CreateClassCategoryInput } from '@maple/ts/domain';
+import { httpsCallable } from 'firebase/functions';
+import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
+import type {
+  ClassCategory,
+  CreateClassCategoryInput,
+  GalleryImage,
+} from '@maple/ts/domain';
+import type {
+  UploadCategoryGalleryImageRequest,
+  UploadCategoryGalleryImageResponse,
+} from '@maple/ts/firebase/api-types';
 import { classCategoryValidation } from '@maple/ts/validation';
+import { GalleryEditor } from '@maple/react/ui';
 import {
   useSignal,
   useComputed,
   batch,
   useSignals,
 } from '@maple/react/signals';
+
+function readFileAsBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      resolve(result.split(',')[1]);
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+}
 
 interface ClassCategoryFormProps {
   open: boolean;
@@ -41,6 +64,7 @@ export function ClassCategoryForm({
 
   const name = useSignal('');
   const description = useSignal('');
+  const galleryImages = useSignal<GalleryImage[]>([]);
 
   const showValidationErrors = useSignal(false);
   const submitError = useSignal<string | null>(null);
@@ -52,6 +76,8 @@ export function ClassCategoryForm({
       name: name.value,
       description: description.value || undefined,
       order: isEdit ? category.order : nextOrder,
+      galleryImages:
+        galleryImages.value.length > 0 ? galleryImages.value : undefined,
     });
   });
 
@@ -67,6 +93,31 @@ export function ClassCategoryForm({
     return fieldErrors?.[0] ?? null;
   };
 
+  const uploadGalleryImage = useCallback(
+    async (file: File): Promise<string> => {
+      const functions = getMapleFunctions();
+      const upload = httpsCallable<
+        UploadCategoryGalleryImageRequest,
+        UploadCategoryGalleryImageResponse
+      >(functions, 'uploadCategoryGalleryImage');
+
+      const imageBase64 = await readFileAsBase64(file);
+
+      const result = await upload({
+        categoryId: category?.id,
+        imageBase64,
+        contentType: file.type,
+      });
+
+      if (!result.data.success) {
+        throw new Error('Pool image upload failed');
+      }
+
+      return result.data.url;
+    },
+    [category?.id]
+  );
+
   useEffect(() => {
     if (!open) return;
 
@@ -74,6 +125,9 @@ export function ClassCategoryForm({
       batch(() => {
         name.value = category.name;
         description.value = category.description ?? '';
+        galleryImages.value = category.galleryImages
+          ? category.galleryImages.map((img) => ({ ...img }))
+          : [];
         showValidationErrors.value = false;
         submitError.value = null;
       });
@@ -81,6 +135,7 @@ export function ClassCategoryForm({
       batch(() => {
         name.value = '';
         description.value = '';
+        galleryImages.value = [];
         showValidationErrors.value = false;
         submitError.value = null;
       });
@@ -102,6 +157,13 @@ export function ClassCategoryForm({
         name: name.value.trim(),
         description: description.value.trim() || undefined,
         order: isEdit ? category.order : nextOrder,
+        galleryImages:
+          galleryImages.value.length > 0
+            ? galleryImages.value.map((img) => ({
+                url: img.url,
+                alt: img.alt.trim(),
+              }))
+            : undefined,
       };
 
       await onSubmit(input);
@@ -122,7 +184,7 @@ export function ClassCategoryForm({
   };
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
       <DialogTitle>
         {isEdit ? 'Edit Class Category' : 'Add Class Category'}
       </DialogTitle>
@@ -155,6 +217,14 @@ export function ClassCategoryForm({
             multiline
             rows={2}
             fullWidth
+          />
+
+          <GalleryEditor
+            label="Image pool (shared across classes in this category)"
+            value={galleryImages.value}
+            onChange={(next) => (galleryImages.value = next)}
+            onUploadFile={uploadGalleryImage}
+            error={getFieldError('galleryImages') ?? undefined}
           />
         </Box>
       </DialogContent>

--- a/docs/reference/deployed-functions.md
+++ b/docs/reference/deployed-functions.md
@@ -34,12 +34,12 @@ Core CRUD operations, auth, triggers, and admin functions. No heavy third-party 
 - `getTeacherPayouts` — aggregates what Katie owes each teacher over a date range from paid private-pay invoice lines + rendered Hope Scholarship lessons
 
 ### Classes
-- `getClasses`, `getClass`, `createClass`, `updateClass`, `deleteClass`, `uploadClassImage`
+- `getClasses`, `getClass`, `createClass`, `updateClass`, `deleteClass`, `uploadClassImage`, `uploadClassGalleryImage`
 - `getPublicClasses` _(minInstances: 1, concurrency: 80)_
 - `getPublicClass` _(minInstances: 1, concurrency: 80)_
 
 ### Class Categories
-- `getClassCategories`
+- `getClassCategories`, `uploadCategoryGalleryImage`
 
 ### Discounts
 - `getDiscounts`, `createDiscount`, `updateDiscount`, `deleteDiscount`, `lookupDiscount`

--- a/libs/firebase/database/src/lib/class-category.repository.ts
+++ b/libs/firebase/database/src/lib/class-category.repository.ts
@@ -30,6 +30,7 @@ function docToClassCategory(
     description: data.description,
     order: data.order,
     icon: data.icon,
+    galleryImages: data.galleryImages,
     createdAt: toDate(data.createdAt),
     updatedAt: toDate(data.updatedAt),
   };

--- a/libs/firebase/database/src/lib/class.repository.ts
+++ b/libs/firebase/database/src/lib/class.repository.ts
@@ -84,6 +84,7 @@ function docToClass(
     capacity: data.capacity,
     priceCents: data.priceCents,
     imageUrl: data.imageUrl,
+    galleryImages: data.galleryImages,
     categoryId: data.categoryId,
     skillLevel: data.skillLevel,
     status: data.status,

--- a/libs/firebase/maple-functions/upload-category-gallery-image/project.json
+++ b/libs/firebase/maple-functions/upload-category-gallery-image/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-upload-category-gallery-image",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/upload-category-gallery-image/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/upload-category-gallery-image/src/index.ts
+++ b/libs/firebase/maple-functions/upload-category-gallery-image/src/index.ts
@@ -1,0 +1,1 @@
+export { uploadCategoryGalleryImage } from './lib/upload-category-gallery-image';

--- a/libs/firebase/maple-functions/upload-category-gallery-image/src/lib/upload-category-gallery-image.ts
+++ b/libs/firebase/maple-functions/upload-category-gallery-image/src/lib/upload-category-gallery-image.ts
@@ -1,0 +1,54 @@
+/**
+ * Upload Class Category Gallery Image Cloud Function
+ *
+ * Uploads an image to a class category's shared image pool (admin only).
+ * Classes can later reference the same URL in their own `galleryImages`
+ * without re-uploading.
+ *
+ * Stored at `categories/{categoryId}/gallery/photo_{timestamp}.{ext}`.
+ */
+import {
+  createAdminFunction,
+  FirebaseProject,
+  throwValidationError,
+} from '@maple/firebase/functions';
+import { imageUploadValidation } from '@maple/ts/validation';
+import admin from 'firebase-admin';
+import type {
+  UploadCategoryGalleryImageRequest,
+  UploadCategoryGalleryImageResponse,
+} from '@maple/ts/firebase/api-types';
+
+export const uploadCategoryGalleryImage = createAdminFunction<
+  UploadCategoryGalleryImageRequest,
+  UploadCategoryGalleryImageResponse
+>(async (data) => {
+  const { categoryId, imageBase64, contentType } = data;
+
+  const validation = imageUploadValidation({ imageBase64, contentType });
+  if (validation.hasErrors()) {
+    throwValidationError(validation.getErrors());
+  }
+
+  const bucket = admin.storage().bucket(FirebaseProject.storageBucket);
+
+  const timestamp = Date.now();
+  const extension = contentType.split('/')[1] || 'jpg';
+  const fileName = categoryId
+    ? `categories/${categoryId}/gallery/photo_${timestamp}.${extension}`
+    : `categories/temp/gallery/photo_${timestamp}.${extension}`;
+
+  const file = bucket.file(fileName);
+  const buffer = Buffer.from(imageBase64, 'base64');
+
+  await file.save(buffer, {
+    metadata: { contentType },
+  });
+
+  const publicUrl = `https://firebasestorage.googleapis.com/v0/b/${bucket.name}/o/${encodeURIComponent(fileName)}?alt=media`;
+
+  return {
+    success: true,
+    url: publicUrl,
+  };
+});

--- a/libs/firebase/maple-functions/upload-category-gallery-image/tsconfig.json
+++ b/libs/firebase/maple-functions/upload-category-gallery-image/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/upload-category-gallery-image/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/upload-category-gallery-image/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/upload-class-gallery-image/project.json
+++ b/libs/firebase/maple-functions/upload-class-gallery-image/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-upload-class-gallery-image",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/upload-class-gallery-image/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/upload-class-gallery-image/src/index.ts
+++ b/libs/firebase/maple-functions/upload-class-gallery-image/src/index.ts
@@ -1,0 +1,1 @@
+export { uploadClassGalleryImage } from './lib/upload-class-gallery-image';

--- a/libs/firebase/maple-functions/upload-class-gallery-image/src/lib/upload-class-gallery-image.ts
+++ b/libs/firebase/maple-functions/upload-class-gallery-image/src/lib/upload-class-gallery-image.ts
@@ -1,0 +1,56 @@
+/**
+ * Upload Class Gallery Image Cloud Function
+ *
+ * Uploads a supplementary gallery image for a class to Firebase Storage
+ * (admin only). The returned URL is appended (with admin-supplied alt
+ * text) to the class's `galleryImages` array on the next `updateClass`.
+ *
+ * Stored at `classes/{classId}/gallery/photo_{timestamp}.{ext}` so that
+ * gallery images live alongside the existing primary `imageUrl` upload
+ * but in a separate subdirectory.
+ */
+import {
+  createAdminFunction,
+  FirebaseProject,
+  throwValidationError,
+} from '@maple/firebase/functions';
+import { imageUploadValidation } from '@maple/ts/validation';
+import admin from 'firebase-admin';
+import type {
+  UploadClassGalleryImageRequest,
+  UploadClassGalleryImageResponse,
+} from '@maple/ts/firebase/api-types';
+
+export const uploadClassGalleryImage = createAdminFunction<
+  UploadClassGalleryImageRequest,
+  UploadClassGalleryImageResponse
+>(async (data) => {
+  const { classId, imageBase64, contentType } = data;
+
+  const validation = imageUploadValidation({ imageBase64, contentType });
+  if (validation.hasErrors()) {
+    throwValidationError(validation.getErrors());
+  }
+
+  const bucket = admin.storage().bucket(FirebaseProject.storageBucket);
+
+  const timestamp = Date.now();
+  const extension = contentType.split('/')[1] || 'jpg';
+  const fileName = classId
+    ? `classes/${classId}/gallery/photo_${timestamp}.${extension}`
+    : `classes/temp/gallery/photo_${timestamp}.${extension}`;
+
+  const file = bucket.file(fileName);
+  const buffer = Buffer.from(imageBase64, 'base64');
+
+  await file.save(buffer, {
+    metadata: { contentType },
+  });
+
+  const publicUrl = `https://firebasestorage.googleapis.com/v0/b/${bucket.name}/o/${encodeURIComponent(fileName)}?alt=media`;
+
+  return {
+    success: true,
+    url: publicUrl,
+  };
+});

--- a/libs/firebase/maple-functions/upload-class-gallery-image/tsconfig.json
+++ b/libs/firebase/maple-functions/upload-class-gallery-image/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/upload-class-gallery-image/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/upload-class-gallery-image/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/react/classes/src/lib/CategoryGalleryPickerDialog.stories.tsx
+++ b/libs/react/classes/src/lib/CategoryGalleryPickerDialog.stories.tsx
@@ -1,0 +1,131 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn, expect, within, userEvent, waitFor } from 'storybook/test';
+import type { GalleryImage } from '@maple/ts/domain';
+import { CategoryGalleryPickerDialog } from './CategoryGalleryPickerDialog';
+
+const POOL: GalleryImage[] = [
+  {
+    url: 'https://picsum.photos/seed/pool-1/600/400',
+    alt: 'Hands at the loom weaving a pattern',
+  },
+  {
+    url: 'https://picsum.photos/seed/pool-2/600/400',
+    alt: 'Yarn skeins in earthy natural-dyed tones',
+  },
+  {
+    url: 'https://picsum.photos/seed/pool-3/600/400',
+    alt: 'Finished tapestry hanging in the studio',
+  },
+  {
+    url: 'https://picsum.photos/seed/pool-4/600/400',
+    alt: 'Close-up of a rigid heddle threaded for warp',
+  },
+];
+
+const meta = {
+  component: CategoryGalleryPickerDialog,
+  title: 'Classes/CategoryGalleryPickerDialog',
+  parameters: {
+    layout: 'fullscreen',
+    a11y: { disable: true },
+  },
+  args: {
+    open: true,
+    categoryName: 'Fiber Arts',
+    onClose: fn(),
+    onConfirm: fn(),
+  },
+} satisfies Meta<typeof CategoryGalleryPickerDialog>;
+
+export default meta;
+type Story = StoryObj<typeof CategoryGalleryPickerDialog>;
+
+/** MUI Dialog portals out of the canvas — query document.body. */
+const dialog = () => within(document.body);
+
+/** Pool is empty — admin needs to upload pool images first. */
+export const EmptyPool: Story = {
+  args: {
+    pool: [],
+    alreadyAdded: new Set<string>(),
+    remainingCapacity: 10,
+  },
+};
+
+/** Full pool, nothing already added, plenty of capacity. */
+export const Populated: Story = {
+  args: {
+    pool: POOL,
+    alreadyAdded: new Set<string>(),
+    remainingCapacity: 10,
+  },
+};
+
+/** Two pool images already in the gallery — they show as checked + disabled. */
+export const WithSomeAlreadyAdded: Story = {
+  args: {
+    pool: POOL,
+    alreadyAdded: new Set<string>([POOL[0].url, POOL[2].url]),
+    remainingCapacity: 8,
+  },
+};
+
+/** Only one slot left — selecting a second should surface the over-capacity warning. */
+export const AtCapacityRemaining: Story = {
+  args: {
+    pool: POOL,
+    alreadyAdded: new Set<string>(),
+    remainingCapacity: 1,
+  },
+};
+
+/**
+ * Interaction test: pick two pool images and confirm.
+ *
+ * Verifies the dialog enables/disables the confirm button correctly and
+ * fires `onConfirm` with the matching `GalleryImage` objects.
+ */
+export const SelectAndConfirm: Story = {
+  args: {
+    pool: POOL,
+    alreadyAdded: new Set<string>(),
+    remainingCapacity: 10,
+  },
+  play: async ({ args }) => {
+    const canvas = dialog();
+
+    await waitFor(() => {
+      expect(canvas.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    // Confirm button is initially disabled (nothing selected).
+    const confirmInitial = canvas.getByRole('button', { name: /add .*image/i });
+    expect(confirmInitial).toBeDisabled();
+
+    // Select the first two pool images via their checkboxes.
+    const checkboxes = canvas.getAllByRole('checkbox');
+    expect(checkboxes.length).toBe(POOL.length);
+    await userEvent.click(checkboxes[0]);
+    await userEvent.click(checkboxes[1]);
+
+    // Confirm button should now read "Add 2 images" and be enabled.
+    await waitFor(() => {
+      expect(
+        canvas.getByRole('button', { name: /add 2 images/i })
+      ).toBeEnabled();
+    });
+
+    await userEvent.click(
+      canvas.getByRole('button', { name: /add 2 images/i })
+    );
+
+    await waitFor(() => {
+      expect(args.onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    const picks = (args.onConfirm as ReturnType<typeof fn>).mock.calls[0][0];
+    expect(picks).toHaveLength(2);
+    expect(picks[0].url).toBe(POOL[0].url);
+    expect(picks[1].url).toBe(POOL[1].url);
+  },
+};

--- a/libs/react/classes/src/lib/CategoryGalleryPickerDialog.tsx
+++ b/libs/react/classes/src/lib/CategoryGalleryPickerDialog.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from '@mui/material';
+import type { GalleryImage } from '@maple/ts/domain';
+
+export interface CategoryGalleryPickerDialogProps {
+  open: boolean;
+  categoryName: string;
+  pool: GalleryImage[];
+  /** URLs already in the class gallery (shown as checked + disabled). */
+  alreadyAdded: Set<string>;
+  /** Maximum new images that can still be added. */
+  remainingCapacity: number;
+  onClose: () => void;
+  onConfirm: (selected: GalleryImage[]) => void;
+}
+
+export function CategoryGalleryPickerDialog({
+  open,
+  categoryName,
+  pool,
+  alreadyAdded,
+  remainingCapacity,
+  onClose,
+  onConfirm,
+}: CategoryGalleryPickerDialogProps) {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (open) setSelected(new Set());
+  }, [open]);
+
+  const toggle = (url: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(url)) next.delete(url);
+      else next.add(url);
+      return next;
+    });
+  };
+
+  const overCapacity = selected.size > remainingCapacity;
+
+  const handleConfirm = () => {
+    const picks = pool.filter((img) => selected.has(img.url));
+    onConfirm(picks);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>Add from {categoryName} pool</DialogTitle>
+      <DialogContent>
+        {pool.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            No images in this category&apos;s pool yet. Upload pool images
+            from the Class Categories admin first.
+          </Typography>
+        ) : (
+          <>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              You can add up to {remainingCapacity} more image
+              {remainingCapacity === 1 ? '' : 's'}. Pool images are shared —
+              adding one here doesn&apos;t copy the file.
+            </Typography>
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))',
+                gap: 1.5,
+              }}
+            >
+              {pool.map((img) => {
+                const isAdded = alreadyAdded.has(img.url);
+                const isSelected = selected.has(img.url);
+                const disabled = isAdded;
+                return (
+                  <Box
+                    key={img.url}
+                    onClick={() => !disabled && toggle(img.url)}
+                    sx={{
+                      position: 'relative',
+                      border: 2,
+                      borderColor: isSelected
+                        ? 'primary.main'
+                        : isAdded
+                          ? 'success.light'
+                          : 'divider',
+                      borderRadius: 1,
+                      overflow: 'hidden',
+                      cursor: disabled ? 'not-allowed' : 'pointer',
+                      opacity: disabled ? 0.6 : 1,
+                    }}
+                  >
+                    <Box
+                      component="img"
+                      src={img.url}
+                      alt={img.alt || 'Pool image'}
+                      sx={{
+                        width: '100%',
+                        height: 120,
+                        objectFit: 'cover',
+                        display: 'block',
+                      }}
+                    />
+                    <Checkbox
+                      checked={isAdded || isSelected}
+                      disabled={disabled}
+                      sx={{
+                        position: 'absolute',
+                        top: 4,
+                        left: 4,
+                        bgcolor: 'rgba(255,255,255,0.85)',
+                        '&:hover': { bgcolor: 'rgba(255,255,255,0.95)' },
+                        p: 0.5,
+                      }}
+                    />
+                    {img.alt && (
+                      <Box
+                        sx={{
+                          position: 'absolute',
+                          bottom: 0,
+                          left: 0,
+                          right: 0,
+                          px: 1,
+                          py: 0.5,
+                          bgcolor: 'rgba(0,0,0,0.55)',
+                          color: 'white',
+                          fontSize: 11,
+                          lineHeight: 1.3,
+                          maxHeight: 40,
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {img.alt}
+                      </Box>
+                    )}
+                  </Box>
+                );
+              })}
+            </Box>
+            {overCapacity && (
+              <Typography variant="caption" color="error" sx={{ mt: 1, display: 'block' }}>
+                You&apos;ve selected {selected.size} but only {remainingCapacity}{' '}
+                more can fit.
+              </Typography>
+            )}
+          </>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          onClick={handleConfirm}
+          variant="contained"
+          disabled={selected.size === 0 || overCapacity}
+        >
+          Add {selected.size > 0 ? `${selected.size} ` : ''}
+          {selected.size === 1 ? 'image' : 'images'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/libs/react/classes/src/lib/ClassForm.spec.tsx
+++ b/libs/react/classes/src/lib/ClassForm.spec.tsx
@@ -26,6 +26,9 @@ vi.mock('@maple/react/ui', () => ({
   ImageUpload: (props: Record<string, unknown>) => (
     <div data-testid="image-upload">{String(props['label'] ?? '')}</div>
   ),
+  GalleryEditor: (props: Record<string, unknown>) => (
+    <div data-testid="gallery-editor">{String(props['label'] ?? '')}</div>
+  ),
 }));
 
 import { ClassForm } from './ClassForm';

--- a/libs/react/classes/src/lib/ClassForm.stories.tsx
+++ b/libs/react/classes/src/lib/ClassForm.stories.tsx
@@ -6,6 +6,8 @@ import {
   mockClassDraft,
   mockClassNoImage,
   mockClassCategories,
+  mockClassWithGallery,
+  mockClassCategoriesWithPool,
 } from '../../../../../apps/maple-spruce/.storybook/fixtures';
 import {
   mockActiveInstructors,
@@ -507,5 +509,66 @@ export const SelectInstructor: Story = {
     if (options.length > 1) {
       await userEvent.click(options[1]); // skip "None" option
     }
+  },
+};
+
+// ============================================================
+// GALLERY
+// ============================================================
+
+/**
+ * Edit a class that already has gallery images set. Visual story —
+ * confirms the editor renders three reorderable rows with their alt text.
+ */
+export const EditWithGallery: Story = {
+  args: {
+    open: true,
+    classItem: mockClassWithGallery,
+    categories: mockClassCategoriesWithPool,
+    isSubmitting: false,
+  },
+};
+
+/**
+ * Edit a class whose category has a populated image pool. Verifies the
+ * "Add from {category} pool" button is enabled and that clicking it
+ * opens the picker dialog with the pool's images visible.
+ */
+export const WithCategoryPoolPicker: Story = {
+  args: {
+    open: true,
+    classItem: mockClassWithGallery,
+    categories: mockClassCategoriesWithPool,
+    isSubmitting: false,
+  },
+  play: async () => {
+    const canvas = await waitForDialog();
+
+    // Pool button is enabled because the class's category has a pool.
+    const poolButton = canvas.getByRole('button', {
+      name: /add from fiber arts pool/i,
+    });
+    await waitFor(() => expect(poolButton).toBeEnabled());
+
+    await userEvent.click(poolButton);
+
+    // The picker dialog opens — its title should be visible somewhere
+    // in the document (still under document.body, since it's a Dialog).
+    await waitFor(() => {
+      expect(
+        canvas.getByRole('heading', { name: /add from fiber arts pool/i })
+      ).toBeInTheDocument();
+    });
+
+    // Pool has 5 images; the 3 already in the gallery should appear as
+    // disabled checkboxes, leaving 2 available to add.
+    const allCheckboxes = canvas
+      .getAllByRole('checkbox')
+      .filter((cb) => cb.closest('[role="dialog"]'));
+    const enabled = allCheckboxes.filter(
+      (cb) => !(cb as HTMLInputElement).disabled
+    );
+    expect(allCheckboxes.length).toBeGreaterThanOrEqual(5);
+    expect(enabled.length).toBe(2);
   },
 };

--- a/libs/react/classes/src/lib/ClassForm.tsx
+++ b/libs/react/classes/src/lib/ClassForm.tsx
@@ -44,12 +44,16 @@ import type {
   ClassSkillLevel,
   Instructor,
   ClassCategory,
+  GalleryImage,
 } from '@maple/ts/domain';
 import type {
   UploadClassImageRequest,
   UploadClassImageResponse,
+  UploadClassGalleryImageRequest,
+  UploadClassGalleryImageResponse,
 } from '@maple/ts/firebase/api-types';
-import { ImageUpload, type ImageUploadState } from '@maple/react/ui';
+import { GalleryEditor, ImageUpload, type ImageUploadState } from '@maple/react/ui';
+import { CategoryGalleryPickerDialog } from './CategoryGalleryPickerDialog';
 import { classValidation } from '@maple/ts/validation';
 import {
   useSignal,
@@ -166,6 +170,8 @@ export function ClassForm({
   const priceCents = useSignal(0);
   const priceDisplay = useSignal('0.00');
   const imageUrl = useSignal('');
+  const galleryImages = useSignal<GalleryImage[]>([]);
+  const isPoolPickerOpen = useSignal(false);
   const categoryId = useSignal('');
   const skillLevel = useSignal<ClassSkillLevel>('all-levels');
   const status = useSignal<ClassStatus>('draft');
@@ -234,6 +240,8 @@ export function ClassForm({
       materialsIncluded: materialsIncluded.value || undefined,
       whatToBring: whatToBring.value || undefined,
       minimumAge: minimumAge.value,
+      galleryImages:
+        galleryImages.value.length > 0 ? galleryImages.value : undefined,
     });
   });
 
@@ -264,6 +272,7 @@ export function ClassForm({
     minimumAge: 'Minimum Age',
     materialsIncluded: 'Materials Included',
     whatToBring: 'What to Bring',
+    galleryImages: 'Gallery',
   };
 
   const hasValidationErrors = useComputed(() => {
@@ -315,6 +324,9 @@ export function ClassForm({
         priceCents.value = classItem.priceCents;
         priceDisplay.value = (classItem.priceCents / 100).toFixed(2);
         imageUrl.value = classItem.imageUrl ?? '';
+        galleryImages.value = classItem.galleryImages
+          ? classItem.galleryImages.map((img) => ({ ...img }))
+          : [];
         categoryId.value = classItem.categoryId ?? '';
         skillLevel.value = classItem.skillLevel;
         status.value = classItem.status;
@@ -364,6 +376,7 @@ export function ClassForm({
         priceCents.value = 4500;
         priceDisplay.value = '45.00';
         imageUrl.value = '';
+        galleryImages.value = [];
         categoryId.value = '';
         skillLevel.value = 'all-levels';
         status.value = 'draft';
@@ -452,6 +465,31 @@ export function ClassForm({
     return result.data.url;
   };
 
+  const uploadGalleryImage = useCallback(
+    async (file: File): Promise<string> => {
+      const functions = getMapleFunctions();
+      const upload = httpsCallable<
+        UploadClassGalleryImageRequest,
+        UploadClassGalleryImageResponse
+      >(functions, 'uploadClassGalleryImage');
+
+      const imageBase64 = await readFileAsBase64(file);
+
+      const result = await upload({
+        classId: classItem?.id,
+        imageBase64,
+        contentType: file.type,
+      });
+
+      if (!result.data.success) {
+        throw new Error('Gallery image upload failed');
+      }
+
+      return result.data.url;
+    },
+    [classItem?.id]
+  );
+
   // ============================================================
   // SUBMIT
   // ============================================================
@@ -512,6 +550,8 @@ export function ClassForm({
         capacity: capacity.value,
         priceCents: priceCents.value,
         imageUrl: currentImageUrl || undefined,
+        galleryImages:
+          galleryImages.value.length > 0 ? galleryImages.value : undefined,
         categoryId: categoryId.value || undefined,
         skillLevel: skillLevel.value,
         status: status.value,
@@ -582,6 +622,64 @@ export function ClassForm({
               existingImageUrl={classItem?.imageUrl}
               label="Class Image"
             />
+
+            {/* Gallery */}
+            {(() => {
+              const selectedCategory = categories.find(
+                (c) => c.id === categoryId.value
+              );
+              const pool = selectedCategory?.galleryImages ?? [];
+              const alreadyAdded = new Set(
+                galleryImages.value.map((img) => img.url)
+              );
+              const remainingCapacity = Math.max(
+                0,
+                10 - galleryImages.value.length
+              );
+              const poolDisabledHint = !selectedCategory
+                ? 'Select a category to access its image pool'
+                : pool.length === 0
+                  ? "This category's pool is empty"
+                  : undefined;
+
+              return (
+                <>
+                  <GalleryEditor
+                    label="Gallery"
+                    value={galleryImages.value}
+                    onChange={(next) => (galleryImages.value = next)}
+                    onUploadFile={uploadGalleryImage}
+                    onPickFromPool={() => (isPoolPickerOpen.value = true)}
+                    pickFromPoolLabel={
+                      selectedCategory
+                        ? `Add from ${selectedCategory.name} pool`
+                        : 'Add from category pool'
+                    }
+                    pickFromPoolDisabled={
+                      !selectedCategory || pool.length === 0
+                    }
+                    pickFromPoolDisabledHint={poolDisabledHint}
+                    error={getFieldError('galleryImages') ?? undefined}
+                  />
+                  {selectedCategory && (
+                    <CategoryGalleryPickerDialog
+                      open={isPoolPickerOpen.value}
+                      categoryName={selectedCategory.name}
+                      pool={pool}
+                      alreadyAdded={alreadyAdded}
+                      remainingCapacity={remainingCapacity}
+                      onClose={() => (isPoolPickerOpen.value = false)}
+                      onConfirm={(picks) => {
+                        galleryImages.value = [
+                          ...galleryImages.value,
+                          ...picks.map((img) => ({ ...img })),
+                        ];
+                      }}
+                    />
+                  )}
+                </>
+              );
+            })()}
 
             {/* Row 1: Name and Status */}
             <Box sx={{ display: 'flex', gap: 2 }}>

--- a/libs/react/ui/src/index.ts
+++ b/libs/react/ui/src/index.ts
@@ -3,3 +3,4 @@ export {
   DeleteConfirmDialog,
   type DeleteConfirmDialogProps,
 } from './lib/DeleteConfirmDialog';
+export { GalleryEditor, type GalleryEditorProps } from './lib/GalleryEditor';

--- a/libs/react/ui/src/lib/GalleryEditor/GalleryEditor.stories.tsx
+++ b/libs/react/ui/src/lib/GalleryEditor/GalleryEditor.stories.tsx
@@ -1,0 +1,205 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn, expect, within, userEvent, waitFor } from 'storybook/test';
+import type { GalleryImage } from '@maple/ts/domain';
+import { GalleryEditor } from './GalleryEditor';
+
+/**
+ * Inline fixtures — pure UI library convention (see ImageUpload.stories.tsx).
+ */
+const SAMPLE_IMAGES: GalleryImage[] = [
+  {
+    url: 'https://picsum.photos/seed/g-1/600/400',
+    alt: 'Hands shaping wet clay on a wheel',
+  },
+  {
+    url: 'https://picsum.photos/seed/g-2/600/400',
+    alt: 'A row of finished bowls cooling on a shelf',
+  },
+  {
+    url: 'https://picsum.photos/seed/g-3/600/400',
+    alt: 'Studio bench with tools laid out before class',
+  },
+];
+
+const FULL_TEN: GalleryImage[] = Array.from({ length: 10 }, (_, i) => ({
+  url: `https://picsum.photos/seed/full-${i}/600/400`,
+  alt: `Studio scene number ${i + 1}`,
+}));
+
+/**
+ * Render helper that holds gallery state so the editor behaves like it
+ * does in a real form. Without this, alt edits and reorders wouldn't
+ * be visible because the component is controlled.
+ */
+function ControlledGalleryEditor(props: {
+  initial: GalleryImage[];
+  onUploadFile?: (file: File) => Promise<string>;
+  onPickFromPool?: () => void;
+  pickFromPoolLabel?: string;
+  pickFromPoolDisabled?: boolean;
+  pickFromPoolDisabledHint?: string;
+  error?: string;
+  label?: string;
+}) {
+  const [images, setImages] = useState<GalleryImage[]>(props.initial);
+  return (
+    <div style={{ width: 720, padding: 16 }}>
+      <GalleryEditor
+        value={images}
+        onChange={setImages}
+        onUploadFile={
+          props.onUploadFile ??
+          ((file: File) =>
+            Promise.resolve(`https://example.com/uploaded/${file.name}`))
+        }
+        onPickFromPool={props.onPickFromPool}
+        pickFromPoolLabel={props.pickFromPoolLabel}
+        pickFromPoolDisabled={props.pickFromPoolDisabled}
+        pickFromPoolDisabledHint={props.pickFromPoolDisabledHint}
+        error={props.error}
+        label={props.label}
+      />
+    </div>
+  );
+}
+
+const meta = {
+  component: GalleryEditor,
+  title: 'UI/GalleryEditor',
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    onChange: fn(),
+    onUploadFile: fn().mockImplementation((file: File) =>
+      Promise.resolve(`https://example.com/uploaded/${file.name}`)
+    ),
+  },
+} satisfies Meta<typeof GalleryEditor>;
+
+export default meta;
+type Story = StoryObj<typeof GalleryEditor>;
+
+/** Empty gallery, prompting the admin to upload their first image. */
+export const Empty: Story = {
+  render: (args) => (
+    <ControlledGalleryEditor
+      initial={[]}
+      onUploadFile={args.onUploadFile}
+      label={args.label}
+    />
+  ),
+};
+
+/** Three images of ten — the typical state mid-curation. */
+export const Partial: Story = {
+  render: (args) => (
+    <ControlledGalleryEditor
+      initial={SAMPLE_IMAGES}
+      onUploadFile={args.onUploadFile}
+      label={args.label}
+    />
+  ),
+};
+
+/** Ten images — upload + pool buttons should be disabled. */
+export const AtCapacity: Story = {
+  render: (args) => (
+    <ControlledGalleryEditor
+      initial={FULL_TEN}
+      onUploadFile={args.onUploadFile}
+      label={args.label}
+    />
+  ),
+};
+
+/** Validation error from the parent's Vest suite (e.g. missing alt text). */
+export const WithError: Story = {
+  render: (args) => (
+    <ControlledGalleryEditor
+      initial={SAMPLE_IMAGES}
+      onUploadFile={args.onUploadFile}
+      error="Every gallery image needs a URL and a description for accessibility"
+      label={args.label}
+    />
+  ),
+};
+
+/** ClassForm variant: a category is selected and its pool has images. */
+export const WithPoolButton: Story = {
+  render: (args) => (
+    <ControlledGalleryEditor
+      initial={SAMPLE_IMAGES}
+      onUploadFile={args.onUploadFile}
+      onPickFromPool={fn()}
+      pickFromPoolLabel="Add from Fiber Arts pool"
+      label={args.label}
+    />
+  ),
+};
+
+/** ClassForm variant: pool button visible but disabled (no category set). */
+export const WithPoolButtonDisabled: Story = {
+  render: (args) => (
+    <ControlledGalleryEditor
+      initial={SAMPLE_IMAGES}
+      onUploadFile={args.onUploadFile}
+      onPickFromPool={fn()}
+      pickFromPoolLabel="Add from category pool"
+      pickFromPoolDisabled
+      pickFromPoolDisabledHint="Select a category to access its image pool"
+      label={args.label}
+    />
+  ),
+};
+
+/**
+ * Interaction test: edit alt text, remove an image, watch the counter.
+ *
+ * Skips drag-to-reorder and file upload — both are difficult to drive
+ * reliably from Playwright (HTML5 DnD + portal'd file pickers). Those
+ * are exercised manually + visually.
+ */
+export const InteractiveEdit: Story = {
+  render: (args) => (
+    <ControlledGalleryEditor
+      initial={SAMPLE_IMAGES}
+      onUploadFile={args.onUploadFile}
+      label={args.label}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(() => {
+      expect(canvas.getByText(/3 \/ 10 images/i)).toBeInTheDocument();
+    });
+
+    // Edit the first alt text input — append a tweak.
+    const altInputs = canvas.getAllByLabelText(/image description/i);
+    expect(altInputs.length).toBe(3);
+    await userEvent.click(altInputs[0]);
+    await userEvent.keyboard(' (updated)');
+    await waitFor(() => {
+      expect(altInputs[0]).toHaveValue(
+        'Hands shaping wet clay on a wheel (updated)'
+      );
+    });
+
+    // Remove the second image; count should drop to 2/10.
+    const removeButtons = canvas.getAllByRole('button', {
+      name: /remove image/i,
+    });
+    expect(removeButtons.length).toBe(3);
+    await userEvent.click(removeButtons[1]);
+    await waitFor(() => {
+      expect(canvas.getByText(/2 \/ 10 images/i)).toBeInTheDocument();
+    });
+
+    // Only two alt inputs remain.
+    await waitFor(() => {
+      expect(canvas.getAllByLabelText(/image description/i).length).toBe(2);
+    });
+  },
+};

--- a/libs/react/ui/src/lib/GalleryEditor/GalleryEditor.tsx
+++ b/libs/react/ui/src/lib/GalleryEditor/GalleryEditor.tsx
@@ -1,0 +1,376 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  IconButton,
+  InputAdornment,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import AccessibilityNewIcon from '@mui/icons-material/AccessibilityNew';
+import AddPhotoAlternateIcon from '@mui/icons-material/AddPhotoAlternate';
+import CollectionsIcon from '@mui/icons-material/Collections';
+import DeleteIcon from '@mui/icons-material/Delete';
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { GALLERY_IMAGE_MAX, type GalleryImage } from '@maple/ts/domain';
+
+const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+const MAX_SIZE_BYTES = 5 * 1024 * 1024;
+
+export interface GalleryEditorProps {
+  value: GalleryImage[];
+  onChange: (images: GalleryImage[]) => void;
+  /** Upload a single file and return its public URL. */
+  onUploadFile: (file: File) => Promise<string>;
+  /** Optional handler that opens a parent-provided picker (e.g. category pool). */
+  onPickFromPool?: () => void;
+  pickFromPoolLabel?: string;
+  pickFromPoolDisabled?: boolean;
+  pickFromPoolDisabledHint?: string;
+  /** Override the default cap of `GALLERY_IMAGE_MAX`. */
+  max?: number;
+  label?: string;
+  /** Validation error from the parent's Vest suite. */
+  error?: string;
+}
+
+interface SortableRowProps {
+  image: GalleryImage;
+  index: number;
+  onAltChange: (index: number, alt: string) => void;
+  onRemove: (index: number) => void;
+}
+
+function rowKey(image: GalleryImage, index: number): string {
+  // URLs are unique per upload, but fall back to index if a pool image
+  // is reused inside the same gallery.
+  return `${image.url}|${index}`;
+}
+
+function SortableRow({ image, index, onAltChange, onRemove }: SortableRowProps) {
+  const id = rowKey(image, index);
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <Box
+      ref={setNodeRef}
+      style={style}
+      sx={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: 1,
+        p: 1,
+        border: 1,
+        borderColor: 'divider',
+        borderRadius: 1,
+        bgcolor: isDragging ? 'action.hover' : 'background.paper',
+      }}
+    >
+      <IconButton
+        {...attributes}
+        {...listeners}
+        size="small"
+        sx={{ cursor: 'grab', '&:active': { cursor: 'grabbing' }, mt: 0.5 }}
+        aria-label="Drag to reorder"
+      >
+        <DragIndicatorIcon fontSize="small" color="action" />
+      </IconButton>
+      <Box
+        component="img"
+        src={image.url}
+        alt={image.alt || 'Gallery image preview'}
+        sx={{
+          width: 96,
+          height: 96,
+          objectFit: 'cover',
+          borderRadius: 1,
+          flexShrink: 0,
+        }}
+      />
+      <TextField
+        label="Image description"
+        value={image.alt}
+        onChange={(e) => onAltChange(index, e.target.value)}
+        placeholder="e.g. Hands shaping wet clay on a wheel"
+        helperText="Describe this image so screen readers and search engines can find it"
+        size="small"
+        fullWidth
+        required
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <Tooltip title="Accessibility: this description helps blind students and search engines understand the image">
+                <AccessibilityNewIcon fontSize="small" color="primary" />
+              </Tooltip>
+            </InputAdornment>
+          ),
+        }}
+      />
+      <IconButton
+        onClick={() => onRemove(index)}
+        size="small"
+        color="error"
+        aria-label="Remove image"
+        sx={{ mt: 0.5 }}
+      >
+        <DeleteIcon fontSize="small" />
+      </IconButton>
+    </Box>
+  );
+}
+
+export function GalleryEditor({
+  value,
+  onChange,
+  onUploadFile,
+  onPickFromPool,
+  pickFromPoolLabel,
+  pickFromPoolDisabled,
+  pickFromPoolDisabledHint,
+  max = GALLERY_IMAGE_MAX,
+  label = 'Gallery',
+  error,
+}: GalleryEditorProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const atCapacity = value.length >= max;
+  const remaining = Math.max(0, max - value.length);
+
+  const handleAltChange = useCallback(
+    (index: number, alt: string) => {
+      const next = value.map((img, i) => (i === index ? { ...img, alt } : img));
+      onChange(next);
+    },
+    [value, onChange]
+  );
+
+  const handleRemove = useCallback(
+    (index: number) => {
+      onChange(value.filter((_, i) => i !== index));
+    },
+    [value, onChange]
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const ids = value.map((img, i) => rowKey(img, i));
+      const oldIndex = ids.indexOf(String(active.id));
+      const newIndex = ids.indexOf(String(over.id));
+      if (oldIndex === -1 || newIndex === -1) return;
+      onChange(arrayMove(value, oldIndex, newIndex));
+    },
+    [value, onChange]
+  );
+
+  const handleFileSelected = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      setUploadError(null);
+      const files = Array.from(event.target.files ?? []);
+      event.target.value = '';
+      if (files.length === 0) return;
+
+      const allowedCount = Math.max(0, max - value.length);
+      const accepted = files.slice(0, allowedCount);
+      if (files.length > accepted.length) {
+        setUploadError(
+          `Only ${allowedCount} more image${allowedCount === 1 ? '' : 's'} can be added (max ${max}).`
+        );
+      }
+
+      for (const file of accepted) {
+        if (!ALLOWED_TYPES.includes(file.type)) {
+          setUploadError(
+            `${file.name}: invalid file type. Allowed: JPEG, PNG, WebP, GIF.`
+          );
+          continue;
+        }
+        if (file.size > MAX_SIZE_BYTES) {
+          setUploadError(`${file.name}: file too large (max 5 MB).`);
+          continue;
+        }
+        setIsUploading(true);
+        try {
+          const url = await onUploadFile(file);
+          // Append using current latest snapshot to avoid stale state when
+          // multiple files upload sequentially.
+          onChange([...(value ?? []), { url, alt: '' }]);
+        } catch (uploadErr) {
+          const message =
+            uploadErr instanceof Error
+              ? uploadErr.message
+              : 'Image upload failed';
+          setUploadError(message);
+        } finally {
+          setIsUploading(false);
+        }
+      }
+    },
+    [max, onChange, onUploadFile, value]
+  );
+
+  const handleUploadClick = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const ids = value.map((img, i) => rowKey(img, i));
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          mb: 1,
+        }}
+      >
+        <Typography variant="subtitle2">{label}</Typography>
+        <Typography variant="caption" color="text.secondary">
+          {value.length} / {max} images
+        </Typography>
+      </Box>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 1 }}>
+          {error}
+        </Alert>
+      )}
+      {uploadError && (
+        <Alert
+          severity="error"
+          sx={{ mb: 1 }}
+          onClose={() => setUploadError(null)}
+        >
+          {uploadError}
+        </Alert>
+      )}
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={ALLOWED_TYPES.join(',')}
+        multiple
+        onChange={handleFileSelected}
+        style={{ display: 'none' }}
+      />
+
+      {value.length > 0 && (
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext items={ids} strategy={verticalListSortingStrategy}>
+            <Stack spacing={1} sx={{ mb: 1 }}>
+              {value.map((image, index) => (
+                <SortableRow
+                  key={rowKey(image, index)}
+                  image={image}
+                  index={index}
+                  onAltChange={handleAltChange}
+                  onRemove={handleRemove}
+                />
+              ))}
+            </Stack>
+          </SortableContext>
+        </DndContext>
+      )}
+
+      <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={
+            isUploading ? (
+              <CircularProgress size={16} />
+            ) : (
+              <AddPhotoAlternateIcon />
+            )
+          }
+          onClick={handleUploadClick}
+          disabled={atCapacity || isUploading}
+        >
+          {isUploading
+            ? 'Uploading…'
+            : `Upload image${remaining > 1 ? 's' : ''}`}
+        </Button>
+        {onPickFromPool && (
+          <Tooltip
+            title={
+              pickFromPoolDisabled && pickFromPoolDisabledHint
+                ? pickFromPoolDisabledHint
+                : ''
+            }
+          >
+            <span>
+              <Button
+                variant="outlined"
+                size="small"
+                startIcon={<CollectionsIcon />}
+                onClick={onPickFromPool}
+                disabled={
+                  atCapacity || pickFromPoolDisabled || isUploading
+                }
+              >
+                {pickFromPoolLabel ?? 'Add from pool'}
+              </Button>
+            </span>
+          </Tooltip>
+        )}
+      </Box>
+
+      {value.length === 0 && !error && (
+        <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
+          Add up to {max} images to give students a richer preview of the class.
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/libs/react/ui/src/lib/GalleryEditor/index.ts
+++ b/libs/react/ui/src/lib/GalleryEditor/index.ts
@@ -1,0 +1,1 @@
+export { GalleryEditor, type GalleryEditorProps } from './GalleryEditor';

--- a/libs/ts/domain/src/index.ts
+++ b/libs/ts/domain/src/index.ts
@@ -1,5 +1,6 @@
 // Shared interfaces
 export * from './lib/payee';
+export * from './lib/gallery-image';
 
 // Domain types
 export * from './lib/artist';

--- a/libs/ts/domain/src/lib/class-category.ts
+++ b/libs/ts/domain/src/lib/class-category.ts
@@ -6,6 +6,7 @@
  *
  * Examples: Fiber Arts, Woodworking, Ceramics, Natural Dyeing
  */
+import type { GalleryImage } from './gallery-image';
 
 /**
  * Class Category entity
@@ -20,6 +21,13 @@ export interface ClassCategory {
   order: number;
   /** Icon or emoji for visual display (e.g., "🧶" or icon name) */
   icon?: string;
+  /**
+   * Shared image pool for classes in this category. Classes can copy
+   * URLs from this pool into their own `galleryImages` without
+   * re-uploading. Order is encoded by array position; capped at
+   * `GALLERY_IMAGE_MAX`.
+   */
+  galleryImages?: GalleryImage[];
   createdAt: Date;
   updatedAt: Date;
 }

--- a/libs/ts/domain/src/lib/class.ts
+++ b/libs/ts/domain/src/lib/class.ts
@@ -10,6 +10,7 @@
  *
  * Future payments will use Square (consistent with existing POS integration).
  */
+import type { GalleryImage } from './gallery-image';
 
 /**
  * Skill level recommendation for a class
@@ -67,6 +68,11 @@ export interface Class {
   priceCents: number;
   /** Primary image URL */
   imageUrl?: string;
+  /**
+   * Optional supplementary images shown alongside the primary `imageUrl`.
+   * Order is encoded by array position. Capped at `GALLERY_IMAGE_MAX`.
+   */
+  galleryImages?: GalleryImage[];
   /** Class category ID for filtering */
   categoryId?: string;
   /** Skill level recommendation */
@@ -136,6 +142,7 @@ export interface PublicClass {
   spotsRemaining: number;
   priceCents: number;
   imageUrl?: string;
+  galleryImages?: GalleryImage[];
   categoryId?: string;
   /** Enriched from ClassCategory.name */
   categoryName?: string;
@@ -210,6 +217,7 @@ export function toPublicClass(
     spotsRemaining: Math.max(0, classEntity.capacity - registrationCount),
     priceCents: classEntity.priceCents,
     imageUrl: classEntity.imageUrl,
+    galleryImages: classEntity.galleryImages,
     categoryId: classEntity.categoryId,
     categoryName,
     skillLevel: classEntity.skillLevel,

--- a/libs/ts/domain/src/lib/gallery-image.ts
+++ b/libs/ts/domain/src/lib/gallery-image.ts
@@ -1,0 +1,13 @@
+/**
+ * Gallery image — a single image with required alt text.
+ *
+ * Used by Class and ClassCategory for image galleries. Order is encoded
+ * by array position; reordering rewrites the array.
+ */
+export interface GalleryImage {
+  url: string;
+  alt: string;
+}
+
+/** Maximum number of gallery images on a single Class or ClassCategory. */
+export const GALLERY_IMAGE_MAX = 10;

--- a/libs/ts/firebase/api-types/src/lib/class-category.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/class-category.types.ts
@@ -82,3 +82,22 @@ export interface ReorderClassCategoriesResponse {
   /** Categories with updated order values */
   categories: ClassCategory[];
 }
+
+// ============================================================================
+// Upload Class Category Gallery Image (shared pool)
+// ============================================================================
+
+export interface UploadCategoryGalleryImageRequest {
+  /** Category ID (optional - can upload before creating the category) */
+  categoryId?: string;
+  /** Base64-encoded image data */
+  imageBase64: string;
+  /** MIME type of the image (e.g., 'image/jpeg', 'image/png') */
+  contentType: string;
+}
+
+export interface UploadCategoryGalleryImageResponse {
+  success: boolean;
+  /** Public URL of the uploaded pool image */
+  url: string;
+}

--- a/libs/ts/firebase/api-types/src/lib/class.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/class.types.ts
@@ -96,6 +96,25 @@ export interface UploadClassImageResponse {
 }
 
 // ============================================================================
+// Upload Class Gallery Image
+// ============================================================================
+
+export interface UploadClassGalleryImageRequest {
+  /** Class ID (optional - can upload before creating class) */
+  classId?: string;
+  /** Base64-encoded image data */
+  imageBase64: string;
+  /** MIME type of the image (e.g., 'image/jpeg', 'image/png') */
+  contentType: string;
+}
+
+export interface UploadClassGalleryImageResponse {
+  success: boolean;
+  /** Public URL of the uploaded gallery image */
+  url: string;
+}
+
+// ============================================================================
 // Get Public Classes (no auth required - for website/Webflow)
 // ============================================================================
 

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -157,6 +157,8 @@ export type {
   DeleteClassResponse,
   UploadClassImageRequest,
   UploadClassImageResponse,
+  UploadClassGalleryImageRequest,
+  UploadClassGalleryImageResponse,
   GetPublicClassesRequest,
   GetPublicClassesResponse,
   GetPublicClassRequest,
@@ -177,6 +179,8 @@ export type {
   DeleteClassCategoryResponse,
   ReorderClassCategoriesRequest,
   ReorderClassCategoriesResponse,
+  UploadCategoryGalleryImageRequest,
+  UploadCategoryGalleryImageResponse,
 } from './class-category.types';
 
 // Phase 3c: Discount types

--- a/libs/ts/validation/src/lib/class-category.validation.spec.ts
+++ b/libs/ts/validation/src/lib/class-category.validation.spec.ts
@@ -158,6 +158,53 @@ describe('classCategoryValidation', () => {
     });
   });
 
+  describe('galleryImages field', () => {
+    it('passes when galleryImages is undefined (optional)', () => {
+      const result = classCategoryValidation({
+        ...validCategory,
+        galleryImages: undefined,
+      });
+      expect(result.isValid()).toBe(true);
+    });
+
+    it('passes with valid pool images', () => {
+      const result = classCategoryValidation({
+        ...validCategory,
+        galleryImages: [
+          { url: 'https://example.com/a.jpg', alt: 'Hands at the loom' },
+        ],
+      });
+      expect(result.isValid()).toBe(true);
+    });
+
+    it('fails when more than 10 pool images', () => {
+      const result = classCategoryValidation({
+        ...validCategory,
+        galleryImages: Array.from({ length: 11 }, (_, i) => ({
+          url: `https://example.com/${i}.jpg`,
+          alt: `Image ${i}`,
+        })),
+      });
+      expect(result.hasErrors('galleryImages')).toBe(true);
+    });
+
+    it('fails when an image is missing alt text', () => {
+      const result = classCategoryValidation({
+        ...validCategory,
+        galleryImages: [{ url: 'https://example.com/a.jpg', alt: '' }],
+      });
+      expect(result.hasErrors('galleryImages')).toBe(true);
+    });
+
+    it('fails when an image is missing url', () => {
+      const result = classCategoryValidation({
+        ...validCategory,
+        galleryImages: [{ url: '   ', alt: 'Has alt text' }],
+      });
+      expect(result.hasErrors('galleryImages')).toBe(true);
+    });
+  });
+
   describe('single-field validation', () => {
     it('only validates specified field', () => {
       const invalidData = {

--- a/libs/ts/validation/src/lib/class-category.validation.ts
+++ b/libs/ts/validation/src/lib/class-category.validation.ts
@@ -5,7 +5,10 @@
  * @see https://vestjs.dev/
  */
 import { staticSuite, test, enforce, only } from 'vest';
-import type { CreateClassCategoryInput } from '@maple/ts/domain';
+import {
+  GALLERY_IMAGE_MAX,
+  type CreateClassCategoryInput,
+} from '@maple/ts/domain';
 
 /**
  * Validate class category form data
@@ -51,5 +54,32 @@ export const classCategoryValidation = staticSuite(
         enforce(data.description).shorterThanOrEquals(200);
       }
     });
+
+    test(
+      'galleryImages',
+      `Gallery pool is limited to ${GALLERY_IMAGE_MAX} images`,
+      () => {
+        if (Array.isArray(data.galleryImages)) {
+          enforce(data.galleryImages.length).lessThanOrEquals(GALLERY_IMAGE_MAX);
+        }
+      }
+    );
+
+    test(
+      'galleryImages',
+      'Every gallery image needs a URL and a description for accessibility',
+      () => {
+        if (Array.isArray(data.galleryImages)) {
+          const allValid = data.galleryImages.every(
+            (img) =>
+              typeof img?.url === 'string' &&
+              img.url.trim().length > 0 &&
+              typeof img?.alt === 'string' &&
+              img.alt.trim().length > 0
+          );
+          enforce(allValid).isTruthy();
+        }
+      }
+    );
   }
 );

--- a/libs/ts/validation/src/lib/class.validation.spec.ts
+++ b/libs/ts/validation/src/lib/class.validation.spec.ts
@@ -631,6 +631,57 @@ describe('classValidation', () => {
     });
   });
 
+  describe('galleryImages field', () => {
+    it('passes when galleryImages is undefined (optional)', () => {
+      const result = classValidation({
+        ...validClass,
+        galleryImages: undefined,
+      });
+      expect(result.isValid()).toBe(true);
+    });
+
+    it('passes with valid gallery images', () => {
+      const result = classValidation({
+        ...validClass,
+        galleryImages: [
+          { url: 'https://example.com/a.jpg', alt: 'Loom up close' },
+          { url: 'https://example.com/b.jpg', alt: 'Finished tapestry' },
+        ],
+      });
+      expect(result.isValid()).toBe(true);
+    });
+
+    it('fails when more than 10 gallery images', () => {
+      const result = classValidation({
+        ...validClass,
+        galleryImages: Array.from({ length: 11 }, (_, i) => ({
+          url: `https://example.com/${i}.jpg`,
+          alt: `Image ${i}`,
+        })),
+      });
+      expect(result.hasErrors('galleryImages')).toBe(true);
+    });
+
+    it('fails when an image is missing alt text', () => {
+      const result = classValidation({
+        ...validClass,
+        galleryImages: [
+          { url: 'https://example.com/a.jpg', alt: 'Good description' },
+          { url: 'https://example.com/b.jpg', alt: '   ' },
+        ],
+      });
+      expect(result.hasErrors('galleryImages')).toBe(true);
+    });
+
+    it('fails when an image is missing url', () => {
+      const result = classValidation({
+        ...validClass,
+        galleryImages: [{ url: '', alt: 'Some description' }],
+      });
+      expect(result.hasErrors('galleryImages')).toBe(true);
+    });
+  });
+
   describe('single-field validation', () => {
     it('only validates specified field', () => {
       const invalidData = {

--- a/libs/ts/validation/src/lib/class.validation.ts
+++ b/libs/ts/validation/src/lib/class.validation.ts
@@ -5,7 +5,7 @@
  * @see https://vestjs.dev/
  */
 import { staticSuite, test, enforce, only } from 'vest';
-import type { CreateClassInput } from '@maple/ts/domain';
+import { GALLERY_IMAGE_MAX, type CreateClassInput } from '@maple/ts/domain';
 
 /**
  * Validate class form data
@@ -219,5 +219,33 @@ export const classValidation = staticSuite(
         enforce(data.whatToBring).shorterThanOrEquals(500);
       }
     });
+
+    // Gallery images validation (optional)
+    test(
+      'galleryImages',
+      `Gallery is limited to ${GALLERY_IMAGE_MAX} images`,
+      () => {
+        if (Array.isArray(data.galleryImages)) {
+          enforce(data.galleryImages.length).lessThanOrEquals(GALLERY_IMAGE_MAX);
+        }
+      }
+    );
+
+    test(
+      'galleryImages',
+      'Every gallery image needs a URL and a description for accessibility',
+      () => {
+        if (Array.isArray(data.galleryImages)) {
+          const allValid = data.galleryImages.every(
+            (img) =>
+              typeof img?.url === 'string' &&
+              img.url.trim().length > 0 &&
+              typeof img?.alt === 'string' &&
+              img.alt.trim().length > 0
+          );
+          enforce(allValid).isTruthy();
+        }
+      }
+    );
   }
 );

--- a/storage.rules
+++ b/storage.rules
@@ -17,6 +17,12 @@ service firebase.storage {
       allow write: if request.auth != null;
     }
 
+    // Class category gallery pool — publicly readable (referenced by classes pulled into Webflow)
+    match /categories/{allPaths=**} {
+      allow read: if true;
+      allow write: if request.auth != null;
+    }
+
     // Default: authenticated access only
     match /{allPaths=**} {
       allow read, write: if request.auth != null;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -203,6 +203,12 @@
       "@maple/firebase/maple-functions/upload-class-image": [
         "libs/firebase/maple-functions/upload-class-image/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/upload-class-gallery-image": [
+        "libs/firebase/maple-functions/upload-class-gallery-image/src/index.ts"
+      ],
+      "@maple/firebase/maple-functions/upload-category-gallery-image": [
+        "libs/firebase/maple-functions/upload-category-gallery-image/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/get-public-classes": [
         "libs/firebase/maple-functions/get-public-classes/src/index.ts"
       ],


### PR DESCRIPTION
## Summary

Adds optional ordered image galleries to Classes and ClassCategories plus the admin UX to manage them. Foundation for richer visual previews on the Webflow class pages.

- `GalleryImage = { url, alt }` with a hard cap of 10 — order encoded by array position
- Required alt text on every image (accessibility-first; Vest enforces non-empty)
- Class-specific gallery + a per-category shared image pool. Classes pull pool URLs in by reference, so adding the same image to many classes (or copying a class in PR 3) duplicates no storage
- Two new callables: `uploadClassGalleryImage`, `uploadCategoryGalleryImage` — write to `classes/{id}/gallery/...` and `categories/{id}/gallery/...` respectively
- Storage rules: `categories/**` is publicly readable (same posture as classes/, since these URLs will be served on Webflow)
- Reusable `<GalleryEditor>` in `@maple/react/ui` — drag-to-reorder via @dnd-kit, ♿ adornment on the alt-text input with helper copy, X/10 counter
- `ClassForm` wires in a `CategoryGalleryPickerDialog` that opens the selected category's pool, showing already-added URLs as checked-and-disabled
- `ClassCategoryForm` gains pool management

## Out of scope (follow-up PRs)

- #357 — Webflow `class-gallery` field, sync mapping, swipeable cards on the class list page, swipeable hero on the individual class page
- #358 — Copy Class admin action (gallery URLs clone for free thanks to this design)

Closes #356.

## Test plan

- [x] `vitest run` for class + class-category validation, ClassForm spec — all 867 tests pass (including 10 new gallery cases)
- [x] `tsc --noEmit` for `apps/functions/tsconfig.app.json` and `apps/maple-spruce/tsconfig.json` — clean
- [x] `./tools/validate-function-tsconfigs.sh` — all checks pass
- [ ] **Manual browser check** (David): in admin, edit a class → upload + reorder + remove gallery images, confirm save round-trips. Edit a class category → manage its pool. Edit a class with a category set → use "Add from {category} pool" picker. Verify the 10-image cap and alt-text-required validation messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)