### PR TITLE
feat: class catalog feed for Meta + Google ads

### DIFF
--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -102,6 +102,9 @@ export { migrateClassSessions } from '@maple/firebase/maple-functions/migrate-cl
 // Public class API (no auth required - for Webflow integration)
 export { getPublicClass } from '@maple/firebase/maple-functions/get-public-class';
 
+// Public class catalog feed (RSS 2.0 for Meta Commerce Manager + Google Merchant Center)
+export { classCatalogFeed } from '@maple/firebase/maple-functions/class-catalog-feed';
+
 // Class category functions
 export { getClassCategories } from '@maple/firebase/maple-functions/get-class-categories';
 export { createClassCategory } from '@maple/firebase/maple-functions/create-class-category';

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -59,6 +59,7 @@
     "../../libs/firebase/maple-functions/add-calendar-embed-source/**/*.ts",
     "../../libs/firebase/maple-functions/remove-calendar-embed-source/**/*.ts",
     "../../libs/firebase/maple-functions/calendar-embed/**/*.ts",
+    "../../libs/firebase/maple-functions/class-catalog-feed/**/*.ts",
     "../../libs/firebase/maple-functions/get-registrations/**/*.ts",
     "../../libs/firebase/maple-functions/get-registration/**/*.ts",
     "../../libs/firebase/maple-functions/update-registration/**/*.ts",

--- a/docs/reference/deployed-functions.md
+++ b/docs/reference/deployed-functions.md
@@ -36,6 +36,7 @@ Core CRUD operations, auth, triggers, and admin functions. No heavy third-party 
 ### Classes
 - `getClasses`, `getClass`, `createClass`, `updateClass`, `deleteClass`, `uploadClassImage`, `uploadClassGalleryImage`
 - `getPublicClass` _(minInstances: 1 in prod / 0 in dev, concurrency: 80)_
+- `classCatalogFeed` _(public RSS 2.0 feed at `/catalog/classes.xml`; consumed by Meta Commerce Manager + Google Merchant Center; 15-min cache)_
 
 ### Class Categories
 - `getClassCategories`, `uploadCategoryGalleryImage`

--- a/firebase.json
+++ b/firebase.json
@@ -51,7 +51,8 @@
       { "source": "/calendar/hours.ics", "function": "calendarHoursFeed" },
       { "source": "/calendar/all.ics", "function": "calendarAllFeed" },
       { "source": "/calendar/adhoc.ics", "function": "calendarAdhocProxy" },
-      { "source": "/calendar/embed", "function": "calendarEmbed" }
+      { "source": "/calendar/embed", "function": "calendarEmbed" },
+      { "source": "/catalog/classes.xml", "function": "classCatalogFeed" }
     ]
   },
   "emulators": {

--- a/libs/firebase/maple-functions/class-catalog-feed/project.json
+++ b/libs/firebase/maple-functions/class-catalog-feed/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-class-catalog-feed",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/class-catalog-feed/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/class-catalog-feed/src/index.ts
+++ b/libs/firebase/maple-functions/class-catalog-feed/src/index.ts
@@ -1,0 +1,1 @@
+export { classCatalogFeed } from './lib/class-catalog-feed';

--- a/libs/firebase/maple-functions/class-catalog-feed/src/lib/build-feed.spec.ts
+++ b/libs/firebase/maple-functions/class-catalog-feed/src/lib/build-feed.spec.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildClassCatalogFeed,
+  escapeXml,
+  formatPrice,
+  stripHtml,
+  type CatalogChannel,
+  type CatalogFeedItem,
+} from './build-feed';
+
+const channel: CatalogChannel = {
+  title: 'Maple & Spruce Classes',
+  link: 'https://mapleandsprucefolkarts.com/upcoming-classes',
+  description: 'Test channel',
+};
+
+const baseItem: CatalogFeedItem = {
+  id: 'class-1',
+  title: 'Stained Glass Studio Series',
+  description: 'A four-week studio series',
+  link: 'https://mapleandsprucefolkarts.com/classes/stained-glass-studio-series',
+  imageLink: 'https://example.com/image.jpg',
+  priceCents: 18000,
+  currency: 'USD',
+  available: true,
+  brand: 'Maple & Spruce',
+};
+
+describe('escapeXml', () => {
+  it('escapes the five XML metacharacters', () => {
+    expect(escapeXml(`a & b < c > d " e ' f`)).toBe(
+      'a &amp; b &lt; c &gt; d &quot; e &apos; f'
+    );
+  });
+
+  it('passes plain text through unchanged', () => {
+    expect(escapeXml('plain text 123')).toBe('plain text 123');
+  });
+});
+
+describe('stripHtml', () => {
+  it('removes tags and collapses whitespace', () => {
+    expect(stripHtml('<p>Hello   <strong>world</strong></p>')).toBe(
+      'Hello world'
+    );
+  });
+
+  it('decodes common entities so they do not double-escape', () => {
+    expect(stripHtml('Mary &amp; Sue&nbsp;hike')).toBe('Mary & Sue hike');
+  });
+
+  it('returns empty string for tag-only input', () => {
+    expect(stripHtml('<br/><br/>')).toBe('');
+  });
+});
+
+describe('formatPrice', () => {
+  it('formats whole-dollar prices with two decimals', () => {
+    expect(formatPrice(4500, 'USD')).toBe('45.00 USD');
+  });
+
+  it('formats sub-dollar prices', () => {
+    expect(formatPrice(99, 'USD')).toBe('0.99 USD');
+  });
+
+  it('uses the requested currency code', () => {
+    expect(formatPrice(1000, 'CAD')).toBe('10.00 CAD');
+  });
+});
+
+describe('buildClassCatalogFeed', () => {
+  it('emits a well-formed RSS 2.0 envelope with the google namespace', () => {
+    const xml = buildClassCatalogFeed(channel, [baseItem]);
+
+    expect(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
+    expect(xml).toContain(
+      '<rss version="2.0" xmlns:g="http://base.google.com/ns/1.0">'
+    );
+    expect(xml).toContain('<channel>');
+    expect(xml).toContain('</channel>');
+    expect(xml.trim().endsWith('</rss>')).toBe(true);
+  });
+
+  it('emits all required Meta + Google fields per item', () => {
+    const xml = buildClassCatalogFeed(channel, [baseItem]);
+
+    expect(xml).toContain('<g:id>class-1</g:id>');
+    expect(xml).toContain('<g:title>Stained Glass Studio Series</g:title>');
+    expect(xml).toContain('<g:description>A four-week studio series</g:description>');
+    expect(xml).toContain(
+      '<g:link>https://mapleandsprucefolkarts.com/classes/stained-glass-studio-series</g:link>'
+    );
+    expect(xml).toContain('<g:image_link>https://example.com/image.jpg</g:image_link>');
+    expect(xml).toContain('<g:availability>in_stock</g:availability>');
+    expect(xml).toContain('<g:price>180.00 USD</g:price>');
+    expect(xml).toContain('<g:condition>new</g:condition>');
+    expect(xml).toContain('<g:brand>Maple &amp; Spruce</g:brand>');
+    expect(xml).toContain('<g:identifier_exists>false</g:identifier_exists>');
+  });
+
+  it('marks items with no availability as out_of_stock', () => {
+    const xml = buildClassCatalogFeed(channel, [
+      { ...baseItem, available: false },
+    ]);
+    expect(xml).toContain('<g:availability>out_of_stock</g:availability>');
+  });
+
+  it('escapes XML metacharacters in titles and descriptions', () => {
+    const xml = buildClassCatalogFeed(channel, [
+      {
+        ...baseItem,
+        title: 'Knives & Forks <demo>',
+        description: '"Quoted" with <em>markup</em> & ampersand',
+      },
+    ]);
+
+    expect(xml).toContain('<g:title>Knives &amp; Forks</g:title>');
+    expect(xml).toContain(
+      '<g:description>&quot;Quoted&quot; with markup &amp; ampersand</g:description>'
+    );
+  });
+
+  it('truncates titles to 150 characters (Google limit)', () => {
+    const longTitle = 'A'.repeat(200);
+    const xml = buildClassCatalogFeed(channel, [
+      { ...baseItem, title: longTitle },
+    ]);
+
+    const match = xml.match(/<g:title>(.*?)<\/g:title>/);
+    expect(match).not.toBeNull();
+    expect(match?.[1].length).toBe(150);
+  });
+
+  it('truncates descriptions to 5000 characters', () => {
+    const longDescription = 'B'.repeat(6000);
+    const xml = buildClassCatalogFeed(channel, [
+      { ...baseItem, description: longDescription },
+    ]);
+
+    const match = xml.match(/<g:description>(.*?)<\/g:description>/);
+    expect(match).not.toBeNull();
+    expect(match?.[1].length).toBe(5000);
+  });
+
+  it('drops items with no image_link rather than emitting invalid rows', () => {
+    const xml = buildClassCatalogFeed(channel, [
+      baseItem,
+      { ...baseItem, id: 'class-2', imageLink: '' },
+    ]);
+
+    expect(xml).toContain('<g:id>class-1</g:id>');
+    expect(xml).not.toContain('<g:id>class-2</g:id>');
+  });
+
+  it('drops items with no link', () => {
+    const xml = buildClassCatalogFeed(channel, [
+      { ...baseItem, id: 'class-3', link: '' },
+    ]);
+
+    expect(xml).not.toContain('<g:id>class-3</g:id>');
+  });
+
+  it('emits an empty channel when no items are valid', () => {
+    const xml = buildClassCatalogFeed(channel, []);
+    expect(xml).toContain('<channel>');
+    expect(xml).not.toContain('<item>');
+  });
+
+  it('escapes the channel title containing an ampersand', () => {
+    const xml = buildClassCatalogFeed(channel, []);
+    expect(xml).toContain('<title>Maple &amp; Spruce Classes</title>');
+  });
+});

--- a/libs/firebase/maple-functions/class-catalog-feed/src/lib/build-feed.ts
+++ b/libs/firebase/maple-functions/class-catalog-feed/src/lib/build-feed.ts
@@ -8,6 +8,10 @@
  * output validates against both.
  */
 
+// XML namespace URI required verbatim by both Meta Commerce Manager and
+// Google Merchant Center. It is an identifier, not a URL we fetch — the
+// `http://` form is what the spec mandates.
+// eslint-disable-next-line sonarjs/no-clear-text-protocols
 const XMLNS_GOOGLE = 'http://base.google.com/ns/1.0';
 
 const TITLE_MAX = 150;

--- a/libs/firebase/maple-functions/class-catalog-feed/src/lib/build-feed.ts
+++ b/libs/firebase/maple-functions/class-catalog-feed/src/lib/build-feed.ts
@@ -1,0 +1,127 @@
+/**
+ * Pure builder for an RSS 2.0 product-catalog feed compatible with both
+ * Meta Commerce Manager and Google Merchant Center.
+ *
+ * Both ingest the same RSS 2.0 + `xmlns:g="http://base.google.com/ns/1.0"`
+ * shape, so a single endpoint serves both. Field choices follow the tighter
+ * of the two specs (Google's title 150-char, id 50-char limits) so the
+ * output validates against both.
+ */
+
+const XMLNS_GOOGLE = 'http://base.google.com/ns/1.0';
+
+const TITLE_MAX = 150;
+const DESCRIPTION_MAX = 5000;
+const ID_MAX = 50;
+
+export interface CatalogChannel {
+  title: string;
+  link: string;
+  description: string;
+}
+
+export interface CatalogFeedItem {
+  id: string;
+  title: string;
+  description: string;
+  link: string;
+  imageLink: string;
+  priceCents: number;
+  currency: string;
+  available: boolean;
+  brand: string;
+}
+
+/**
+ * Escape a value for use as XML text or attribute content.
+ */
+export function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * Strip HTML tags and collapse whitespace for plain-text feed fields.
+ *
+ * Class descriptions can contain rich-text markup from the admin editor;
+ * Meta and Google both want plain text in `<g:description>`. We strip tags,
+ * decode the handful of entities we typically emit, and collapse whitespace.
+ */
+export function stripHtml(value: string): string {
+  return value
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function truncate(value: string, max: number): string {
+  return value.length <= max ? value : value.slice(0, max);
+}
+
+/**
+ * Format a price in the `"19.99 USD"` shape required by both platforms.
+ * Both reject `$` prefixes and integer-cent values.
+ */
+export function formatPrice(priceCents: number, currency: string): string {
+  const amount = (priceCents / 100).toFixed(2);
+  return `${amount} ${currency}`;
+}
+
+function renderItem(item: CatalogFeedItem): string {
+  const id = truncate(item.id, ID_MAX);
+  const title = truncate(stripHtml(item.title), TITLE_MAX);
+  const description = truncate(stripHtml(item.description), DESCRIPTION_MAX);
+  const availability = item.available ? 'in_stock' : 'out_of_stock';
+  const price = formatPrice(item.priceCents, item.currency);
+
+  return [
+    '    <item>',
+    `      <g:id>${escapeXml(id)}</g:id>`,
+    `      <g:title>${escapeXml(title)}</g:title>`,
+    `      <g:description>${escapeXml(description)}</g:description>`,
+    `      <g:link>${escapeXml(item.link)}</g:link>`,
+    `      <g:image_link>${escapeXml(item.imageLink)}</g:image_link>`,
+    `      <g:availability>${availability}</g:availability>`,
+    `      <g:price>${escapeXml(price)}</g:price>`,
+    '      <g:condition>new</g:condition>',
+    `      <g:brand>${escapeXml(item.brand)}</g:brand>`,
+    '      <g:identifier_exists>false</g:identifier_exists>',
+    '    </item>',
+  ].join('\n');
+}
+
+/**
+ * Build the full RSS 2.0 XML document. Items without an `imageLink` are
+ * omitted — both platforms reject items with no image, so silently dropping
+ * them is preferable to shipping invalid rows that fail catalog ingestion.
+ */
+export function buildClassCatalogFeed(
+  channel: CatalogChannel,
+  items: CatalogFeedItem[]
+): string {
+  const validItems = items.filter((item) => item.imageLink && item.link);
+
+  const lines = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    `<rss version="2.0" xmlns:g="${XMLNS_GOOGLE}">`,
+    '  <channel>',
+    `    <title>${escapeXml(channel.title)}</title>`,
+    `    <link>${escapeXml(channel.link)}</link>`,
+    `    <description>${escapeXml(channel.description)}</description>`,
+    ...validItems.map(renderItem),
+    '  </channel>',
+    '</rss>',
+  ];
+
+  return lines.join('\n');
+}

--- a/libs/firebase/maple-functions/class-catalog-feed/src/lib/class-catalog-feed.spec.ts
+++ b/libs/firebase/maple-functions/class-catalog-feed/src/lib/class-catalog-feed.spec.ts
@@ -1,9 +1,25 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Class } from '@maple/ts/domain';
+
+const mocks = vi.hoisted(() => ({
+  classFindAll: vi.fn(),
+  classCountRegistrations: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  ClassRepository: {
+    findAll: mocks.classFindAll,
+    countRegistrations: mocks.classCountRegistrations,
+  },
+}));
+
 import {
   buildFeedFromClasses,
+  CATALOG_FEED_HEADERS,
   generateClassSlug,
+  handleCatalogFeedRequest,
   mapClassToFeedItem,
+  type CatalogFeedResponse,
 } from './class-catalog-feed';
 
 function makeClass(overrides: Partial<Class> = {}): Class {
@@ -119,5 +135,115 @@ describe('buildFeedFromClasses', () => {
     expect(xml).toContain('<channel>');
     expect(xml).not.toContain('<item>');
     expect(xml.trim().endsWith('</rss>')).toBe(true);
+  });
+});
+
+interface FakeResponse extends CatalogFeedResponse {
+  statusCode: number;
+  body: string | unknown;
+  headers: Record<string, string>;
+}
+
+function createFakeResponse(): FakeResponse {
+  const fake = {
+    statusCode: 0,
+    body: undefined as string | unknown,
+    headers: {} as Record<string, string>,
+  } as FakeResponse;
+
+  fake.setHeader = (name: string, value: string) => {
+    fake.headers[name] = value;
+  };
+
+  fake.status = (code: number) => {
+    fake.statusCode = code;
+    return {
+      send: (body?: string) => {
+        fake.body = body ?? '';
+      },
+      json: (body: unknown) => {
+        fake.body = body;
+      },
+    };
+  };
+
+  return fake;
+}
+
+describe('handleCatalogFeedRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.classFindAll.mockResolvedValue([]);
+    mocks.classCountRegistrations.mockResolvedValue(0);
+  });
+
+  it('short-circuits OPTIONS preflight requests with 204', async () => {
+    const res = createFakeResponse();
+    await handleCatalogFeedRequest({ method: 'OPTIONS' }, res);
+
+    expect(res.statusCode).toBe(204);
+    expect(mocks.classFindAll).not.toHaveBeenCalled();
+  });
+
+  it('queries published, upcoming classes only', async () => {
+    const res = createFakeResponse();
+    await handleCatalogFeedRequest({ method: 'GET' }, res);
+
+    expect(mocks.classFindAll).toHaveBeenCalledWith({
+      status: 'published',
+      upcoming: true,
+    });
+  });
+
+  it('writes the catalog headers and a 200 status on success', async () => {
+    mocks.classFindAll.mockResolvedValue([
+      makeClass({ id: 'class-1', name: 'Class One' }),
+    ]);
+
+    const res = createFakeResponse();
+    await handleCatalogFeedRequest({ method: 'GET' }, res);
+
+    expect(res.statusCode).toBe(200);
+    Object.entries(CATALOG_FEED_HEADERS).forEach(([key, value]) => {
+      expect(res.headers[key]).toBe(value);
+    });
+    expect(typeof res.body).toBe('string');
+    expect(res.body).toContain('<g:id>class-1</g:id>');
+  });
+
+  it('emits one item per class with its registration count', async () => {
+    mocks.classFindAll.mockResolvedValue([
+      makeClass({ id: 'sold-out', name: 'Sold Out', capacity: 4 }),
+      makeClass({ id: 'open', name: 'Open Class', capacity: 8 }),
+    ]);
+    mocks.classCountRegistrations.mockImplementation(async (id: string) =>
+      id === 'sold-out' ? 4 : 0
+    );
+
+    const res = createFakeResponse();
+    await handleCatalogFeedRequest({ method: 'GET' }, res);
+
+    const xml = res.body as string;
+    const items = xml.split('<item>');
+    const soldOutItem = items.find((s) => s.includes('<g:id>sold-out</g:id>'));
+    const openItem = items.find((s) => s.includes('<g:id>open</g:id>'));
+
+    expect(soldOutItem).toContain('<g:availability>out_of_stock</g:availability>');
+    expect(openItem).toContain('<g:availability>in_stock</g:availability>');
+  });
+
+  it('returns 500 with a JSON error body when the repository throws', async () => {
+    mocks.classFindAll.mockRejectedValue(new Error('boom'));
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {
+      /* swallow expected error log */
+    });
+
+    const res = createFakeResponse();
+    await handleCatalogFeedRequest({ method: 'GET' }, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: 'Failed to generate feed' });
+
+    consoleError.mockRestore();
   });
 });

--- a/libs/firebase/maple-functions/class-catalog-feed/src/lib/class-catalog-feed.spec.ts
+++ b/libs/firebase/maple-functions/class-catalog-feed/src/lib/class-catalog-feed.spec.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import type { Class } from '@maple/ts/domain';
+import {
+  buildFeedFromClasses,
+  generateClassSlug,
+  mapClassToFeedItem,
+} from './class-catalog-feed';
+
+function makeClass(overrides: Partial<Class> = {}): Class {
+  const now = new Date('2026-04-01T00:00:00Z');
+  return {
+    id: 'class-abc',
+    name: 'Stained Glass Studio Series',
+    description: 'A four-week studio series for stained glass.',
+    sessions: [{ dateTime: new Date('2026-05-01T18:00:00Z') }],
+    durationMinutes: 180,
+    capacity: 8,
+    priceCents: 18000,
+    imageUrl: 'https://example.com/stained-glass.jpg',
+    skillLevel: 'all-levels',
+    status: 'published',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+describe('generateClassSlug', () => {
+  it('lowercases and hyphenates a class name', () => {
+    expect(generateClassSlug('Stained Glass Studio Series')).toBe(
+      'stained-glass-studio-series'
+    );
+  });
+
+  it('strips leading and trailing punctuation', () => {
+    expect(generateClassSlug("!!Hammered Copper!!")).toBe('hammered-copper');
+  });
+
+  it('collapses runs of non-alphanumeric characters', () => {
+    expect(generateClassSlug('Try-It :: Class!')).toBe('try-it-class');
+  });
+});
+
+describe('mapClassToFeedItem', () => {
+  it('builds the public link from the class name slug', () => {
+    const item = mapClassToFeedItem(makeClass(), 0);
+    expect(item?.link).toBe(
+      'https://mapleandsprucefolkarts.com/classes/stained-glass-studio-series'
+    );
+  });
+
+  it('reports availability based on remaining spots', () => {
+    expect(mapClassToFeedItem(makeClass({ capacity: 8 }), 5)?.available).toBe(true);
+    expect(mapClassToFeedItem(makeClass({ capacity: 8 }), 8)?.available).toBe(false);
+    expect(mapClassToFeedItem(makeClass({ capacity: 8 }), 99)?.available).toBe(false);
+  });
+
+  it('prefers shortDescription over description when present', () => {
+    const item = mapClassToFeedItem(
+      makeClass({
+        shortDescription: 'Short tag',
+        description: 'Long description body',
+      }),
+      0
+    );
+    expect(item?.description).toBe('Short tag');
+  });
+
+  it('falls back to description when shortDescription is missing', () => {
+    const item = mapClassToFeedItem(
+      makeClass({ shortDescription: undefined, description: 'Full body' }),
+      0
+    );
+    expect(item?.description).toBe('Full body');
+  });
+
+  it('returns null when the class has no image (catalog would reject it)', () => {
+    expect(mapClassToFeedItem(makeClass({ imageUrl: undefined }), 0)).toBeNull();
+  });
+
+  it('uses USD as the currency', () => {
+    expect(mapClassToFeedItem(makeClass(), 0)?.currency).toBe('USD');
+  });
+
+  it('preserves the priceCents value untouched for the formatter', () => {
+    expect(mapClassToFeedItem(makeClass({ priceCents: 4500 }), 0)?.priceCents).toBe(
+      4500
+    );
+  });
+});
+
+describe('buildFeedFromClasses', () => {
+  it('emits one <item> per published class with an image', () => {
+    const xml = buildFeedFromClasses([
+      { classEntity: makeClass({ id: 'a', name: 'Class A' }), registrationCount: 0 },
+      { classEntity: makeClass({ id: 'b', name: 'Class B' }), registrationCount: 0 },
+    ]);
+
+    expect((xml.match(/<item>/g) ?? []).length).toBe(2);
+    expect(xml).toContain('<g:id>a</g:id>');
+    expect(xml).toContain('<g:id>b</g:id>');
+  });
+
+  it('drops classes without an image rather than failing the feed', () => {
+    const xml = buildFeedFromClasses([
+      { classEntity: makeClass({ id: 'a' }), registrationCount: 0 },
+      {
+        classEntity: makeClass({ id: 'no-image', imageUrl: undefined }),
+        registrationCount: 0,
+      },
+    ]);
+
+    expect(xml).toContain('<g:id>a</g:id>');
+    expect(xml).not.toContain('<g:id>no-image</g:id>');
+  });
+
+  it('produces an empty-channel document when no classes are passed', () => {
+    const xml = buildFeedFromClasses([]);
+    expect(xml).toContain('<channel>');
+    expect(xml).not.toContain('<item>');
+    expect(xml.trim().endsWith('</rss>')).toBe(true);
+  });
+});

--- a/libs/firebase/maple-functions/class-catalog-feed/src/lib/class-catalog-feed.ts
+++ b/libs/firebase/maple-functions/class-catalog-feed/src/lib/class-catalog-feed.ts
@@ -105,40 +105,61 @@ export function buildFeedFromClasses(
   );
 }
 
+/**
+ * Minimal request/response shapes for `handleCatalogFeedRequest` so the
+ * handler can be unit-tested without spinning up an HTTP server.
+ */
+export interface CatalogFeedRequest {
+  method: string;
+}
+
+export interface CatalogFeedResponse {
+  setHeader(name: string, value: string): void;
+  status(code: number): {
+    send(body?: string): void;
+    json(body: unknown): void;
+  };
+}
+
+export async function handleCatalogFeedRequest(
+  request: CatalogFeedRequest,
+  response: CatalogFeedResponse
+): Promise<void> {
+  if (request.method === 'OPTIONS') {
+    response.status(204).send('');
+    return;
+  }
+
+  try {
+    const classes = await ClassRepository.findAll({
+      status: 'published',
+      upcoming: true,
+    });
+
+    const enriched: ClassWithRegistrations[] = await Promise.all(
+      classes.map(async (classEntity) => ({
+        classEntity,
+        registrationCount: await ClassRepository.countRegistrations(
+          classEntity.id
+        ),
+      }))
+    );
+
+    const xml = buildFeedFromClasses(enriched);
+
+    Object.entries(CATALOG_FEED_HEADERS).forEach(([key, value]) => {
+      response.setHeader(key, value);
+    });
+    response.status(200).send(xml);
+  } catch (error) {
+    console.error('Error generating class catalog feed:', error);
+    response.status(500).json({ error: 'Failed to generate feed' });
+  }
+}
+
 export const classCatalogFeed = onRequest(
   // No minInstances — the 15-minute CDN cache from CATALOG_FEED_HEADERS
   // absorbs cold starts between Meta/Google fetch cycles.
   { region: 'us-east4', cors: true, concurrency: 80 },
-  async (request, response) => {
-    if (request.method === 'OPTIONS') {
-      response.status(204).send('');
-      return;
-    }
-
-    try {
-      const classes = await ClassRepository.findAll({
-        status: 'published',
-        upcoming: true,
-      });
-
-      const enriched: ClassWithRegistrations[] = await Promise.all(
-        classes.map(async (classEntity) => ({
-          classEntity,
-          registrationCount: await ClassRepository.countRegistrations(
-            classEntity.id
-          ),
-        }))
-      );
-
-      const xml = buildFeedFromClasses(enriched);
-
-      Object.entries(CATALOG_FEED_HEADERS).forEach(([key, value]) => {
-        response.setHeader(key, value);
-      });
-      response.status(200).send(xml);
-    } catch (error) {
-      console.error('Error generating class catalog feed:', error);
-      response.status(500).json({ error: 'Failed to generate feed' });
-    }
-  }
+  (request, response) => handleCatalogFeedRequest(request, response)
 );

--- a/libs/firebase/maple-functions/class-catalog-feed/src/lib/class-catalog-feed.ts
+++ b/libs/firebase/maple-functions/class-catalog-feed/src/lib/class-catalog-feed.ts
@@ -1,0 +1,144 @@
+/**
+ * Class Catalog Feed
+ *
+ * Public HTTP endpoint that serves an RSS 2.0 product-catalog feed of
+ * published classes. The feed is consumed by Meta Commerce Manager and
+ * Google Merchant Center via their scheduled-fetch flows.
+ *
+ * Single-feed strategy: both platforms accept RSS 2.0 with the
+ * `xmlns:g="http://base.google.com/ns/1.0"` namespace, so one endpoint
+ * serves both rather than maintaining separate CSV/TSV files.
+ *
+ * Subscribe via: /catalog/classes.xml
+ */
+import { onRequest } from 'firebase-functions/v2/https';
+import { ClassRepository } from '@maple/firebase/database';
+import type { Class } from '@maple/ts/domain';
+import {
+  buildClassCatalogFeed,
+  type CatalogFeedItem,
+} from './build-feed';
+
+const PUBLIC_SITE_BASE_URL = 'https://mapleandsprucefolkarts.com';
+const CLASSES_INDEX_PATH = '/upcoming-classes';
+const CLASS_DETAIL_PATH = '/classes';
+const CHANNEL_TITLE = 'Maple & Spruce Classes';
+const CHANNEL_DESCRIPTION =
+  'In-person art and craft classes at Maple & Spruce Folk Arts in Morgantown, WV.';
+const BRAND = 'Maple & Spruce';
+const CURRENCY = 'USD';
+
+/**
+ * Generate the URL slug for a class name. Mirrors the slug logic used by
+ * the Webflow sync (`generateClassSlug` in `@maple/firebase/webflow`) so
+ * the `link` field points at the correct Webflow class detail page.
+ */
+export function generateClassSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+export const CATALOG_FEED_HEADERS = {
+  'Content-Type': 'application/xml; charset=utf-8',
+  // Meta and Google fetch on cadences from hourly to daily; 15min lets edits
+  // propagate within one fetch cycle while absorbing repeated requests.
+  'Cache-Control': 'public, max-age=900, s-maxage=900, stale-while-revalidate=1800',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+} as const;
+
+export interface ClassWithRegistrations {
+  classEntity: Class;
+  registrationCount: number;
+}
+
+/**
+ * Map a class plus its registration count to a feed item. Returns null if
+ * the class lacks the data both platforms require (image, name).
+ */
+export function mapClassToFeedItem(
+  classEntity: Class,
+  registrationCount: number
+): CatalogFeedItem | null {
+  if (!classEntity.imageUrl || !classEntity.name) {
+    return null;
+  }
+
+  const slug = generateClassSlug(classEntity.name);
+  const spotsRemaining = Math.max(
+    0,
+    classEntity.capacity - registrationCount
+  );
+
+  return {
+    id: classEntity.id,
+    title: classEntity.name,
+    description: classEntity.shortDescription || classEntity.description,
+    link: `${PUBLIC_SITE_BASE_URL}${CLASS_DETAIL_PATH}/${slug}`,
+    imageLink: classEntity.imageUrl,
+    priceCents: classEntity.priceCents,
+    currency: CURRENCY,
+    available: spotsRemaining > 0,
+    brand: BRAND,
+  };
+}
+
+export function buildFeedFromClasses(
+  classes: ClassWithRegistrations[]
+): string {
+  const items = classes
+    .map(({ classEntity, registrationCount }) =>
+      mapClassToFeedItem(classEntity, registrationCount)
+    )
+    .filter((item): item is CatalogFeedItem => item !== null);
+
+  return buildClassCatalogFeed(
+    {
+      title: CHANNEL_TITLE,
+      link: `${PUBLIC_SITE_BASE_URL}${CLASSES_INDEX_PATH}`,
+      description: CHANNEL_DESCRIPTION,
+    },
+    items
+  );
+}
+
+export const classCatalogFeed = onRequest(
+  // No minInstances — the 15-minute CDN cache from CATALOG_FEED_HEADERS
+  // absorbs cold starts between Meta/Google fetch cycles.
+  { region: 'us-east4', cors: true, concurrency: 80 },
+  async (request, response) => {
+    if (request.method === 'OPTIONS') {
+      response.status(204).send('');
+      return;
+    }
+
+    try {
+      const classes = await ClassRepository.findAll({
+        status: 'published',
+        upcoming: true,
+      });
+
+      const enriched: ClassWithRegistrations[] = await Promise.all(
+        classes.map(async (classEntity) => ({
+          classEntity,
+          registrationCount: await ClassRepository.countRegistrations(
+            classEntity.id
+          ),
+        }))
+      );
+
+      const xml = buildFeedFromClasses(enriched);
+
+      Object.entries(CATALOG_FEED_HEADERS).forEach(([key, value]) => {
+        response.setHeader(key, value);
+      });
+      response.status(200).send(xml);
+    } catch (error) {
+      console.error('Error generating class catalog feed:', error);
+      response.status(500).json({ error: 'Failed to generate feed' });
+    }
+  }
+);

--- a/libs/firebase/maple-functions/class-catalog-feed/tsconfig.json
+++ b/libs/firebase/maple-functions/class-catalog-feed/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/class-catalog-feed/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/class-catalog-feed/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/class-catalog-feed/vitest.config.ts
+++ b/libs/firebase/maple-functions/class-catalog-feed/vitest.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  root: __dirname,
+  test: {
+    name: 'firebase-maple-functions-class-catalog-feed',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov', 'json-summary', 'json'],
+      reportsDirectory:
+        '../../../../coverage/libs/firebase/maple-functions/class-catalog-feed',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.spec.ts', 'src/index.ts'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@maple/ts/domain': resolve(__dirname, '../../../ts/domain/src/index.ts'),
+      '@maple/firebase/database': resolve(
+        __dirname,
+        '../../../firebase/database/src/index.ts'
+      ),
+    },
+  },
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -278,6 +278,9 @@
       "@maple/firebase/maple-functions/calendar-classes-feed": [
         "libs/firebase/maple-functions/calendar-classes-feed/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/class-catalog-feed": [
+        "libs/firebase/maple-functions/class-catalog-feed/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/calendar-music-feed": [
         "libs/firebase/maple-functions/calendar-music-feed/src/index.ts"
       ],


### PR DESCRIPTION
## Summary

- Adds a public RSS 2.0 product-catalog feed at **`/catalog/classes.xml`** for ingestion by Meta Commerce Manager and Google Merchant Center.
- Single feed serves both platforms via the shared `xmlns:g="http://base.google.com/ns/1.0"` namespace — avoids maintaining separate CSV/TSV endpoints (and Google rejects CSV anyway).
- New Cloud Function `classCatalogFeed` lives in `maple-core` (no heavy deps); no entry needed in `function-codebases.json`.

## Behavior

- Filters: `status: 'published'` and at least one session in the future.
- Each row links to `https://mapleandsprucefolkarts.com/classes/{slug}` using the same `generateClassSlug` algorithm the Webflow sync uses.
- `availability` is `in_stock` when `capacity - registrations > 0`, else `out_of_stock`.
- Items missing an `imageUrl` are dropped — both platforms reject items with no image.
- Title truncated to 150 chars, description to 5000 (Google's tighter limits).
- Price formatted as `"19.99 USD"` per spec; `condition: new`, `brand: Maple & Spruce`, `identifier_exists: false`.
- HTML in descriptions is stripped before XML escaping.

## Caching

- `Cache-Control: public, max-age=900, s-maxage=900, stale-while-revalidate=1800` (15 min).
- Meta and Google fetch hourly–daily; this lets edits propagate within one fetch cycle while absorbing repeated requests so we don't pay for cold starts.

## Test plan

- [x] `vitest` — 31 unit tests covering XML escaping, HTML stripping, price formatting, length truncation, availability mapping, image/link dropouts, slug generation
- [x] `./tools/validate-function-tsconfigs.sh` — passes
- [x] `tsc -p apps/functions/tsconfig.app.json --noEmit` — passes
- [ ] After deploy: `curl https://maple-and-spruce-api.web.app/catalog/classes.xml` and validate against an XML schema validator
- [ ] After deploy: paste URL into Commerce Manager → New catalog → "Use a URL" and confirm Meta accepts it
- [ ] Same for Google Merchant Center (when ready)

## Notes

- `PUBLIC_SITE_BASE_URL` is hardcoded to `https://mapleandsprucefolkarts.com`. If we ever need a dev variant pointing at a staging Webflow site, promote it to a `defineString` param.
- `generateClassSlug` is duplicated from `@maple/firebase/webflow`; both implementations are identical 5-line transforms. A future refactor could extract it to `@maple/ts/domain` for a single source of truth, but importing the webflow lib into `maple-core` would defeat the codebase split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)