### PR TITLE
fix: locality fields on class catalog feed

### DIFF
--- a/libs/firebase/maple-functions/class-catalog-feed/src/lib/build-feed.spec.ts
+++ b/libs/firebase/maple-functions/class-catalog-feed/src/lib/build-feed.spec.ts
@@ -24,6 +24,7 @@ const baseItem: CatalogFeedItem = {
   currency: 'USD',
   available: true,
   brand: 'Maple & Spruce',
+  availabilityPostalCodes: '26508',
 };
 
 describe('escapeXml', () => {
@@ -96,6 +97,18 @@ describe('buildClassCatalogFeed', () => {
     expect(xml).toContain('<g:condition>new</g:condition>');
     expect(xml).toContain('<g:brand>Maple &amp; Spruce</g:brand>');
     expect(xml).toContain('<g:identifier_exists>false</g:identifier_exists>');
+    expect(xml).toContain(
+      '<g:availability_postal_codes>26508</g:availability_postal_codes>'
+    );
+  });
+
+  it('emits availability_postal_codes for each item (Meta locality requirement)', () => {
+    const xml = buildClassCatalogFeed(channel, [
+      { ...baseItem, availabilityPostalCodes: '26505,26508' },
+    ]);
+    expect(xml).toContain(
+      '<g:availability_postal_codes>26505,26508</g:availability_postal_codes>'
+    );
   });
 
   it('marks items with no availability as out_of_stock', () => {

--- a/libs/firebase/maple-functions/class-catalog-feed/src/lib/build-feed.ts
+++ b/libs/firebase/maple-functions/class-catalog-feed/src/lib/build-feed.ts
@@ -34,6 +34,13 @@ export interface CatalogFeedItem {
   currency: string;
   available: boolean;
   brand: string;
+  /**
+   * Comma-separated postal codes where this item can be purchased.
+   * Required for non-shippable / locally-fulfilled items in Meta Commerce
+   * Manager — without it, items are rejected with "Locality fields are
+   * missing or incomplete".
+   */
+  availabilityPostalCodes: string;
 }
 
 /**
@@ -100,6 +107,7 @@ function renderItem(item: CatalogFeedItem): string {
     '      <g:condition>new</g:condition>',
     `      <g:brand>${escapeXml(item.brand)}</g:brand>`,
     '      <g:identifier_exists>false</g:identifier_exists>',
+    `      <g:availability_postal_codes>${escapeXml(item.availabilityPostalCodes)}</g:availability_postal_codes>`,
     '    </item>',
   ].join('\n');
 }

--- a/libs/firebase/maple-functions/class-catalog-feed/src/lib/class-catalog-feed.spec.ts
+++ b/libs/firebase/maple-functions/class-catalog-feed/src/lib/class-catalog-feed.spec.ts
@@ -103,6 +103,12 @@ describe('mapClassToFeedItem', () => {
       4500
     );
   });
+
+  it('attaches the studio postal code so Meta accepts the row as locally available', () => {
+    expect(mapClassToFeedItem(makeClass(), 0)?.availabilityPostalCodes).toBe(
+      '26508'
+    );
+  });
 });
 
 describe('buildFeedFromClasses', () => {

--- a/libs/firebase/maple-functions/class-catalog-feed/src/lib/class-catalog-feed.ts
+++ b/libs/firebase/maple-functions/class-catalog-feed/src/lib/class-catalog-feed.ts
@@ -27,6 +27,10 @@ const CHANNEL_DESCRIPTION =
   'In-person art and craft classes at Maple & Spruce Folk Arts in Morgantown, WV.';
 const BRAND = 'Maple & Spruce';
 const CURRENCY = 'USD';
+// Studio postal code in Morgantown, WV. Meta requires `availability_postal_codes`
+// for non-shippable / locally-fulfilled items; without it, every row fails
+// catalog ingestion with "Locality fields are missing or incomplete".
+const STUDIO_POSTAL_CODES = '26508';
 
 /**
  * Generate the URL slug for a class name. Mirrors the slug logic used by
@@ -83,6 +87,7 @@ export function mapClassToFeedItem(
     currency: CURRENCY,
     available: spotsRemaining > 0,
     brand: BRAND,
+    availabilityPostalCodes: STUDIO_POSTAL_CODES,
   };
 }
 


### PR DESCRIPTION
## Summary

Meta Commerce Manager rejected every row in the just-launched class catalog feed (#371) with **"Locality fields are missing or incomplete"** — in-person classes aren't shippable, so Meta needs to know where they're available.

Adds `<g:availability_postal_codes>` to every feed item with the studio's ZIP `26508`.

## Why a single hardcoded ZIP

All Maple & Spruce classes happen at one studio in Morgantown, WV. Per-item postal codes would only matter if classes ran at multiple locations — not the case today. Hardcoding keeps the change minimal and the field is set on `CatalogFeedItem` so it can vary per-item later if that ever changes.

## Test plan

- [x] `vitest` — 38 tests, all green (added 2 new ones for the field on `CatalogFeedItem` + the mapper)
- [x] `eslint` — clean
- [ ] After deploy: re-upload `https://maple-and-spruce-api.web.app/catalog/classes.xml` to Commerce Manager and confirm rows are accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)