### PR TITLE
feat: per-class referral program — auto-generate single-use codes (#373)

### DIFF
--- a/apps/functions-integration-tests-square/src/create-registration.spec.ts
+++ b/apps/functions-integration-tests-square/src/create-registration.spec.ts
@@ -11,6 +11,7 @@ import {
   clearAuthEmulator,
   clearFirestoreEmulator,
   setFirestoreDoc,
+  listFirestoreDocs,
   callFunction,
 } from '@maple/firebase/integration-test-utils';
 import type { TestUser } from '@maple/firebase/integration-test-utils';
@@ -535,6 +536,181 @@ describe('createRegistration', () => {
 
       const loser = both.find((r) => r !== redeemed[0])!;
       expect(loser.status).not.toBe(200);
+    });
+  });
+
+  describe('Referral program (auto-generated codes in confirmation email)', () => {
+    const REFERRAL_OFF_CLASS_ID = 'test-reg-referral-off-class';
+    const REFERRAL_ON_CLASS_ID = 'test-reg-referral-on-class';
+    const FRIEND_CLASS_ID = 'test-reg-friend-class';
+
+    beforeAll(async () => {
+      // Class WITHOUT referralDiscount — control case.
+      await setFirestoreDoc('classes', REFERRAL_OFF_CLASS_ID, {
+        ...TEST_CLASS,
+        name: 'No-Referral Workshop',
+        capacity: 10,
+      });
+
+      // Class WITH referralDiscount — opted in.
+      await setFirestoreDoc('classes', REFERRAL_ON_CLASS_ID, {
+        ...TEST_CLASS,
+        name: 'Referral Workshop',
+        capacity: 10,
+        referralDiscount: {
+          percent: 50,
+          expiresAfterDays: 60,
+        },
+      });
+
+      // Class for the friend to redeem the referral code on.
+      await setFirestoreDoc('classes', FRIEND_CLASS_ID, {
+        ...TEST_CLASS,
+        name: 'Friend Workshop',
+        capacity: 10,
+      });
+    });
+
+    it('does not create a referral code for classes without referralDiscount', async () => {
+      const result = await callFunction<
+        CreateRegistrationRequest,
+        CreateRegistrationResponse
+      >({
+        functionName: 'createRegistration',
+        data: {
+          classId: REFERRAL_OFF_CLASS_ID,
+          customerEmail: 'no-referral@test.com',
+          customerName: 'No Referral',
+          quantity: 1,
+          paymentNonce: 'cnon:card-nonce-ok',
+        },
+      });
+      expect(result.status).toBe(200);
+      const registrationId = result.data?.registration.id;
+
+      // No discount doc was generated from this registration.
+      const discounts = await listFirestoreDocs('discounts');
+      const generated = discounts.filter(
+        (d) => d.data.generatedFromRegistrationId === registrationId
+      );
+      expect(generated.length).toBe(0);
+
+      // Mail doc for this registration has no referralCode field.
+      const mail = await listFirestoreDocs('mail');
+      const ours = mail.find((m) => {
+        const tmpl = m.data.template as { data?: { confirmationNumber?: string } } | undefined;
+        return tmpl?.data?.confirmationNumber === result.data?.confirmationNumber;
+      });
+      expect(ours).toBeDefined();
+      const tmpl = ours!.data.template as { data: Record<string, unknown> };
+      expect(tmpl.data.referralCode).toBeFalsy();
+    });
+
+    it('generates a single-use referral code and includes it in the email payload', async () => {
+      const result = await callFunction<
+        CreateRegistrationRequest,
+        CreateRegistrationResponse
+      >({
+        functionName: 'createRegistration',
+        data: {
+          classId: REFERRAL_ON_CLASS_ID,
+          customerEmail: 'referrer@test.com',
+          customerName: 'Referrer Person',
+          quantity: 1,
+          paymentNonce: 'cnon:card-nonce-ok',
+        },
+      });
+      expect(result.status).toBe(200);
+      const registrationId = result.data?.registration.id;
+
+      // Exactly one discount doc was generated for this registration.
+      const discounts = await listFirestoreDocs('discounts');
+      const generated = discounts.filter(
+        (d) => d.data.generatedFromRegistrationId === registrationId
+      );
+      expect(generated.length).toBe(1);
+      const referral = generated[0].data;
+      expect(referral.code).toMatch(/^FR-[A-Z0-9]{6}$/);
+      expect(referral.type).toBe('percent');
+      expect(referral.percent).toBe(50);
+      expect(referral.usageLimit).toBe(1);
+      expect(referral.usageCount).toBe(0);
+      expect(referral.appliesTo).toBe('order');
+      expect(referral.status).toBe('active');
+      // expiresAt is ~60 days out; allow a generous window for test timing.
+      expect(referral.expiresAt).toBeDefined();
+
+      // Mail doc has the same code in its template payload.
+      const mail = await listFirestoreDocs('mail');
+      const ours = mail.find((m) => {
+        const tmpl = m.data.template as { data?: { confirmationNumber?: string } } | undefined;
+        return tmpl?.data?.confirmationNumber === result.data?.confirmationNumber;
+      });
+      expect(ours).toBeDefined();
+      const tmpl = ours!.data.template as { data: Record<string, unknown> };
+      expect(tmpl.data.referralCode).toBe(referral.code);
+      expect(tmpl.data.referralPercent).toBe(50);
+      expect(typeof tmpl.data.referralExpires).toBe('string');
+    });
+
+    it('generated code is redeemable as a single-use discount on a different class', async () => {
+      // First, generate a referral code via the referrer's registration.
+      const referrer = await callFunction<
+        CreateRegistrationRequest,
+        CreateRegistrationResponse
+      >({
+        functionName: 'createRegistration',
+        data: {
+          classId: REFERRAL_ON_CLASS_ID,
+          customerEmail: 'referrer-2@test.com',
+          customerName: 'Second Referrer',
+          quantity: 1,
+          paymentNonce: 'cnon:card-nonce-ok',
+        },
+      });
+      expect(referrer.status).toBe(200);
+      const referrerRegId = referrer.data?.registration.id;
+
+      const discounts = await listFirestoreDocs('discounts');
+      const generated = discounts.find(
+        (d) => d.data.generatedFromRegistrationId === referrerRegId
+      );
+      expect(generated).toBeDefined();
+      const code = generated!.data.code as string;
+
+      // Friend uses the code on a different class.
+      const friend = await callFunction<
+        CreateRegistrationRequest,
+        CreateRegistrationResponse
+      >({
+        functionName: 'createRegistration',
+        data: {
+          classId: FRIEND_CLASS_ID,
+          customerEmail: 'friend@test.com',
+          customerName: 'The Friend',
+          quantity: 1,
+          discountCode: code,
+          paymentNonce: 'cnon:card-nonce-ok',
+        },
+      });
+      expect(friend.status).toBe(200);
+      expect(friend.data?.registration.discountCode).toBe(code);
+      // 50% off $45 = $22.50 + 6% tax = 2385 cents
+      expect(friend.data?.registration.pricePaidCents).toBe(2385);
+
+      // Second redemption of the same code must fail (single-use).
+      const friendOfFriend = await callFunction<CreateRegistrationRequest>({
+        functionName: 'createRegistration',
+        data: {
+          classId: FRIEND_CLASS_ID,
+          customerEmail: 'friend-of-friend@test.com',
+          customerName: 'Friend of Friend',
+          quantity: 1,
+          discountCode: code,
+          paymentNonce: 'cnon:card-nonce-ok',
+        },
+      });
+      expect(friendOfFriend.status).not.toBe(200);
     });
   });
 });

--- a/libs/firebase/database/src/lib/class.repository.ts
+++ b/libs/firebase/database/src/lib/class.repository.ts
@@ -93,6 +93,15 @@ function docToClass(
     whatToBring: data.whatToBring,
     minimumAge: data.minimumAge,
     webflowItemId: data.webflowItemId,
+    referralDiscount:
+      data.referralDiscount &&
+      typeof data.referralDiscount.percent === 'number' &&
+      typeof data.referralDiscount.expiresAfterDays === 'number'
+        ? {
+            percent: data.referralDiscount.percent,
+            expiresAfterDays: data.referralDiscount.expiresAfterDays,
+          }
+        : undefined,
     createdAt: toDate(data.createdAt),
     updatedAt: toDate(data.updatedAt),
   };

--- a/libs/firebase/integration-test-utils/src/index.ts
+++ b/libs/firebase/integration-test-utils/src/index.ts
@@ -12,6 +12,7 @@ export {
   clearFirestoreEmulator,
   setFirestoreDoc,
   getFirestoreDoc,
+  listFirestoreDocs,
   deleteFirestoreDoc,
   FirestoreRef,
   FirestoreTimestamp,

--- a/libs/firebase/integration-test-utils/src/lib/utils/firestore-helper.ts
+++ b/libs/firebase/integration-test-utils/src/lib/utils/firestore-helper.ts
@@ -39,6 +39,39 @@ export async function getFirestoreDoc(
   return parseFirestoreFields(body.fields);
 }
 
+/**
+ * List all documents in a Firestore collection. Used by integration tests
+ * to verify side-effects of cloud functions (e.g., that a discount or mail
+ * doc was created with the expected shape).
+ */
+export async function listFirestoreDocs(
+  collectionPath: string
+): Promise<Array<{ id: string; data: Record<string, unknown> }>> {
+  const url = `${FIRESTORE_URL}/v1/projects/${EMULATOR_CONFIG.projectId}/databases/(default)/documents/${collectionPath}`;
+
+  const response = await fetch(url, {
+    headers: { Authorization: 'Bearer owner' },
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) return [];
+    throw new Error(
+      `Failed to list Firestore docs at ${collectionPath}: ${await response.text()}`
+    );
+  }
+
+  const body = (await response.json()) as {
+    documents?: Array<{ name: string; fields?: Record<string, unknown> }>;
+  };
+  if (!body.documents) return [];
+
+  return body.documents.map((doc) => {
+    const id = doc.name.split('/').pop()!;
+    const data = doc.fields ? parseFirestoreFields(doc.fields) : {};
+    return { id, data };
+  });
+}
+
 export async function deleteFirestoreDoc(
   collectionPath: string,
   docId: string

--- a/libs/firebase/maple-functions/create-registration/src/lib/create-registration.ts
+++ b/libs/firebase/maple-functions/create-registration/src/lib/create-registration.ts
@@ -49,7 +49,11 @@ import type {
   CreateRegistrationResponse,
   InlineAgreementSigningData,
 } from '@maple/ts/firebase/api-types';
-import type { AgreementTemplate, MediaReleaseChoice } from '@maple/ts/domain';
+import type {
+  AgreementTemplate,
+  MediaReleaseChoice,
+  PercentDiscountData,
+} from '@maple/ts/domain';
 import { getStorage } from 'firebase-admin/storage';
 import { randomBytes } from 'crypto';
 
@@ -65,6 +69,21 @@ function generateConfirmationNumber(): string {
     code += chars[bytes[i] % chars.length];
   }
   return `MS-${code}`;
+}
+
+/**
+ * Generate a referral discount code shared via the confirmation email.
+ * Distinct prefix (`FR-`) makes the code recognizable as a referral when
+ * customers redeem it.
+ */
+function generateReferralCode(): string {
+  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+  const bytes = randomBytes(6);
+  let code = '';
+  for (let i = 0; i < 6; i++) {
+    code += chars[bytes[i] % chars.length];
+  }
+  return `FR-${code}`;
 }
 
 /**
@@ -597,6 +616,51 @@ export const createRegistration = Functions.endpoint
         );
       }
 
+      // 9b. Generate a referral code if the class opts into the program.
+      // Best-effort: a failure here must NOT fail the registration — the
+      // customer's class is paid for and reserved. We just won't include a
+      // referral code in their email.
+      let referralCode: string | undefined;
+      let referralExpiresFormatted: string | undefined;
+      if (classEntity.referralDiscount) {
+        try {
+          const { percent, expiresAfterDays } = classEntity.referralDiscount;
+          const expiresAt = new Date();
+          expiresAt.setDate(expiresAt.getDate() + expiresAfterDays);
+          const code = generateReferralCode();
+          // Construct an explicit PercentDiscountData shape so TypeScript
+          // can resolve the Discount discriminated union.
+          const referralInput: Omit<
+            PercentDiscountData,
+            'id' | 'createdAt' | 'updatedAt'
+          > = {
+            code,
+            description: `Friend referral from ${data.customerName} (${classEntity.name})`,
+            type: 'percent',
+            percent,
+            status: 'active',
+            appliesTo: 'order',
+            nthSlot: 1,
+            usageLimit: 1,
+            usageCount: 0,
+            expiresAt,
+            generatedFromRegistrationId: registrationDocRef.id,
+          };
+          await DiscountRepository.create(referralInput);
+          referralCode = code;
+          referralExpiresFormatted = expiresAt.toLocaleDateString('en-US', {
+            month: 'long',
+            day: 'numeric',
+            year: 'numeric',
+          });
+        } catch (referralError) {
+          console.error(
+            'Failed to generate referral code (registration unaffected):',
+            referralError
+          );
+        }
+      }
+
       // 10. Write to mail collection for confirmation email
       try {
         const formatCurrency = (cents: number): string =>
@@ -636,6 +700,9 @@ export const createRegistration = Functions.endpoint
               whatToBring: classEntity.whatToBring,
               agreementsSigned: agreementsSigned || undefined,
               waiverUrl,
+              referralCode,
+              referralExpires: referralExpiresFormatted,
+              referralPercent: classEntity.referralDiscount?.percent,
             },
           },
         });

--- a/libs/ts/domain/src/lib/class.ts
+++ b/libs/ts/domain/src/lib/class.ts
@@ -92,8 +92,28 @@ export interface Class {
    * @see docs/decisions/ADR-016-webflow-integration-strategy.md
    */
   webflowItemId?: string;
+  /**
+   * Opt-in to the friend-referral program for this class. When set, every
+   * confirmed registration auto-generates a single-use Discount and the
+   * confirmation email includes a code the customer can share.
+   *
+   * Initially configured by editing the class document directly in
+   * Firestore; admin form controls will land in a follow-up.
+   */
+  referralDiscount?: ClassReferralDiscount;
   createdAt: Date;
   updatedAt: Date;
+}
+
+/**
+ * Per-class friend-referral configuration.
+ * - `percent`: percentage off the friend's first registration (1–100).
+ * - `expiresAfterDays`: how long the generated code stays valid before
+ *   the friend must use it (1–365).
+ */
+export interface ClassReferralDiscount {
+  percent: number;
+  expiresAfterDays: number;
 }
 
 /**

--- a/tools/seed-email-templates.ts
+++ b/tools/seed-email-templates.ts
@@ -141,6 +141,17 @@ const registrationConfirmationHtml = `<!DOCTYPE html>
     </div>
     {{/if}}
 
+    {{#if referralCode}}
+    <div class="highlight-box">
+      <strong style="color: #4A3728;">Bring a friend &#8212; share this code</strong><br>
+      <p>We'd love to have a friend join you. Share this single-use code and they'll get <strong>{{referralPercent}}% off</strong> their first registration:</p>
+      <p style="text-align: center; margin: 12px 0;">
+        <span style="display: inline-block; background-color: #ffffff; border: 2px dashed #6B7B5E; color: #4A3728; font-family: 'Courier New', monospace; font-size: 18px; font-weight: bold; letter-spacing: 2px; padding: 10px 20px; border-radius: 4px;">{{referralCode}}</span>
+      </p>
+      <p style="font-size: 14px; color: #7A7A6E; text-align: center;">Valid for one use, expires {{referralExpires}}.</p>
+    </div>
+    {{/if}}
+
     <p>If you have any questions, please reach out at
       <a href="mailto:katie@mapleandsprucefolkarts.com" style="color: #6B7B5E;">katie@mapleandsprucefolkarts.com</a>,
       call us at <a href="tel:+13043144506" style="color: #6B7B5E;">304-314-4506</a>,


### PR DESCRIPTION
## Summary

Closes the "bring a friend" loop from #365 / #369. When a customer registers for an opted-in class, their confirmation email includes a unique single-use code. The friend uses the code to register at a discount, with single-use semantics enforced atomically by #369's redemption mechanism.

This PR is the **backend + email** side of the original B-2 plan. Admin UI for opting classes in/out is a deliberate follow-up — for early validation, opt a class in by editing the class document directly in Firestore (one or two manually-configured classes are enough to validate the customer-facing experience before paying for UI work).

## How to opt a class into the program

```
classes/<class-id> → set field `referralDiscount` to:
  { percent: 50, expiresAfterDays: 60 }
```

No re-deploy needed. The next confirmed registration on that class auto-generates a code.

## Changes

- **Class domain** (`libs/ts/domain/src/lib/class.ts`): optional `referralDiscount: { percent: number; expiresAfterDays: number }`. Legacy classes default to undefined (program off, zero behavior change for everyone else).
- **Class repository** (`libs/firebase/database/src/lib/class.repository.ts`): reads the field with defensive shape-checking; null/missing → undefined.
- **`create-registration`**: after the registration is confirmed (post-payment for paid classes; immediately after the transaction for free classes), if `classEntity.referralDiscount` is set, generate a unique `FR-XXXXXX` code and create a `PercentDiscountData` with `usageLimit: 1`, `usageCount: 0`, `expiresAt = now + expiresAfterDays`, and `generatedFromRegistrationId` pointing at the new registration. **Best-effort** — a failure here logs but does NOT fail the registration. The customer's class is already paid for and reserved.
- **Email template** (`tools/seed-email-templates.ts`): `registration-confirmation` template gains optional `referralCode`, `referralExpires`, and `referralPercent` fields. HTML conditionally renders a "Bring a friend — share this code" block with the code displayed in a dashed-border monospace box and a friendly expiry note.
- **Test utility** (`libs/firebase/integration-test-utils`): new `listFirestoreDocs(collectionPath)` helper. Used to assert collection-level side effects (new discount docs, mail-collection writes) in integration tests.

## Test plan

- [x] `nx test domain` — pass
- [x] `nx typecheck maple-spruce` — pass
- [x] `./tools/run-integration-tests.sh square` — 31/31 (3 new):
  - Class without `referralDiscount` → no new Discount doc tied to the registration, no `referralCode` in the mail-collection write (regression guard)
  - Class with `referralDiscount` → exactly one new Discount with the expected shape (FR-XXXXXX code, percent, usageLimit=1, generatedFromRegistrationId match), mail doc includes the code
  - Generated code redeems once on a different class; second redemption fails per #369's atomic-redemption path
- [x] Lint clean across 5 affected projects
- [ ] Manual smoke after merge: opt one class into the program in Firestore, register on it, verify the confirmation email shows the FR-XXXXXX code, share it with a "friend" account, register on a different class with that code, verify the discount applies and a second use of the code fails.

I didn't re-run the discount or registration integration suites — they have no functional dependency on this PR (Discount type unchanged; the only addition is an optional Class field that doesn't affect any existing path). Happy to run them as a regression sweep if you'd like — just let me know.

## Out of scope (a future PR if/when wanted)

- Admin UI on the Class form for setting `referralDiscount` without editing Firestore
- Limiting referral codes to a specific class or category (current: code applies to any class, same as a normal discount)
- Per-class anti-abuse caps (max-discount, etc.)

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)