### PR TITLE
feat: admin UI for per-class referral program (#376)

### DIFF
--- a/apps/maple-spruce/.storybook/fixtures/classes.ts
+++ b/apps/maple-spruce/.storybook/fixtures/classes.ts
@@ -52,6 +52,19 @@ export const mockClass2: Class = {
   updatedAt: new Date('2024-05-15T16:45:00Z'),
 };
 
+/** Class opted into the friend-referral program. */
+export const mockClassWithReferral: Class = {
+  ...mockClass,
+  id: 'class-005',
+  name: 'Hand-Stitched Journal Workshop',
+  description:
+    'Bring a friend and stitch your own custom journal in this two-evening workshop. We will cover signatures, kettle stitch binding, and decorative covers — you will leave with a finished book to fill with your own writing or sketches.',
+  shortDescription: 'Bind your own journal — bring a friend and split the price.',
+  sessions: [{ dateTime: new Date('2030-05-04T18:00:00Z') }],
+  imageUrl: 'https://picsum.photos/seed/journal/800/600',
+  referralDiscount: { percent: 50, expiresAfterDays: 60 },
+};
+
 export const mockClassDraft: Class = {
   id: 'class-003',
   name: 'Advanced Tapestry Techniques',

--- a/libs/react/classes/src/lib/ClassForm.stories.tsx
+++ b/libs/react/classes/src/lib/ClassForm.stories.tsx
@@ -7,6 +7,7 @@ import {
   mockClassNoImage,
   mockClassCategories,
   mockClassWithGallery,
+  mockClassWithReferral,
   mockClassCategoriesWithPool,
 } from '../../../../../apps/maple-spruce/.storybook/fixtures';
 import {
@@ -279,6 +280,26 @@ export const WithInstructor: Story = {
     await waitFor(() => {
       expect(canvas.getByLabelText(/class name/i)).toHaveValue(mockClass.name);
     });
+  },
+};
+
+/**
+ * Editing a class that's opted into the friend-referral program — toggle
+ * is on and the percent + expiry fields show the saved values.
+ */
+export const EditWithReferralProgram: Story = {
+  args: {
+    open: true,
+    isSubmitting: false,
+    classItem: mockClassWithReferral,
+  },
+  play: async () => {
+    const canvas = await waitForDialog();
+    await waitFor(() => {
+      expect(canvas.getByLabelText(/enable friend referral program/i)).toBeChecked();
+    });
+    expect(canvas.getByLabelText(/friend gets/i)).toHaveValue(50);
+    expect(canvas.getByLabelText(/code expires after/i)).toHaveValue(60);
   },
 };
 

--- a/libs/react/classes/src/lib/ClassForm.tsx
+++ b/libs/react/classes/src/lib/ClassForm.tsx
@@ -181,6 +181,13 @@ export function ClassForm({
   const whatToBring = useSignal('');
   const minimumAge = useSignal<number | undefined>(undefined);
 
+  // Referral program (per-class opt-in). When the toggle is on, every
+  // confirmed registration auto-generates a single-use code in the
+  // confirmation email — see #373/#375.
+  const referralEnabled = useSignal(false);
+  const referralPercent = useSignal<number>(50);
+  const referralExpiresAfterDays = useSignal<number>(60);
+
   // ============================================================
   // UI STATE SIGNALS
   // ============================================================
@@ -242,6 +249,12 @@ export function ClassForm({
       minimumAge: minimumAge.value,
       galleryImages:
         galleryImages.value.length > 0 ? galleryImages.value : undefined,
+      referralDiscount: referralEnabled.value
+        ? {
+            percent: referralPercent.value,
+            expiresAfterDays: referralExpiresAfterDays.value,
+          }
+        : undefined,
     });
   });
 
@@ -335,6 +348,13 @@ export function ClassForm({
         materialsIncluded.value = classItem.materialsIncluded ?? '';
         whatToBring.value = classItem.whatToBring ?? '';
         minimumAge.value = classItem.minimumAge;
+        // Hydrate the toggle from the class doc; keep editable defaults of
+        // 50% / 60d so toggling ON for a previously-disabled class shows
+        // sensible starting values without requiring extra typing.
+        referralEnabled.value = !!classItem.referralDiscount;
+        referralPercent.value = classItem.referralDiscount?.percent ?? 50;
+        referralExpiresAfterDays.value =
+          classItem.referralDiscount?.expiresAfterDays ?? 60;
 
         if (classItem.imageUrl) {
           imageUploadState.value = {
@@ -384,6 +404,9 @@ export function ClassForm({
         materialsIncluded.value = '';
         whatToBring.value = '';
         minimumAge.value = undefined;
+        referralEnabled.value = false;
+        referralPercent.value = 50;
+        referralExpiresAfterDays.value = 60;
         imageUploadState.value = { status: 'idle' };
         pendingImageFile.value = null;
         showValidationErrors.value = false;
@@ -559,6 +582,12 @@ export function ClassForm({
         materialsIncluded: materialsIncluded.value || undefined,
         whatToBring: whatToBring.value || undefined,
         minimumAge: minimumAge.value,
+        referralDiscount: referralEnabled.value
+          ? {
+              percent: referralPercent.value,
+              expiresAfterDays: referralExpiresAfterDays.value,
+            }
+          : undefined,
       };
 
       await onSubmit(input);
@@ -1085,6 +1114,66 @@ export function ClassForm({
               helperText="Optional age requirement (leave blank for no minimum)"
               sx={{ width: 160 }}
             />
+
+            {/* Friend referral program (per-class opt-in) */}
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={referralEnabled.value}
+                    onChange={(e) => (referralEnabled.value = e.target.checked)}
+                  />
+                }
+                label="Enable friend referral program"
+              />
+              <Typography variant="caption" color="text.secondary" sx={{ mt: -1 }}>
+                When enabled, every confirmed registration includes a unique
+                single-use code in the confirmation email that the customer
+                can share with a friend.
+              </Typography>
+              {referralEnabled.value && (
+                <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+                  <TextField
+                    label="Friend gets"
+                    type="number"
+                    value={referralPercent.value}
+                    onChange={(e) => {
+                      const val = parseInt(e.target.value);
+                      referralPercent.value = isNaN(val) ? 0 : val;
+                    }}
+                    error={!!getFieldError('referralDiscount')}
+                    helperText={
+                      getFieldError('referralDiscount') ?? '1–100% off'
+                    }
+                    InputProps={{
+                      endAdornment: (
+                        <InputAdornment position="end">% off</InputAdornment>
+                      ),
+                    }}
+                    inputProps={{ min: 1, max: 100, step: 1 }}
+                    sx={{ width: 200 }}
+                  />
+                  <TextField
+                    label="Code expires after"
+                    type="number"
+                    value={referralExpiresAfterDays.value}
+                    onChange={(e) => {
+                      const val = parseInt(e.target.value);
+                      referralExpiresAfterDays.value = isNaN(val) ? 0 : val;
+                    }}
+                    error={!!getFieldError('referralDiscount')}
+                    helperText="1–365 days"
+                    InputProps={{
+                      endAdornment: (
+                        <InputAdornment position="end">days</InputAdornment>
+                      ),
+                    }}
+                    inputProps={{ min: 1, max: 365, step: 1 }}
+                    sx={{ width: 220 }}
+                  />
+                </Box>
+              )}
+            </Box>
           </Box>
         </DialogContent>
         <DialogActions>

--- a/libs/ts/validation/src/lib/class.validation.spec.ts
+++ b/libs/ts/validation/src/lib/class.validation.spec.ts
@@ -682,6 +682,63 @@ describe('classValidation', () => {
     });
   });
 
+  describe('referralDiscount field', () => {
+    it('passes when omitted (program off)', () => {
+      const result = classValidation(validClass);
+      expect(result.hasErrors('referralDiscount')).toBe(false);
+    });
+
+    it('passes with valid percent and expiresAfterDays', () => {
+      const result = classValidation({
+        ...validClass,
+        referralDiscount: { percent: 50, expiresAfterDays: 60 },
+      });
+      expect(result.hasErrors('referralDiscount')).toBe(false);
+    });
+
+    it('passes at boundary values (1% / 1 day, 100% / 365 days)', () => {
+      [
+        { percent: 1, expiresAfterDays: 1 },
+        { percent: 100, expiresAfterDays: 365 },
+      ].forEach((referralDiscount) => {
+        const result = classValidation({ ...validClass, referralDiscount });
+        expect(result.hasErrors('referralDiscount')).toBe(false);
+      });
+    });
+
+    it('fails when percent is 0', () => {
+      const result = classValidation({
+        ...validClass,
+        referralDiscount: { percent: 0, expiresAfterDays: 60 },
+      });
+      expect(result.hasErrors('referralDiscount')).toBe(true);
+    });
+
+    it('fails when percent exceeds 100', () => {
+      const result = classValidation({
+        ...validClass,
+        referralDiscount: { percent: 101, expiresAfterDays: 60 },
+      });
+      expect(result.hasErrors('referralDiscount')).toBe(true);
+    });
+
+    it('fails when expiresAfterDays is 0', () => {
+      const result = classValidation({
+        ...validClass,
+        referralDiscount: { percent: 50, expiresAfterDays: 0 },
+      });
+      expect(result.hasErrors('referralDiscount')).toBe(true);
+    });
+
+    it('fails when expiresAfterDays exceeds 365', () => {
+      const result = classValidation({
+        ...validClass,
+        referralDiscount: { percent: 50, expiresAfterDays: 400 },
+      });
+      expect(result.hasErrors('referralDiscount')).toBe(true);
+    });
+  });
+
   describe('single-field validation', () => {
     it('only validates specified field', () => {
       const invalidData = {

--- a/libs/ts/validation/src/lib/class.validation.ts
+++ b/libs/ts/validation/src/lib/class.validation.ts
@@ -220,6 +220,31 @@ export const classValidation = staticSuite(
       }
     });
 
+    // Referral discount validation (optional). When set, both inner fields
+    // must be in valid ranges. We test under the parent key so the form can
+    // surface a single error message regardless of which inner field is bad.
+    test(
+      'referralDiscount',
+      'Referral percent must be between 1 and 100',
+      () => {
+        if (data.referralDiscount) {
+          enforce(data.referralDiscount.percent).greaterThanOrEquals(1);
+          enforce(data.referralDiscount.percent).lessThanOrEquals(100);
+        }
+      }
+    );
+
+    test(
+      'referralDiscount',
+      'Code expiry must be between 1 and 365 days',
+      () => {
+        if (data.referralDiscount) {
+          enforce(data.referralDiscount.expiresAfterDays).greaterThanOrEquals(1);
+          enforce(data.referralDiscount.expiresAfterDays).lessThanOrEquals(365);
+        }
+      }
+    );
+
     // Gallery images validation (optional)
     test(
       'galleryImages',


### PR DESCRIPTION
## Summary

Surfaces the `referralDiscount` config (#373/#375) in the Class admin form so admins can opt classes into the friend-referral program without editing Firestore directly.

This is the deliberate follow-up from #375's "out of scope" — once this lands, no Firestore-editing required to enable referrals on a class.

## Changes

- **ClassForm** (`libs/react/classes/src/lib/ClassForm.tsx`): "Enable friend referral program" `<Switch>` with conditional `<TextField>`s for "Friend gets X% off" (1–100) and "Code expires after Y days" (1–365). Defaults: 50% / 60 days. Hydrates from `classItem.referralDiscount` on edit; sets the field to undefined on save when the toggle is off (clears it from Firestore).
- **Validation** (`libs/ts/validation/src/lib/class.validation.ts`): when `referralDiscount` is set, both inner fields must be in valid ranges. Errors surface under the parent `referralDiscount` key so the form can show one error message regardless of which inner field is bad.
- **Storybook**: new `mockClassWithReferral` fixture and `EditWithReferralProgram` story that asserts hydration loads the toggle ON with saved values.

## Test plan

- [x] `nx test validation` — passing, includes 6 new tests covering on/off, boundaries (1/100, 1/365), and out-of-range values for both inner fields
- [x] `nx typecheck maple-spruce` — clean
- [x] Direct `tsc` typecheck on `react-classes` — clean
- [x] Per-file lint of `ClassForm.tsx` — warnings only, all matching existing patterns
- [ ] Manual smoke after merge: open an existing class without referral, toggle ON, save, verify Firestore has `referralDiscount: { percent: 50, expiresAfterDays: 60 }`. Then edit the same class, change percent to 25, save, verify Firestore updated. Then toggle OFF, save, verify the field is cleared.

## Note about lint

`npx nx lint react-classes` crashes inside an unrelated `@nx/enforce-module-boundaries` autofix bug while inspecting `ClassFilterToolbar.stories.tsx` (pre-existing on main, not introduced by this PR). Per-file lint of my actual changes is clean. CI may surface the same crash — flagging proactively. If it does, that's not this PR's regression to fix.

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)