### PR TITLE
test: harden PeriodPicker storybook test against month rollover (#378)

### DIFF
--- a/libs/react/payouts/src/lib/PeriodPicker.stories.tsx
+++ b/libs/react/payouts/src/lib/PeriodPicker.stories.tsx
@@ -24,14 +24,19 @@ export const PreviousMonthClickedFiresOnChange: Story = {
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
     const btn = canvas.getByRole('button', { name: /previous month/i });
+    // Compute the expected range using the same `new Date()` semantics the
+    // component uses, so the assertion stays correct regardless of which
+    // month "today" happens to be. (The previous version compared against
+    // a hardcoded April reference and broke every May 1st.)
+    const expected = monthRangeFor(new Date(), -1);
     await userEvent.click(btn);
     await waitFor(() => {
       expect(args.onChange).toHaveBeenCalledTimes(1);
       const arg = (args.onChange as ReturnType<typeof fn>).mock.calls[0][0];
       expect(arg.from).toBeInstanceOf(Date);
       expect(arg.to).toBeInstanceOf(Date);
-      // Previous month from April → March
-      expect(arg.from.getMonth() < april.from.getMonth()).toBe(true);
+      expect(arg.from.getTime()).toBe(expected.from.getTime());
+      expect(arg.to.getTime()).toBe(expected.to.getTime());
     });
   },
 };


### PR DESCRIPTION
## Summary

The \`Previous Month Clicked Fires On Change\` storybook test in \`libs/react/payouts/\` started failing in CI on May 1st. The button under test calls \`monthRangeFor(new Date(), -1)\` (previous month relative to *now*), but the test was asserting against a hardcoded April reference with a strict \`<\` comparison. Once "now" rolled into May, "previous month" became April, which equalled the hardcoded April → \`3 < 3 === false\` → fail.

## Fix

Derive the expected range from \`monthRangeFor(new Date(), -1)\` at click time and assert exact equality on both \`from\` and \`to\`. Robust to any month going forward.

## Test plan

- [x] Visual check of the diff — single-file, single-block change
- [ ] CI passes the \`Previous Month Clicked Fires On Change\` story

## Note

This was the first of two unrelated CI failures observed on PR #377 (the referral admin UI PR). The other one — a \`5 NOT_FOUND\` flake in the \`teacher-payout\` integration suite — is being investigated separately.

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)