### PR TITLE
fix: tolerate invoice doc deletion mid-Square-sync (#380)

### DIFF
--- a/libs/firebase/database/src/lib/invoice.repository.spec.ts
+++ b/libs/firebase/database/src/lib/invoice.repository.spec.ts
@@ -467,4 +467,67 @@ describe('InvoiceRepository', () => {
       expect(mockDelete).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('Square sync writebacks tolerate missing doc', () => {
+    // Firestore throws NOT_FOUND (gRPC code 5) when update() targets a
+    // doc that no longer exists. The syncInvoiceToSquare trigger races
+    // against admin/test deletion; these writebacks must swallow that
+    // case rather than crashing the function.
+    function firestoreNotFoundError() {
+      return Object.assign(
+        new Error(
+          '5 NOT_FOUND: no entity to update: app: "dev~maple-and-spruce-dev"'
+        ),
+        { code: 5 }
+      );
+    }
+
+    it('markSquareSynced resolves silently when the invoice was deleted in flight', async () => {
+      const mockUpdate = vi.fn().mockRejectedValue(firestoreNotFoundError());
+      const mockDoc = vi.fn().mockReturnValue({ update: mockUpdate });
+      vi.mocked(db.collection).mockReturnValue({
+        doc: mockDoc,
+      } as unknown as FirebaseFirestore.CollectionReference);
+
+      await expect(
+        InvoiceRepository.markSquareSynced({
+          id: 'inv-deleted',
+          squareOrderId: 'sq-order',
+          squareInvoiceId: 'sq-invoice',
+        })
+      ).resolves.toBeUndefined();
+    });
+
+    it('markSquareSynced rethrows non-NOT_FOUND errors', async () => {
+      const otherError = Object.assign(new Error('5 INTERNAL'), { code: 13 });
+      const mockUpdate = vi.fn().mockRejectedValue(otherError);
+      const mockDoc = vi.fn().mockReturnValue({ update: mockUpdate });
+      vi.mocked(db.collection).mockReturnValue({
+        doc: mockDoc,
+      } as unknown as FirebaseFirestore.CollectionReference);
+
+      await expect(
+        InvoiceRepository.markSquareSynced({
+          id: 'inv-1',
+          squareOrderId: 'sq-order',
+          squareInvoiceId: 'sq-invoice',
+        })
+      ).rejects.toThrow('5 INTERNAL');
+    });
+
+    it('recordSquareSyncError resolves silently when the invoice was deleted in flight', async () => {
+      const mockUpdate = vi.fn().mockRejectedValue(firestoreNotFoundError());
+      const mockDoc = vi.fn().mockReturnValue({ update: mockUpdate });
+      vi.mocked(db.collection).mockReturnValue({
+        doc: mockDoc,
+      } as unknown as FirebaseFirestore.CollectionReference);
+
+      await expect(
+        InvoiceRepository.recordSquareSyncError({
+          id: 'inv-deleted',
+          error: 'Square API timeout',
+        })
+      ).resolves.toBeUndefined();
+    });
+  });
 });

--- a/libs/firebase/database/src/lib/invoice.repository.ts
+++ b/libs/firebase/database/src/lib/invoice.repository.ts
@@ -22,6 +22,19 @@ import { computeInvoiceTotalCents } from '@maple/ts/domain';
 
 const COLLECTION = 'invoices';
 
+/**
+ * Detect Firestore's NOT_FOUND error (gRPC code 5). Used by Square-sync
+ * writebacks that race against doc deletion.
+ */
+function isNotFoundError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code: unknown }).code === 5
+  );
+}
+
 function docToInvoice(
   doc: FirebaseFirestore.DocumentSnapshot
 ): Invoice | undefined {
@@ -279,33 +292,49 @@ export const InvoiceRepository = {
   /**
    * Persist the Square ids stamped during a successful send, and clear
    * any prior sync error.
+   *
+   * Tolerates the doc being deleted in flight: the syncInvoiceToSquare
+   * trigger runs asynchronously, and an admin (or test teardown) can
+   * delete the invoice between when the trigger started and when this
+   * writeback lands. In that case there's nothing to update — silently
+   * skip rather than crashing the function with NOT_FOUND.
    */
   async markSquareSynced(args: {
     id: string;
     squareOrderId: string;
     squareInvoiceId: string;
   }): Promise<void> {
-    await db.collection(COLLECTION).doc(args.id).update({
-      squareOrderId: args.squareOrderId,
-      squareInvoiceId: args.squareInvoiceId,
-      squareSyncError: null,
-      updatedAt: new Date(),
-    });
+    try {
+      await db.collection(COLLECTION).doc(args.id).update({
+        squareOrderId: args.squareOrderId,
+        squareInvoiceId: args.squareInvoiceId,
+        squareSyncError: null,
+        updatedAt: new Date(),
+      });
+    } catch (error) {
+      if (isNotFoundError(error)) return;
+      throw error;
+    }
   },
 
   /**
    * Persist a Square sync error so the admin UI can surface it. The
    * invoice stays in whatever status it was in; only the error field is
-   * updated.
+   * updated. Same NOT_FOUND tolerance as `markSquareSynced`.
    */
   async recordSquareSyncError(args: {
     id: string;
     error: string;
   }): Promise<void> {
-    await db.collection(COLLECTION).doc(args.id).update({
-      squareSyncError: args.error,
-      updatedAt: new Date(),
-    });
+    try {
+      await db.collection(COLLECTION).doc(args.id).update({
+        squareSyncError: args.error,
+        updatedAt: new Date(),
+      });
+    } catch (error) {
+      if (isNotFoundError(error)) return;
+      throw error;
+    }
   },
 
   async delete(id: string): Promise<void> {


### PR DESCRIPTION
## Summary

\`syncInvoiceToSquare\` is a Firestore trigger that runs asynchronously when an invoice goes to 'sent'. It calls Square's API (a few hundred ms), then writes the resulting \`squareInvoiceId\` back to the Firestore invoice doc. If the doc was deleted between trigger fire and writeback, \`update()\` throws \`5 NOT_FOUND\` and the function crashes — even though the Square-side work already succeeded.

This is the second of two unrelated CI failures observed on PR #377 (the referral admin UI). It bit when the \`teacher-payout\` integration suite created an invoice, churned its status, and then \`afterAll\` cleared Firestore while the sync trigger was still in flight.

## Fix

\`InvoiceRepository.markSquareSynced\` and \`InvoiceRepository.recordSquareSyncError\` now catch NOT_FOUND (gRPC code 5) and treat it as a no-op. Other Firestore errors still propagate.

This is the right semantics regardless of tests: in production, an admin can plausibly delete an invoice while a sync is mid-flight. Today that crashes the function unhelpfully; with this change, it's a benign skip.

## Test plan

- [x] \`nx test firebase-database\` — passes, including 3 new unit cases:
  - \`markSquareSynced\` resolves silently on NOT_FOUND
  - \`markSquareSynced\` rethrows non-NOT_FOUND errors
  - \`recordSquareSyncError\` resolves silently on NOT_FOUND
- [x] Lint clean
- [ ] CI: re-run the \`teacher-payout\` integration suite on this branch and confirm green.

## Notes

- I'm only catching the writeback errors here, not changing \`syncInvoiceToSquare\`'s outer try/catch — production-side, the trigger already wraps the Square API call in try/catch and only the repo writeback was unguarded.
- Tagging this \`bug\` rather than \`test\` because the production code path is also vulnerable; CI just exposed it first.

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)