### PR TITLE
fix: Meta Pixel catalog match — emit ViewContent/AddToCart/Purchase with content_ids

### DIFF
--- a/apps/webflow-components/src/RegistrationWidget.tsx
+++ b/apps/webflow-components/src/RegistrationWidget.tsx
@@ -35,6 +35,11 @@ import type {
   InlineAgreementSigningData,
 } from '@maple/ts/firebase/api-types';
 import { getWidgetFunctions } from './firebase-init';
+import {
+  trackAddClassToCart,
+  trackPurchaseClass,
+  trackViewClass,
+} from './lib/class-analytics';
 
 
 /**
@@ -204,11 +209,20 @@ export function RegistrationWidget({
           })),
         ]);
 
+        const publicClass = classResult.data.class;
         setState({
           status: 'ready',
-          publicClass: classResult.data.class,
+          publicClass,
           requiredAgreements: agreementsResult.data.agreements,
         });
+        trackViewClass(
+          typeof window !== 'undefined' ? window : null,
+          {
+            classId: publicClass.id,
+            className: publicClass.name,
+            priceCents: publicClass.priceCents,
+          }
+        );
       } catch (err) {
         console.error('Failed to fetch class:', err);
         setState({
@@ -259,10 +273,22 @@ export function RegistrationWidget({
         CreateRegistrationResponse
       >(functions, 'createRegistration');
 
+      if (state.status === 'ready') {
+        trackAddClassToCart(
+          typeof window !== 'undefined' ? window : null,
+          {
+            classId: state.publicClass.id,
+            className: state.publicClass.name,
+            priceCents: state.publicClass.priceCents,
+            quantity: data.quantity,
+          }
+        );
+      }
+
       const result = await createRegistration(data);
       return result.data;
     },
-    [functions]
+    [functions, state]
   );
 
   const handleSuccess = useCallback(
@@ -278,7 +304,6 @@ export function RegistrationWidget({
 
       const pc = state.publicClass;
       const className = pc.name;
-      const value = details.pricePaidCents / 100;
 
       // Calculate class end time (use first session)
       const firstSessionIso = pc.sessions?.[0]?.dateTime ?? '';
@@ -287,30 +312,16 @@ export function RegistrationWidget({
         startDate.getTime() + pc.durationMinutes * 60 * 1000
       );
 
-      // Meta Pixel: CompleteRegistration event
-      const win = typeof window !== 'undefined' ? (window as unknown as Record<string, unknown>) : null;
-      if (win?.fbq) {
-        (win.fbq as (...args: unknown[]) => void)(
-          'track', 'CompleteRegistration', {
-            value,
-            currency: 'USD',
-            content_name: className,
-          }
-        );
-      }
-
-      // GTM dataLayer: for GA4 and other tags
-      if (win) {
-        const dataLayer = (win.dataLayer || []) as Record<string, unknown>[];
-        dataLayer.push({
-          event: 'complete_registration',
-          registration_value: value,
-          registration_currency: 'USD',
-          class_name: className,
-          confirmation_number: details.confirmationNumber,
-        });
-        win.dataLayer = dataLayer;
-      }
+      trackPurchaseClass(
+        typeof window !== 'undefined' ? window : null,
+        {
+          classId: pc.id,
+          className,
+          pricePaidCents: details.pricePaidCents,
+          quantity: details.quantity,
+          confirmationNumber: details.confirmationNumber,
+        }
+      );
 
       setState({
         status: 'confirmed',

--- a/apps/webflow-components/src/lib/class-analytics.spec.ts
+++ b/apps/webflow-components/src/lib/class-analytics.spec.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildAddToCartDataLayerEvent,
+  buildAddToCartPixelEvent,
+  buildPurchaseDataLayerEvent,
+  buildPurchasePixelEvent,
+  buildViewContentPixelEvent,
+  buildViewItemDataLayerEvent,
+  trackAddClassToCart,
+  trackPurchaseClass,
+  trackViewClass,
+} from './class-analytics';
+
+const CLASS_ID = 'cls_abc123';
+const CLASS_NAME = 'Beginner Pottery';
+
+describe('Meta Pixel event builders', () => {
+  it('ViewContent carries the catalog id, type, value, and currency', () => {
+    const event = buildViewContentPixelEvent({
+      classId: CLASS_ID,
+      className: CLASS_NAME,
+      priceCents: 4500,
+    });
+
+    expect(event.name).toBe('ViewContent');
+    expect(event.params).toMatchObject({
+      content_ids: [CLASS_ID],
+      content_type: 'product',
+      content_name: CLASS_NAME,
+      value: 45,
+      currency: 'USD',
+    });
+  });
+
+  it('AddToCart multiplies value by quantity and sets num_items', () => {
+    const event = buildAddToCartPixelEvent({
+      classId: CLASS_ID,
+      className: CLASS_NAME,
+      priceCents: 4500,
+      quantity: 3,
+    });
+
+    expect(event.name).toBe('AddToCart');
+    expect(event.params).toMatchObject({
+      content_ids: [CLASS_ID],
+      content_type: 'product',
+      value: 135,
+      currency: 'USD',
+      num_items: 3,
+    });
+  });
+
+  it('Purchase uses the actual amount paid (post-discount), not list price', () => {
+    const event = buildPurchasePixelEvent({
+      classId: CLASS_ID,
+      className: CLASS_NAME,
+      pricePaidCents: 8000, // 2 × $45 = $90 list, $80 after discount
+      quantity: 2,
+      confirmationNumber: 'REG-001',
+    });
+
+    expect(event.name).toBe('Purchase');
+    expect(event.params).toMatchObject({
+      content_ids: [CLASS_ID],
+      content_type: 'product',
+      value: 80,
+      currency: 'USD',
+      num_items: 2,
+    });
+  });
+});
+
+describe('GA4 dataLayer event builders', () => {
+  it('view_item populates ecommerce.items with the class id and unit price', () => {
+    const event = buildViewItemDataLayerEvent({
+      classId: CLASS_ID,
+      className: CLASS_NAME,
+      priceCents: 4500,
+    });
+
+    expect(event.event).toBe('view_item');
+    expect(event.ecommerce).toMatchObject({
+      currency: 'USD',
+      value: 45,
+      items: [
+        { item_id: CLASS_ID, item_name: CLASS_NAME, price: 45, quantity: 1 },
+      ],
+    });
+  });
+
+  it('add_to_cart uses unit price per item with quantity', () => {
+    const event = buildAddToCartDataLayerEvent({
+      classId: CLASS_ID,
+      className: CLASS_NAME,
+      priceCents: 4500,
+      quantity: 2,
+    });
+
+    expect(event.event).toBe('add_to_cart');
+    expect(event.ecommerce).toMatchObject({
+      currency: 'USD',
+      value: 90,
+      items: [
+        { item_id: CLASS_ID, item_name: CLASS_NAME, price: 45, quantity: 2 },
+      ],
+    });
+  });
+
+  it('purchase derives unit price from pricePaid / quantity and includes transaction_id', () => {
+    const event = buildPurchaseDataLayerEvent({
+      classId: CLASS_ID,
+      className: CLASS_NAME,
+      pricePaidCents: 8000,
+      quantity: 2,
+      confirmationNumber: 'REG-001',
+    });
+
+    expect(event.event).toBe('purchase');
+    expect(event.ecommerce).toMatchObject({
+      currency: 'USD',
+      value: 80,
+      transaction_id: 'REG-001',
+      items: [
+        { item_id: CLASS_ID, item_name: CLASS_NAME, price: 40, quantity: 2 },
+      ],
+    });
+  });
+});
+
+describe('trackers fire pixel + dataLayer side effects', () => {
+  it('trackViewClass calls fbq and pushes to dataLayer', () => {
+    const fbq = vi.fn();
+    const win: { fbq: typeof fbq; dataLayer?: Record<string, unknown>[] } = {
+      fbq,
+    };
+
+    trackViewClass(win, {
+      classId: CLASS_ID,
+      className: CLASS_NAME,
+      priceCents: 4500,
+    });
+
+    expect(fbq).toHaveBeenCalledWith('track', 'ViewContent', {
+      content_ids: [CLASS_ID],
+      content_type: 'product',
+      content_name: CLASS_NAME,
+      value: 45,
+      currency: 'USD',
+    });
+    expect(win.dataLayer).toHaveLength(1);
+    expect(win.dataLayer?.[0]).toMatchObject({ event: 'view_item' });
+  });
+
+  it('trackAddClassToCart appends to an existing dataLayer queue', () => {
+    const fbq = vi.fn();
+    const existing = [{ event: 'pageview' }];
+    const win = { fbq, dataLayer: existing };
+
+    trackAddClassToCart(win, {
+      classId: CLASS_ID,
+      className: CLASS_NAME,
+      priceCents: 4500,
+      quantity: 1,
+    });
+
+    expect(win.dataLayer).toHaveLength(2);
+    expect(win.dataLayer[1]).toMatchObject({ event: 'add_to_cart' });
+  });
+
+  it('trackPurchaseClass works when fbq is not yet installed (dataLayer only)', () => {
+    const win: { dataLayer?: Record<string, unknown>[] } = {};
+
+    trackPurchaseClass(win, {
+      classId: CLASS_ID,
+      className: CLASS_NAME,
+      pricePaidCents: 4500,
+      quantity: 1,
+      confirmationNumber: 'REG-002',
+    });
+
+    expect(win.dataLayer).toHaveLength(1);
+    expect(win.dataLayer?.[0]).toMatchObject({
+      event: 'purchase',
+      ecommerce: { transaction_id: 'REG-002' },
+    });
+  });
+
+  it('all trackers are no-ops when window is null (SSR-safe)', () => {
+    expect(() =>
+      trackViewClass(null, {
+        classId: CLASS_ID,
+        className: CLASS_NAME,
+        priceCents: 4500,
+      })
+    ).not.toThrow();
+    expect(() =>
+      trackAddClassToCart(null, {
+        classId: CLASS_ID,
+        className: CLASS_NAME,
+        priceCents: 4500,
+        quantity: 1,
+      })
+    ).not.toThrow();
+    expect(() =>
+      trackPurchaseClass(null, {
+        classId: CLASS_ID,
+        className: CLASS_NAME,
+        pricePaidCents: 4500,
+        quantity: 1,
+        confirmationNumber: 'REG-003',
+      })
+    ).not.toThrow();
+  });
+});
+
+describe('Catalog match contract', () => {
+  it('Pixel event content_ids matches the field used by mapClassToFeedItem', () => {
+    // The class catalog feed (libs/firebase/maple-functions/class-catalog-feed/
+    // src/lib/class-catalog-feed.ts) sets `id: classEntity.id` on each feed
+    // item. Meta matches catalog items by comparing this id to the
+    // `content_ids` in pixel events. Both must be the Firestore class doc id.
+    const firestoreClassDocId = 'cls_xyz789';
+
+    const view = buildViewContentPixelEvent({
+      classId: firestoreClassDocId,
+      className: CLASS_NAME,
+      priceCents: 4500,
+    });
+    const cart = buildAddToCartPixelEvent({
+      classId: firestoreClassDocId,
+      className: CLASS_NAME,
+      priceCents: 4500,
+      quantity: 1,
+    });
+    const purchase = buildPurchasePixelEvent({
+      classId: firestoreClassDocId,
+      className: CLASS_NAME,
+      pricePaidCents: 4500,
+      quantity: 1,
+      confirmationNumber: 'REG-004',
+    });
+
+    for (const event of [view, cart, purchase]) {
+      expect(event.params['content_ids']).toEqual([firestoreClassDocId]);
+      expect(event.params['content_type']).toBe('product');
+    }
+  });
+});

--- a/apps/webflow-components/src/lib/class-analytics.ts
+++ b/apps/webflow-components/src/lib/class-analytics.ts
@@ -1,0 +1,235 @@
+/**
+ * Class registration analytics events.
+ *
+ * Emits Meta Pixel + GA4 dataLayer events for the standard e-commerce funnel
+ * (view → add_to_cart → purchase) so Meta can attribute conversions to items
+ * in the class catalog feed (`/catalog/classes.xml`).
+ *
+ * Catalog match contract: every Meta event includes
+ *   `content_ids: [classId]` and `content_type: 'product'`
+ * where `classId` is the Firestore class document ID — the same value used
+ * as the `id` field in `mapClassToFeedItem` (libs/firebase/maple-functions/
+ * class-catalog-feed). If those drift apart, catalog match rate drops to 0%
+ * and Advantage+ catalog ads stop targeting these items.
+ */
+
+const CURRENCY = 'USD';
+
+export interface ViewClassInput {
+  classId: string;
+  className: string;
+  priceCents: number;
+}
+
+export interface AddClassToCartInput {
+  classId: string;
+  className: string;
+  priceCents: number;
+  quantity: number;
+}
+
+export interface PurchaseClassInput {
+  classId: string;
+  className: string;
+  pricePaidCents: number;
+  quantity: number;
+  confirmationNumber: string;
+}
+
+export interface MetaPixelEvent {
+  name: 'ViewContent' | 'AddToCart' | 'Purchase';
+  params: Record<string, unknown>;
+}
+
+export interface DataLayerEvent {
+  event: 'view_item' | 'add_to_cart' | 'purchase';
+  ecommerce: Record<string, unknown>;
+}
+
+function centsToAmount(cents: number): number {
+  return Math.round(cents) / 100;
+}
+
+export function buildViewContentPixelEvent(
+  input: ViewClassInput
+): MetaPixelEvent {
+  return {
+    name: 'ViewContent',
+    params: {
+      content_ids: [input.classId],
+      content_type: 'product',
+      content_name: input.className,
+      value: centsToAmount(input.priceCents),
+      currency: CURRENCY,
+    },
+  };
+}
+
+export function buildAddToCartPixelEvent(
+  input: AddClassToCartInput
+): MetaPixelEvent {
+  return {
+    name: 'AddToCart',
+    params: {
+      content_ids: [input.classId],
+      content_type: 'product',
+      content_name: input.className,
+      value: centsToAmount(input.priceCents * input.quantity),
+      currency: CURRENCY,
+      num_items: input.quantity,
+    },
+  };
+}
+
+export function buildPurchasePixelEvent(
+  input: PurchaseClassInput
+): MetaPixelEvent {
+  return {
+    name: 'Purchase',
+    params: {
+      content_ids: [input.classId],
+      content_type: 'product',
+      content_name: input.className,
+      value: centsToAmount(input.pricePaidCents),
+      currency: CURRENCY,
+      num_items: input.quantity,
+    },
+  };
+}
+
+export function buildViewItemDataLayerEvent(
+  input: ViewClassInput
+): DataLayerEvent {
+  const price = centsToAmount(input.priceCents);
+  return {
+    event: 'view_item',
+    ecommerce: {
+      currency: CURRENCY,
+      value: price,
+      items: [
+        {
+          item_id: input.classId,
+          item_name: input.className,
+          price,
+          quantity: 1,
+        },
+      ],
+    },
+  };
+}
+
+export function buildAddToCartDataLayerEvent(
+  input: AddClassToCartInput
+): DataLayerEvent {
+  const price = centsToAmount(input.priceCents);
+  return {
+    event: 'add_to_cart',
+    ecommerce: {
+      currency: CURRENCY,
+      value: centsToAmount(input.priceCents * input.quantity),
+      items: [
+        {
+          item_id: input.classId,
+          item_name: input.className,
+          price,
+          quantity: input.quantity,
+        },
+      ],
+    },
+  };
+}
+
+export function buildPurchaseDataLayerEvent(
+  input: PurchaseClassInput
+): DataLayerEvent {
+  const value = centsToAmount(input.pricePaidCents);
+  // Per-unit price after discounts; GA4 expects unit price in `items[].price`.
+  const unitPrice =
+    input.quantity > 0
+      ? centsToAmount(input.pricePaidCents / input.quantity)
+      : value;
+  return {
+    event: 'purchase',
+    ecommerce: {
+      currency: CURRENCY,
+      value,
+      transaction_id: input.confirmationNumber,
+      items: [
+        {
+          item_id: input.classId,
+          item_name: input.className,
+          price: unitPrice,
+          quantity: input.quantity,
+        },
+      ],
+    },
+  };
+}
+
+type FbqFn = (...args: unknown[]) => void;
+
+/**
+ * Accepts `unknown` rather than a structural `Window` type so callers can pass
+ * the real `window` object without fighting third-party global augmentations
+ * (gtag.js, fbevents, etc. each declare their own shape for `window.fbq` /
+ * `window.dataLayer`).
+ */
+type WindowLike = unknown;
+
+interface AnalyticsWindow {
+  fbq?: FbqFn;
+  dataLayer?: Record<string, unknown>[];
+}
+
+function asAnalyticsWindow(win: WindowLike): AnalyticsWindow | null {
+  if (win === null || typeof win !== 'object') return null;
+  return win as AnalyticsWindow;
+}
+
+function dispatch(
+  win: WindowLike,
+  pixel: MetaPixelEvent,
+  dataLayer: DataLayerEvent
+): void {
+  const w = asAnalyticsWindow(win);
+  if (!w) return;
+  if (typeof w.fbq === 'function') {
+    w.fbq('track', pixel.name, pixel.params);
+  }
+  const layer = w.dataLayer ?? [];
+  layer.push(dataLayer as unknown as Record<string, unknown>);
+  w.dataLayer = layer;
+}
+
+export function trackViewClass(
+  win: WindowLike,
+  input: ViewClassInput
+): void {
+  dispatch(
+    win,
+    buildViewContentPixelEvent(input),
+    buildViewItemDataLayerEvent(input)
+  );
+}
+
+export function trackAddClassToCart(
+  win: WindowLike,
+  input: AddClassToCartInput
+): void {
+  dispatch(
+    win,
+    buildAddToCartPixelEvent(input),
+    buildAddToCartDataLayerEvent(input)
+  );
+}
+
+export function trackPurchaseClass(
+  win: WindowLike,
+  input: PurchaseClassInput
+): void {
+  dispatch(
+    win,
+    buildPurchasePixelEvent(input),
+    buildPurchaseDataLayerEvent(input)
+  );
+}

--- a/apps/webflow-components/src/lib/class-analytics.ts
+++ b/apps/webflow-components/src/lib/class-analytics.ts
@@ -168,26 +168,22 @@ export function buildPurchaseDataLayerEvent(
 
 type FbqFn = (...args: unknown[]) => void;
 
-/**
- * Accepts `unknown` rather than a structural `Window` type so callers can pass
- * the real `window` object without fighting third-party global augmentations
- * (gtag.js, fbevents, etc. each declare their own shape for `window.fbq` /
- * `window.dataLayer`).
- */
-type WindowLike = unknown;
-
 interface AnalyticsWindow {
   fbq?: FbqFn;
   dataLayer?: Record<string, unknown>[];
 }
 
-function asAnalyticsWindow(win: WindowLike): AnalyticsWindow | null {
+// Trackers accept `unknown` (rather than a structural Window type) so callers
+// can pass the real `window` object without fighting third-party global
+// augmentations — gtag.js, fbevents, etc. each declare their own shapes for
+// `window.fbq` / `window.dataLayer`.
+function asAnalyticsWindow(win: unknown): AnalyticsWindow | null {
   if (win === null || typeof win !== 'object') return null;
   return win as AnalyticsWindow;
 }
 
 function dispatch(
-  win: WindowLike,
+  win: unknown,
   pixel: MetaPixelEvent,
   dataLayer: DataLayerEvent
 ): void {
@@ -202,7 +198,7 @@ function dispatch(
 }
 
 export function trackViewClass(
-  win: WindowLike,
+  win: unknown,
   input: ViewClassInput
 ): void {
   dispatch(
@@ -213,7 +209,7 @@ export function trackViewClass(
 }
 
 export function trackAddClassToCart(
-  win: WindowLike,
+  win: unknown,
   input: AddClassToCartInput
 ): void {
   dispatch(
@@ -224,7 +220,7 @@ export function trackAddClassToCart(
 }
 
 export function trackPurchaseClass(
-  win: WindowLike,
+  win: unknown,
   input: PurchaseClassInput
 ): void {
   dispatch(


### PR DESCRIPTION
## Summary

- The class catalog feed (#371) gives Meta a list of items keyed by Firestore class doc id, but the registration widget never emitted matching pixel events with `content_ids: [classId]`. Meta Events Manager reported **0% catalog match rate** and the catalog can't be used for Advantage+ ads.
- Fires all three standard e-commerce events (ViewContent / AddToCart / Purchase) from `RegistrationWidget`, each carrying `content_ids: [classId]` and `content_type: 'product'` so they match the `id` field set by `mapClassToFeedItem` in `libs/firebase/maple-functions/class-catalog-feed/`.
- Mirrors equivalent GA4 events (`view_item` / `add_to_cart` / `purchase`) into the GTM `dataLayer` so any GA4 tag set up via GTM (#116) benefits from the same funnel data.

## What changed

| Funnel step | Before | After |
|---|---|---|
| Class detail page loads | nothing | `fbq('track', 'ViewContent', { content_ids: [classId], ... })` + `dataLayer.push({ event: 'view_item', ... })` |
| User clicks Register | nothing | `fbq('track', 'AddToCart', ...)` + `dataLayer.push({ event: 'add_to_cart', ... })` |
| Payment succeeds | `CompleteRegistration` w/ no `content_ids`; ad-hoc `complete_registration` dataLayer event | `fbq('track', 'Purchase', ...)` + `dataLayer.push({ event: 'purchase', transaction_id: confirmation#, items: [...] })` |

`CompleteRegistration` is replaced by `Purchase`. `Purchase` is the standard e-commerce conversion event Meta uses for catalog matching, and the previous `CompleteRegistration` call wasn't carrying `content_ids` so it couldn't match anyway.

## Architecture

Analytics logic lives in `apps/webflow-components/src/lib/class-analytics.ts` as pure builder functions plus thin dispatchers. This keeps the catalog-match contract (pixel `content_ids` must equal feed `id` must equal `classEntity.id`) enforceable by node-environment unit test, matching the existing `image2pages-tile.spec.ts` pattern.

## Test plan

- [x] `npx vitest run --config apps/webflow-components/vitest.config.ts` — 27 tests pass (16 existing + 11 new)
- [x] `npx tsc --noEmit -p apps/webflow-components/tsconfig.json` — clean
- [ ] After merge: republish `webflow-components` library so the updated widget reaches the live class detail pages
- [ ] After republish: verify in Meta Events Manager → Test Events that ViewContent / AddToCart / Purchase fire with `content_ids` matching catalog item ids
- [ ] After 24-48h of traffic: confirm catalog match rate climbs above 90% in Meta Commerce Manager (currently 0%)

## Notes

- Catalog feed `id` source: `libs/firebase/maple-functions/class-catalog-feed/src/lib/class-catalog-feed.ts:77` (`id: classEntity.id`).
- Pixel events stay client-side. A server-side Meta Conversions API hook from `createRegistration` would improve attribution further (relevant for #224 follow-up) but isn't required for catalog matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)