### PR TITLE
fix: PeriodPicker storybook test + bundle axios CVE bump (#378)

### DIFF
--- a/apps/functions-integration-tests-teacher-payout/src/teacher-payout-functions.spec.ts
+++ b/apps/functions-integration-tests-teacher-payout/src/teacher-payout-functions.spec.ts
@@ -27,13 +27,27 @@ import type {
 /**
  * End-to-end test: seed one private-pay student + one Hope student,
  * schedule lessons, render the Hope one, send + pay the private-pay
- * invoice, then call getTeacherPayouts for April 2026. Verify each
- * teacher's aggregated total, per-line payout math, and substitute
+ * invoice, then call getTeacherPayouts for the current month. Verify
+ * each teacher's aggregated total, per-line payout math, and substitute
  * attribution using the primaryTeacherAtCreateId snapshot.
  */
 
-const FROM = new Date('2026-04-01T00:00:00Z');
-const TO = new Date('2026-04-30T23:59:59Z');
+// Query window = the current calendar month. The aggregation gates paid
+// invoices on `paidAt`, which the repository auto-stamps to `new Date()`
+// when status transitions to 'paid' — there's no API to override it. So
+// the only way to keep the assertion stable across wall-clock months is
+// to keep the query window aligned with whenever the test actually runs.
+// Lessons scheduledAt below are computed from this same `now` for the
+// same reason.
+const NOW = new Date();
+const FROM = new Date(Date.UTC(NOW.getUTCFullYear(), NOW.getUTCMonth(), 1));
+const TO = new Date(
+  Date.UTC(NOW.getUTCFullYear(), NOW.getUTCMonth() + 1, 0, 23, 59, 59, 999)
+);
+
+function dayInCurrentMonth(day: number): Date {
+  return new Date(Date.UTC(NOW.getUTCFullYear(), NOW.getUTCMonth(), day, 15));
+}
 
 describe('getTeacherPayouts integration', () => {
   let adminUser: TestUser;
@@ -181,9 +195,9 @@ describe('getTeacherPayouts integration', () => {
       // 1. Schedule three lessons for private student, taught by primary,
       //    then invoice + mark paid.
       const privateLessonDates = [
-        new Date('2026-04-07T15:00:00Z'),
-        new Date('2026-04-14T15:00:00Z'),
-        new Date('2026-04-21T15:00:00Z'),
+        dayInCurrentMonth(7),
+        dayInCurrentMonth(14),
+        dayInCurrentMonth(21),
       ];
       const privateLessonIds: string[] = [];
       for (const scheduledAt of privateLessonDates) {
@@ -256,7 +270,7 @@ describe('getTeacherPayouts integration', () => {
         data: {
           studentId: hopeStudentId,
           teacherId: primaryTeacherId,
-          scheduledAt: new Date('2026-04-10T15:00:00Z'),
+          scheduledAt: dayInCurrentMonth(10),
           durationMinutes: 45,
           status: 'scheduled',
         },
@@ -276,7 +290,7 @@ describe('getTeacherPayouts integration', () => {
         data: {
           studentId: hopeStudentId,
           teacherId: primaryTeacherId,
-          scheduledAt: new Date('2026-04-17T15:00:00Z'),
+          scheduledAt: dayInCurrentMonth(17),
           durationMinutes: 45,
           status: 'scheduled',
         },

--- a/libs/react/payouts/src/lib/PeriodPicker.stories.tsx
+++ b/libs/react/payouts/src/lib/PeriodPicker.stories.tsx
@@ -2,15 +2,18 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { fn, expect, userEvent, waitFor, within } from 'storybook/test';
 import { PeriodPicker, monthRangeFor } from './PeriodPicker';
 
-const april = monthRangeFor(new Date('2026-04-15T00:00:00Z'));
+// Seed default args with the *current* month. The "Previous month" quick-pick
+// always emits `monthRangeFor(new Date(), -1)`, so the test below can assert
+// equality against that same expression — independent of wall-clock month.
+const thisMonth = monthRangeFor(new Date());
 
 const meta = {
   component: PeriodPicker,
   title: 'Payouts/PeriodPicker',
   parameters: { layout: 'padded' },
   args: {
-    from: april.from,
-    to: april.to,
+    from: thisMonth.from,
+    to: thisMonth.to,
     onChange: fn(),
   },
 } satisfies Meta<typeof PeriodPicker>;
@@ -24,14 +27,18 @@ export const PreviousMonthClickedFiresOnChange: Story = {
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
     const btn = canvas.getByRole('button', { name: /previous month/i });
+    // Compute expected adjacent to the click so both `new Date()` calls
+    // (here and in the component's onClick) land in the same wall-clock
+    // moment — no month-boundary races.
+    const expected = monthRangeFor(new Date(), -1);
     await userEvent.click(btn);
     await waitFor(() => {
       expect(args.onChange).toHaveBeenCalledTimes(1);
       const arg = (args.onChange as ReturnType<typeof fn>).mock.calls[0][0];
       expect(arg.from).toBeInstanceOf(Date);
       expect(arg.to).toBeInstanceOf(Date);
-      // Previous month from April → March
-      expect(arg.from.getMonth() < april.from.getMonth()).toBe(true);
+      expect(arg.from.getTime()).toBe(expected.from.getTime());
+      expect(arg.to.getTime()).toBe(expected.to.getTime());
     });
   },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   lodash: '>=4.18.0'
-  axios: '>=1.15.0'
+  axios: '>=1.15.1'
   koa: '>=3.1.2'
   vite@>=7.0.0 <7.3.2: '>=7.3.2'
   basic-ftp: '>=5.2.2'
@@ -4982,8 +4982,8 @@ packages:
     resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
     engines: {node: '>=4'}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -11096,7 +11096,7 @@ snapshots:
       '@apimatic/http-query': 0.3.9
       '@apimatic/json-bigint': 1.2.0
       '@apimatic/proxy': 0.1.4
-      axios: 1.15.0
+      axios: 1.16.0
       detect-browser: 5.3.0
       detect-node: 2.1.0
       form-data: 4.0.5
@@ -13423,7 +13423,7 @@ snapshots:
       '@module-federation/third-party-dts-extractor': 0.20.0
       adm-zip: 0.5.17
       ansi-colors: 4.1.3
-      axios: 1.15.0
+      axios: 1.16.0
       chalk: 3.0.0
       fs-extra: 9.1.0
       isomorphic-ws: 5.0.0(ws@8.18.0)
@@ -16567,7 +16567,7 @@ snapshots:
 
   axe-core@4.11.3: {}
 
-  axios@1.15.0:
+  axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.5
@@ -20452,7 +20452,7 @@ snapshots:
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.2
       '@zkochan/js-yaml': 0.0.7
-      axios: 1.15.0
+      axios: 1.16.0
       cli-cursor: 3.1.0
       cli-spinners: 2.6.1
       cliui: 8.0.1
@@ -23076,7 +23076,7 @@ snapshots:
 
   wait-on@9.0.5:
     dependencies:
-      axios: 1.15.0
+      axios: 1.16.0
       joi: 18.1.2
       lodash: 4.18.1
       minimist: 1.2.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,8 +23,13 @@ strictPeerDependencies: false
 overrides:
   # GHSA-r5fr-rjxr-66jc: Code injection via _.template. Transitive dep of html-webpack-plugin, pretty-error, firebase-tools, wait-on. Added 2026-04-01.
   lodash: '>=4.18.0'
-  # GHSA-3p68-rc4w-qgx5 (SSRF via NO_PROXY bypass) and GHSA (cloud metadata exfiltration via header injection). Transitive dep of nx@22.6.4 and square@43.2.1. Updated 2026-04-12.
-  axios: '>=1.15.0'
+  # GHSA-3p68-rc4w-qgx5 (SSRF via NO_PROXY bypass), GHSA-jr5f-v2jv-69x6
+  # (header injection cloud-metadata exfil), GHSA-4hjh-wcwx-xvwj (prototype
+  # pollution → response tampering / data exfil / request hijacking),
+  # GHSA-rfp4-9hxv-h4v3 (header injection via prototype pollution). All
+  # patched in axios 1.15.1. Transitive dep of nx@22.6.5 and square@43.2.1.
+  # Updated 2026-05-04.
+  axios: '>=1.15.1'
   # GHSA-7gcc-r8m5-44qm: Host Header Injection via ctx.hostname. Transitive dep of @webflow/webflow-cli > @module-federation/dts-plugin. Added 2026-04-04.
   koa: '>=3.1.2'
   # GHSA-v2wj-q39q-566r (server.fs.deny bypass) and GHSA-p9ff-h696-f583 (arbitrary file read via dev server WebSocket). Transitive dep of @nx/vitest@22.6.4 > vitest@4.1.2. Added 2026-04-07.


### PR DESCRIPTION
## Summary

Closes #378.

The `PreviousMonthClickedFiresOnChange` storybook test seeded its args from a hardcoded `monthRangeFor('2026-04-15')` and asserted `arg.from.getMonth() < april.from.getMonth()`. The component itself computes `monthRangeFor(new Date(), -1)` at click time — so once the wall clock moved past April, the strict-less-than check started failing (`3 < 3 → false`) and Storybook CI broke for everyone.

## Fix

Compare the callback arg to the same expression the component uses, captured adjacent to the click so both `new Date()` evaluations land in the same wall-clock moment. Test is stable regardless of which month "today" is.

## Test plan

- [x] Local typecheck on `libs/react/payouts` — clean
- [ ] Storybook check on this PR passes (was failing on this exact test on main)
- [ ] No production behavior change — `PeriodPicker.tsx` is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)