### PR TITLE
chore(deps): bump transitive axios to >=1.15.1 to clear 4 high CVEs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   lodash: '>=4.18.0'
-  axios: '>=1.15.0'
+  axios: '>=1.15.1'
   koa: '>=3.1.2'
   vite@>=7.0.0 <7.3.2: '>=7.3.2'
   basic-ftp: '>=5.2.2'
@@ -4982,8 +4982,8 @@ packages:
     resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
     engines: {node: '>=4'}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -11096,7 +11096,7 @@ snapshots:
       '@apimatic/http-query': 0.3.9
       '@apimatic/json-bigint': 1.2.0
       '@apimatic/proxy': 0.1.4
-      axios: 1.15.0
+      axios: 1.16.0
       detect-browser: 5.3.0
       detect-node: 2.1.0
       form-data: 4.0.5
@@ -13423,7 +13423,7 @@ snapshots:
       '@module-federation/third-party-dts-extractor': 0.20.0
       adm-zip: 0.5.17
       ansi-colors: 4.1.3
-      axios: 1.15.0
+      axios: 1.16.0
       chalk: 3.0.0
       fs-extra: 9.1.0
       isomorphic-ws: 5.0.0(ws@8.18.0)
@@ -16567,7 +16567,7 @@ snapshots:
 
   axe-core@4.11.3: {}
 
-  axios@1.15.0:
+  axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.5
@@ -20452,7 +20452,7 @@ snapshots:
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.2
       '@zkochan/js-yaml': 0.0.7
-      axios: 1.15.0
+      axios: 1.16.0
       cli-cursor: 3.1.0
       cli-spinners: 2.6.1
       cliui: 8.0.1
@@ -23076,7 +23076,7 @@ snapshots:
 
   wait-on@9.0.5:
     dependencies:
-      axios: 1.15.0
+      axios: 1.16.0
       joi: 18.1.2
       lodash: 4.18.1
       minimist: 1.2.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,8 +23,13 @@ strictPeerDependencies: false
 overrides:
   # GHSA-r5fr-rjxr-66jc: Code injection via _.template. Transitive dep of html-webpack-plugin, pretty-error, firebase-tools, wait-on. Added 2026-04-01.
   lodash: '>=4.18.0'
-  # GHSA-3p68-rc4w-qgx5 (SSRF via NO_PROXY bypass) and GHSA (cloud metadata exfiltration via header injection). Transitive dep of nx@22.6.4 and square@43.2.1. Updated 2026-04-12.
-  axios: '>=1.15.0'
+  # GHSA-3p68-rc4w-qgx5 (SSRF via NO_PROXY bypass), GHSA-jr5f-v2jv-69x6
+  # (header injection cloud-metadata exfil), GHSA-4hjh-wcwx-xvwj (prototype
+  # pollution → response tampering / data exfil / request hijacking),
+  # GHSA-rfp4-9hxv-h4v3 (header injection via prototype pollution). All
+  # patched in axios 1.15.1. Transitive dep of nx@22.6.5 and square@43.2.1.
+  # Updated 2026-05-04.
+  axios: '>=1.15.1'
   # GHSA-7gcc-r8m5-44qm: Host Header Injection via ctx.hostname. Transitive dep of @webflow/webflow-cli > @module-federation/dts-plugin. Added 2026-04-04.
   koa: '>=3.1.2'
   # GHSA-v2wj-q39q-566r (server.fs.deny bypass) and GHSA-p9ff-h696-f583 (arbitrary file read via dev server WebSocket). Transitive dep of @nx/vitest@22.6.4 > vitest@4.1.2. Added 2026-04-07.


### PR DESCRIPTION
## Summary

`pnpm audit --audit-level=high` was failing every PR with 4 high-severity axios findings. The existing override pinned `axios: '>=1.15.0'`, but axios 1.15.0 is itself vulnerable — the patches for the recent disclosures landed in **1.15.1**.

## CVEs cleared

| Advisory | Issue |
|---|---|
| GHSA-4hjh-wcwx-xvwj | Prototype Pollution → Response Tampering / Data Exfil / Request Hijacking |
| GHSA-rfp4-9hxv-h4v3 | Header Injection via Prototype Pollution |
| GHSA-3p68-rc4w-qgx5 | SSRF via NO_PROXY bypass (already covered by old `>=1.15.0`) |
| GHSA-jr5f-v2jv-69x6 | Cloud-metadata exfil via header injection (already covered) |

All four are patched in axios `1.15.1`. After this PR, `pnpm install` resolves axios to **1.16.0** across the tree (transitive via `square` SDK and `@nx/devkit`).

## Verification

```
$ pnpm why axios | head -3
axios@1.16.0
├─┬ @apimatic/axios-client-adapter@0.3.21
│ └─┬ square@39.1.1

$ pnpm audit --audit-level=high
5 vulnerabilities found
Severity: 2 low | 3 moderate
```

→ 0 high-severity findings (was 4). CI Security Audit job will pass.

## Why one patch version

The CVE database lists vulnerable range `>=1.0.0 <1.15.1`. The current override floor of `>=1.15.0` happens to permit the *first* version that is still vulnerable. Bumping by exactly one patch (`>=1.15.1`) is the minimal change to exit the vulnerable range.

## Test plan

- [x] `pnpm install` regenerates lockfile cleanly
- [x] `pnpm audit --audit-level=high` returns 0 high
- [ ] CI: Build, TypeScript Check, Unit Tests, Integration Tests all pass — confirms square SDK + nx tooling still work on axios 1.16.0
- [ ] CI: Security Audit passes (the whole point of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)