### PR TITLE
refactor: move invoice NOT_FOUND swallow from repo to trigger handler

### DIFF
--- a/libs/firebase/database/src/lib/invoice.repository.spec.ts
+++ b/libs/firebase/database/src/lib/invoice.repository.spec.ts
@@ -468,11 +468,10 @@ describe('InvoiceRepository', () => {
     });
   });
 
-  // syncInvoiceToSquare fires async after invoice status transitions; if the
-  // invoice is deleted (test cleanup, admin churn, rapid status flips) before
-  // Square responds, the writeback used to crash the function. These tests
-  // lock in that NOT_FOUND is swallowed and other errors still propagate.
-  // Regression test for #380.
+  // Repo methods used by the syncInvoiceToSquare trigger. They throw any
+  // Firestore error (including NOT_FOUND) verbatim — discrimination of
+  // "benign mid-sync delete" vs. "real bug like wrong id" is the trigger
+  // handler's job because only it has the surrounding context.
   function mockDocUpdate(impl: () => Promise<unknown>) {
     const update = vi.fn().mockImplementation(impl);
     const mockDoc = vi.fn().mockReturnValue({ update });
@@ -501,7 +500,7 @@ describe('InvoiceRepository', () => {
       });
     });
 
-    it('swallows gRPC NOT_FOUND when the invoice was deleted mid-sync', async () => {
+    it('propagates Firestore errors (caller decides what to swallow)', async () => {
       const notFound = Object.assign(
         new Error('5 NOT_FOUND: no entity to update'),
         { code: 5 }
@@ -514,23 +513,7 @@ describe('InvoiceRepository', () => {
           squareOrderId: 'order-1',
           squareInvoiceId: 'sq-inv-1',
         })
-      ).resolves.toBeUndefined();
-    });
-
-    it('rethrows other Firestore errors (e.g. PERMISSION_DENIED)', async () => {
-      const permissionDenied = Object.assign(
-        new Error('7 PERMISSION_DENIED'),
-        { code: 7 }
-      );
-      mockDocUpdate(() => Promise.reject(permissionDenied));
-
-      await expect(
-        InvoiceRepository.markSquareSynced({
-          id: 'inv-1',
-          squareOrderId: 'order-1',
-          squareInvoiceId: 'sq-inv-1',
-        })
-      ).rejects.toThrow('PERMISSION_DENIED');
+      ).rejects.toThrow('NOT_FOUND');
     });
   });
 
@@ -549,7 +532,7 @@ describe('InvoiceRepository', () => {
       });
     });
 
-    it('swallows gRPC NOT_FOUND when the invoice was deleted mid-sync', async () => {
+    it('propagates Firestore errors (caller decides what to swallow)', async () => {
       const notFound = Object.assign(
         new Error('5 NOT_FOUND: no entity to update'),
         { code: 5 }
@@ -561,22 +544,7 @@ describe('InvoiceRepository', () => {
           id: 'deleted-inv',
           error: 'Square 500',
         })
-      ).resolves.toBeUndefined();
-    });
-
-    it('rethrows other Firestore errors', async () => {
-      const internal = Object.assign(
-        new Error('13 INTERNAL'),
-        { code: 13 }
-      );
-      mockDocUpdate(() => Promise.reject(internal));
-
-      await expect(
-        InvoiceRepository.recordSquareSyncError({
-          id: 'inv-1',
-          error: 'Square 500',
-        })
-      ).rejects.toThrow('INTERNAL');
+      ).rejects.toThrow('NOT_FOUND');
     });
   });
 });

--- a/libs/firebase/database/src/lib/invoice.repository.ts
+++ b/libs/firebase/database/src/lib/invoice.repository.ts
@@ -22,24 +22,6 @@ import { computeInvoiceTotalCents } from '@maple/ts/domain';
 
 const COLLECTION = 'invoices';
 
-/**
- * gRPC NOT_FOUND status code — Firestore throws this from `update()` when
- * the target doc has been deleted. The `syncInvoiceToSquare` trigger fires
- * async after status transitions; if the invoice is deleted (test cleanup,
- * admin churn, rapid status flips) before Square responds, the writeback
- * here would otherwise crash the function.
- */
-const GRPC_NOT_FOUND = 5;
-
-function isNotFoundError(err: unknown): boolean {
-  return (
-    typeof err === 'object' &&
-    err !== null &&
-    'code' in err &&
-    (err as { code: unknown }).code === GRPC_NOT_FOUND
-  );
-}
-
 function docToInvoice(
   doc: FirebaseFirestore.DocumentSnapshot
 ): Invoice | undefined {
@@ -303,17 +285,12 @@ export const InvoiceRepository = {
     squareOrderId: string;
     squareInvoiceId: string;
   }): Promise<void> {
-    try {
-      await db.collection(COLLECTION).doc(args.id).update({
-        squareOrderId: args.squareOrderId,
-        squareInvoiceId: args.squareInvoiceId,
-        squareSyncError: null,
-        updatedAt: new Date(),
-      });
-    } catch (err) {
-      if (isNotFoundError(err)) return;
-      throw err;
-    }
+    await db.collection(COLLECTION).doc(args.id).update({
+      squareOrderId: args.squareOrderId,
+      squareInvoiceId: args.squareInvoiceId,
+      squareSyncError: null,
+      updatedAt: new Date(),
+    });
   },
 
   /**
@@ -325,15 +302,10 @@ export const InvoiceRepository = {
     id: string;
     error: string;
   }): Promise<void> {
-    try {
-      await db.collection(COLLECTION).doc(args.id).update({
-        squareSyncError: args.error,
-        updatedAt: new Date(),
-      });
-    } catch (err) {
-      if (isNotFoundError(err)) return;
-      throw err;
-    }
+    await db.collection(COLLECTION).doc(args.id).update({
+      squareSyncError: args.error,
+      updatedAt: new Date(),
+    });
   },
 
   async delete(id: string): Promise<void> {

--- a/libs/firebase/maple-functions/sync-invoice-to-square/src/lib/sync-invoice-to-square.spec.ts
+++ b/libs/firebase/maple-functions/sync-invoice-to-square/src/lib/sync-invoice-to-square.spec.ts
@@ -500,4 +500,96 @@ describe('syncInvoiceToSquare trigger', () => {
       expect(mocks.cancelInvoice).not.toHaveBeenCalled();
     });
   });
+
+  // Race: doc deleted between trigger fire and Square-call completion. The
+  // trigger has positive context that the doc existed (it just fired on a
+  // change to it), so a NOT_FOUND on the writeback is benign. Anything
+  // else from the writeback is a real failure and must propagate.
+  describe('writeback NOT_FOUND tolerance (mid-sync delete)', () => {
+    const grpcNotFound = (): Error =>
+      Object.assign(new Error('5 NOT_FOUND: no entity to update'), { code: 5 });
+
+    beforeEach(() => {
+      mocks.studentFindById.mockResolvedValue(sampleStudent);
+      mocks.sendInvoice.mockResolvedValue({
+        squareCustomerId: 'SQ-CUST',
+        squareOrderId: 'SQ-ORDER',
+        squareInvoiceId: 'SQ-INV',
+      });
+    });
+
+    it('returns cleanly when send-success writeback hits NOT_FOUND', async () => {
+      mocks.markSquareSynced.mockRejectedValueOnce(grpcNotFound());
+
+      await expect(
+        handler({
+          params: { invoiceId: 'inv-1' },
+          data: {
+            before: makeSnap(true, { ...baseSent, status: 'draft' }),
+            after: makeSnap(true, baseSent),
+          },
+        })
+      ).resolves.toBeUndefined();
+    });
+
+    it('returns cleanly when send-error writeback hits NOT_FOUND', async () => {
+      mocks.sendInvoice.mockRejectedValueOnce(new Error('Square 500'));
+      mocks.recordSquareSyncError.mockRejectedValueOnce(grpcNotFound());
+
+      await expect(
+        handler({
+          params: { invoiceId: 'inv-1' },
+          data: {
+            before: makeSnap(true, { ...baseSent, status: 'draft' }),
+            after: makeSnap(true, baseSent),
+          },
+        })
+      ).resolves.toBeUndefined();
+    });
+
+    it('returns cleanly when cancel-success writeback hits NOT_FOUND', async () => {
+      mocks.cancelInvoice.mockResolvedValueOnce(undefined);
+      mocks.recordSquareSyncError.mockRejectedValueOnce(grpcNotFound());
+
+      await expect(
+        handler({
+          params: { invoiceId: 'inv-1' },
+          data: {
+            before: makeSnap(true, {
+              ...baseSent,
+              squareInvoiceId: 'SQ-INV-1',
+            }),
+            after: makeSnap(true, {
+              ...baseSent,
+              status: 'void',
+              squareInvoiceId: 'SQ-INV-1',
+            }),
+          },
+        })
+      ).resolves.toBeUndefined();
+    });
+
+    it('propagates non-NOT_FOUND errors from the error-writeback', async () => {
+      // Square call fails → outer catch records a sync error → that
+      // recordSquareSyncError write hits PERMISSION_DENIED. NOT_FOUND
+      // would be benign; PERMISSION_DENIED is a real config bug we want
+      // surfaced (Firestore will retry the trigger).
+      mocks.sendInvoice.mockRejectedValueOnce(new Error('Square 500'));
+      const permissionDenied = Object.assign(
+        new Error('7 PERMISSION_DENIED: caller missing iam.firestore.update'),
+        { code: 7 }
+      );
+      mocks.recordSquareSyncError.mockRejectedValueOnce(permissionDenied);
+
+      await expect(
+        handler({
+          params: { invoiceId: 'inv-1' },
+          data: {
+            before: makeSnap(true, { ...baseSent, status: 'draft' }),
+            after: makeSnap(true, baseSent),
+          },
+        })
+      ).rejects.toThrow('PERMISSION_DENIED');
+    });
+  });
 });

--- a/libs/firebase/maple-functions/sync-invoice-to-square/src/lib/sync-invoice-to-square.ts
+++ b/libs/firebase/maple-functions/sync-invoice-to-square/src/lib/sync-invoice-to-square.ts
@@ -34,6 +34,49 @@ import {
 const squareSecretParams = SQUARE_SECRET_NAMES.map((name) => defineSecret(name));
 const squareStringParams = SQUARE_STRING_NAMES.map((name) => defineString(name));
 
+/** gRPC NOT_FOUND — Firestore throws this from `update()` when the doc is gone. */
+const GRPC_NOT_FOUND = 5;
+
+function isFirestoreNotFound(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code: unknown }).code === GRPC_NOT_FOUND
+  );
+}
+
+/**
+ * Run a writeback to a doc whose existence we already confirmed (the
+ * trigger fired because it existed). If the doc has since been deleted
+ * — test cleanup, admin churn, rapid status flips — Firestore throws
+ * NOT_FOUND. That's benign here, but log loudly with `context` so any
+ * unexpected occurrence stays visible. Rethrow anything else.
+ *
+ * The swallow lives at this layer, not in the repository: a generic
+ * `update(id)` can't tell "benign mid-sync delete" apart from "caller
+ * bug with the wrong id", so a repo-level swallow would silence real
+ * bugs. Here we have positive context — we know we just synced this
+ * exact invoice with Square — and can swallow narrowly.
+ */
+async function tolerateMidSyncDelete(
+  invoiceId: string,
+  context: string,
+  fn: () => Promise<void>
+): Promise<void> {
+  try {
+    await fn();
+  } catch (err) {
+    if (isFirestoreNotFound(err)) {
+      console.warn(
+        `[sync-invoice] ${invoiceId} ${context}: invoice deleted mid-sync, dropping writeback`
+      );
+      return;
+    }
+    throw err;
+  }
+}
+
 /** Firestore Timestamp-ish → Date helper. */
 function toDateLike(value: unknown): Date | undefined {
   if (!value) return undefined;
@@ -165,11 +208,13 @@ export const syncInvoiceToSquare = onDocumentWritten(
           })),
         });
 
-        await InvoiceRepository.markSquareSynced({
-          id: invoiceId,
-          squareOrderId: result.squareOrderId,
-          squareInvoiceId: result.squareInvoiceId,
-        });
+        await tolerateMidSyncDelete(invoiceId, 'send-success writeback', () =>
+          InvoiceRepository.markSquareSynced({
+            id: invoiceId,
+            squareOrderId: result.squareOrderId,
+            squareInvoiceId: result.squareInvoiceId,
+          })
+        );
 
         console.log(
           `[sync-invoice] ${invoiceId} sent via Square (invoice=${result.squareInvoiceId})`
@@ -178,10 +223,12 @@ export const syncInvoiceToSquare = onDocumentWritten(
         const message =
           error instanceof Error ? error.message : 'Unknown Square sync error';
         console.error(`[sync-invoice] ${invoiceId} send failed:`, message);
-        await InvoiceRepository.recordSquareSyncError({
-          id: invoiceId,
-          error: message,
-        });
+        await tolerateMidSyncDelete(invoiceId, 'send-error writeback', () =>
+          InvoiceRepository.recordSquareSyncError({
+            id: invoiceId,
+            error: message,
+          })
+        );
       }
       return;
     }
@@ -189,10 +236,12 @@ export const syncInvoiceToSquare = onDocumentWritten(
     if (needsCancel && after.squareInvoiceId) {
       try {
         await square.invoicesService.cancelInvoice(after.squareInvoiceId);
-        await InvoiceRepository.recordSquareSyncError({
-          id: invoiceId,
-          error: '',
-        });
+        await tolerateMidSyncDelete(invoiceId, 'cancel-success writeback', () =>
+          InvoiceRepository.recordSquareSyncError({
+            id: invoiceId,
+            error: '',
+          })
+        );
         console.log(
           `[sync-invoice] ${invoiceId} cancelled on Square (invoice=${after.squareInvoiceId})`
         );
@@ -200,10 +249,12 @@ export const syncInvoiceToSquare = onDocumentWritten(
         const message =
           error instanceof Error ? error.message : 'Unknown Square sync error';
         console.error(`[sync-invoice] ${invoiceId} cancel failed:`, message);
-        await InvoiceRepository.recordSquareSyncError({
-          id: invoiceId,
-          error: message,
-        });
+        await tolerateMidSyncDelete(invoiceId, 'cancel-error writeback', () =>
+          InvoiceRepository.recordSquareSyncError({
+            id: invoiceId,
+            error: message,
+          })
+        );
       }
     }
   }


### PR DESCRIPTION
## Summary

Follow-up to #385 addressing review feedback that the repo-level swallow was too broad.

## Why

The original fix for #380 swallowed Firestore \`NOT_FOUND\` inside \`InvoiceRepository.markSquareSynced\` and \`recordSquareSyncError\`. That layer has no context to tell:

- ✅ **benign mid-sync delete** — the trigger fired on a real doc that was then cleaned up before writeback. We want to swallow this.
- ❌ **caller bug with a stale/wrong id** — should surface as a real failure but would be silently no-op'd.

A repo-level swallow can't distinguish them; one is masked by the fix for the other.

## Fix

Push the swallow up to the only caller (\`syncInvoiceToSquare\`) where the context is unambiguous:

1. The trigger fires *because* the doc existed at write time
2. The Square API call already returned (idempotent invoice creation, we have the resulting id in scope)
3. A NOT_FOUND on the writeback can therefore only mean "doc deleted between trigger fire and writeback" — exactly the race we want to swallow

New helper \`tolerateMidSyncDelete(invoiceId, context, fn)\` wraps each writeback, logs a warning with call-site context, and rethrows anything other than NOT_FOUND. Repository methods restored to throw any Firestore error verbatim.

## Changes

| File | Change |
|---|---|
| \`libs/firebase/database/src/lib/invoice.repository.ts\` | Revert swallow; methods throw verbatim |
| \`libs/firebase/database/src/lib/invoice.repository.spec.ts\` | Drop NOT_FOUND-swallow tests, replace with "propagates Firestore errors" assertions |
| \`libs/firebase/maple-functions/sync-invoice-to-square/src/lib/sync-invoice-to-square.ts\` | Add \`tolerateMidSyncDelete\` helper; wrap all 4 writeback call sites |
| \`libs/firebase/maple-functions/sync-invoice-to-square/src/lib/sync-invoice-to-square.spec.ts\` | 4 new tests — NOT_FOUND tolerance per writeback site + non-NOT_FOUND propagation |

## Test plan

- [x] Repo unit tests: 142 pass
- [x] Trigger unit tests: 22 pass (was 18)
- [x] Lint clean (0 errors)
- [ ] CI integration tests stay green (the original race that #385 fixed is still handled, just one layer up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)