### PR TITLE
fix: non-breaking space between month and day in class date displays

### DIFF
--- a/libs/ts/domain/src/lib/class.spec.ts
+++ b/libs/ts/domain/src/lib/class.spec.ts
@@ -310,9 +310,11 @@ describe('Class domain helpers', () => {
         'America/New_York'
       );
       expect(result.sharedTime).toBe(true);
-      // Both dates should be listed
-      expect(result.dateDisplay).toContain('Jun 15');
-      expect(result.dateDisplay).toContain('Jun 22');
+      // Month + day are joined with a non-breaking space so "Jun 15" never
+      // wraps across lines in a comma-separated list of dates.
+      expect(result.dateDisplay).toContain('Jun 15');
+      expect(result.dateDisplay).toContain('Jun 22');
+      expect(result.dateDisplay).not.toContain('Jun 15');
     });
 
     it('detects different times across sessions', () => {
@@ -388,8 +390,8 @@ describe('Class domain helpers', () => {
         'America/New_York'
       );
       expect(result.sharedTime).toBe(true);
-      expect(result.dateDisplay).toContain('Jun 15');
-      expect(result.dateDisplay).toContain('Jun 22');
+      expect(result.dateDisplay).toContain('Jun 15');
+      expect(result.dateDisplay).toContain('Jun 22');
     });
   });
 });

--- a/libs/ts/domain/src/lib/class.ts
+++ b/libs/ts/domain/src/lib/class.ts
@@ -341,11 +341,15 @@ export function formatSessions(
     });
 
   const dateOf = (d: Date | string): string =>
-    ensureDate(d).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      timeZone,
-    });
+    // Glue month + day with a non-breaking space so e.g. "Jun 13" never wraps
+    // mid-token in a comma-separated list of dates.
+    ensureDate(d)
+      .toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        timeZone,
+      })
+      .replace(' ', ' ');
 
   const firstTime = timeOf(sorted[0].dateTime);
   const sharedTime = sorted.every((s) => timeOf(s.dateTime) === firstTime);


### PR DESCRIPTION
## Summary
- `formatSessions` (used by Webflow class CMS sync, the registration confirmation email, and `ClassList`) now joins month and day with a non-breaking space, so a list like `Jun 13, Jun 20, Jun 27` no longer wraps with `Jun` and `13` on separate lines.
- Only the *month↔day* gap changes — comma-separated tokens still wrap normally, and the date↔time space (varying-time case) is unchanged.
- Updated `class.spec.ts` assertions to use NBSP, plus a regression guard asserting the regular-space form is *not* present.

## Test plan
- [x] `npx vitest run libs/ts/domain/src/lib/class.spec.ts` — 36 passed
- [x] `npx vitest run libs/firebase/webflow/src/lib/class.service.spec.ts` — 35 passed
- [ ] After deploy, spot-check a multi-session class on the live Webflow site to confirm dates no longer break mid-token

🤖 Generated with [Claude Code](https://claude.com/claude-code)