### PR TITLE
fix: clarify multi-session class duration is per-session

### DIFF
--- a/libs/firebase/webflow/src/lib/class.service.spec.ts
+++ b/libs/firebase/webflow/src/lib/class.service.spec.ts
@@ -99,6 +99,26 @@ describe('mapClassToFieldData', () => {
     expect(mapClassToFieldData(short, { isDev: false })['duration-display']).toBe('45 min');
   });
 
+  it('appends "each" to duration when class has multiple sessions', () => {
+    const multiSession = {
+      ...mockClass,
+      durationMinutes: 90,
+      sessions: [
+        { dateTime: new Date('2026-05-31T17:00:00.000Z') },
+        { dateTime: new Date('2026-06-07T17:00:00.000Z') },
+        { dateTime: new Date('2026-06-14T17:00:00.000Z') },
+      ],
+    };
+    expect(mapClassToFieldData(multiSession, { isDev: false })['duration-display']).toBe(
+      '1.5 hours each'
+    );
+
+    const multiSessionShort = { ...multiSession, durationMinutes: 45 };
+    expect(mapClassToFieldData(multiSessionShort, { isDev: false })['duration-display']).toBe(
+      '45 min each'
+    );
+  });
+
   it('formats spots display correctly', () => {
     expect(
       mapClassToFieldData(mockClass, { isDev: false, registrationCount: 9 })['spots-display']

--- a/libs/firebase/webflow/src/lib/class.service.ts
+++ b/libs/firebase/webflow/src/lib/class.service.ts
@@ -109,11 +109,15 @@ export function mapClassToFieldData(
       ? `$${priceDollars}`
       : `$${priceDollars.toFixed(2)}`;
 
-  const durationDisplay = classEntity.durationMinutes >= 60
+  const baseDuration = classEntity.durationMinutes >= 60
     ? classEntity.durationMinutes % 60 === 0
       ? `${classEntity.durationMinutes / 60} hour${classEntity.durationMinutes / 60 === 1 ? '' : 's'}`
       : `${(classEntity.durationMinutes / 60).toFixed(1)} hours`
     : `${classEntity.durationMinutes} min`;
+  // Multi-session classes: clarify duration is per session, not summed across sessions
+  const durationDisplay = classEntity.sessions.length > 1
+    ? `${baseDuration} each`
+    : baseDuration;
 
   const spotsDisplay = spotsRemaining <= 0
     ? 'Class Full'


### PR DESCRIPTION
## Summary
- For classes with multiple session dates, append `each` to the Webflow `duration-display` field so a 3-session 1.5-hour class reads `1.5 hours each` instead of `1.5 hours`.
- Without this, the duration on cards/detail pages read ambiguously next to a list of dates (e.g. `May 31, Jun 7, Jun 14    1.5 hours`) — users could read it as the total across dates.
- Single-session classes are unchanged. The same CMS field renders on both the class card and the detail page, so one change covers both surfaces.

## Test plan
- [x] Unit test added in `class.service.spec.ts` covering multi-session duration suffix for both `hours` and `min` cases
- [x] Existing duration-display tests still pass (single-session unchanged)
- [ ] After merge, verify on the live Webflow site that a multi-session class card shows `1.5 hours each` and a single-session card still shows `3 hours`

🤖 Generated with [Claude Code](https://claude.com/claude-code)