### PR TITLE
feat: Tally email-signup tracking (generate_lead + Meta Pixel Lead)

### DIFF
--- a/tools/webflow-tally-form-events.html
+++ b/tools/webflow-tally-form-events.html
@@ -1,0 +1,64 @@
+<!--
+  Maple & Spruce — Tally email-signup analytics tracking
+
+  Pushes a `generate_lead` event to the GA4 dataLayer AND a `Lead` event to
+  Meta Pixel whenever the Tally email-signup popup form is submitted.
+
+  Paste destination:
+    Webflow Designer → Site Settings (gear icon) → Custom Code →
+    "Footer Code". Append this snippet (do not replace existing footer code).
+
+  After pasting:
+    1. Save site settings.
+    2. Publish the site (top right → Publish).
+    3. Verify in GA4 → Admin → DebugView: open the email-signup popup on
+       the live site, submit a real or test entry, watch for a
+       `generate_lead` event row.
+    4. Verify in Meta Events Manager → Test Events: confirm a `Lead` event
+       fires for pixel 1625932185289127.
+    5. In GA4 → Admin → Events: mark `generate_lead` as a conversion event.
+       (Without this step the event fires but is not counted as a conversion.)
+
+  Why match by string instead of origin:
+    Tally posts the FormSubmitted message from the popup iframe (origin
+    https://tally.so) but the popup is also wrapped by Webflow CDN-hosted
+    glue scripts that may relay events from the same origin as the page.
+    Matching on the literal string "Tally.FormSubmitted" is the pattern
+    Tally's own docs recommend and is robust to either path.
+-->
+
+<script>
+  (function () {
+    var FORM_NAME = 'email-signup';
+
+    window.addEventListener('message', function (event) {
+      if (typeof event.data !== 'string') return;
+      if (event.data.indexOf('Tally.FormSubmitted') === -1) return;
+
+      var formId = null;
+      try {
+        var parsed = JSON.parse(event.data);
+        formId = (parsed && parsed.payload && parsed.payload.formId) || null;
+      } catch (_e) {
+        // not JSON — keep formId null and continue
+      }
+
+      // GA4 via dataLayer (GTM container GTM-P5NDCZSX forwards to G-TY0E9X31V6)
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        event: 'generate_lead',
+        form_id: formId,
+        form_name: FORM_NAME,
+      });
+
+      // Meta Pixel — Lead standard event so Meta can optimize ads for email
+      // signups and report on them in Ads Manager
+      if (typeof window.fbq === 'function') {
+        window.fbq('track', 'Lead', {
+          content_name: FORM_NAME,
+          content_category: 'newsletter',
+        });
+      }
+    });
+  })();
+</script>


### PR DESCRIPTION
## Summary

- Adds a paste-into-Webflow snippet (`tools/webflow-tally-form-events.html`) that listens for Tally `FormSubmitted` postMessage events and pushes matching events to:
  - **GA4 dataLayer** as `generate_lead` (forwarded by GTM `GTM-P5NDCZSX` to `G-TY0E9X31V6`)
  - **Meta Pixel** as the standard `Lead` event (pixel `1625932185289127`)
- Closes the GA4 conversion-tracking gap for email signups, which currently appear nowhere in analytics. Lets us answer "which traffic source drove this email subscriber?" once the snippet is pasted into Webflow.

## Why this matters

Channel attribution analysis (Apr 22 – May 6) showed ~70% of site traffic is Meta-driven (Paid Social 49% + Organic Social 22%) and email signup is the primary visitor goal of the homepage banner. Without `generate_lead` firing, none of that conversion path is visible in GA4 — `conversions` reports 0 across every channel because no events are configured. This PR provides the snippet; the manual paste step activates it.

## Manual steps after merge

1. Paste the `<script>` block (and only that block, append — do not replace) into **Webflow Designer → Site Settings (gear icon) → Custom Code → Footer Code**.
2. Publish the Webflow site.
3. Open the live site, click "Sign Up for Updates", submit a test email, watch GA4 → Admin → DebugView for a `generate_lead` event.
4. In Meta Events Manager → Test Events, confirm a `Lead` event fires.
5. In **GA4 → Admin → Events**, mark `generate_lead` as a conversion event (otherwise it fires but isn't counted as a conversion).

## Companion follow-up (NOT in this PR)

The `apps/webflow-components` registration widget already calls `trackViewClass` / `trackAddClassToCart` / `trackPurchaseClass` (added in cbe6050). However, **a live class page does not push `view_item` to the dataLayer when the widget loads** — verified via chrome-devtools on `/classes/stained-glass-tryit-class-94fde`. This means the Webflow Code Component bundle on the live site is stale and needs to be rebuilt + pushed to Webflow. That's a separate manual deploy, not a code change.

After both this PR ships and the widget is redeployed, GA4 will see all four custom events: `view_item`, `add_to_cart`, `purchase`, `generate_lead`.

## Test plan

- [ ] Paste snippet into Webflow Site Settings → Custom Code → Footer Code, publish
- [ ] Visit live site, click "Sign Up for Updates", submit test entry
- [ ] Confirm `generate_lead` event in GA4 DebugView with `form_name: email-signup` and `form_id: 0QPRq9`
- [ ] Confirm `Lead` event in Meta Events Manager → Test Events
- [ ] Mark `generate_lead` as a conversion event in GA4 admin
- [ ] After 7 days, check that `Direct` channel attribution shows the expected Meta-driven volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)