### PR TITLE
config: set real Google review URL for class reminders

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -27,5 +27,4 @@ GOOGLE_CALENDAR_ADHOC_ICS_URL=
 
 # Class Reminders
 # Google Business Profile review shortlink used in the day-of class reminder email.
-# Placeholder until Katie pulls the real URL from business.google.com → "Get more reviews".
-GOOGLE_REVIEW_URL=https://g.page/r/REPLACE_WITH_GOOGLE_CID/review
+GOOGLE_REVIEW_URL=https://g.page/r/CVjnXa8bifPBEBM/review

--- a/.env.prod
+++ b/.env.prod
@@ -25,3 +25,7 @@ ETSY_REDIRECT_URI=https://business.mapleandsprucefolkarts.com/settings/etsy-call
 # Calendar System
 # Katie's public Google Calendar ICS URL (set when she creates "M&S Ad Hoc" calendar)
 GOOGLE_CALENDAR_ADHOC_ICS_URL=
+
+# Class Reminders
+# Google Business Profile review shortlink used in the day-of class reminder email.
+GOOGLE_REVIEW_URL=https://g.page/r/CVjnXa8bifPBEBM/review


### PR DESCRIPTION
## Summary

Swap the \`GOOGLE_REVIEW_URL\` placeholder for the real review shortlink from Maple & Spruce's Google Business Profile: \`https://g.page/r/CVjnXa8bifPBEBM/review\`.

The day-of class reminder email (PR #392) currently renders the literal \`REPLACE_WITH_GOOGLE_CID\` placeholder in its review CTA. After this merges and CI redeploys \`sendClassReminders\`, real reviews flow through.

## Changes

- \`.env.dev\` — replace placeholder
- \`.env.prod\` — add the var (was missing, so prod was using the function's hardcoded default)

## Test plan

- [ ] Confirm CI redeploys \`sendClassReminders\`
- [ ] Manually trigger \`triggerClassReminders\` (admin callable) on a test registration and verify the rendered email points to https://g.page/r/CVjnXa8bifPBEBM/review

🤖 Generated with [Claude Code](https://claude.com/claude-code)