### PR TITLE
fix: Webflow sync — omit slug on update, use webflowItemId fast-path, paginate fallback (#395)

### DIFF
--- a/libs/firebase/maple-functions/sync-artist-to-webflow/src/lib/sync-artist-to-webflow.ts
+++ b/libs/firebase/maple-functions/sync-artist-to-webflow/src/lib/sync-artist-to-webflow.ts
@@ -100,7 +100,8 @@ export const syncArtistToWebflow = onDocumentWritten(
         console.log('Artist deleted, removing from Webflow');
         const removed = await webflow.artistService.removeArtist(
           event.params.artistId,
-          publishRemoval
+          publishRemoval,
+          beforeArtist?.webflowItemId
         );
         console.log(
           removed
@@ -118,7 +119,8 @@ export const syncArtistToWebflow = onDocumentWritten(
         console.log('Artist became inactive, removing from Webflow');
         const removed = await webflow.artistService.removeArtist(
           afterArtist.id,
-          publishRemoval
+          publishRemoval,
+          afterArtist.webflowItemId
         );
         console.log(
           removed
@@ -148,6 +150,7 @@ export const syncArtistToWebflow = onDocumentWritten(
         artist: afterArtist,
         publish: shouldPublish,
         isDev,
+        existingWebflowItemId: afterArtist.webflowItemId,
       });
 
       console.log('Webflow sync result:', {

--- a/libs/firebase/maple-functions/sync-class-to-webflow/src/lib/sync-class-to-webflow.ts
+++ b/libs/firebase/maple-functions/sync-class-to-webflow/src/lib/sync-class-to-webflow.ts
@@ -153,7 +153,8 @@ export const syncClassToWebflow = onDocumentWritten(
         console.log('Class deleted, removing from Webflow');
         const removed = await webflow.classService.removeClass(
           event.params.classId,
-          shouldPublish
+          shouldPublish,
+          beforeClass?.webflowItemId
         );
         console.log(
           removed
@@ -171,7 +172,8 @@ export const syncClassToWebflow = onDocumentWritten(
         console.log('Class unpublished, removing from Webflow');
         const removed = await webflow.classService.removeClass(
           afterClass.id,
-          shouldPublish
+          shouldPublish,
+          afterClass.webflowItemId
         );
         console.log(
           removed
@@ -228,6 +230,7 @@ export const syncClassToWebflow = onDocumentWritten(
         instructorImage: instructor?.photoUrl,
         categoryName: category?.name,
         registrationCount,
+        existingWebflowItemId: publishable.webflowItemId,
       });
 
       console.log('Webflow sync result:', {

--- a/libs/firebase/maple-functions/sync-instructor-to-webflow/src/lib/sync-instructor-to-webflow.ts
+++ b/libs/firebase/maple-functions/sync-instructor-to-webflow/src/lib/sync-instructor-to-webflow.ts
@@ -100,7 +100,8 @@ export const syncInstructorToWebflow = onDocumentWritten(
         console.log('Instructor deleted, removing from Webflow');
         const removed = await webflow.instructorService.removeInstructor(
           event.params.instructorId,
-          shouldPublish
+          shouldPublish,
+          beforeInstructor?.webflowItemId
         );
         console.log(
           removed
@@ -118,7 +119,8 @@ export const syncInstructorToWebflow = onDocumentWritten(
         console.log('Instructor became inactive, removing from Webflow');
         const removed = await webflow.instructorService.removeInstructor(
           afterInstructor.id,
-          shouldPublish
+          shouldPublish,
+          afterInstructor.webflowItemId
         );
         console.log(
           removed
@@ -147,6 +149,7 @@ export const syncInstructorToWebflow = onDocumentWritten(
         instructor: afterInstructor,
         publish: shouldPublish,
         isDev,
+        existingWebflowItemId: afterInstructor.webflowItemId,
       });
 
       console.log('Webflow sync result:', {

--- a/libs/firebase/maple-functions/sync-registration-count/src/lib/sync-registration-count.ts
+++ b/libs/firebase/maple-functions/sync-registration-count/src/lib/sync-registration-count.ts
@@ -201,6 +201,7 @@ export const syncRegistrationCount = onDocumentWritten(
         instructorName: instructor?.name,
         categoryName: category?.name,
         registrationCount,
+        existingWebflowItemId: publishable.webflowItemId,
       });
 
       console.log('Webflow sync result:', {

--- a/libs/firebase/webflow/src/lib/artist.service.spec.ts
+++ b/libs/firebase/webflow/src/lib/artist.service.spec.ts
@@ -166,6 +166,7 @@ describe('ArtistService', () => {
     collections: {
       items: {
         listItems: vi.fn(),
+        getItem: vi.fn(),
         createItem: vi.fn(),
         updateItem: vi.fn(),
         deleteItem: vi.fn(),
@@ -259,6 +260,12 @@ describe('ArtistService', () => {
           }),
         })
       );
+
+      // Slug must not be sent on update — Webflow rejects with 400 when
+      // a slug collides (it auto-suffixes on create but not on update).
+      const sentFieldData = mockClient.collections.items.updateItem.mock
+        .calls[0][2].fieldData;
+      expect(sentFieldData).not.toHaveProperty('slug');
     });
 
     it('publishes the item after sync when publish is true', async () => {
@@ -306,6 +313,78 @@ describe('ArtistService', () => {
       expect(mockClient.collections.items.publishItem).not.toHaveBeenCalled();
       const createCall = mockClient.collections.items.createItem.mock.calls[0];
       expect(createCall[1].fieldData['is-dev-environment']).toBe(false);
+    });
+
+    it('uses existingWebflowItemId fast path and skips listItems scan', async () => {
+      mockClient.collections.items.getItem.mockResolvedValue({
+        id: 'wf-known',
+        fieldData: { 'firebase-id': 'artist-abc' },
+      });
+      mockClient.collections.items.updateItem.mockResolvedValue({});
+
+      const result = await service.syncArtist({
+        artist: mockArtist,
+        existingWebflowItemId: 'wf-known',
+      });
+
+      expect(result).toEqual({
+        success: true,
+        webflowItemId: 'wf-known',
+        isNew: false,
+      });
+      expect(mockClient.collections.items.getItem).toHaveBeenCalledWith(
+        COLLECTION_ID,
+        'wf-known'
+      );
+      expect(mockClient.collections.items.listItems).not.toHaveBeenCalled();
+    });
+
+    it('falls back to listItems scan when known Webflow item is gone', async () => {
+      mockClient.collections.items.getItem.mockRejectedValue(
+        new Error('Not found')
+      );
+      mockClient.collections.items.listItems.mockResolvedValue({ items: [] });
+      mockClient.collections.items.createItem.mockResolvedValue({
+        id: 'wf-recreated',
+      });
+
+      const result = await service.syncArtist({
+        artist: mockArtist,
+        existingWebflowItemId: 'wf-deleted',
+      });
+
+      expect(result.isNew).toBe(true);
+      expect(result.webflowItemId).toBe('wf-recreated');
+      expect(mockClient.collections.items.listItems).toHaveBeenCalled();
+    });
+
+    it('paginates findByFirebaseId past the first 100 items', async () => {
+      const fillerItems = Array.from({ length: 100 }, (_, i) => ({
+        id: `wf-other-${i}`,
+        fieldData: { 'firebase-id': `other-artist-${i}` },
+      }));
+      mockClient.collections.items.listItems
+        .mockResolvedValueOnce({ items: fillerItems })
+        .mockResolvedValueOnce({
+          items: [
+            {
+              id: 'wf-needle',
+              fieldData: { 'firebase-id': 'artist-abc' },
+            },
+          ],
+        });
+      mockClient.collections.items.updateItem.mockResolvedValue({});
+
+      const result = await service.syncArtist({ artist: mockArtist });
+
+      expect(result.isNew).toBe(false);
+      expect(result.webflowItemId).toBe('wf-needle');
+      expect(mockClient.collections.items.listItems).toHaveBeenCalledTimes(2);
+      expect(mockClient.collections.items.listItems).toHaveBeenNthCalledWith(
+        2,
+        COLLECTION_ID,
+        { limit: 100, offset: 100 }
+      );
     });
   });
 

--- a/libs/firebase/webflow/src/lib/artist.service.ts
+++ b/libs/firebase/webflow/src/lib/artist.service.ts
@@ -38,6 +38,12 @@ export interface SyncArtistInput {
   publish?: boolean;
   /** Whether this sync is from a dev environment */
   isDev?: boolean;
+  /**
+   * Known Webflow item ID from a prior sync (stored on the artist entity).
+   * When provided, we skip the by-firebase-id list scan and update directly.
+   * Falls back to the scan if the item has been deleted from Webflow.
+   */
+  existingWebflowItemId?: string;
 }
 
 /**
@@ -140,21 +146,26 @@ export class ArtistService {
    * @returns Result with Webflow item ID
    */
   async syncArtist(input: SyncArtistInput): Promise<SyncArtistResult> {
-    const { artist, publish = false, isDev = false } = input;
+    const {
+      artist,
+      publish = false,
+      isDev = false,
+      existingWebflowItemId,
+    } = input;
 
-    // Check if artist already exists in Webflow by firebase-id
-    const existingItem = await this.findByFirebaseId(artist.id);
+    const existingItemId = await this.resolveExistingItemId(
+      artist.id,
+      existingWebflowItemId
+    );
 
     let webflowItemId: string;
     let isNew: boolean;
 
-    if (existingItem) {
-      // Update existing item
-      await this.updateItem(existingItem.id, artist, isDev);
-      webflowItemId = existingItem.id;
+    if (existingItemId) {
+      await this.updateItem(existingItemId, artist, isDev);
+      webflowItemId = existingItemId;
       isNew = false;
     } else {
-      // Create new item
       const newItem = await this.createItem(artist, isDev);
       webflowItemId = newItem.id;
       isNew = true;
@@ -193,22 +204,29 @@ export class ArtistService {
    * @param publish - Whether to also publish the deletion to the live site
    * @returns True if deleted, false if not found
    */
-  async removeArtist(firebaseId: string, publish = false): Promise<boolean> {
-    const existingItem = await this.findByFirebaseId(firebaseId);
+  async removeArtist(
+    firebaseId: string,
+    publish = false,
+    knownWebflowItemId?: string
+  ): Promise<boolean> {
+    const existingItemId = await this.resolveExistingItemId(
+      firebaseId,
+      knownWebflowItemId
+    );
 
-    if (!existingItem) {
+    if (!existingItemId) {
       return false;
     }
 
     if (publish) {
       await this.client.collections.items.deleteItemLive(
         this.collectionId,
-        existingItem.id
+        existingItemId
       );
     } else {
       await this.client.collections.items.deleteItem(
         this.collectionId,
-        existingItem.id
+        existingItemId
       );
     }
 
@@ -216,34 +234,81 @@ export class ArtistService {
   }
 
   /**
-   * Find a Webflow CMS item by Firebase ID
+   * Resolve the Webflow item ID for an artist, preferring a known ID over a
+   * collection scan. Returns `null` if no matching item exists yet.
+   */
+  private async resolveExistingItemId(
+    firebaseId: string,
+    knownWebflowItemId: string | undefined
+  ): Promise<string | null> {
+    if (knownWebflowItemId) {
+      const verified = await this.getItemById(knownWebflowItemId);
+      if (verified) return verified.id;
+      // Item gone in Webflow — fall through to scan + recreate.
+    }
+
+    const found = await this.findByFirebaseId(firebaseId);
+    return found?.id ?? null;
+  }
+
+  /**
+   * Fetch a Webflow item by its Webflow ID. Returns `null` on 404 or
+   * transient errors so the caller can fall back to a scan.
+   */
+  private async getItemById(
+    itemId: string
+  ): Promise<WebflowItemWithId | null> {
+    try {
+      const item = await this.client.collections.items.getItem(
+        this.collectionId,
+        itemId
+      );
+      return item?.id ? (item as WebflowItemWithId) : null;
+    } catch (error) {
+      console.warn('Webflow getItem failed, falling back to scan:', {
+        itemId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Find a Webflow CMS item by Firebase ID. Webflow doesn't support field
+   * filters, so we paginate through the collection until we match or
+   * exhaust it. Page size capped at 100 by the API.
    */
   private async findByFirebaseId(
     firebaseId: string
   ): Promise<WebflowItemWithId | null> {
+    const PAGE_SIZE = 100;
+    let offset = 0;
+
     try {
-      // List items and filter by firebase-id field
-      // Note: Webflow API doesn't support field filtering, so we fetch all and filter
-      const response = await this.client.collections.items.listItems(
-        this.collectionId,
-        {
-          limit: 100, // Reasonable limit for artist collection
+      // Bound the loop so a misbehaving API can't spin forever.
+      while (offset < 5000) {
+        const response = await this.client.collections.items.listItems(
+          this.collectionId,
+          { limit: PAGE_SIZE, offset }
+        );
+
+        const items = response.items ?? [];
+
+        const matchingItem = items.find((item) => {
+          const fieldData = item.fieldData as Record<string, unknown>;
+          return fieldData?.['firebase-id'] === firebaseId;
+        });
+
+        if (matchingItem && matchingItem.id) {
+          return matchingItem as WebflowItemWithId;
         }
-      );
 
-      const items = response.items ?? [];
+        if (items.length < PAGE_SIZE) {
+          return null;
+        }
 
-      // Find item matching our firebase-id
-      const matchingItem = items.find((item) => {
-        const fieldData = item.fieldData as Record<string, unknown>;
-        return fieldData?.['firebase-id'] === firebaseId;
-      });
-
-      // Ensure we have an ID before returning
-      if (matchingItem && matchingItem.id) {
-        return matchingItem as WebflowItemWithId;
+        offset += PAGE_SIZE;
       }
-
       return null;
     } catch (error) {
       console.error('Error finding Webflow item by Firebase ID:', error);
@@ -286,10 +351,14 @@ export class ArtistService {
   ): Promise<void> {
     const fieldData = mapArtistToFieldData(artist, { isDev });
 
+    // Omit `slug` on update — Webflow auto-suffixes slug collisions on
+    // create (e.g. `name-94fde` when `name` is taken), but on update it
+    // 400s with a uniqueness error and freezes every later sync.
+    const { slug: _slug, ...fieldDataWithoutSlug } = fieldData;
     await this.client.collections.items.updateItem(this.collectionId, itemId, {
       isArchived: false,
       isDraft: false,
-      fieldData,
+      fieldData: fieldDataWithoutSlug,
     });
   }
 }

--- a/libs/firebase/webflow/src/lib/class.service.spec.ts
+++ b/libs/firebase/webflow/src/lib/class.service.spec.ts
@@ -298,6 +298,7 @@ describe('ClassService', () => {
     collections: {
       items: {
         listItems: vi.fn(),
+        getItem: vi.fn(),
         createItem: vi.fn(),
         updateItem: vi.fn(),
         deleteItem: vi.fn(),
@@ -408,6 +409,12 @@ describe('ClassService', () => {
           }),
         })
       );
+
+      // Slug must not be sent on update — Webflow rejects with 400 when
+      // a slug collides (it auto-suffixes on create but not on update).
+      const sentFieldData = mockClient.collections.items.updateItem.mock
+        .calls[0][2].fieldData;
+      expect(sentFieldData).not.toHaveProperty('slug');
     });
 
     it('publishes the item after sync when publish is true', async () => {
@@ -481,6 +488,89 @@ describe('ClassService', () => {
         url: 'https://example.com/jane.jpg',
         alt: 'Jane profile photo',
       });
+    });
+
+    it('uses existingWebflowItemId fast path and skips listItems scan', async () => {
+      mockClient.collections.items.getItem.mockResolvedValue({
+        id: 'wf-known',
+        fieldData: { 'firebase-id': 'class-abc' },
+      });
+      mockClient.collections.items.updateItem.mockResolvedValue({});
+
+      const result = await service.syncClass({
+        classEntity: mockClass,
+        existingWebflowItemId: 'wf-known',
+        registrationCount: 4,
+      });
+
+      expect(result).toEqual({
+        success: true,
+        webflowItemId: 'wf-known',
+        isNew: false,
+      });
+      expect(mockClient.collections.items.getItem).toHaveBeenCalledWith(
+        COLLECTION_ID,
+        'wf-known'
+      );
+      // No collection scan needed when we have the ID.
+      expect(mockClient.collections.items.listItems).not.toHaveBeenCalled();
+      expect(mockClient.collections.items.updateItem).toHaveBeenCalledWith(
+        COLLECTION_ID,
+        'wf-known',
+        expect.any(Object)
+      );
+    });
+
+    it('falls back to listItems scan when known Webflow item is gone (404)', async () => {
+      // getItem rejects (item deleted in Webflow)
+      mockClient.collections.items.getItem.mockRejectedValue(
+        new Error('Not found')
+      );
+      mockClient.collections.items.listItems.mockResolvedValue({ items: [] });
+      mockClient.collections.items.createItem.mockResolvedValue({
+        id: 'wf-recreated',
+      });
+
+      const result = await service.syncClass({
+        classEntity: mockClass,
+        existingWebflowItemId: 'wf-deleted',
+      });
+
+      expect(result.isNew).toBe(true);
+      expect(result.webflowItemId).toBe('wf-recreated');
+      expect(mockClient.collections.items.listItems).toHaveBeenCalled();
+      expect(mockClient.collections.items.createItem).toHaveBeenCalled();
+    });
+
+    it('paginates findByFirebaseId past the first 100 items', async () => {
+      const fillerItems = Array.from({ length: 100 }, (_, i) => ({
+        id: `wf-other-${i}`,
+        fieldData: { 'firebase-id': `other-class-${i}` },
+      }));
+      // First page: 100 items, none matching → caller pages forward
+      // Second page: contains the match
+      mockClient.collections.items.listItems
+        .mockResolvedValueOnce({ items: fillerItems })
+        .mockResolvedValueOnce({
+          items: [
+            {
+              id: 'wf-needle',
+              fieldData: { 'firebase-id': 'class-abc' },
+            },
+          ],
+        });
+      mockClient.collections.items.updateItem.mockResolvedValue({});
+
+      const result = await service.syncClass({ classEntity: mockClass });
+
+      expect(result.isNew).toBe(false);
+      expect(result.webflowItemId).toBe('wf-needle');
+      expect(mockClient.collections.items.listItems).toHaveBeenCalledTimes(2);
+      expect(mockClient.collections.items.listItems).toHaveBeenNthCalledWith(
+        2,
+        COLLECTION_ID,
+        { limit: 100, offset: 100 }
+      );
     });
   });
 

--- a/libs/firebase/webflow/src/lib/class.service.ts
+++ b/libs/firebase/webflow/src/lib/class.service.ts
@@ -47,6 +47,12 @@ export interface SyncClassInput {
   categoryName?: string;
   /** Current registration count for spots remaining calculation */
   registrationCount?: number;
+  /**
+   * Known Webflow item ID from a prior sync (stored on the class entity).
+   * When provided, we skip the by-firebase-id list scan and update directly.
+   * Falls back to the scan if the item has been deleted from Webflow.
+   */
+  existingWebflowItemId?: string;
 }
 
 /**
@@ -244,9 +250,13 @@ export class ClassService {
       instructorImage,
       categoryName,
       registrationCount,
+      existingWebflowItemId,
     } = input;
 
-    const existingItem = await this.findByFirebaseId(classEntity.id);
+    const existingItemId = await this.resolveExistingItemId(
+      classEntity.id,
+      existingWebflowItemId
+    );
 
     let webflowItemId: string;
     let isNew: boolean;
@@ -260,9 +270,9 @@ export class ClassService {
       registrationCount,
     });
 
-    if (existingItem) {
-      await this.updateItem(existingItem.id, fieldData);
-      webflowItemId = existingItem.id;
+    if (existingItemId) {
+      await this.updateItem(existingItemId, fieldData);
+      webflowItemId = existingItemId;
       isNew = false;
     } else {
       const newItem = await this.createItem(fieldData);
@@ -291,46 +301,110 @@ export class ClassService {
    * When publish=true, uses deleteItemLive so the deletion is reflected on
    * the live site without a manual republish.
    */
-  async removeClass(firebaseId: string, publish = false): Promise<boolean> {
-    const existingItem = await this.findByFirebaseId(firebaseId);
-    if (!existingItem) return false;
+  async removeClass(
+    firebaseId: string,
+    publish = false,
+    knownWebflowItemId?: string
+  ): Promise<boolean> {
+    const existingItemId = await this.resolveExistingItemId(
+      firebaseId,
+      knownWebflowItemId
+    );
+    if (!existingItemId) return false;
 
     if (publish) {
       await this.client.collections.items.deleteItemLive(
         this.collectionId,
-        existingItem.id
+        existingItemId
       );
     } else {
       await this.client.collections.items.deleteItem(
         this.collectionId,
-        existingItem.id
+        existingItemId
       );
     }
     return true;
   }
 
   /**
-   * Find a Webflow CMS item by Firebase ID
+   * Resolve the Webflow item ID for a class, preferring a known ID over a
+   * collection scan. Returns `null` if no matching item exists yet (caller
+   * should create one).
+   */
+  private async resolveExistingItemId(
+    firebaseId: string,
+    knownWebflowItemId: string | undefined
+  ): Promise<string | null> {
+    if (knownWebflowItemId) {
+      const verified = await this.getItemById(knownWebflowItemId);
+      if (verified) return verified.id;
+      // Item was deleted in Webflow; fall through to a fresh scan so we can
+      // recreate (or pick up a different item with this firebase-id).
+    }
+
+    const found = await this.findByFirebaseId(firebaseId);
+    return found?.id ?? null;
+  }
+
+  /**
+   * Fetch a Webflow item by its Webflow ID. Returns `null` if missing —
+   * 404s and transient errors are treated as "not found" so the caller can
+   * fall back to a scan or recreate.
+   */
+  private async getItemById(
+    itemId: string
+  ): Promise<WebflowItemWithId | null> {
+    try {
+      const item = await this.client.collections.items.getItem(
+        this.collectionId,
+        itemId
+      );
+      return item?.id ? (item as WebflowItemWithId) : null;
+    } catch (error) {
+      console.warn('Webflow getItem failed, falling back to scan:', {
+        itemId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Find a Webflow CMS item by Firebase ID. Paginates through the entire
+   * collection — Webflow's listItems caps page size at 100, so we must
+   * page until we either match or exhaust the collection.
    */
   private async findByFirebaseId(
     firebaseId: string
   ): Promise<WebflowItemWithId | null> {
+    const PAGE_SIZE = 100;
+    let offset = 0;
+
     try {
-      const response = await this.client.collections.items.listItems(
-        this.collectionId,
-        { limit: 100 }
-      );
+      // Bound the loop so a misbehaving API can't spin forever; 5000 items
+      // is far above any realistic collection size for this site.
+      while (offset < 5000) {
+        const response = await this.client.collections.items.listItems(
+          this.collectionId,
+          { limit: PAGE_SIZE, offset }
+        );
 
-      const items = response.items ?? [];
-      const matchingItem = items.find((item) => {
-        const fieldData = item.fieldData as Record<string, unknown>;
-        return fieldData?.['firebase-id'] === firebaseId;
-      });
+        const items = response.items ?? [];
+        const matchingItem = items.find((item) => {
+          const fieldData = item.fieldData as Record<string, unknown>;
+          return fieldData?.['firebase-id'] === firebaseId;
+        });
 
-      if (matchingItem?.id) {
-        return matchingItem as WebflowItemWithId;
+        if (matchingItem?.id) {
+          return matchingItem as WebflowItemWithId;
+        }
+
+        if (items.length < PAGE_SIZE) {
+          return null;
+        }
+
+        offset += PAGE_SIZE;
       }
-
       return null;
     } catch (error) {
       console.error('Error finding Webflow class item:', error);
@@ -357,10 +431,15 @@ export class ClassService {
     itemId: string,
     fieldData: ClassWebflowFieldData
   ): Promise<void> {
+    // Omit `slug` on update — Webflow auto-suffixes slug collisions on
+    // create (e.g. `name-94fde` when `name` is taken), but on update it
+    // 400s with a uniqueness error. Re-sending the deterministic slug
+    // would freeze every later sync (incl. spots-remaining).
+    const { slug: _slug, ...fieldDataWithoutSlug } = fieldData;
     await this.client.collections.items.updateItem(this.collectionId, itemId, {
       isArchived: false,
       isDraft: false,
-      fieldData,
+      fieldData: fieldDataWithoutSlug,
     });
   }
 }

--- a/libs/firebase/webflow/src/lib/instructor.service.spec.ts
+++ b/libs/firebase/webflow/src/lib/instructor.service.spec.ts
@@ -160,6 +160,7 @@ function createMockClient() {
     collections: {
       items: {
         listItems: vi.fn(),
+        getItem: vi.fn(),
         createItem: vi.fn(),
         updateItem: vi.fn(),
         deleteItem: vi.fn(),
@@ -188,6 +189,7 @@ describe('InstructorService', () => {
   const items = () =>
     mockClient.collections.items as unknown as {
       listItems: ReturnType<typeof vi.fn>;
+      getItem: ReturnType<typeof vi.fn>;
       createItem: ReturnType<typeof vi.fn>;
       updateItem: ReturnType<typeof vi.fn>;
       deleteItem: ReturnType<typeof vi.fn>;
@@ -234,6 +236,11 @@ describe('InstructorService', () => {
         'wf-existing',
         expect.objectContaining({ isArchived: false, isDraft: false })
       );
+
+      // Slug must not be sent on update — Webflow rejects with 400 when
+      // a slug collides (it auto-suffixes on create but not on update).
+      const sentFieldData = items().updateItem.mock.calls[0][2].fieldData;
+      expect(sentFieldData).not.toHaveProperty('slug');
     });
 
     it('publishes item when publish is true', async () => {
@@ -272,6 +279,72 @@ describe('InstructorService', () => {
       await expect(
         service.syncInstructor({ instructor: testInstructor, isDev: false })
       ).rejects.toThrow('Webflow API did not return an item ID after creation');
+    });
+
+    it('uses existingWebflowItemId fast path and skips listItems scan', async () => {
+      items().getItem.mockResolvedValue({
+        id: 'wf-known',
+        fieldData: { 'firebase-id': 'inst-001' },
+      });
+      items().updateItem.mockResolvedValue({});
+
+      const result = await service.syncInstructor({
+        instructor: testInstructor,
+        existingWebflowItemId: 'wf-known',
+      });
+
+      expect(result).toEqual({
+        success: true,
+        webflowItemId: 'wf-known',
+        isNew: false,
+      });
+      expect(items().getItem).toHaveBeenCalledWith(collectionId, 'wf-known');
+      expect(items().listItems).not.toHaveBeenCalled();
+    });
+
+    it('falls back to listItems scan when known Webflow item is gone', async () => {
+      items().getItem.mockRejectedValue(new Error('Not found'));
+      items().listItems.mockResolvedValue({ items: [] });
+      items().createItem.mockResolvedValue({ id: 'wf-recreated' });
+
+      const result = await service.syncInstructor({
+        instructor: testInstructor,
+        existingWebflowItemId: 'wf-deleted',
+      });
+
+      expect(result.isNew).toBe(true);
+      expect(result.webflowItemId).toBe('wf-recreated');
+      expect(items().listItems).toHaveBeenCalled();
+    });
+
+    it('paginates findByFirebaseId past the first 100 items', async () => {
+      const fillerItems = Array.from({ length: 100 }, (_, i) => ({
+        id: `wf-other-${i}`,
+        fieldData: { 'firebase-id': `other-inst-${i}` },
+      }));
+      items()
+        .listItems.mockResolvedValueOnce({ items: fillerItems })
+        .mockResolvedValueOnce({
+          items: [
+            {
+              id: 'wf-needle',
+              fieldData: { 'firebase-id': 'inst-001' },
+            },
+          ],
+        });
+      items().updateItem.mockResolvedValue({});
+
+      const result = await service.syncInstructor({
+        instructor: testInstructor,
+      });
+
+      expect(result.isNew).toBe(false);
+      expect(result.webflowItemId).toBe('wf-needle');
+      expect(items().listItems).toHaveBeenCalledTimes(2);
+      expect(items().listItems).toHaveBeenNthCalledWith(2, collectionId, {
+        limit: 100,
+        offset: 100,
+      });
     });
   });
 

--- a/libs/firebase/webflow/src/lib/instructor.service.ts
+++ b/libs/firebase/webflow/src/lib/instructor.service.ts
@@ -27,6 +27,12 @@ export interface SyncInstructorInput {
   publish?: boolean;
   /** Whether this sync is from a dev environment */
   isDev?: boolean;
+  /**
+   * Known Webflow item ID from a prior sync (stored on the instructor entity).
+   * When provided, we skip the by-firebase-id list scan and update directly.
+   * Falls back to the scan if the item has been deleted from Webflow.
+   */
+  existingWebflowItemId?: string;
 }
 
 /**
@@ -138,21 +144,26 @@ export class InstructorService {
    * @returns Result with Webflow item ID
    */
   async syncInstructor(input: SyncInstructorInput): Promise<SyncInstructorResult> {
-    const { instructor, publish = false, isDev = false } = input;
+    const {
+      instructor,
+      publish = false,
+      isDev = false,
+      existingWebflowItemId,
+    } = input;
 
-    // Check if instructor already exists in Webflow by firebase-id
-    const existingItem = await this.findByFirebaseId(instructor.id);
+    const existingItemId = await this.resolveExistingItemId(
+      instructor.id,
+      existingWebflowItemId
+    );
 
     let webflowItemId: string;
     let isNew: boolean;
 
-    if (existingItem) {
-      // Update existing item
-      await this.updateItem(existingItem.id, instructor, isDev);
-      webflowItemId = existingItem.id;
+    if (existingItemId) {
+      await this.updateItem(existingItemId, instructor, isDev);
+      webflowItemId = existingItemId;
       isNew = false;
     } else {
-      // Create new item
       const newItem = await this.createItem(instructor, isDev);
       webflowItemId = newItem.id;
       isNew = true;
@@ -193,23 +204,27 @@ export class InstructorService {
    */
   async removeInstructor(
     firebaseId: string,
-    publish = false
+    publish = false,
+    knownWebflowItemId?: string
   ): Promise<boolean> {
-    const existingItem = await this.findByFirebaseId(firebaseId);
+    const existingItemId = await this.resolveExistingItemId(
+      firebaseId,
+      knownWebflowItemId
+    );
 
-    if (!existingItem) {
+    if (!existingItemId) {
       return false;
     }
 
     if (publish) {
       await this.client.collections.items.deleteItemLive(
         this.collectionId,
-        existingItem.id
+        existingItemId
       );
     } else {
       await this.client.collections.items.deleteItem(
         this.collectionId,
-        existingItem.id
+        existingItemId
       );
     }
 
@@ -217,34 +232,80 @@ export class InstructorService {
   }
 
   /**
-   * Find a Webflow CMS item by Firebase ID
+   * Resolve the Webflow item ID for an instructor, preferring a known ID
+   * over a collection scan. Returns `null` if no matching item exists yet.
+   */
+  private async resolveExistingItemId(
+    firebaseId: string,
+    knownWebflowItemId: string | undefined
+  ): Promise<string | null> {
+    if (knownWebflowItemId) {
+      const verified = await this.getItemById(knownWebflowItemId);
+      if (verified) return verified.id;
+      // Item gone in Webflow — fall through to scan + recreate.
+    }
+
+    const found = await this.findByFirebaseId(firebaseId);
+    return found?.id ?? null;
+  }
+
+  /**
+   * Fetch a Webflow item by its Webflow ID. Returns `null` on 404 or
+   * transient errors so the caller can fall back to a scan.
+   */
+  private async getItemById(
+    itemId: string
+  ): Promise<WebflowItemWithId | null> {
+    try {
+      const item = await this.client.collections.items.getItem(
+        this.collectionId,
+        itemId
+      );
+      return item?.id ? (item as WebflowItemWithId) : null;
+    } catch (error) {
+      console.warn('Webflow getItem failed, falling back to scan:', {
+        itemId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Find a Webflow CMS item by Firebase ID. Webflow doesn't support field
+   * filters, so we paginate through the collection until we match or
+   * exhaust it. Page size capped at 100 by the API.
    */
   private async findByFirebaseId(
     firebaseId: string
   ): Promise<WebflowItemWithId | null> {
+    const PAGE_SIZE = 100;
+    let offset = 0;
+
     try {
-      // List items and filter by firebase-id field
-      // Note: Webflow API doesn't support field filtering, so we fetch all and filter
-      const response = await this.client.collections.items.listItems(
-        this.collectionId,
-        {
-          limit: 100, // Reasonable limit for instructor collection
+      while (offset < 5000) {
+        const response = await this.client.collections.items.listItems(
+          this.collectionId,
+          { limit: PAGE_SIZE, offset }
+        );
+
+        const items = response.items ?? [];
+
+        const matchingItem = items.find((item) => {
+          const fieldData = item.fieldData as Record<string, unknown>;
+          return fieldData?.['firebase-id'] === firebaseId;
+        });
+
+        if (matchingItem && matchingItem.id) {
+          return matchingItem as WebflowItemWithId;
         }
-      );
 
-      const items = response.items ?? [];
+        if (items.length < PAGE_SIZE) {
+          return null;
+        }
 
-      // Find item matching our firebase-id
-      const matchingItem = items.find((item) => {
-        const fieldData = item.fieldData as Record<string, unknown>;
-        return fieldData?.['firebase-id'] === firebaseId;
-      });
-
-      // Ensure we have an ID before returning
-      if (matchingItem && matchingItem.id) {
-        return matchingItem as WebflowItemWithId;
+        offset += PAGE_SIZE;
       }
-
       return null;
     } catch (error) {
       console.error('Error finding Webflow item by Firebase ID:', error);
@@ -287,10 +348,14 @@ export class InstructorService {
   ): Promise<void> {
     const fieldData = mapInstructorToFieldData(instructor, { isDev });
 
+    // Omit `slug` on update — Webflow auto-suffixes slug collisions on
+    // create (e.g. `name-94fde` when `name` is taken), but on update it
+    // 400s with a uniqueness error and freezes every later sync.
+    const { slug: _slug, ...fieldDataWithoutSlug } = fieldData;
     await this.client.collections.items.updateItem(this.collectionId, itemId, {
       isArchived: false,
       isDraft: false,
-      fieldData,
+      fieldData: fieldDataWithoutSlug,
     });
   }
 }


### PR DESCRIPTION
## Summary

Three related fixes to the Webflow CMS sync layer (class / artist / instructor) that together make registration-count and other entity updates land reliably on the right Webflow item.

Diagnosed via prod Cloud Function logs: \`syncRegistrationCount\` for "Stained Glass - TryIt Class" was firing on every registration but each PATCH was rejected by Webflow with:

\`\`\`
{ \"param\": \"slug\", \"description\": \"Unique value is already in database: 'stained-glass-tryit-class'\" }
\`\`\`

The class's Webflow slug had been auto-suffixed by Webflow at creation time (\`stained-glass-tryit-class-94fde\` because the bare slug was already taken), and we were re-sending the bare slug on every update. The function swallows the error to avoid retry loops, so the spots count silently froze at the value from the last successful sync.

## Changes

### 1. Strip \`slug\` from update payloads
**Why:** Webflow auto-suffixes slug collisions on \`createItem\`, but on \`updateItem\` it 400s with a uniqueness error. Once an item exists, its slug is Webflow's identifier — we shouldn't be PATCHing it.

Applied to all three services (class, artist, instructor) in their private \`updateItem\` methods.

### 2. Use \`webflowItemId\` from Firestore as a fast-path lookup
**Why:** \`syncClass\` was always doing \`listItems\` (up to 100 results) then filtering by \`firebase-id\`. We already store \`webflowItemId\` on the Firestore entity after the first successful sync — use it.

- New \`existingWebflowItemId\` input on \`syncClass\` / \`syncArtist\` / \`syncInstructor\`
- New \`knownWebflowItemId\` parameter on \`removeClass\` / \`removeArtist\` / \`removeInstructor\`
- When provided, calls \`getItem(collectionId, itemId)\` directly (one API call) and falls back to the scan if Webflow returns 404 (item deleted)
- Plumbed through all 4 Firestore-trigger functions: \`syncClassToWebflow\`, \`syncRegistrationCount\`, \`syncArtistToWebflow\`, \`syncInstructorToWebflow\`

### 3. Paginate \`findByFirebaseId\`
**Why:** All three services used \`listItems\` with \`limit: 100\` and no \`offset\`. Once any collection grew past 100 items, lookups for items on later pages would return \`null\` → \`syncClass\` would think the item didn't exist → \`createItem\` would either create a duplicate or 400 on slug collision. Latent ticking bomb.

Now pages forward (max 5000 items as a safety bound) until match or exhaustion.

## Testing

- 137 unit tests pass (9 new), covering:
  - \`slug\` is omitted from \`updateItem\` payloads (3 services)
  - \`existingWebflowItemId\` triggers \`getItem\` and skips \`listItems\` (3 services)
  - 404 from \`getItem\` falls back to scan (3 services)
  - Pagination finds matches past page 1 (3 services)
- \`webflow\` lib builds clean
- \`functions-sync\` app bundle builds clean

## Manual cleanup needed (already noted, not in this PR)

The current "Stained Glass - TryIt Class" item on Webflow has a stale spots count from before the fix. Manually adjust in Webflow CMS — once corrected, future registrations will land via the fixed sync.

Closes #395