### PR TITLE
fix: useUserRole tolerates legacy checkAdminStatus response

### DIFF
--- a/libs/react/auth/src/lib/useUserRole.ts
+++ b/libs/react/auth/src/lib/useUserRole.ts
@@ -32,7 +32,19 @@ export function useUserRole() {
         CheckAdminStatusResponse
       >(getMapleFunctions(), 'checkAdminStatus');
       const result = await fn({});
-      setRoleState({ status: 'success', data: result.data.role });
+      // Tolerate the legacy response shape `{ isAdmin: true }` so the admin
+      // app keeps working during a deploy when the web app ships before the
+      // updated checkAdminStatus function. Once `role` is present, trust it.
+      const data = result.data;
+      const role: UserRole =
+        data.role !== undefined
+          ? data.role
+          : data.isAdmin
+            ? 'admin'
+            : data.isEmployee
+              ? 'employee'
+              : null;
+      setRoleState({ status: 'success', data: role });
     } catch (error) {
       console.error('Failed to check user role:', error);
       setRoleState({

--- a/libs/ts/firebase/api-types/src/lib/auth.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/auth.types.ts
@@ -10,10 +10,16 @@ export type CheckAdminStatusRequest = Record<string, never>;
 /** Highest-privilege role the user holds. */
 export type UserRole = 'admin' | 'employee' | null;
 
-/** Response from checkAdminStatus */
+/**
+ * Response from checkAdminStatus.
+ *
+ * `isAdmin` is the original field and is always present. `isEmployee` and
+ * `role` were added later and are optional on the type so a freshly-shipped
+ * web app can still parse a response from a not-yet-redeployed function
+ * during a rolling deploy. Callers should derive role using all three fields.
+ */
 export interface CheckAdminStatusResponse {
-  /** Kept for backwards compatibility — equivalent to `role === 'admin'` */
   isAdmin: boolean;
-  isEmployee: boolean;
-  role: UserRole;
+  isEmployee?: boolean;
+  role?: UserRole;
 }


### PR DESCRIPTION
## Summary

Bugfix for #398 (timekeeping MVP). Production showed Katie the **employee-only** sidenav after #398 merged because the deployed web app started reading `result.data.role` from `checkAdminStatus`, but the Cloud Function deploy lagged behind — the response was still the legacy `{ "data": { "isAdmin": true } }` shape with no `role` field. `useUserRole` resolved `role = undefined` and treated even admins as having no role.

## What changed

- `useUserRole` now derives the role from whichever fields are present: `role` (preferred) → `isAdmin` → `isEmployee` → `null`. Once the updated function is fully deployed, the explicit `role` field wins and behavior is unchanged.
- `CheckAdminStatusResponse.role` and `.isEmployee` are now optional on the type, so the legacy-shape check typechecks cleanly. `isAdmin` stays required since it's been on every response since the function was created.

## Why this should be merged before re-investigating Katie's screenshot

Even after the function fully redeploys, this fix is correct: any future change to `checkAdminStatus`'s response shape that ships with web-app-first ordering would re-introduce the same admin-locked-out class of bug. The hook should always tolerate legacy / partial responses.

## Test plan

- [x] `npx vitest run libs/react/auth libs/firebase/maple-functions/check-admin-status libs/ts/validation` — all green (480 tests)
- [x] `npx tsc -p apps/maple-spruce/tsconfig.json --noEmit` — clean
- [x] `npx tsc -p apps/functions/tsconfig.app.json --noEmit` — clean
- [ ] Manually verify on production after merge: Katie's nav re-expands to the full admin nav (Store / Classes / Music Lessons / Payroll / Calendar / Admin) once this deploys, regardless of whether `checkAdminStatus` has redeployed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)