### PR TITLE
chore(deps): patch high-severity advisories surfaced by pnpm audit

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,10 @@ overrides:
   axios: '>=1.15.1'
   koa: '>=3.1.2'
   vite@>=7.0.0 <7.3.2: '>=7.3.2'
-  basic-ftp: '>=5.2.2'
+  basic-ftp: ^5.3.1
+  fast-xml-builder: '>=1.1.7'
+  fast-uri: '>=3.1.1'
+  '@babel/plugin-transform-modules-systemjs': '>=7.29.4'
   path-to-regexp@>=2: '>=8.4.0'
 
 importers:
@@ -702,8 +705,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0':
-    resolution: {integrity: sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==}
+  '@babel/plugin-transform-modules-systemjs@7.29.4':
+    resolution: {integrity: sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -5121,8 +5124,8 @@ packages:
     resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
     engines: {node: '>= 0.8'}
 
-  basic-ftp@5.3.0:
-    resolution: {integrity: sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==}
+  basic-ftp@5.3.1:
+    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
 
   batch@0.6.1:
@@ -6423,11 +6426,11 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
-  fast-xml-builder@1.1.4:
-    resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
 
   fast-xml-parser@5.6.0:
     resolution: {integrity: sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==}
@@ -10956,6 +10959,10 @@ packages:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
@@ -11602,7 +11609,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
@@ -11875,7 +11882,7 @@ snapshots:
       '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0)
@@ -16384,7 +16391,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -16700,7 +16707,7 @@ snapshots:
     dependencies:
       safe-buffer: 5.1.2
 
-  basic-ftp@5.3.0: {}
+  basic-ftp@5.3.1: {}
 
   batch@0.6.1: {}
 
@@ -18223,17 +18230,18 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
-  fast-xml-builder@1.1.4:
+  fast-xml-builder@1.2.0:
     dependencies:
       path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
     optional: true
 
   fast-xml-parser@5.6.0:
     dependencies:
       '@nodable/entities': 1.1.0
-      fast-xml-builder: 1.1.4
+      fast-xml-builder: 1.2.0
       path-expression-matcher: 1.5.0
       strnum: 2.2.3
     optional: true
@@ -18772,7 +18780,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.3.0
+      basic-ftp: 5.3.1
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
@@ -23405,6 +23413,9 @@ snapshots:
   xdg-basedir@4.0.0: {}
 
   xml-name-validator@5.0.0: {}
+
+  xml-naming@0.1.0:
+    optional: true
 
   xmlchars@2.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,7 +34,13 @@ overrides:
   koa: '>=3.1.2'
   # GHSA-v2wj-q39q-566r (server.fs.deny bypass) and GHSA-p9ff-h696-f583 (arbitrary file read via dev server WebSocket). Transitive dep of @nx/vitest@22.6.4 > vitest@4.1.2. Added 2026-04-07.
   vite@>=7.0.0 <7.3.2: '>=7.3.2'
-  # GHSA-chqc-8p9q-pq6q (FTP command injection via CRLF) and GHSA-6v7q-wjvx-w8wg (incomplete CRLF protection). Transitive dep of firebase-tools@15.11.0 > proxy-agent > pac-proxy-agent > get-uri. Updated 2026-04-12.
-  basic-ftp: '>=5.2.2'
+  # GHSA-chqc-8p9q-pq6q (FTP command injection via CRLF), GHSA-6v7q-wjvx-w8wg (incomplete CRLF protection), and GHSA-rpmf-866q-6p89 (client-side DoS via unbounded multiline control response buffering, patched in 5.3.1). Transitive dep of firebase-tools > proxy-agent > pac-proxy-agent > get-uri. Pinned to 5.x because get-uri targets the 5.x API; 6.0.0 is a major bump. Updated 2026-05-08.
+  basic-ftp: '^5.3.1'
+  # GHSA-5wm8-gmm8-39j9: fast-xml-builder allows attribute values with unwanted quotes to bypass malicious or unwanted attributes (patched in 1.1.7). Transitive dep of firebase-admin > @google-cloud/storage > fast-xml-parser. Added 2026-05-08.
+  fast-xml-builder: '>=1.1.7'
+  # GHSA-q3j6-qgpj-74h6: fast-uri vulnerable to path traversal via percent-encoded dot segments (patched in 3.1.1). Transitive dep of @nx/next > @nx/react > @nx/module-federation > ajv. Added 2026-05-08.
+  fast-uri: '>=3.1.1'
+  # GHSA-fv7c-fp4j-7gwp: @babel/plugin-transform-modules-systemjs generates arbitrary code when compiling malicious input (patched in 7.29.4). Transitive dep of @nx/* > @nx/js > @babel/preset-env. Added 2026-05-08.
+  '@babel/plugin-transform-modules-systemjs': '>=7.29.4'
   # path-to-regexp override
   path-to-regexp@>=2: '>=8.4.0'


### PR DESCRIPTION
## Summary
- Fixes the **Security Audit** failure on PR #398's CI run (3 high-severity advisories: `basic-ftp`, `fast-xml-builder`, `fast-uri`) plus a 4th advisory (`@babel/plugin-transform-modules-systemjs` GHSA-fv7c-fp4j-7gwp) that landed since.
- Adds/updates `pnpm.overrides` in `pnpm-workspace.yaml` so transitive deps land on patched versions:
  - `basic-ftp` `^5.3.1` (GHSA-rpmf-866q-6p89, also covers prior CRLF advisories) — pinned to 5.x because `get-uri` targets the 5.x API; 6.0.0 is a major bump.
  - `fast-xml-builder` `>=1.1.7` (GHSA-5wm8-gmm8-39j9)
  - `fast-uri` `>=3.1.1` (GHSA-q3j6-qgpj-74h6)
  - `@babel/plugin-transform-modules-systemjs` `>=7.29.4` (GHSA-fv7c-fp4j-7gwp)
- After this, `pnpm audit --audit-level=high` exits clean (`8 vulnerabilities found, Severity: 2 low | 6 moderate`).

## Test plan
- [x] Local `pnpm install` succeeds with the new overrides.
- [x] Local `pnpm audit --audit-level=high` exits 0.
- [x] Lockfile diff is scoped to the four targeted packages (no unrelated dep churn).
- [ ] CI **Security Audit** job goes green.
- [ ] Other CI jobs (build/test/integration) stay green — the basic-ftp pin to `^5.3.1` keeps `firebase-tools > get-uri` on the 5.x API surface, and the other bumps are minor/patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)