### PR TITLE
feat: variants in ProductForm + DataTable (#312)

### DIFF
--- a/apps/maple-spruce/.storybook/fixtures/products.ts
+++ b/apps/maple-spruce/.storybook/fixtures/products.ts
@@ -165,12 +165,61 @@ export const mockProductOutOfStock: Product = {
   },
 };
 
+export const mockProductMultiVariant: Product = {
+  id: 'prod-006',
+  artistId: 'artist-001',
+  categoryId: 'cat-002',
+  status: 'active',
+  squareItemId: 'sq-item-006',
+  squareCatalogVersion: 1,
+  squareLocationId: 'sq-loc-001',
+  createdAt: new Date('2024-09-10T12:00:00Z'),
+  updatedAt: new Date('2024-10-01T09:00:00Z'),
+  variantProperties: ['Size'],
+  variants: [
+    {
+      id: 'var-006a',
+      label: 'Small',
+      sku: 'prd_size_sm',
+      priceCents: 3000,
+      quantity: 4,
+      squareVariationId: 'sq-var-006a',
+    },
+    {
+      id: 'var-006b',
+      label: 'Medium',
+      sku: 'prd_size_md',
+      priceCents: 3500,
+      quantity: 7,
+      squareVariationId: 'sq-var-006b',
+    },
+    {
+      id: 'var-006c',
+      label: 'Large',
+      sku: 'prd_size_lg',
+      priceCents: 4000,
+      quantity: 2,
+      squareVariationId: 'sq-var-006c',
+    },
+  ],
+  squareCache: {
+    name: 'Hand-knit Wool Hat',
+    description: 'Soft merino wool hat, available in three sizes.',
+    priceCents: 3000,
+    quantity: 13,
+    sku: 'prd_size_sm',
+    imageUrl: 'https://picsum.photos/seed/product6/400/400',
+    syncedAt: new Date('2024-10-01T09:00:00Z'),
+  },
+};
+
 export const mockProducts: Product[] = [
   mockProduct,
   mockProductNoImage,
   mockProductDraft,
   mockProductDiscontinued,
   mockProductOutOfStock,
+  mockProductMultiVariant,
 ];
 
 export const mockActiveProducts: Product[] = mockProducts.filter(

--- a/apps/maple-spruce/src/components/etsy-import/EtsyImportDialog.tsx
+++ b/apps/maple-spruce/src/components/etsy-import/EtsyImportDialog.tsx
@@ -211,8 +211,8 @@ export function EtsyImportDialog({
           />
 
           <Typography variant="caption" color="text.secondary">
-            Listings with multiple variants are not supported in this import
-            pass and will be skipped automatically.
+            Multi-variant listings are imported with all variants — each
+            becomes a Product variant with its own price, quantity, and SKU.
           </Typography>
         </Box>
       </DialogContent>

--- a/apps/maple-spruce/src/components/inventory/ProductDataTable.tsx
+++ b/apps/maple-spruce/src/components/inventory/ProductDataTable.tsx
@@ -1,12 +1,21 @@
 'use client';
 
 import { useMemo } from 'react';
-import { Box, Chip, IconButton, Typography, Alert, Paper } from '@mui/material';
+import {
+  Box,
+  Chip,
+  IconButton,
+  Stack,
+  Tooltip,
+  Typography,
+  Alert,
+  Paper,
+} from '@mui/material';
 import { DataGrid, GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import type { Product, Artist, Category, RequestState } from '@maple/ts/domain';
-import { formatPrice } from '@maple/ts/domain';
+import { formatPrice, getTotalQuantity, isMultiVariant } from '@maple/ts/domain';
 import { surfaces, borders, radii, shadows } from '@maple/react/theme';
 
 interface ProductDataTableProps {
@@ -80,6 +89,34 @@ export function ProductDataTable({
         flex: 1,
         minWidth: 200,
         valueGetter: (_value, row: Product) => row.squareCache?.name || '',
+        renderCell: (params: GridRenderCellParams<Product>) => {
+          const variantCount = params.row.variants?.length ?? 0;
+          const showBadge = isMultiVariant(params.row);
+          return (
+            <Stack direction="row" spacing={1} alignItems="center">
+              <Typography
+                variant="body2"
+                sx={{
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {(params.value as string) || ''}
+              </Typography>
+              {showBadge && (
+                <Tooltip title={`${variantCount} variants`}>
+                  <Chip
+                    label={`${variantCount} variants`}
+                    size="small"
+                    color="primary"
+                    variant="outlined"
+                  />
+                </Tooltip>
+              )}
+            </Stack>
+          );
+        },
       },
       {
         field: 'category',
@@ -109,20 +146,39 @@ export function ProductDataTable({
       {
         field: 'price',
         headerName: 'Price',
-        width: 100,
+        width: 110,
         valueGetter: (_value, row: Product) =>
-          row.squareCache?.priceCents || 0,
-        renderCell: (params: GridRenderCellParams) => (
-          <Typography variant="body2" fontWeight="medium">
-            {formatPrice(params.value as number)}
-          </Typography>
-        ),
+          row.variants?.[0]?.priceCents ?? row.squareCache?.priceCents ?? 0,
+        renderCell: (params: GridRenderCellParams<Product>) => {
+          const variants = params.row.variants ?? [];
+          if (variants.length > 1) {
+            const prices = variants.map((v) => v.priceCents);
+            const min = Math.min(...prices);
+            const max = Math.max(...prices);
+            return (
+              <Typography variant="body2" fontWeight="medium">
+                {min === max
+                  ? formatPrice(min)
+                  : `${formatPrice(min)} – ${formatPrice(max)}`}
+              </Typography>
+            );
+          }
+          return (
+            <Typography variant="body2" fontWeight="medium">
+              {formatPrice(params.value as number)}
+            </Typography>
+          );
+        },
       },
       {
         field: 'quantity',
         headerName: 'Qty',
         width: 80,
-        valueGetter: (_value, row: Product) => row.squareCache?.quantity || 0,
+        // Sum across all variants — surfaces total stock across sizes/colors.
+        valueGetter: (_value, row: Product) =>
+          row.variants?.length
+            ? getTotalQuantity(row)
+            : row.squareCache?.quantity || 0,
         renderCell: (params: GridRenderCellParams) => {
           const qty = params.value as number;
           return (
@@ -151,7 +207,10 @@ export function ProductDataTable({
         field: 'sku',
         headerName: 'SKU',
         width: 130,
-        valueGetter: (_value, row: Product) => row.squareCache?.sku || '',
+        valueGetter: (_value, row: Product) => {
+          if (isMultiVariant(row)) return '—';
+          return row.variants?.[0]?.sku ?? row.squareCache?.sku ?? '';
+        },
       },
       {
         field: 'actions',

--- a/apps/maple-spruce/src/components/inventory/ProductForm.stories.tsx
+++ b/apps/maple-spruce/src/components/inventory/ProductForm.stories.tsx
@@ -7,6 +7,7 @@ import type { Product, CreateProductInput } from '@maple/ts/domain';
 import {
   mockProduct,
   mockProductNoImage,
+  mockProductMultiVariant,
   mockArtists,
   mockCategories,
 } from '../../../.storybook/fixtures';
@@ -165,6 +166,49 @@ export const Submitting: Story = {
     open: true,
     product: mockProduct,
     isSubmitting: true,
+  },
+};
+
+/**
+ * Edit a product that has multiple variants — shows the variants table
+ * instead of the single price/qty pair.
+ */
+export const EditMultiVariant: Story = {
+  args: {
+    open: true,
+    product: mockProductMultiVariant,
+    isSubmitting: false,
+  },
+};
+
+/**
+ * Test: Switching from single → multi variant mode reveals the variants
+ * table and seeds the first row with the existing price/qty.
+ */
+export const SwitchToMultiVariant: Story = {
+  args: {
+    open: true,
+    isSubmitting: false,
+  },
+  play: async () => {
+    const canvas = await waitForDialog();
+
+    // Single mode: simple Price + Quantity inputs are visible.
+    expect(canvas.getByLabelText(/^price$/i)).toBeInTheDocument();
+    expect(canvas.getByLabelText(/^quantity$/i)).toBeInTheDocument();
+
+    const switchButton = canvas.getByRole('button', {
+      name: /add variants/i,
+    });
+    await userEvent.click(switchButton);
+
+    // Multi mode: variant property + per-row Label/Price/Qty/SKU appear.
+    await waitFor(() => {
+      expect(canvas.getByLabelText(/variant property/i)).toBeInTheDocument();
+      expect(canvas.getAllByLabelText(/^label$/i).length).toBeGreaterThanOrEqual(
+        2
+      );
+    });
   },
 };
 

--- a/apps/maple-spruce/src/components/inventory/ProductForm.stories.tsx
+++ b/apps/maple-spruce/src/components/inventory/ProductForm.stories.tsx
@@ -194,18 +194,18 @@ export const SwitchToMultiVariant: Story = {
     const canvas = await waitForDialog();
 
     // Single mode: simple Price + Quantity inputs are visible.
-    expect(canvas.getByLabelText(/^price$/i)).toBeInTheDocument();
-    expect(canvas.getByLabelText(/^quantity$/i)).toBeInTheDocument();
+    expect(canvas.getByLabelText(/price/i)).toBeInTheDocument();
+    expect(canvas.getByLabelText(/quantity/i)).toBeInTheDocument();
 
     const switchButton = canvas.getByRole('button', {
-      name: /add variants/i,
+      name: /multiple variants/i,
     });
     await userEvent.click(switchButton);
 
-    // Multi mode: variant property + per-row Label/Price/Qty/SKU appear.
+    // Multi mode: variant property + at least 2 per-row Label inputs appear.
     await waitFor(() => {
       expect(canvas.getByLabelText(/variant property/i)).toBeInTheDocument();
-      expect(canvas.getAllByLabelText(/^label$/i).length).toBeGreaterThanOrEqual(
+      expect(canvas.getAllByLabelText(/^label/i).length).toBeGreaterThanOrEqual(
         2
       );
     });

--- a/apps/maple-spruce/src/components/inventory/ProductForm.tsx
+++ b/apps/maple-spruce/src/components/inventory/ProductForm.tsx
@@ -642,7 +642,7 @@ export function ProductForm({
                 onClick={handleSwitchToMulti}
                 sx={{ alignSelf: 'flex-start' }}
               >
-                + Add variants (size, color, …)
+                Use multiple variants (size, color, …)
               </Button>
             </>
           ) : (

--- a/apps/maple-spruce/src/components/inventory/ProductForm.tsx
+++ b/apps/maple-spruce/src/components/inventory/ProductForm.tsx
@@ -18,7 +18,12 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
+  Divider,
+  IconButton,
+  Stack,
   TextField,
+  Tooltip,
+  Typography,
   FormControl,
   FormHelperText,
   InputLabel,
@@ -27,11 +32,14 @@ import {
   InputAdornment,
   Alert,
 } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import { httpsCallable } from 'firebase/functions';
 import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
 import type {
   Product,
   CreateProductInput,
+  CreateVariantInput,
   ProductStatus,
   Artist,
   Category,
@@ -49,6 +57,37 @@ import {
   batch,
   useSignals,
 } from '@maple/react/signals';
+
+/**
+ * Editable shape for a single variant row in the form. SKU is optional —
+ * the backend auto-generates one when missing.
+ */
+interface VariantRow {
+  label: string;
+  priceDollars: number;
+  quantity: number;
+  sku: string;
+}
+
+function emptyVariantRow(label = ''): VariantRow {
+  return { label, priceDollars: 0, quantity: 0, sku: '' };
+}
+
+function rowToCreateInput(row: VariantRow): CreateVariantInput {
+  const base: CreateVariantInput = {
+    label: row.label.trim(),
+    priceCents: toCents(row.priceDollars),
+    quantity: row.quantity,
+  };
+  return row.sku.trim() ? { ...base, sku: row.sku.trim() } : base;
+}
+
+function parseVariantProperties(text: string): string[] {
+  return text
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
 
 interface ProductFormProps {
   open: boolean;
@@ -106,6 +145,15 @@ export function ProductForm({
   const commissionPercent = useSignal<number | ''>('');
 
   // ============================================================
+  // VARIANT SIGNALS
+  // Single mode reuses priceDollars/quantity above.
+  // Multi mode drives the table below.
+  // ============================================================
+  const variantMode = useSignal<'single' | 'multi'>('single');
+  const variants = useSignal<VariantRow[]>([]);
+  const variantPropertiesText = useSignal('');
+
+  // ============================================================
   // UI STATE SIGNALS
   // ============================================================
   const showValidationErrors = useSignal(false);
@@ -123,18 +171,29 @@ export function ProductForm({
 
   // Validation runs automatically when ANY form field changes
   const validation = useComputed(() => {
+    const customCommissionRate =
+      commissionPercent.value !== '' && !Number.isNaN(commissionPercent.value)
+        ? commissionPercent.value / 100
+        : undefined;
+
+    if (variantMode.value === 'multi') {
+      return productValidation({
+        artistId: artistId.value,
+        name: name.value,
+        status: status.value,
+        customCommissionRate,
+        variants: variants.value.map(rowToCreateInput),
+        variantProperties: parseVariantProperties(variantPropertiesText.value),
+      });
+    }
+
     return productValidation({
       artistId: artistId.value,
       name: name.value,
       priceCents: Math.round(priceDollars.value * 100),
       quantity: quantity.value,
       status: status.value,
-      // Only include commission if provided
-      customCommissionRate:
-        commissionPercent.value !== '' &&
-        !Number.isNaN(commissionPercent.value)
-          ? commissionPercent.value / 100
-          : undefined,
+      customCommissionRate,
     });
   });
 
@@ -167,18 +226,46 @@ export function ProductForm({
 
     if (product) {
       // Populate form from existing product
+      const productVariants = product.variants ?? [];
+      const isMulti = productVariants.length > 1;
+      const firstVariant = productVariants[0];
+
       batch(() => {
         artistId.value = product.artistId;
         categoryId.value = product.categoryId ?? '';
         name.value = product.squareCache.name;
         description.value = product.squareCache.description ?? '';
-        priceDollars.value = (product.squareCache.priceCents ?? 0) / 100;
-        quantity.value = product.squareCache.quantity ?? 0;
         status.value = product.status;
         commissionPercent.value =
           product.customCommissionRate !== undefined
             ? product.customCommissionRate * 100
             : '';
+
+        if (isMulti) {
+          variantMode.value = 'multi';
+          variants.value = productVariants.map((v) => ({
+            label: v.label,
+            priceDollars: v.priceCents / 100,
+            quantity: v.quantity,
+            sku: v.sku,
+          }));
+          variantPropertiesText.value = (product.variantProperties ?? []).join(
+            ', '
+          );
+          // Single-variant fields aren't shown in multi mode, but seed them
+          // so a mid-edit switch back to single doesn't surprise the user.
+          priceDollars.value = (firstVariant?.priceCents ?? 0) / 100;
+          quantity.value = firstVariant?.quantity ?? 0;
+        } else {
+          variantMode.value = 'single';
+          priceDollars.value =
+            (firstVariant?.priceCents ?? product.squareCache.priceCents ?? 0) /
+            100;
+          quantity.value =
+            firstVariant?.quantity ?? product.squareCache.quantity ?? 0;
+          variants.value = [];
+          variantPropertiesText.value = '';
+        }
 
         // Set image state
         if (product.squareCache.imageUrl) {
@@ -206,6 +293,9 @@ export function ProductForm({
         quantity.value = 1;
         status.value = 'active';
         commissionPercent.value = '';
+        variantMode.value = 'single';
+        variants.value = [];
+        variantPropertiesText.value = '';
         imageUploadState.value = { status: 'idle' };
         pendingImageFile.value = null;
         showValidationErrors.value = false;
@@ -255,6 +345,63 @@ export function ProductForm({
     return result.data.imageUrl;
   };
 
+  const handleSwitchToMulti = useCallback(() => {
+    batch(() => {
+      // Seed with two rows so the user has something to fill in immediately.
+      // Row 0 carries over the current single-variant price/qty so nothing is
+      // lost when switching modes.
+      variants.value = [
+        {
+          label: 'Variant 1',
+          priceDollars: priceDollars.value,
+          quantity: quantity.value,
+          sku: '',
+        },
+        emptyVariantRow('Variant 2'),
+      ];
+      variantMode.value = 'multi';
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleSwitchToSingle = useCallback(() => {
+    batch(() => {
+      const first = variants.value[0];
+      if (first) {
+        priceDollars.value = first.priceDollars;
+        quantity.value = first.quantity;
+      }
+      variantMode.value = 'single';
+      variants.value = [];
+      variantPropertiesText.value = '';
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const addVariant = useCallback(() => {
+    variants.value = [
+      ...variants.value,
+      emptyVariantRow(`Variant ${variants.value.length + 1}`),
+    ];
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const removeVariant = useCallback((index: number) => {
+    if (variants.value.length <= 1) return;
+    variants.value = variants.value.filter((_, i) => i !== index);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const updateVariant = useCallback(
+    (index: number, patch: Partial<VariantRow>) => {
+      variants.value = variants.value.map((row, i) =>
+        i === index ? { ...row, ...patch } : row
+      );
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
   const handleSubmit = async () => {
     // Show validation errors on first submit attempt
     showValidationErrors.value = true;
@@ -273,10 +420,17 @@ export function ProductForm({
         categoryId: categoryId.value || undefined,
         name: name.value,
         description: description.value || undefined,
-        priceCents: toCents(priceDollars.value),
-        quantity: quantity.value,
         status: status.value,
       };
+
+      if (variantMode.value === 'multi') {
+        input.variants = variants.value.map(rowToCreateInput);
+        const props = parseVariantProperties(variantPropertiesText.value);
+        if (props.length > 0) input.variantProperties = props;
+      } else {
+        input.priceCents = toCents(priceDollars.value);
+        input.quantity = quantity.value;
+      }
 
       // Add commission rate if provided
       if (
@@ -436,40 +590,183 @@ export function ProductForm({
             fullWidth
           />
 
-          {/* Price */}
-          <TextField
-            label="Price"
-            type="number"
-            value={priceDollars.value}
-            onChange={(e) =>
-              (priceDollars.value = parseFloat(e.target.value) || 0)
-            }
-            error={!!getFieldError('priceCents')}
-            helperText={getFieldError('priceCents')}
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">$</InputAdornment>
-              ),
-            }}
-            inputProps={{ step: 0.01, min: 0 }}
-            required
-            fullWidth
-          />
+          {/* Variants section */}
+          <Divider textAlign="left">
+            <Typography variant="overline" color="text.secondary">
+              {variantMode.value === 'multi'
+                ? 'Variants'
+                : 'Price & Inventory'}
+            </Typography>
+          </Divider>
 
-          {/* Quantity */}
-          <TextField
-            label="Quantity"
-            type="number"
-            value={quantity.value}
-            onChange={(e) =>
-              (quantity.value = parseInt(e.target.value, 10) || 0)
-            }
-            error={!!getFieldError('quantity')}
-            helperText={getFieldError('quantity')}
-            inputProps={{ min: 0 }}
-            required
-            fullWidth
-          />
+          {variantMode.value === 'single' ? (
+            <>
+              {/* Price */}
+              <TextField
+                label="Price"
+                type="number"
+                value={priceDollars.value}
+                onChange={(e) =>
+                  (priceDollars.value = parseFloat(e.target.value) || 0)
+                }
+                error={!!getFieldError('priceCents')}
+                helperText={getFieldError('priceCents')}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">$</InputAdornment>
+                  ),
+                }}
+                inputProps={{ step: 0.01, min: 0 }}
+                required
+                fullWidth
+              />
+
+              {/* Quantity */}
+              <TextField
+                label="Quantity"
+                type="number"
+                value={quantity.value}
+                onChange={(e) =>
+                  (quantity.value = parseInt(e.target.value, 10) || 0)
+                }
+                error={!!getFieldError('quantity')}
+                helperText={getFieldError('quantity')}
+                inputProps={{ min: 0 }}
+                required
+                fullWidth
+              />
+
+              <Button
+                size="small"
+                variant="text"
+                onClick={handleSwitchToMulti}
+                sx={{ alignSelf: 'flex-start' }}
+              >
+                + Add variants (size, color, …)
+              </Button>
+            </>
+          ) : (
+            <>
+              <TextField
+                label="Variant property"
+                placeholder="e.g. Size, Color"
+                value={variantPropertiesText.value}
+                onChange={(e) => (variantPropertiesText.value = e.target.value)}
+                helperText="What do these variants represent? Comma-separate if more than one."
+                fullWidth
+              />
+
+              <Stack spacing={1}>
+                {variants.value.map((row, index) => {
+                  const variantError = getFieldError('variants');
+                  return (
+                    <Stack
+                      key={index}
+                      direction={{ xs: 'column', sm: 'row' }}
+                      spacing={1}
+                      alignItems={{ xs: 'stretch', sm: 'flex-start' }}
+                    >
+                      <TextField
+                        label="Label"
+                        value={row.label}
+                        onChange={(e) =>
+                          updateVariant(index, { label: e.target.value })
+                        }
+                        size="small"
+                        sx={{ flex: 1 }}
+                        required
+                      />
+                      <TextField
+                        label="Price"
+                        type="number"
+                        value={row.priceDollars}
+                        onChange={(e) =>
+                          updateVariant(index, {
+                            priceDollars: parseFloat(e.target.value) || 0,
+                          })
+                        }
+                        size="small"
+                        InputProps={{
+                          startAdornment: (
+                            <InputAdornment position="start">$</InputAdornment>
+                          ),
+                        }}
+                        inputProps={{ step: 0.01, min: 0 }}
+                        sx={{ width: { xs: '100%', sm: 130 } }}
+                        required
+                      />
+                      <TextField
+                        label="Qty"
+                        type="number"
+                        value={row.quantity}
+                        onChange={(e) =>
+                          updateVariant(index, {
+                            quantity: parseInt(e.target.value, 10) || 0,
+                          })
+                        }
+                        size="small"
+                        inputProps={{ min: 0 }}
+                        sx={{ width: { xs: '100%', sm: 90 } }}
+                        required
+                      />
+                      <TextField
+                        label="SKU"
+                        value={row.sku}
+                        onChange={(e) =>
+                          updateVariant(index, { sku: e.target.value })
+                        }
+                        size="small"
+                        placeholder="auto"
+                        sx={{ width: { xs: '100%', sm: 130 } }}
+                      />
+                      <Tooltip
+                        title={
+                          variants.value.length <= 1
+                            ? 'At least one variant required'
+                            : 'Remove variant'
+                        }
+                      >
+                        <span>
+                          <IconButton
+                            aria-label={`Remove variant ${index + 1}`}
+                            onClick={() => removeVariant(index)}
+                            disabled={variants.value.length <= 1}
+                            size="small"
+                            sx={{ alignSelf: { sm: 'center' } }}
+                          >
+                            <DeleteOutlineIcon fontSize="small" />
+                          </IconButton>
+                        </span>
+                      </Tooltip>
+                      {showValidationErrors.value && variantError && index === 0 && (
+                        <FormHelperText error sx={{ mx: 0, width: '100%' }}>
+                          {variantError}
+                        </FormHelperText>
+                      )}
+                    </Stack>
+                  );
+                })}
+              </Stack>
+
+              <Stack direction="row" spacing={1}>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  startIcon={<AddIcon />}
+                  onClick={addVariant}
+                >
+                  Add variant
+                </Button>
+                <Button
+                  size="small"
+                  variant="text"
+                  onClick={handleSwitchToSingle}
+                >
+                  Use a single price/qty instead
+                </Button>
+              </Stack>
+            </>
+          )}
 
           {/* Status */}
           <FormControl fullWidth error={!!getFieldError('status')}>

--- a/docs/sessions/SESSION.md
+++ b/docs/sessions/SESSION.md
@@ -49,23 +49,24 @@ All 6 sub-issues of epic #10 implemented:
 
 ### Phase 5: Unified Inventory, Etsy Push, & Sales Tracking
 
-**Planning completed 2026-04-19.** Admin app becomes single source of truth for products, pushing to Etsy + Square. Sales on either channel auto-recorded with cross-channel inventory sync.
+**Planning completed 2026-04-19.** Admin app is single source of truth for products, pushing to Etsy + Square. Sales on either channel auto-record with cross-channel inventory sync.
 
 **Etsy API approved** (2026-03-27, `maplspruce-listings` app, Personal Access tier).
 
-| PR | Issue | Title | Depends On | Status |
-|----|-------|-------|------------|--------|
-| 1 | #305 | Product variant model refactor | — | **In progress** |
-| 2 | #306 | Square multi-variation catalog support | #305 | Not started |
-| 3 | #307 | Push-to-Etsy Cloud Function | #305 | Not started |
-| 4 | #308 | Etsy import multi-variant support | #305, #306 | Not started |
-| 5 | #309 | Sale recording + InventoryMovement audit log | #305 | Not started |
-| 6 | #310 | Etsy order polling + cross-channel inventory sync | #307, #309 | Not started |
-| 7 | #311 | Etsy sync conflict detection + resolution | #305, #307 | Not started |
-| 8 | #312 | Admin UI — variant management + sales page | #305, #306, #309 | Not started |
-| 9 | #313 | Artist payout calculation + admin page | #309 | Not started |
+8 of 9 PRs merged 2026-04-19 → 2026-04-22. Picking up the remaining admin UI work (#312) on 2026-05-08, split into two reviewable PRs.
 
-**Critical path:** PR 1 → PR 2 → PR 5 → PR 6 (end-to-end sales tracking)
+| PR | Issue | Title | Status |
+|----|-------|-------|--------|
+| 1 | #305 | Product variant model refactor | Merged (#314) |
+| 2 | #306 | Square multi-variation catalog support | Merged (#318) |
+| 3 | #307 | Push-to-Etsy Cloud Function | Merged (#319) |
+| 4 | #308 | Etsy import multi-variant support | Merged (#322) |
+| 5 | #309 | Sale recording + InventoryMovement audit log | Merged (#317) |
+| 6 | #310 | Etsy order polling + cross-channel inventory sync | Merged (#324) |
+| 7 | #311 | Etsy sync conflict detection + resolution | Merged (#325) |
+| 8a | #312 | Admin UI — variants in ProductForm + DataTable | **In progress** (this PR) |
+| 8b | #312 | Admin UI — `/sales` page + Push-to-Etsy button | Not started |
+| 9 | #313 | Artist payout calculation + admin page | Merged (#321) |
 
 **Full plan:** `.claude/plans/wild-scribbling-stearns.md`
 


### PR DESCRIPTION
## Summary

First slice of the remaining Phase 5 admin UI (#312). Wires the existing variant-aware backend (Product.variants[], multi-variation Square + Etsy push, multi-variant Etsy import) into the inventory editor and product table.

A follow-up PR will add the `/sales` page and the "Push to Etsy" button on product edit.

## Changes

### `ProductForm`
- Single-variant flow unchanged: simple Price + Quantity inputs.
- New "+ Add variants (size, color, …)" button switches into multi-variant mode, seeding the first row with the existing single-variant price/qty so nothing is lost.
- Multi mode shows a "Variant property" field (e.g. "Size, Color") plus a per-row table of Label / Price / Qty / SKU with add/remove buttons.
- Editing a product with `variants.length > 1` opens directly into multi mode.
- Validation switches branches via the existing `productValidation` Vest suite — no validation suite changes needed.
- Submit sends `input.variants[]` + `input.variantProperties` in multi mode, or legacy `priceCents`/`quantity` in single mode (server's `resolveVariants` keeps single-mode behavior identical).

### `ProductDataTable`
- "N variants" chip next to the product name when `isMultiVariant`.
- Quantity column now sums across all variants via `getTotalQuantity`.
- Price column shows a min–max range when variant prices differ; single price otherwise.
- SKU column shows "—" for multi-variant products (where there's no single SKU).

### `EtsyImportDialog`
- Drops the stale "multi-variant listings will be skipped automatically" copy. PR #322 added end-to-end multi-variant import — the dialog now describes the actual behavior.

### Storybook
- New `mockProductMultiVariant` fixture (3 sizes, prices $30/$35/$40).
- New `EditMultiVariant` story (visual snapshot of multi-variant edit UI).
- New `SwitchToMultiVariant` interaction test verifying the single → multi toggle reveals the variants table.

### `docs/sessions/SESSION.md`
- Refreshed Phase 5 table to reflect that 8 of 9 PRs merged in late April. Adds 8a/8b split for the remaining #312 work.

## Test plan
- [x] `nx run maple-spruce:typecheck` clean
- [x] `nx run validation:test` + `nx run domain:test` pass
- [ ] Manually verify in dev: edit single-variant product, switch to multi, add/remove rows, save; edit existing multi-variant product, change a price, save
- [ ] Visual regression on new Storybook snapshots

Refs #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)