### PR TITLE
fix: hydrate Date fields from listUsers httpsCallable response

### DIFF
--- a/libs/react/data/src/lib/useUsers.ts
+++ b/libs/react/data/src/lib/useUsers.ts
@@ -3,7 +3,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import { httpsCallable } from 'firebase/functions';
 import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
-import type { AppUser, RequestState } from '@maple/ts/domain';
+import type { AppUser, Employee, RequestState } from '@maple/ts/domain';
 import type {
   GetUsersRequest,
   GetUsersResponse,
@@ -12,6 +12,41 @@ import type {
   RevokeAdminRoleRequest,
   RevokeAdminRoleResponse,
 } from '@maple/ts/firebase/api-types';
+
+/**
+ * httpsCallable serializes the response to JSON, so server-side `Date`
+ * fields arrive as ISO strings even though the typed surface still says
+ * `Date`. Hydrate them at the boundary so consumers can call `.getTime()`,
+ * `toLocaleDateString()`, etc. without the type lying.
+ */
+function toDate(value: unknown): Date | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (value instanceof Date) return value;
+  if (typeof value === 'string' || typeof value === 'number') {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+  }
+  return undefined;
+}
+
+function hydrateEmployee(raw: Employee | undefined): Employee | undefined {
+  if (!raw) return undefined;
+  return {
+    ...raw,
+    grantedAt: toDate(raw.grantedAt) ?? new Date(0),
+    createdAt: toDate(raw.createdAt) ?? new Date(0),
+    updatedAt: toDate(raw.updatedAt) ?? new Date(0),
+  };
+}
+
+function hydrateUser(raw: AppUser): AppUser {
+  return {
+    ...raw,
+    createdAt: toDate(raw.createdAt) ?? new Date(0),
+    lastSignInAt: toDate(raw.lastSignInAt),
+    employee: hydrateEmployee(raw.employee),
+  };
+}
 
 /**
  * Hook for the admin /users page.
@@ -35,7 +70,10 @@ export function useUsers() {
         'listUsers'
       );
       const result = await fn({});
-      setUsersState({ status: 'success', data: result.data.users });
+      setUsersState({
+        status: 'success',
+        data: result.data.users.map(hydrateUser),
+      });
       setHasMore(result.data.hasMore);
     } catch (error) {
       console.error('Failed to fetch users:', error);


### PR DESCRIPTION
## Summary

The `/users` page crashed on load with `TypeError: e.getTime is not a function`. `UserList.formatRelativeDate` calls `user.lastSignInAt.getTime()`, but `httpsCallable` returns JSON — server-side `Date` objects arrive on the client as ISO strings even though the typed surface claims `Date`. Calling a Date method on a string blows up rendering and propagates as a React error boundary failure.

## Fix

Hydrate at the data boundary in `useUsers`. After fetching, walk the response and convert known date fields back to real `Date` instances:

- `AppUser.createdAt`, `AppUser.lastSignInAt` (optional)
- nested `AppUser.employee.grantedAt`, `.createdAt`, `.updatedAt`

A small `toDate` helper handles null/undefined and rejects strings that don't parse to a valid date. The TypeScript types now match runtime — anyone calling `.getTime()` on these fields downstream gets the expected behavior.

## Why hydrate in the hook (not patch the helper)

Patching `formatRelativeDate` to accept `Date | string` would silence this one crash, but the type system would keep lying — every future consumer of `AppUser` dates would have to think about whether they got a real `Date`. Putting the conversion at the boundary fixes it once.

I considered also hydrating in `useEmployees` for symmetry. Skipped because no current consumer of `Employee` reads its date fields, so there's nothing to crash. Easy to add when needed.

## Test plan

- [x] `npx tsc -p libs/react/data/tsconfig.lib.json --noEmit` — clean
- [x] `npx tsc -p apps/maple-spruce/tsconfig.json --noEmit` — clean
- [ ] **Manual after deploy**: `/users` loads without crashing; "Last sign-in" column shows relative date strings ("Today", "3 days ago", etc.) instead of erroring out the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)