### PR TITLE
fix: align brand fonts to live Webflow site (Georgia + Archivo)

### DIFF
--- a/.claude/rules/react-components.md
+++ b/.claude/rules/react-components.md
@@ -7,6 +7,28 @@ globs:
 
 # React Component Rules
 
+## Brand Typography
+
+The admin React app mirrors the live Webflow type system. Do not substitute `system-ui`, `Inter`, `Roboto`, or `Lora` — those are not the brand fonts.
+
+| Role | Stack | Source |
+|------|-------|--------|
+| Body / heading | `Georgia, Times, "Times New Roman", serif` | `fonts.body` / `fonts.heading` |
+| Button | `Archivo, system-ui, -apple-system, sans-serif` | `fonts.button` |
+| Mono (codes, IDs) | `ui-monospace, SFMono-Regular, Menlo, Monaco, monospace` | `fonts.mono` |
+
+Import from `@maple/react/theme`:
+
+```typescript
+import { fonts } from '@maple/react/theme';
+// Inline overrides only when MUI's theme can't reach the element (e.g. native <button>).
+<button style={{ fontFamily: fonts.button }}>Pay</button>
+```
+
+The MUI theme already wires headings and `MuiButton` to the right stacks — most components need no overrides at all. Apple Pay buttons are the documented exception (HIG requires the system font).
+
+See `docs/reference/webflow-design-system.md` for the canonical Webflow values.
+
 ## MUI Theme Colors
 
 Always use MUI theme tokens, not hardcoded hex values.

--- a/apps/maple-spruce/src/app/global.css
+++ b/apps/maple-spruce/src/app/global.css
@@ -107,9 +107,11 @@ img, svg {
   --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
   --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
 
-  /* Fonts (must match libs/react/theme/src/lib/theme.ts `fonts`) */
-  --font-heading: "Lora", Georgia, "Times New Roman", serif;
-  --font-body: "Archivo", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  /* Fonts — mirror the live Webflow site. Must match libs/react/theme/src/lib/theme.ts `fonts`. */
+  --font-body: Georgia, Times, "Times New Roman", serif;
+  --font-heading: Georgia, Times, "Times New Roman", serif;
+  --font-button: "Archivo", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
 
   /* Transitions */
   --transition-fast: 150ms ease;

--- a/apps/maple-spruce/src/app/layout.tsx
+++ b/apps/maple-spruce/src/app/layout.tsx
@@ -23,7 +23,7 @@ export default function RootLayout({
         />
         <link
           rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700&family=Lora:wght@400;500;700&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700&display=swap"
         />
       </head>
       <body>

--- a/docs/architecture/PATTERNS-AND-PRACTICES.md
+++ b/docs/architecture/PATTERNS-AND-PRACTICES.md
@@ -640,14 +640,21 @@ export const theme = createTheme({
     },
   },
   typography: {
-    fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
+    // Brand fonts mirror the live Webflow site. See docs/reference/webflow-design-system.md.
+    fontFamily: 'Georgia, Times, "Times New Roman", serif',
     h1: {
       color: '#4A3728',
-      fontWeight: 600,
+      fontFamily: 'Georgia, Times, "Times New Roman", serif',
+      fontWeight: 700,
     },
     h2: {
       color: '#4A3728',
-      fontWeight: 600,
+      fontFamily: 'Georgia, Times, "Times New Roman", serif',
+      fontWeight: 700,
+    },
+    button: {
+      fontFamily: 'Archivo, system-ui, -apple-system, sans-serif',
+      textTransform: 'none',
     },
   },
   components: {

--- a/docs/reference/webflow-design-system.md
+++ b/docs/reference/webflow-design-system.md
@@ -41,32 +41,20 @@ Modes:
 | `font-size-body` | `variable-fca0c8af-8495-2ac9-afb3-adb425c4f25b` | 16px | 16px | 16px | 15px |
 | `font-size-caption` | `variable-10ba276e-ed81-3c5d-bd0d-082afbb166c9` | 14px | 14px | 13px | 13px |
 
-#### Font Families — TO ADD
+#### Font Family (live values)
 
-The React MUI theme now uses **Lora** for headings and **Archivo** for body
-(see `libs/react/theme/src/lib/theme.ts`). Webflow does NOT yet have matching
-`font-family-*` variables, so the published site falls back to the template's
-default fonts — meaning Webflow and the admin app are currently **inconsistent**.
+The Webflow Typography collection does not yet expose font-family as a token, but the published CSS resolves these stacks (verified 2026-05-09 against `cdn.prod.website-files.com/.../maple-spruce-folk-arts-collective.webflow.shared.2bd19ec02.css`):
 
-To bring them into parity, add these variables to the Typography collection:
+| Role | CSS variable | Stack |
+|------|--------------|-------|
+| Heading | `--_typography---font--heading-font` | `Georgia, Times, "Times New Roman", serif` |
+| Body | `--_typography---font--body-font` | `Georgia, Times, "Times New Roman", serif` |
+| Button | `--_typography---font--button-font` | `Archivo, sans-serif` |
+| Eyebrow / blockquote | (alias of body) | `Georgia, Times, "Times New Roman", serif` |
 
-| Token | Value | Used by |
-|-------|-------|---------|
-| `font-family-heading` | `"Lora", Georgia, "Times New Roman", serif` | `heading-1`, `heading-2`, `heading-3` |
-| `font-family-body` | `"Archivo", system-ui, -apple-system, sans-serif` | `subtitle-text`, `body-text`, `caption-text`, button styles |
+Google Fonts loaded by Webflow: `Archivo` (300–700) and `Lora` (300–700). **Lora is loaded but not referenced** by any active variable — leftover from the original Webflow template, do not introduce new uses.
 
-After creating the variables:
-1. Apply `font-family-heading` to `heading-1`, `heading-2`, `heading-3` styles.
-2. Apply `font-family-body` to `body-text` (and inherit through `subtitle-text`, `caption-text`, button styles).
-3. In Webflow Project Settings → Custom Code (Head), add the same Google Fonts link served by the admin app:
-   ```html
-   <link rel="preconnect" href="https://fonts.googleapis.com" />
-   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700&family=Lora:wght@400;500;700&display=swap" />
-   ```
-4. Republish the site.
-
-Required weights (must match the admin app): **Lora 400/500/700**, **Archivo 400/500/600/700**.
+The admin React app mirrors this stack via `fonts.body` / `fonts.heading` / `fonts.button` exported from `@maple/react/theme` (see `libs/react/theme/src/lib/theme.ts`). The `feat: brand fonts — Lora (headings) + Archivo (body)` change in PR #397 was based on a misread of the Webflow site; PR `feat/brand-fonts-georgia` corrects it.
 
 ### Sizes
 
@@ -129,11 +117,12 @@ The tokens and styles are created but not yet applied to existing page elements.
 2. **Replace inline styles** — Swap hardcoded values for the new design token variables
 3. **Apply typography classes** — Set `heading-1`, `heading-2`, `heading-3`, `subtitle-text`, `body-text`, `caption-text` on text elements
 4. **Apply button classes** — Set `btn-primary`, `btn-secondary`, `btn-outline` on buttons/links
-5. **Add font family tokens** — Add `font-family-heading` (Lora) and `font-family-body` (Archivo) variables to the Typography collection (see "Font Families — TO ADD" above for exact values)
+5. **Add font family tokens** — Promote the resolved heading/body/button stacks above into formal `font-family-heading`, `font-family-body`, `font-family-button` variables in the Typography collection so they're editable in the Designer rather than embedded in CSS.
 6. **Review at all breakpoints** — Verify responsive scaling looks correct on tablet and mobile
+7. **Drop unused Lora load** — Remove `Lora` from the Google Fonts loader once we've confirmed no class still references it. Keep `Archivo` (used by buttons).
 
 ### Notes
 
 - The site has ~1050 existing styles from a template. Many may use hardcoded values that should migrate to tokens.
-- Font family variables are NOT yet defined in Webflow. The React MUI theme uses Lora (headings) and Archivo (body) as of the typography font PR — Webflow needs matching variables and a Google Fonts link in the site head to stay in sync.
-- The MUI theme in the React app uses the same brand colors (see `.claude/rules/react-components.md`).
+- Heading + body fonts are confirmed: **Georgia** (with Times / Times New Roman / serif fallbacks). Buttons are **Archivo**. The live CSS uses these even though they aren't promoted to Designer variables yet.
+- The MUI theme in the React app mirrors both colors and fonts (see `.claude/rules/react-components.md` and the `fonts` export from `@maple/react/theme`).

--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
@@ -16,6 +16,7 @@ import {
   batch,
 } from '@maple/react/signals';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import { fonts } from '@maple/react/theme';
 import { SquareCardForm } from './SquareCardForm';
 import { CostSummary } from './CostSummary';
 import { SigningForm } from '@maple/react/agreements';
@@ -682,7 +683,8 @@ export function RegistrationCheckoutForm({
               border: 'none',
               cursor: isButtonDisabled.value ? 'not-allowed' : 'pointer',
               opacity: isButtonDisabled.value ? 0.7 : 1,
-              fontFamily: 'system-ui, -apple-system, sans-serif',
+              // Apple Pay HIG: button text uses the system font, not brand fonts.
+              fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
               letterSpacing: '0.02em',
               marginBottom: 8,
             }}
@@ -712,7 +714,7 @@ export function RegistrationCheckoutForm({
                 padding: '14px 24px',
                 fontSize: '16px',
                 fontWeight: 600,
-                fontFamily: 'system-ui, -apple-system, sans-serif',
+                fontFamily: fonts.button,
                 color: '#D5D6C8',
                 backgroundColor: isButtonDisabled.value ? '#8a7b6e' : '#4A3728',
                 border: 'none',

--- a/libs/react/theme/src/index.ts
+++ b/libs/react/theme/src/index.ts
@@ -8,6 +8,7 @@ export {
   spacing,
   radii,
   shadows,
+  fonts,
   cssVariables,
 } from './lib/theme';
 

--- a/libs/react/theme/src/lib/theme.ts
+++ b/libs/react/theme/src/lib/theme.ts
@@ -123,14 +123,18 @@ export const shadows = {
 } as const;
 
 /**
- * Font family stacks
+ * Brand font stacks — mirror the live Webflow site so the admin app and
+ * marketing site share one type system. Verified against the published
+ * Webflow CSS (May 2026): heading + body are Georgia, button is Archivo.
  *
- * Loaded via Google Fonts <link> tags in apps/maple-spruce/src/app/layout.tsx.
- * Required weights: Lora 400/500/700, Archivo 400/500/600/700.
+ * Georgia is a system font, no Google Fonts load required. Archivo is loaded
+ * via <link> in apps/maple-spruce/src/app/layout.tsx (weights 400/500/600/700).
  */
 export const fonts = {
-  heading: '"Lora", Georgia, "Times New Roman", serif',
-  body: '"Archivo", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
+  body: 'Georgia, Times, "Times New Roman", serif',
+  heading: 'Georgia, Times, "Times New Roman", serif',
+  button: '"Archivo", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
+  mono: 'ui-monospace, SFMono-Regular, Menlo, Monaco, monospace',
 } as const;
 
 // =============================================================================
@@ -181,6 +185,7 @@ export const theme = createTheme({
     h4: { color: text.primary, fontFamily: fonts.heading, fontWeight: 600 },
     h5: { color: text.primary, fontFamily: fonts.heading, fontWeight: 500 },
     h6: { color: text.primary, fontFamily: fonts.heading, fontWeight: 500 },
+    button: { fontFamily: fonts.button, textTransform: 'none' },
   },
   components: {
     MuiButton: {
@@ -333,7 +338,9 @@ export const cssVariables = `
     --shadow-lg: ${shadows.lg};
 
     /* Fonts */
-    --font-heading: ${fonts.heading};
     --font-body: ${fonts.body};
+    --font-heading: ${fonts.heading};
+    --font-button: ${fonts.button};
+    --font-mono: ${fonts.mono};
   }
 `;


### PR DESCRIPTION
## Summary

PR #397 wired the MUI theme to **Lora (headings) + Archivo (body)** based on a misread of the Webflow site. The published Webflow CSS actually uses **Georgia** for both heading and body, with **Archivo** reserved for buttons. This PR aligns the admin app, repo docs, and the brand-and-identity business doc to that ground truth.

Verified against `cdn.prod.website-files.com/691a5d6c07ba1bf4714e826f/css/maple-spruce-folk-arts-collective.webflow.shared.2bd19ec02.css`:

```
--_typography---font--heading-font: Georgia, Times, "Times New Roman", serif
--_typography---font--body-font:    Georgia, Times, "Times New Roman", serif
--_typography---font--button-font:  Archivo, sans-serif
```

Lora is loaded by Webflow but referenced by zero active variables — leftover from the original template.

### What changed

- **`libs/react/theme`** — `fonts.body` / `fonts.heading` flipped to Georgia, new `fonts.button` (Archivo) and `fonts.mono`. `cssVariables` exports `--font-body`, `--font-heading`, `--font-button`, `--font-mono`. MUI typography wires headings + `MuiButton` to the right stacks.
- **`apps/maple-spruce/src/app/global.css`** — `--font-*` values flipped to match.
- **`apps/maple-spruce/src/app/layout.tsx`** — drop `Lora` from the Google Fonts URL (Georgia is a system font, no load needed). Keep Archivo for buttons.
- **`libs/react/registrations/RegistrationCheckoutForm.tsx`** — the brand "Pay" button now uses `fonts.button`. The Apple Pay button keeps `-apple-system` (Apple HIG).
- **`apps/webflow-components/Image2PagesWidget.tsx`** — drop the inline `system-ui` override so the `ThemeProvider`'s body font takes effect.
- **`docs/reference/webflow-design-system.md`** — replace the speculative "TO ADD" section with the verified live values; flag Lora as an unused template leftover.
- **`docs/architecture/PATTERNS-AND-PRACTICES.md`** — typography example now uses the brand stacks.
- **`.claude/rules/react-components.md`** — new "Brand Typography" rule so future Claude sessions don't drift back to `system-ui` / `Inter` / `Lora`.

### Out-of-repo follow-ups (already done in this session)

- `Maple and Spruce Workspace/_business_context/03-brand-and-identity.md` updated to record Georgia + Archivo with the May 9 2026 verification note.

## Test plan

- [ ] `pnpm install && pnpm exec nx build maple-spruce` builds clean
- [ ] `pnpm exec nx test react-theme` passes
- [ ] Local dev: open admin app, confirm headings + body render in Georgia and buttons render in Archivo
- [ ] Storybook visual regression review — expect heading/body/button font snapshots to update

🤖 Generated with [Claude Code](https://claude.com/claude-code)