### PR TITLE
fix: write etsyListingId atomically with Product on import

### DIFF
--- a/libs/firebase/database/src/lib/product.repository.spec.ts
+++ b/libs/firebase/database/src/lib/product.repository.spec.ts
@@ -239,6 +239,7 @@ describe('ProductRepository', () => {
         etsyListingId: '1234567890',
         etsyCache: {
           title: 'Etsy-imported product',
+          taxonomyId: 1,
           priceCents: 4500,
           quantity: 3,
           state: 'active',

--- a/libs/firebase/database/src/lib/product.repository.spec.ts
+++ b/libs/firebase/database/src/lib/product.repository.spec.ts
@@ -201,6 +201,72 @@ describe('ProductRepository', () => {
       expect(result.categoryId).toBeUndefined();
       expect(savedData.categoryId).toBeUndefined();
     });
+
+    it('writes etsyListingId and etsyCache atomically when extras are passed', async () => {
+      const input: CreateProductInput = {
+        artistId: 'artist-1',
+        status: 'active',
+        name: 'Etsy-imported product',
+        priceCents: 4500,
+        quantity: 3,
+      };
+
+      const squareResult: SquareProductResult = {
+        squareItemId: 'sq-item-etsy',
+        squareVariationId: 'sq-var-etsy',
+        squareCatalogVersion: 1,
+        squareLocationId: 'sq-loc-001',
+        sku: 'prd_etsy',
+        variations: [
+          { variantId: 'var-etsy', squareVariationId: 'sq-var-etsy', sku: 'prd_etsy' },
+        ],
+      };
+
+      let savedData: Record<string, unknown> = {};
+      const mockSet = vi.fn().mockImplementation((data) => {
+        savedData = data;
+        return Promise.resolve();
+      });
+      const mockDocRef = vi
+        .fn()
+        .mockReturnValue({ id: 'prod-etsy', set: mockSet });
+      vi.mocked(db.collection).mockImplementation(
+        vi.fn().mockReturnValue({ doc: mockDocRef })
+      );
+
+      const syncedAt = new Date('2024-10-01T00:00:00Z');
+      const result = await ProductRepository.create(input, squareResult, {
+        etsyListingId: '1234567890',
+        etsyCache: {
+          title: 'Etsy-imported product',
+          priceCents: 4500,
+          quantity: 3,
+          state: 'active',
+          syncedAt,
+        },
+      });
+
+      // Both Etsy linkage fields land on the returned domain object …
+      expect(result.etsyListingId).toBe('1234567890');
+      expect(result.etsyCache?.title).toBe('Etsy-imported product');
+      expect(result.etsyCache?.syncedAt).toBe(syncedAt);
+
+      // … and on the Firestore doc body, in a single set() call. This is the
+      // race-closing assertion: prior versions wrote etsyListingId via a
+      // follow-up updateEtsyCache, leaving an orphan window if the import
+      // function timed out between the two writes.
+      expect(mockSet).toHaveBeenCalledTimes(1);
+      expect(savedData['etsyListingId']).toBe('1234567890');
+      // Listing-level Etsy fields land on the Firestore doc; per-variant
+      // priceCents/quantity are intentionally derived from variants[0] at
+      // read time (see EtsyCache backward-compat shape) so they're not
+      // serialized here.
+      const cache = savedData['etsyCache'] as Record<string, unknown>;
+      expect(cache).toMatchObject({
+        title: 'Etsy-imported product',
+        state: 'active',
+      });
+    });
   });
 
   describe('update', () => {

--- a/libs/firebase/database/src/lib/product.repository.spec.ts
+++ b/libs/firebase/database/src/lib/product.repository.spec.ts
@@ -258,14 +258,16 @@ describe('ProductRepository', () => {
       // function timed out between the two writes.
       expect(mockSet).toHaveBeenCalledTimes(1);
       expect(savedData['etsyListingId']).toBe('1234567890');
-      // Listing-level Etsy fields land on the Firestore doc; per-variant
-      // priceCents/quantity are intentionally derived from variants[0] at
-      // read time (see EtsyCache backward-compat shape) so they're not
-      // serialized here.
+      // Both listing-level fields AND the deprecated per-variant fields
+      // land on the Firestore doc — the latter so the atomic-create path
+      // produces the same stored doc shape as the prior
+      // create + updateEtsyCache pair (integration tests read raw docs).
       const cache = savedData['etsyCache'] as Record<string, unknown>;
       expect(cache).toMatchObject({
         title: 'Etsy-imported product',
         state: 'active',
+        priceCents: 4500,
+        quantity: 3,
       });
     });
   });

--- a/libs/firebase/database/src/lib/product.repository.ts
+++ b/libs/firebase/database/src/lib/product.repository.ts
@@ -283,10 +283,18 @@ export const ProductRepository = {
    *
    * Called after successfully creating the item in Square.
    * The Square result provides the IDs and SKU.
+   *
+   * Optional `extras` carries Etsy linkage fields. When provided, they're
+   * written to the same Firestore doc atomically with the rest of the
+   * Product — closes the timeout window where importEtsyListings used to
+   * leave orphan Products that had no `etsyListingId` (next retry's
+   * dedup check returned null and re-imported the same listing). Pass
+   * extras when the Product is born from an Etsy import; omit otherwise.
    */
   async create(
     input: CreateProductInput,
-    squareResult: SquareProductResult
+    squareResult: SquareProductResult,
+    extras?: { etsyListingId?: string; etsyCache?: EtsyCache }
   ): Promise<Product> {
     const docRef = db.collection(COLLECTION).doc();
     const now = new Date();
@@ -328,8 +336,9 @@ export const ProductRepository = {
       squareCatalogVersion: squareResult.squareCatalogVersion,
       squareLocationId: squareResult.squareLocationId,
 
-      // No Etsy yet
-      etsyListingId: undefined,
+      // Etsy linkage (optional, written atomically with the rest)
+      etsyListingId: extras?.etsyListingId,
+      etsyCache: extras?.etsyCache,
 
       // Listing-level cache + deprecated per-variant fields for compat
       squareCache: {

--- a/libs/firebase/database/src/lib/product.repository.ts
+++ b/libs/firebase/database/src/lib/product.repository.ts
@@ -204,6 +204,13 @@ function productToDoc(product: Omit<Product, 'id'>): Record<string, unknown> {
         tags: product.etsyCache.tags,
         state: product.etsyCache.state,
         syncedAt: product.etsyCache.syncedAt,
+        // Deprecated per-variant fields. docToProduct re-derives them
+        // from variants[0] at read time, but persisting them keeps the
+        // stored doc identical to what updateEtsyCache writes — so the
+        // atomic-create path round-trips the same way to integration
+        // tests that read raw Firestore docs.
+        priceCents: product.etsyCache.priceCents,
+        quantity: product.etsyCache.quantity,
       },
     }),
   };

--- a/libs/firebase/maple-functions/import-etsy-listings/src/lib/import-etsy-listings.spec.ts
+++ b/libs/firebase/maple-functions/import-etsy-listings/src/lib/import-etsy-listings.spec.ts
@@ -348,7 +348,8 @@ describe('importEtsyListings', () => {
     // Should set inventory per variant
     expect(mocks.setQuantity).toHaveBeenCalledTimes(2);
 
-    // Should create product with variants
+    // Should create product with variants — and also pass the Etsy
+    // linkage atomically as the third arg (race-closing fix).
     expect(mocks.createProduct).toHaveBeenCalledWith(
       expect.objectContaining({
         variants: expect.arrayContaining([
@@ -363,6 +364,10 @@ describe('importEtsyListings', () => {
           expect.objectContaining({ sku: 'v1-sku' }),
           expect.objectContaining({ sku: 'v2-sku' }),
         ]),
+      }),
+      expect.objectContaining({
+        etsyListingId: expect.any(String),
+        etsyCache: expect.objectContaining({ state: 'active' }),
       })
     );
 

--- a/libs/firebase/maple-functions/import-etsy-listings/src/lib/import-etsy-listings.spec.ts
+++ b/libs/firebase/maple-functions/import-etsy-listings/src/lib/import-etsy-listings.spec.ts
@@ -445,18 +445,21 @@ describe('importEtsyListings', () => {
       }),
       expect.objectContaining({
         squareItemId: 'sqi-1',
-      })
-    );
-    expect(mocks.updateEtsyCache).toHaveBeenCalledWith(
-      'prod-1',
-      '1001',
+      }),
+      // Etsy linkage is written atomically with the Product create — no
+      // follow-up updateEtsyCache call. Closes the race that left orphan
+      // Products without etsyListingId on import timeouts.
       expect.objectContaining({
-        title: 'Handmade Mug',
-        priceCents: 2500,
-        taxonomyId: 42,
-        state: 'active',
+        etsyListingId: '1001',
+        etsyCache: expect.objectContaining({
+          title: 'Handmade Mug',
+          priceCents: 2500,
+          taxonomyId: 42,
+          state: 'active',
+        }),
       })
     );
+    expect(mocks.updateEtsyCache).not.toHaveBeenCalled();
     expect(mocks.createImport).toHaveBeenCalledWith(
       expect.objectContaining({
         productId: 'prod-1',

--- a/libs/firebase/maple-functions/import-etsy-listings/src/lib/import-etsy-listings.ts
+++ b/libs/firebase/maple-functions/import-etsy-listings/src/lib/import-etsy-listings.ts
@@ -41,7 +41,7 @@ import type {
   ImportEtsyListingsResponse,
   ImportEtsyListingResult,
 } from '@maple/ts/firebase/api-types';
-import type { Product, ProductVariant } from '@maple/ts/domain';
+import type { ProductVariant } from '@maple/ts/domain';
 import { generateVariantId, generateSku } from '@maple/ts/domain';
 import type { EtsyInventoryProduct } from '@maple/firebase/etsy';
 
@@ -339,7 +339,13 @@ async function importSingleListing(options: {
       };
     });
 
-    // 5. Create Firestore Product with all variant data
+    // 5. Create Firestore Product with all variant data, atomically linked
+    //    to the Etsy listing. The etsyListingId + etsyCache are passed in
+    //    here (rather than via a follow-up updateEtsyCache call) so a
+    //    timeout between create and the cache write can't leave orphan
+    //    Products without etsyListingId — the prior shape leaked enough
+    //    duplicates on retry to need a one-off cleanup tool. See
+    //    tools/dedupe-etsy-imported-products.ts.
     const product = await ProductRepository.create(
       {
         artistId,
@@ -364,26 +370,27 @@ async function importSingleListing(options: {
         squareLocationId: square.locationId,
         sku: catalogResult.sku,
         variations: variationsWithEtsy,
+      },
+      {
+        etsyListingId: listingId,
+        etsyCache: {
+          title: listing.title,
+          description: listing.description,
+          priceCents,
+          quantity,
+          url: listing.url,
+          taxonomyId: listing.taxonomy_id,
+          tags: listing.tags,
+          state:
+            listing.state === 'active' || listing.state === 'draft'
+              ? listing.state
+              : 'inactive',
+          syncedAt: new Date(),
+        },
       }
     );
 
-    // 6. Link Etsy listing + populate etsyCache
-    await ProductRepository.updateEtsyCache(product.id, listingId, {
-      title: listing.title,
-      description: listing.description,
-      priceCents,
-      quantity,
-      url: listing.url,
-      taxonomyId: listing.taxonomy_id,
-      tags: listing.tags,
-      state:
-        listing.state === 'active' || listing.state === 'draft'
-          ? listing.state
-          : 'inactive',
-      syncedAt: new Date(),
-    });
-
-    // 7. Persist raw snapshot for later insights / template seeding
+    // 6. Persist raw snapshot for later insights / template seeding
     await EtsyImportRepository.create({
       productId: product.id,
       listingId,
@@ -393,14 +400,11 @@ async function importSingleListing(options: {
       importedBy,
     });
 
-    // Refetch to return the Product with populated etsyCache.
-    const refreshed = (await ProductRepository.findById(product.id)) as Product;
-
     return {
       listingId,
       success: true,
       productId: product.id,
-      product: refreshed,
+      product,
     };
   } catch (err) {
     console.error(`Failed to import Etsy listing ${listingId}:`, err);


### PR DESCRIPTION
## Summary

The importer race that produced ~600 orphan Products on prod (cleaned up via #408 / #409 / #413). Closes the gap that let it happen.

## What was wrong

\`importSingleListing\` used to do:

1. \`findByEtsyListingId(listingId)\` — dedup check
2. Square \`createItem\`
3. Square \`setQuantity\`
4. image upload
5. \`ProductRepository.create(...)\` — Product written **without** \`etsyListingId\`
6. \`ProductRepository.updateEtsyCache(...)\` — \`etsyListingId\` set here

When the function timed out anywhere between 5 and 6, an orphan Product with no \`etsyListingId\` survived. The next retry's \`findByEtsyListingId\` returned null for that listing, so it created a fresh Product + Square catalog item. After several retries that cascaded into hundreds of dupes.

## What changes

- \`ProductRepository.create()\` takes an optional 3rd \`extras\` parameter for \`etsyListingId\` + \`etsyCache\`. Both are written to the same Firestore doc in a single \`set()\` call.
- \`importEtsyListings\` passes the linkage at create time and drops the follow-up \`updateEtsyCache\` call. Also drops the \`findById\` refetch — the result of \`create\` already carries the populated fields.
- New repo unit test exercises the atomic-write path and asserts \`set()\` is called exactly once with both \`etsyListingId\` and \`etsyCache\` on the doc body.
- Importer spec updated to assert: (a) \`createProduct\` is called with the new third \`extras\` argument carrying the Etsy linkage, and (b) \`updateEtsyCache\` is **never** called.

Future timeouts mid-loop now leave Products that the next retry's \`findByEtsyListingId\` correctly identifies and skips.

## What this doesn't fix

A truly concurrent import (two browser tabs hitting the function simultaneously) can still produce two distinct Products for the same Etsy listing because both pass \`findByEtsyListingId\` before either commits its \`set()\`. That's the smaller failure mode (only ~11 of the 600 prod orphans). Closing it cleanly needs either a transaction wrapping all the external API calls (not safe, transactions can't run that long) or a deterministic doc id like \`etsy_{listingId}\`. Worth a follow-up if it ever recurs; the dedupe tool's pass-2 already handles cleanup if it does.

## Test plan
- [x] \`nx run maple-spruce:typecheck\` clean
- [x] \`firebase-database\` repo tests: 10/10 passing locally (includes the new atomic-write assertion)
- [ ] CI runs \`firebase-maple-functions-import-etsy-listings\` specs (vitest config can't load through worktree symlinks locally — known issue, runs fine in CI)
- [ ] Manual: re-import a listing on dev, verify the resulting Product has \`etsyListingId\` set in a single Firestore write (check Firestore audit log if helpful)

🤖 Generated with [Claude Code](https://claude.com/claude-code)