### PR TITLE
feat: add Registration.source field (web vs POS) for in-person POS class registrations

### DIFF
--- a/apps/maple-spruce/.storybook/fixtures/registrations.ts
+++ b/apps/maple-spruce/.storybook/fixtures/registrations.ts
@@ -13,6 +13,7 @@ export const mockRegistrationConfirmed: Registration = {
   taxRatePercent: 6.0,
   squarePaymentId: 'sq-pay-abc123',
   status: 'confirmed',
+  source: 'web',
   notes: 'Please let me know about parking.',
   createdAt: new Date('2024-08-01T14:30:00Z'),
   updatedAt: new Date('2024-08-01T14:30:00Z'),
@@ -31,6 +32,7 @@ export const mockRegistrationPending: Registration = {
   discountCode: 'SAVE10',
   discountAmountCents: 1500,
   status: 'pending',
+  source: 'web',
   createdAt: new Date('2024-08-02T10:00:00Z'),
   updatedAt: new Date('2024-08-02T10:00:00Z'),
 };
@@ -47,6 +49,7 @@ export const mockRegistrationCancelled: Registration = {
   taxRatePercent: 6.0,
   squarePaymentId: 'sq-pay-def456',
   status: 'cancelled',
+  source: 'web',
   notes: 'Cancelled due to scheduling conflict.',
   createdAt: new Date('2024-07-15T09:00:00Z'),
   updatedAt: new Date('2024-07-20T11:00:00Z'),
@@ -64,6 +67,7 @@ export const mockRegistrationRefunded: Registration = {
   taxRatePercent: 6.0,
   squarePaymentId: 'sq-pay-ghi789',
   status: 'refunded',
+  source: 'pos',
   createdAt: new Date('2024-07-10T16:00:00Z'),
   updatedAt: new Date('2024-07-22T08:00:00Z'),
 };

--- a/apps/maple-spruce/src/app/(admin)/registrations/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/registrations/page.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mui/material';
 import type {
   Registration,
+  RegistrationSource,
   RegistrationStatus,
 } from '@maple/ts/domain';
 import {
@@ -126,6 +127,26 @@ export default function RegistrationsPage() {
             <MenuItem value="cancelled">Cancelled</MenuItem>
             <MenuItem value="refunded">Refunded</MenuItem>
             <MenuItem value="no-show">No Show</MenuItem>
+          </Select>
+        </FormControl>
+
+        <FormControl size="small" sx={{ minWidth: 150 }}>
+          <InputLabel>Filter by Source</InputLabel>
+          <Select
+            value={filters.source ?? ''}
+            label="Filter by Source"
+            onChange={(e) =>
+              setFilters((prev) => ({
+                ...prev,
+                source: (e.target.value as RegistrationSource) || undefined,
+              }))
+            }
+          >
+            <MenuItem value="">
+              <em>All Sources</em>
+            </MenuItem>
+            <MenuItem value="web">Web</MenuItem>
+            <MenuItem value="pos">POS (in person)</MenuItem>
           </Select>
         </FormControl>
       </Box>

--- a/libs/firebase/database/src/lib/registration.repository.spec.ts
+++ b/libs/firebase/database/src/lib/registration.repository.spec.ts
@@ -61,6 +61,7 @@ function firestoreRegData(overrides: Record<string, unknown> = {}) {
     discountCode: undefined,
     discountAmountCents: undefined,
     status: 'confirmed',
+    source: 'web',
     notes: undefined,
     confirmationSentAt: new Date('2026-03-01'),
     reminderSentAt: undefined,
@@ -146,6 +147,14 @@ describe('RegistrationRepository', () => {
       await RegistrationRepository.findAll({ status: 'cancelled' });
 
       expect(mockWhere).toHaveBeenCalledWith('status', '==', 'cancelled');
+    });
+
+    it('applies source filter when provided', async () => {
+      const { mockWhere } = setupFindAll([]);
+
+      await RegistrationRepository.findAll({ source: 'pos' });
+
+      expect(mockWhere).toHaveBeenCalledWith('source', '==', 'pos');
     });
 
     it('orders results by createdAt desc', async () => {
@@ -245,6 +254,36 @@ describe('RegistrationRepository', () => {
 
       expect(result!.confirmationSentAt).toBeInstanceOf(Date);
       expect(result!.reminderSentAt).toBeInstanceOf(Date);
+    });
+
+    it("defaults source to 'web' for documents missing the field (back-compat)", async () => {
+      const mockDoc = mockDocSnapshot(
+        'reg-old',
+        firestoreRegData({ source: undefined })
+      );
+      const mockGet = vi.fn().mockResolvedValue(mockDoc);
+      const mockDocFn = vi.fn().mockReturnValue({ get: mockGet });
+      const mockCollection = vi.fn().mockReturnValue({ doc: mockDocFn });
+      vi.mocked(db.collection).mockImplementation(mockCollection);
+
+      const result = await RegistrationRepository.findById('reg-old');
+
+      expect(result!.source).toBe('web');
+    });
+
+    it("reads source as 'pos' when set", async () => {
+      const mockDoc = mockDocSnapshot(
+        'reg-pos',
+        firestoreRegData({ source: 'pos' })
+      );
+      const mockGet = vi.fn().mockResolvedValue(mockDoc);
+      const mockDocFn = vi.fn().mockReturnValue({ get: mockGet });
+      const mockCollection = vi.fn().mockReturnValue({ doc: mockDocFn });
+      vi.mocked(db.collection).mockImplementation(mockCollection);
+
+      const result = await RegistrationRepository.findById('reg-pos');
+
+      expect(result!.source).toBe('pos');
     });
 
     it('leaves optional date fields undefined when not set', async () => {
@@ -442,6 +481,7 @@ describe('RegistrationRepository', () => {
         taxAmountCents: 600,
         taxRatePercent: 6,
         status: 'confirmed' as const,
+        source: 'web' as const,
       };
 
       const result = await RegistrationRepository.create(input);
@@ -474,6 +514,7 @@ describe('RegistrationRepository', () => {
         taxAmountCents: 300,
         taxRatePercent: 6,
         status: 'pending' as const,
+        source: 'web' as const,
       });
 
       expect(result.createdAt.getTime()).toBe(result.updatedAt.getTime());
@@ -504,6 +545,7 @@ describe('RegistrationRepository', () => {
         taxRatePercent: 6,
         squarePaymentId: 'sq-pay-5',
         status: 'confirmed' as const,
+        source: 'pos' as const,
         notes: 'Window seat please',
       });
 

--- a/libs/firebase/database/src/lib/registration.repository.ts
+++ b/libs/firebase/database/src/lib/registration.repository.ts
@@ -11,6 +11,7 @@ import type {
   CreateRegistrationInput,
   UpdateRegistrationInput,
   RegistrationStatus,
+  RegistrationSource,
 } from '@maple/ts/domain';
 
 const COLLECTION = 'registrations';
@@ -43,6 +44,9 @@ function docToRegistration(
     discountCode: data.discountCode,
     discountAmountCents: data.discountAmountCents,
     status: data.status as RegistrationStatus,
+    // Default to 'web' so registrations created before the source field
+    // existed (all of which were web checkouts) read back with a usable value.
+    source: (data.source as RegistrationSource | undefined) ?? 'web',
     notes: data.notes,
     confirmationSentAt: data.confirmationSentAt
       ? toDate(data.confirmationSentAt)
@@ -88,6 +92,7 @@ export interface RegistrationFilters {
   classId?: string;
   customerEmail?: string;
   status?: RegistrationStatus;
+  source?: RegistrationSource;
 }
 
 /**
@@ -110,6 +115,10 @@ export const RegistrationRepository = {
 
     if (filters?.status) {
       query = query.where('status', '==', filters.status);
+    }
+
+    if (filters?.source) {
+      query = query.where('source', '==', filters.source);
     }
 
     query = query.orderBy('createdAt', 'desc');

--- a/libs/firebase/maple-functions/create-registration/src/lib/create-registration.ts
+++ b/libs/firebase/maple-functions/create-registration/src/lib/create-registration.ts
@@ -362,6 +362,7 @@ export const createRegistration = Functions.endpoint
           discountCode: discountCode || null,
           discountAmountCents: discountAmountCents || null,
           status: 'pending',
+          source: 'web',
           notes: data.notes || null,
           confirmationNumber,
           createdAt: now,

--- a/libs/firebase/maple-functions/get-registrations/src/lib/get-registrations.ts
+++ b/libs/firebase/maple-functions/get-registrations/src/lib/get-registrations.ts
@@ -20,6 +20,7 @@ export const getRegistrations = createAdminFunction<
     classId: data.classId,
     status: data.status,
     customerEmail: data.customerEmail,
+    source: data.source,
   });
 
   return { registrations };

--- a/libs/react/data/src/lib/useRegistrations.ts
+++ b/libs/react/data/src/lib/useRegistrations.ts
@@ -7,6 +7,7 @@ import type {
   Registration,
   UpdateRegistrationInput,
   RegistrationStatus,
+  RegistrationSource,
   RequestState,
 } from '@maple/ts/domain';
 import type {
@@ -25,6 +26,7 @@ export interface UseRegistrationsFilters {
   classId?: string;
   status?: RegistrationStatus;
   customerEmail?: string;
+  source?: RegistrationSource;
 }
 
 /**
@@ -51,6 +53,7 @@ export function useRegistrations(filters?: UseRegistrationsFilters) {
         classId: filters?.classId,
         status: filters?.status,
         customerEmail: filters?.customerEmail,
+        source: filters?.source,
       });
       setRegistrationsState({
         status: 'success',
@@ -66,7 +69,12 @@ export function useRegistrations(filters?: UseRegistrationsFilters) {
             : 'Failed to fetch registrations',
       });
     }
-  }, [filters?.classId, filters?.status, filters?.customerEmail]);
+  }, [
+    filters?.classId,
+    filters?.status,
+    filters?.customerEmail,
+    filters?.source,
+  ]);
 
   const updateRegistration = useCallback(
     async (input: UpdateRegistrationInput): Promise<Registration> => {

--- a/libs/react/registrations/src/lib/RegistrationDetailDialog.tsx
+++ b/libs/react/registrations/src/lib/RegistrationDetailDialog.tsx
@@ -116,7 +116,7 @@ export function RegistrationDetailDialog({
             <Alert severity="success">{cancelSuccess}</Alert>
           )}
 
-          {/* Status */}
+          {/* Status + Source */}
           <Box
             sx={{
               display: 'flex',
@@ -127,10 +127,18 @@ export function RegistrationDetailDialog({
             <Typography variant="subtitle2" color="text.secondary">
               Status
             </Typography>
-            <Chip
-              label={registration.status}
-              color={getStatusColor(registration.status)}
-            />
+            <Box sx={{ display: 'flex', gap: 1 }}>
+              <Chip
+                label={registration.source === 'pos' ? 'POS' : 'Web'}
+                size="small"
+                variant="outlined"
+                color={registration.source === 'pos' ? 'primary' : 'default'}
+              />
+              <Chip
+                label={registration.status}
+                color={getStatusColor(registration.status)}
+              />
+            </Box>
           </Box>
 
           <Divider />

--- a/libs/react/registrations/src/lib/RegistrationList.tsx
+++ b/libs/react/registrations/src/lib/RegistrationList.tsx
@@ -16,7 +16,12 @@ import {
   Alert,
 } from '@mui/material';
 import VisibilityIcon from '@mui/icons-material/Visibility';
-import type { Registration, RequestState, Class } from '@maple/ts/domain';
+import type {
+  Registration,
+  RegistrationSource,
+  RequestState,
+  Class,
+} from '@maple/ts/domain';
 
 interface RegistrationListProps {
   registrationsState: RequestState<Registration[]>;
@@ -55,6 +60,10 @@ function getStatusColor(
     default:
       return 'default';
   }
+}
+
+function getSourceLabel(source: RegistrationSource): string {
+  return source === 'pos' ? 'POS' : 'Web';
 }
 
 export function RegistrationList({
@@ -108,6 +117,7 @@ export function RegistrationList({
             <TableCell>Qty</TableCell>
             <TableCell>Amount</TableCell>
             <TableCell>Status</TableCell>
+            <TableCell>Source</TableCell>
             <TableCell>Date</TableCell>
             <TableCell align="right">Actions</TableCell>
           </TableRow>
@@ -133,6 +143,14 @@ export function RegistrationList({
                   label={registration.status}
                   size="small"
                   color={getStatusColor(registration.status)}
+                />
+              </TableCell>
+              <TableCell>
+                <Chip
+                  label={getSourceLabel(registration.source)}
+                  size="small"
+                  variant="outlined"
+                  color={registration.source === 'pos' ? 'primary' : 'default'}
                 />
               </TableCell>
               <TableCell>

--- a/libs/ts/domain/src/lib/registration.spec.ts
+++ b/libs/ts/domain/src/lib/registration.spec.ts
@@ -17,6 +17,7 @@ const baseRegistration: Registration = {
   taxAmountCents: 300,
   taxRatePercent: 6.0,
   status: 'confirmed',
+  source: 'web',
   createdAt: new Date(),
   updatedAt: new Date(),
 };

--- a/libs/ts/domain/src/lib/registration.ts
+++ b/libs/ts/domain/src/lib/registration.ts
@@ -18,6 +18,16 @@ export type RegistrationStatus =
   | 'no-show'; // Customer didn't attend
 
 /**
+ * Channel the registration was created through.
+ * Used for reporting and to gate the dedup logic in the Square POS webhook
+ * (a `web` registration's Square order carries metadata so the POS handler
+ * skips it).
+ */
+export type RegistrationSource =
+  | 'web' // Customer self-registered on the public Webflow site
+  | 'pos'; // Staff rang up the class on Square POS in person
+
+/**
  * Registration entity - customer signed up for a class
  */
 export interface Registration {
@@ -52,6 +62,11 @@ export interface Registration {
   discountAmountCents?: number;
   /** Registration status */
   status: RegistrationStatus;
+  /**
+   * Channel the registration came from. Defaults to `'web'` for any record
+   * predating the field — see `docToRegistration` for the back-compat read.
+   */
+  source: RegistrationSource;
   /** Notes from customer (e.g., dietary restrictions, accessibility needs) */
   notes?: string;
   /** Confirmation email sent */

--- a/libs/ts/firebase/api-types/src/lib/registration.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/registration.types.ts
@@ -8,6 +8,7 @@ import type {
   Registration,
   UpdateRegistrationInput,
   RegistrationStatus,
+  RegistrationSource,
 } from '@maple/ts/domain';
 import type { InlineAgreementSigningData } from './agreement.types';
 
@@ -22,6 +23,8 @@ export interface GetRegistrationsRequest {
   status?: RegistrationStatus;
   /** Filter by customer email */
   customerEmail?: string;
+  /** Filter by registration channel (web vs in-person POS) */
+  source?: RegistrationSource;
 }
 
 export interface GetRegistrationsResponse {


### PR DESCRIPTION
## Summary

PR 1 of 3 in the Square POS class-registration plan. Adds a `source: 'web' | 'pos'` field to `Registration` so the upcoming POS flow has a clean reporting/dedup hook. No behavior change today — every registration is `'web'`.

- New `RegistrationSource` type in `@maple/ts/domain`
- `createRegistration` writes `source: 'web'`
- Repository back-compat: existing Firestore docs without the field read back as `'web'`
- Admin `/registrations`: source chip in the list + a "Filter by Source" dropdown
- Source filter plumbed through `getRegistrations` callable + `useRegistrations` hook

## Why now

Lays the groundwork for PR 2 (`syncClassToSquare` + Square inventory mirror) and PR 3 (Square `order.updated` webhook → POS registration). PR 3 will tag the existing web-flow Square order with metadata for dedup; the source field is the read-side complement of that.

## Test plan
- [x] `nx run domain:test` passes (fixture updated to include `source`)
- [x] `nx run firebase-database:test` passes (back-compat default + filter tests added)
- [x] `nx run maple-spruce:typecheck` passes
- [x] All 4 cloud function codebases build cleanly
- [ ] Manual smoke: open `/registrations`, confirm source chip renders and filter narrows results

## Out of scope
- Square catalog/inventory sync (PR 2)
- POS webhook handler (PR 3)
- Required POS modifier "Added customer email (required)?" (seeded in PR 2)