### PR TITLE
feat: sync classes to Square as catalog items + mirror capacity to inventory

### DIFF
--- a/apps/functions-square/src/index.ts
+++ b/apps/functions-square/src/index.ts
@@ -36,3 +36,13 @@ export { importEtsyListings } from '@maple/firebase/maple-functions/import-etsy-
 
 // Cross-channel inventory sync (Square)
 export { syncInventoryToSquare } from '@maple/firebase/maple-functions/sync-inventory-to-square';
+
+// Class → Square catalog sync (Firestore trigger on classes/{id})
+// Mirrors a class as a Square catalog item + variation + required modifier
+// list so it can be rung up on POS in person.
+export { syncClassToSquare } from '@maple/firebase/maple-functions/sync-class-to-square';
+
+// Class capacity → Square inventory sync (Firestore trigger on registrations/{id})
+// Keeps Square inventory in sync with Firestore registration count so POS
+// refuses to ring up a sold-out class.
+export { syncClassInventoryToSquare } from '@maple/firebase/maple-functions/sync-class-inventory-to-square';

--- a/apps/functions-square/tsconfig.app.json
+++ b/apps/functions-square/tsconfig.app.json
@@ -17,6 +17,8 @@
     "../../libs/firebase/maple-functions/sync-invoice-to-square/**/*.ts",
     "../../libs/firebase/maple-functions/import-etsy-listings/**/*.ts",
     "../../libs/firebase/maple-functions/sync-inventory-to-square/**/*.ts",
+    "../../libs/firebase/maple-functions/sync-class-to-square/**/*.ts",
+    "../../libs/firebase/maple-functions/sync-class-inventory-to-square/**/*.ts",
     "../../libs/firebase/database/src/**/*.ts",
     "../../libs/firebase/functions/src/**/*.ts",
     "../../libs/firebase/square/src/**/*.ts",

--- a/function-codebases.json
+++ b/function-codebases.json
@@ -35,7 +35,9 @@
     "firebase-maple-functions-update-etsy-listing": "maple-sync",
     "firebase-maple-functions-poll-etsy-orders": "maple-sync",
     "firebase-maple-functions-sync-inventory-to-etsy": "maple-sync",
-    "firebase-maple-functions-sync-inventory-to-square": "maple-square"
+    "firebase-maple-functions-sync-inventory-to-square": "maple-square",
+    "firebase-maple-functions-sync-class-to-square": "maple-square",
+    "firebase-maple-functions-sync-class-inventory-to-square": "maple-square"
   },
   "defaultCodebase": "maple-core"
 }

--- a/libs/firebase/database/src/lib/class.repository.ts
+++ b/libs/firebase/database/src/lib/class.repository.ts
@@ -93,6 +93,13 @@ function docToClass(
     whatToBring: data.whatToBring,
     minimumAge: data.minimumAge,
     webflowItemId: data.webflowItemId,
+    squareCatalogItemId: data.squareCatalogItemId,
+    squareVariationId: data.squareVariationId,
+    squareModifierListId: data.squareModifierListId,
+    squareCatalogVersion:
+      typeof data.squareCatalogVersion === 'number'
+        ? data.squareCatalogVersion
+        : undefined,
     referralDiscount:
       data.referralDiscount &&
       typeof data.referralDiscount.percent === 'number' &&
@@ -273,6 +280,56 @@ export const ClassRepository = {
   async updateWebflowItemId(id: string, webflowItemId: string): Promise<void> {
     const docRef = db.collection(COLLECTION).doc(id);
     await docRef.update({ webflowItemId });
+  },
+
+  /**
+   * Stamp the Square sync IDs onto a class after a successful sync.
+   *
+   * Deliberately bare update with NO `updatedAt` bump — the class document
+   * triggers `syncClassToSquare` on every write, and bumping `updatedAt`
+   * would re-fire the trigger in a loop. Same back-reference pattern as
+   * `updateWebflowItemId`.
+   */
+  async updateSquareSyncIds(
+    id: string,
+    ids: {
+      squareCatalogItemId?: string;
+      squareVariationId?: string;
+      squareModifierListId?: string;
+      squareCatalogVersion?: number;
+    }
+  ): Promise<void> {
+    const docRef = db.collection(COLLECTION).doc(id);
+    const update: Record<string, unknown> = {};
+    if (ids.squareCatalogItemId !== undefined) {
+      update.squareCatalogItemId = ids.squareCatalogItemId;
+    }
+    if (ids.squareVariationId !== undefined) {
+      update.squareVariationId = ids.squareVariationId;
+    }
+    if (ids.squareModifierListId !== undefined) {
+      update.squareModifierListId = ids.squareModifierListId;
+    }
+    if (ids.squareCatalogVersion !== undefined) {
+      update.squareCatalogVersion = ids.squareCatalogVersion;
+    }
+    if (Object.keys(update).length === 0) return;
+    await docRef.update(update);
+  },
+
+  /**
+   * Clear all Square sync IDs (called after deleting the catalog item, e.g.
+   * when a class is unpublished). Not bumping `updatedAt` for the same
+   * reason as `updateSquareSyncIds`.
+   */
+  async clearSquareSyncIds(id: string): Promise<void> {
+    const docRef = db.collection(COLLECTION).doc(id);
+    await docRef.update({
+      squareCatalogItemId: null,
+      squareVariationId: null,
+      squareModifierListId: null,
+      squareCatalogVersion: null,
+    });
   },
 
   /**

--- a/libs/firebase/maple-functions/create-registration/src/lib/create-registration.ts
+++ b/libs/firebase/maple-functions/create-registration/src/lib/create-registration.ts
@@ -386,11 +386,19 @@ export const createRegistration = Functions.endpoint
       let squareOrderId: string | undefined;
       try {
         if (subtotalCents > 0) {
-          // Create Square Order with line item and tax
+          // Create Square Order with line item and tax.
+          // Metadata tags this as a web-originated order so the (forthcoming)
+          // POS Square webhook handler skips it — POS orders won't carry
+          // the `web-registration` source tag and become the trigger to
+          // create a registration on our side.
           const orderResult = await square.ordersService.createOrder({
             locationId: square.locationId,
             idempotencyKey: `order-${registrationDocRef.id}-${Date.now()}`,
             referenceId: registrationDocRef.id,
+            metadata: {
+              source: 'web-registration',
+              registrationId: registrationDocRef.id,
+            },
             lineItems: [
               {
                 name: classEntity.name,

--- a/libs/firebase/maple-functions/square-webhook/src/lib/square-webhook.spec.ts
+++ b/libs/firebase/maple-functions/square-webhook/src/lib/square-webhook.spec.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => {
     createProduct: vi.fn(),
     findBySquareInvoiceId: vi.fn(),
     markPaidBySquareWebhook: vi.fn(),
+    classFindAll: vi.fn(),
     // Square catalogService
     getItem: vi.fn(),
     listItems: vi.fn(),
@@ -24,7 +25,7 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-// Mock ProductRepository + InvoiceRepository
+// Mock ProductRepository + InvoiceRepository + ClassRepository
 vi.mock('@maple/firebase/database', () => ({
   ProductRepository: {
     findAll: mocks.findAll,
@@ -36,6 +37,9 @@ vi.mock('@maple/firebase/database', () => ({
   InvoiceRepository: {
     findBySquareInvoiceId: mocks.findBySquareInvoiceId,
     markPaidBySquareWebhook: mocks.markPaidBySquareWebhook,
+  },
+  ClassRepository: {
+    findAll: mocks.classFindAll,
   },
 }));
 
@@ -745,6 +749,8 @@ describe('Square Webhook - handleCatalogUpdate', () => {
 describe('Square Webhook - handleInventoryUpdate', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: no class variations so the class-skip guard is a no-op.
+    mocks.classFindAll.mockResolvedValue([]);
   });
 
   const makeInventoryEvent = (
@@ -812,6 +818,35 @@ describe('Square Webhook - handleInventoryUpdate', () => {
 
     expect(mocks.updateCachedQuantity).not.toHaveBeenCalled();
     expect(result.details).toMatch(/not tracked/);
+  });
+
+  it('skips class variations (Firestore is source of truth for class capacity)', async () => {
+    mocks.findAll.mockResolvedValue([
+      {
+        id: 'prod-001',
+        squareItemId: 'ITEM_001',
+        squareVariationId: 'VAR_PRODUCT',
+      },
+    ]);
+    mocks.classFindAll.mockResolvedValue([
+      {
+        id: 'class-001',
+        squareCatalogItemId: 'ITEM_CLASS_001',
+        squareVariationId: 'VAR_CLASS',
+      },
+    ]);
+
+    const { handleInventoryUpdate } = await import('./square-webhook');
+    const result = await handleInventoryUpdate(
+      makeInventoryEvent([
+        { catalog_object_id: 'VAR_CLASS', quantity: '4', state: 'IN_STOCK' },
+      ])
+    );
+
+    // Must not write to product cache for a class variation —
+    // would corrupt the Firestore-driven inventory mirror.
+    expect(mocks.updateCachedQuantity).not.toHaveBeenCalled();
+    expect(result.details).toMatch(/class — Firestore is source of truth/);
   });
 
   it('skips counts with no catalog_object_id', async () => {

--- a/libs/firebase/maple-functions/square-webhook/src/lib/square-webhook.ts
+++ b/libs/firebase/maple-functions/square-webhook/src/lib/square-webhook.ts
@@ -21,6 +21,7 @@ import { onRequest } from 'firebase-functions/v2/https';
 import { defineSecret, defineString } from 'firebase-functions/params';
 import { createHmac } from 'crypto';
 import {
+  ClassRepository,
   InvoiceRepository,
   ProductRepository,
 } from '@maple/firebase/database';
@@ -345,13 +346,33 @@ export async function handleInventoryUpdate(
     };
   }
 
-  // Process each inventory count update
-  const products = await ProductRepository.findAll();
+  // Process each inventory count update.
+  // Class variations are excluded: Firestore registration counts are the
+  // source of truth for class capacity, and `syncClassInventoryToSquare`
+  // mirrors them outward — accepting Square's count back here would create
+  // a write loop and could clobber the Firestore-driven value.
+  const [products, classes] = await Promise.all([
+    ProductRepository.findAll(),
+    ClassRepository.findAll(),
+  ]);
+  const classVariationIds = new Set(
+    classes
+      .map((c) => c.squareVariationId)
+      .filter((id): id is string => Boolean(id))
+  );
   const results: string[] = [];
 
   for (const count of inventoryCounts) {
     if (!count.catalog_object_id) {
       results.push('skipped (no catalog_object_id)');
+      continue;
+    }
+
+    // Skip class variations — Firestore is the source of truth.
+    if (classVariationIds.has(count.catalog_object_id)) {
+      results.push(
+        `skipped variation ${count.catalog_object_id} (class — Firestore is source of truth)`
+      );
       continue;
     }
 

--- a/libs/firebase/maple-functions/sync-class-inventory-to-square/eslint.config.mjs
+++ b/libs/firebase/maple-functions/sync-class-inventory-to-square/eslint.config.mjs
@@ -1,0 +1,22 @@
+import baseConfig from '../../../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredFiles: [
+            '{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}',
+            '{projectRoot}/esbuild.config.{js,ts,mjs,mts}',
+          ],
+        },
+      ],
+    },
+    languageOptions: {
+      parser: await import('jsonc-eslint-parser'),
+    },
+  },
+];

--- a/libs/firebase/maple-functions/sync-class-inventory-to-square/project.json
+++ b/libs/firebase/maple-functions/sync-class-inventory-to-square/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-sync-class-inventory-to-square",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/sync-class-inventory-to-square/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/sync-class-inventory-to-square/src/index.ts
+++ b/libs/firebase/maple-functions/sync-class-inventory-to-square/src/index.ts
@@ -1,0 +1,1 @@
+export { syncClassInventoryToSquare } from './lib/sync-class-inventory-to-square';

--- a/libs/firebase/maple-functions/sync-class-inventory-to-square/src/lib/sync-class-inventory-to-square.spec.ts
+++ b/libs/firebase/maple-functions/sync-class-inventory-to-square/src/lib/sync-class-inventory-to-square.spec.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Class } from '@maple/ts/domain';
+
+/**
+ * Tests for sync-class-inventory-to-square.ts
+ *
+ * Verifies that registration writes mirror remaining-seat counts onto the
+ * Square variation, with the same count-relevance guard as
+ * sync-registration-count to avoid trigger churn.
+ */
+
+const mocks = vi.hoisted(() => ({
+  classFindById: vi.fn(),
+  countByClassId: vi.fn(),
+  setQuantity: vi.fn(),
+  locationId: 'mock-location',
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  ClassRepository: { findById: mocks.classFindById },
+  RegistrationRepository: { countByClassId: mocks.countByClassId },
+}));
+
+vi.mock('@maple/firebase/square', () => ({
+  Square: class MockSquare {
+    inventoryService = { setQuantity: mocks.setQuantity };
+    locationId = mocks.locationId;
+  },
+  SQUARE_SECRET_NAMES: ['SQUARE_ACCESS_TOKEN'],
+  SQUARE_STRING_NAMES: ['SQUARE_LOCATION_ID'],
+}));
+
+vi.mock('firebase-functions/v2/firestore', () => ({
+  onDocumentWritten: vi.fn((_config, handler) => handler),
+}));
+
+vi.mock('firebase-functions/params', () => ({
+  defineSecret: vi.fn((name: string) => ({ name, value: () => `mock-${name}` })),
+  defineString: vi.fn((name: string) => ({ name, value: () => `mock-${name}` })),
+}));
+
+import { syncClassInventoryToSquare } from './sync-class-inventory-to-square';
+
+const handler = syncClassInventoryToSquare as unknown as (
+  event: unknown
+) => Promise<void>;
+
+function makeSnapshot(
+  exists: boolean,
+  data?: Record<string, unknown>
+): unknown {
+  return { exists, data: () => (exists ? data : undefined) };
+}
+
+function makeClass(overrides: Partial<Class> = {}): Class {
+  return {
+    id: 'class-001',
+    name: 'X',
+    description: '',
+    sessions: [{ dateTime: new Date('2026-06-01T10:00:00Z') }],
+    durationMinutes: 60,
+    capacity: 10,
+    priceCents: 1000,
+    skillLevel: 'all-levels',
+    status: 'published',
+    squareCatalogItemId: 'SQ-ITEM-1',
+    squareVariationId: 'SQ-VAR-1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('syncClassInventoryToSquare', () => {
+  it('mirrors remaining seats to Square on registration create', async () => {
+    mocks.classFindById.mockResolvedValue(makeClass());
+    mocks.countByClassId.mockResolvedValue(3);
+
+    const after = makeSnapshot(true, {
+      classId: 'class-001',
+      status: 'pending',
+      quantity: 1,
+    });
+
+    await handler({
+      params: { registrationId: 'reg-1' },
+      data: { before: makeSnapshot(false), after },
+    });
+
+    expect(mocks.setQuantity).toHaveBeenCalledWith({
+      squareVariationId: 'SQ-VAR-1',
+      locationId: 'mock-location',
+      quantity: 7,
+    });
+  });
+
+  it('skips writes that did not change classId/status/quantity', async () => {
+    const same = makeSnapshot(true, {
+      classId: 'class-001',
+      status: 'confirmed',
+      quantity: 2,
+      // unrelated change to a non-count-relevant field would still hit
+      // this branch — the guard ignores everything outside the COUNT
+      // relevant set.
+    });
+
+    await handler({
+      params: { registrationId: 'reg-x' },
+      data: { before: same, after: same },
+    });
+
+    expect(mocks.classFindById).not.toHaveBeenCalled();
+    expect(mocks.setQuantity).not.toHaveBeenCalled();
+  });
+
+  it('skips classes that are not yet mirrored to Square', async () => {
+    mocks.classFindById.mockResolvedValue(
+      makeClass({ squareVariationId: undefined })
+    );
+
+    await handler({
+      params: { registrationId: 'reg-2' },
+      data: {
+        before: makeSnapshot(false),
+        after: makeSnapshot(true, {
+          classId: 'class-001',
+          status: 'pending',
+          quantity: 1,
+        }),
+      },
+    });
+
+    expect(mocks.setQuantity).not.toHaveBeenCalled();
+  });
+
+  it('clamps quantity at zero (oversold safety net)', async () => {
+    mocks.classFindById.mockResolvedValue(makeClass({ capacity: 5 }));
+    mocks.countByClassId.mockResolvedValue(8);
+
+    await handler({
+      params: { registrationId: 'reg-3' },
+      data: {
+        before: makeSnapshot(false),
+        after: makeSnapshot(true, {
+          classId: 'class-001',
+          status: 'pending',
+          quantity: 1,
+        }),
+      },
+    });
+
+    expect(mocks.setQuantity).toHaveBeenCalledWith(
+      expect.objectContaining({ quantity: 0 })
+    );
+  });
+});

--- a/libs/firebase/maple-functions/sync-class-inventory-to-square/src/lib/sync-class-inventory-to-square.ts
+++ b/libs/firebase/maple-functions/sync-class-inventory-to-square/src/lib/sync-class-inventory-to-square.ts
@@ -1,0 +1,131 @@
+/**
+ * Sync Class Inventory to Square Cloud Function
+ *
+ * Firestore trigger on `registrations/{registrationId}` that mirrors
+ * remaining-seat counts to Square inventory so POS staff see the right
+ * stock when ringing up a class. Firestore is the source of truth for
+ * class capacity; Square inventory is a write-through projection.
+ *
+ * Strategy: on every count-relevant write (create / delete / status or
+ * quantity change), recompute the registration count and PHYSICAL_COUNT
+ * the Square variation to `(capacity - count)`. PHYSICAL_COUNT is
+ * idempotent — preferred over delta-based ADJUSTMENT because two near-
+ * simultaneous registration writes can't double-decrement.
+ *
+ * Skips:
+ * - Writes that don't change classId/status/quantity (mirror of the
+ *   `sync-registration-count` guard — prevents trigger churn).
+ * - Classes with no `squareVariationId` (not yet synced to Square; the
+ *   `syncClassToSquare` trigger will set inventory when it runs).
+ */
+import {
+  onDocumentWritten,
+  type Change,
+  type DocumentSnapshot,
+} from 'firebase-functions/v2/firestore';
+import { defineSecret, defineString } from 'firebase-functions/params';
+import {
+  Square,
+  SQUARE_SECRET_NAMES,
+  SQUARE_STRING_NAMES,
+} from '@maple/firebase/square';
+import {
+  ClassRepository,
+  RegistrationRepository,
+} from '@maple/firebase/database';
+
+const squareSecretParams = SQUARE_SECRET_NAMES.map((name) =>
+  defineSecret(name)
+);
+const squareStringParams = SQUARE_STRING_NAMES.map((name) =>
+  defineString(name)
+);
+
+function extractClassId(snapshot: DocumentSnapshot | undefined): string | null {
+  if (!snapshot || !snapshot.exists) return null;
+  const data = snapshot.data();
+  return (data?.['classId'] as string | undefined) ?? null;
+}
+
+const COUNT_RELEVANT_FIELDS = ['classId', 'status', 'quantity'] as const;
+
+function isCountRelevantChange(
+  before: DocumentSnapshot | undefined,
+  after: DocumentSnapshot | undefined
+): boolean {
+  const beforeExists = before?.exists ?? false;
+  const afterExists = after?.exists ?? false;
+  if (!beforeExists || !afterExists) return true;
+
+  const beforeData = before!.data();
+  const afterData = after!.data();
+  if (!beforeData || !afterData) return true;
+
+  return COUNT_RELEVANT_FIELDS.some(
+    (field) => beforeData[field] !== afterData[field]
+  );
+}
+
+export const syncClassInventoryToSquare = onDocumentWritten(
+  {
+    document: 'registrations/{registrationId}',
+    region: 'us-east4',
+    secrets: squareSecretParams,
+  },
+  async (event) => {
+    const change: Change<DocumentSnapshot> = event.data!;
+
+    if (!isCountRelevantChange(change.before, change.after)) {
+      return;
+    }
+
+    const classId =
+      extractClassId(change.after) ?? extractClassId(change.before);
+    if (!classId) {
+      console.log('Registration write has no classId, skipping Square inventory sync');
+      return;
+    }
+
+    const classEntity = await ClassRepository.findById(classId);
+    if (!classEntity) {
+      console.log('Class not found, skipping Square inventory sync', { classId });
+      return;
+    }
+
+    if (!classEntity.squareVariationId) {
+      // syncClassToSquare hasn't run yet (or class isn't published);
+      // it will set inventory itself when it does.
+      return;
+    }
+
+    const registrationCount = await RegistrationRepository.countByClassId(classId);
+    const remaining = Math.max(classEntity.capacity - registrationCount, 0);
+
+    const secrets = Object.fromEntries(
+      squareSecretParams.map((s) => [s.name, s.value()])
+    ) as Record<(typeof SQUARE_SECRET_NAMES)[number], string>;
+    const strings = Object.fromEntries(
+      squareStringParams.map((s) => [s.name, s.value()])
+    ) as Record<(typeof SQUARE_STRING_NAMES)[number], string>;
+
+    const square = new Square(secrets, strings);
+
+    try {
+      console.log('Syncing class inventory to Square', {
+        classId,
+        squareVariationId: classEntity.squareVariationId,
+        capacity: classEntity.capacity,
+        registrationCount,
+        remaining,
+      });
+      await square.inventoryService.setQuantity({
+        squareVariationId: classEntity.squareVariationId,
+        locationId: square.locationId,
+        quantity: remaining,
+      });
+    } catch (error) {
+      // Same retry-loop concern as syncClassToSquare — swallow.
+      console.error('Square inventory sync error (class):', error);
+    }
+  }
+);

--- a/libs/firebase/maple-functions/sync-class-inventory-to-square/tsconfig.json
+++ b/libs/firebase/maple-functions/sync-class-inventory-to-square/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/sync-class-inventory-to-square/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/sync-class-inventory-to-square/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/libs/firebase/maple-functions/sync-class-to-square/eslint.config.mjs
+++ b/libs/firebase/maple-functions/sync-class-to-square/eslint.config.mjs
@@ -1,0 +1,22 @@
+import baseConfig from '../../../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredFiles: [
+            '{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}',
+            '{projectRoot}/esbuild.config.{js,ts,mjs,mts}',
+          ],
+        },
+      ],
+    },
+    languageOptions: {
+      parser: await import('jsonc-eslint-parser'),
+    },
+  },
+];

--- a/libs/firebase/maple-functions/sync-class-to-square/project.json
+++ b/libs/firebase/maple-functions/sync-class-to-square/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-sync-class-to-square",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/sync-class-to-square/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/sync-class-to-square/src/index.ts
+++ b/libs/firebase/maple-functions/sync-class-to-square/src/index.ts
@@ -1,0 +1,1 @@
+export { syncClassToSquare } from './lib/sync-class-to-square';

--- a/libs/firebase/maple-functions/sync-class-to-square/src/lib/sync-class-to-square.spec.ts
+++ b/libs/firebase/maple-functions/sync-class-to-square/src/lib/sync-class-to-square.spec.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Class } from '@maple/ts/domain';
+
+/**
+ * Tests for sync-class-to-square.ts
+ *
+ * Covers the four lifecycle branches of the trigger:
+ *  - Published create  → creates Square catalog item + seeds inventory
+ *  - Published update  → updates name/price; resets inventory on capacity change
+ *  - Unpublished       → deletes catalog item + clears back-refs
+ *  - Deleted           → deletes catalog item if it existed
+ *
+ * Plus the Square-relevant change guard (skip writes that touch nothing
+ * material — prevents the trigger feedback loop with `updateSquareSyncIds`).
+ */
+
+const mocks = vi.hoisted(() => ({
+  classFindById: vi.fn(),
+  registrationCountByClassId: vi.fn(),
+  updateSquareSyncIds: vi.fn(),
+  clearSquareSyncIds: vi.fn(),
+  // Square service mocks
+  createClassCatalogItem: vi.fn(),
+  updateItem: vi.fn(),
+  deleteItem: vi.fn(),
+  setQuantity: vi.fn(),
+  locationId: 'mock-location',
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  ClassRepository: {
+    findById: mocks.classFindById,
+    updateSquareSyncIds: mocks.updateSquareSyncIds,
+    clearSquareSyncIds: mocks.clearSquareSyncIds,
+  },
+  RegistrationRepository: {
+    countByClassId: mocks.registrationCountByClassId,
+  },
+}));
+
+vi.mock('@maple/firebase/square', () => {
+  return {
+    Square: class MockSquare {
+      catalogService = {
+        createClassCatalogItem: mocks.createClassCatalogItem,
+        updateItem: mocks.updateItem,
+        deleteItem: mocks.deleteItem,
+      };
+      inventoryService = { setQuantity: mocks.setQuantity };
+      locationId = mocks.locationId;
+    },
+    SQUARE_SECRET_NAMES: ['SQUARE_ACCESS_TOKEN'],
+    SQUARE_STRING_NAMES: ['SQUARE_LOCATION_ID'],
+  };
+});
+
+vi.mock('firebase-functions/v2/firestore', () => ({
+  onDocumentWritten: vi.fn((_config, handler) => handler),
+}));
+
+vi.mock('firebase-functions/params', () => ({
+  defineSecret: vi.fn((name: string) => ({ name, value: () => `mock-${name}` })),
+  defineString: vi.fn((name: string) => ({ name, value: () => `mock-${name}` })),
+}));
+
+import { syncClassToSquare } from './sync-class-to-square';
+
+const handler = syncClassToSquare as unknown as (
+  event: unknown
+) => Promise<void>;
+
+function makeSnapshot(exists: boolean, data?: Record<string, unknown>): unknown {
+  return {
+    id: (data?.['id'] as string | undefined) ?? 'class-001',
+    exists,
+    data: () => (exists ? data : undefined),
+  };
+}
+
+function makeClassData(overrides: Partial<Class> = {}): Record<string, unknown> {
+  const base: Class = {
+    id: 'class-001',
+    name: 'Intro to Pottery',
+    description: 'Learn pottery basics',
+    sessions: [{ dateTime: new Date('2026-05-15T14:00:00Z') }],
+    durationMinutes: 120,
+    capacity: 10,
+    priceCents: 4500,
+    skillLevel: 'beginner',
+    status: 'published',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+  return { ...base } as unknown as Record<string, unknown>;
+}
+
+function makeEvent(beforeData: unknown, afterData: unknown) {
+  return {
+    params: { classId: 'class-001' },
+    data: {
+      before: beforeData,
+      after: afterData,
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.registrationCountByClassId.mockResolvedValue(0);
+});
+
+describe('syncClassToSquare — published create', () => {
+  it('creates the Square catalog item, stores the IDs, and seeds inventory', async () => {
+    mocks.createClassCatalogItem.mockResolvedValue({
+      squareItemId: 'SQ-ITEM-1',
+      squareVariationId: 'SQ-VAR-1',
+      squareModifierListId: 'SQ-MOD-1',
+      squareCatalogVersion: 1,
+    });
+
+    const before = makeSnapshot(false);
+    const after = makeSnapshot(true, makeClassData({ capacity: 8 }));
+
+    await handler(makeEvent(before, after));
+
+    expect(mocks.createClassCatalogItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        classId: 'class-001',
+        name: 'Intro to Pottery',
+        priceCents: 4500,
+      })
+    );
+    expect(mocks.updateSquareSyncIds).toHaveBeenCalledWith('class-001', {
+      squareCatalogItemId: 'SQ-ITEM-1',
+      squareVariationId: 'SQ-VAR-1',
+      squareModifierListId: 'SQ-MOD-1',
+      squareCatalogVersion: 1,
+    });
+    expect(mocks.setQuantity).toHaveBeenCalledWith({
+      squareVariationId: 'SQ-VAR-1',
+      locationId: 'mock-location',
+      quantity: 8,
+    });
+  });
+
+  it('seeds inventory at (capacity - existingRegistrationCount)', async () => {
+    mocks.createClassCatalogItem.mockResolvedValue({
+      squareItemId: 'I',
+      squareVariationId: 'V',
+      squareModifierListId: 'M',
+      squareCatalogVersion: 1,
+    });
+    mocks.registrationCountByClassId.mockResolvedValue(3);
+
+    const before = makeSnapshot(false);
+    const after = makeSnapshot(true, makeClassData({ capacity: 10 }));
+
+    await handler(makeEvent(before, after));
+
+    expect(mocks.setQuantity).toHaveBeenCalledWith(
+      expect.objectContaining({ quantity: 7 })
+    );
+  });
+
+  it('skips inventory seeding when remaining capacity is zero', async () => {
+    mocks.createClassCatalogItem.mockResolvedValue({
+      squareItemId: 'I',
+      squareVariationId: 'V',
+      squareModifierListId: 'M',
+      squareCatalogVersion: 1,
+    });
+    mocks.registrationCountByClassId.mockResolvedValue(10);
+
+    const before = makeSnapshot(false);
+    const after = makeSnapshot(true, makeClassData({ capacity: 10 }));
+
+    await handler(makeEvent(before, after));
+
+    expect(mocks.setQuantity).not.toHaveBeenCalled();
+  });
+});
+
+describe('syncClassToSquare — published update on existing mirror', () => {
+  it('updates name and price when changed and persists the new catalog version', async () => {
+    mocks.updateItem.mockResolvedValue({ squareCatalogVersion: 5 });
+
+    const before = makeSnapshot(
+      true,
+      makeClassData({
+        name: 'Old Name',
+        priceCents: 4000,
+        squareCatalogItemId: 'SQ-ITEM-1',
+        squareVariationId: 'SQ-VAR-1',
+        squareCatalogVersion: 4,
+      })
+    );
+    const after = makeSnapshot(
+      true,
+      makeClassData({
+        name: 'New Name',
+        priceCents: 5000,
+        squareCatalogItemId: 'SQ-ITEM-1',
+        squareVariationId: 'SQ-VAR-1',
+        squareCatalogVersion: 4,
+      })
+    );
+
+    await handler(makeEvent(before, after));
+
+    expect(mocks.updateItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        squareItemId: 'SQ-ITEM-1',
+        name: 'New Name',
+        variations: [
+          { squareVariationId: 'SQ-VAR-1', priceCents: 5000 },
+        ],
+      })
+    );
+    expect(mocks.updateSquareSyncIds).toHaveBeenCalledWith('class-001', {
+      squareCatalogVersion: 5,
+    });
+    // No catalog create when mirror already exists
+    expect(mocks.createClassCatalogItem).not.toHaveBeenCalled();
+  });
+
+  it('resets Square inventory when capacity changes', async () => {
+    mocks.registrationCountByClassId.mockResolvedValue(2);
+
+    const before = makeSnapshot(
+      true,
+      makeClassData({
+        capacity: 8,
+        squareCatalogItemId: 'I',
+        squareVariationId: 'V',
+        squareCatalogVersion: 1,
+      })
+    );
+    const after = makeSnapshot(
+      true,
+      makeClassData({
+        capacity: 12,
+        squareCatalogItemId: 'I',
+        squareVariationId: 'V',
+        squareCatalogVersion: 1,
+      })
+    );
+
+    await handler(makeEvent(before, after));
+
+    expect(mocks.setQuantity).toHaveBeenCalledWith({
+      squareVariationId: 'V',
+      locationId: 'mock-location',
+      quantity: 10, // 12 - 2
+    });
+  });
+
+  it('skips writes that change no Square-relevant field (feedback-loop guard)', async () => {
+    const data = makeClassData({
+      squareCatalogItemId: 'I',
+      squareVariationId: 'V',
+    });
+    const before = makeSnapshot(true, data);
+    const after = makeSnapshot(true, data); // identical — only updatedAt-style write
+
+    await handler(makeEvent(before, after));
+
+    expect(mocks.createClassCatalogItem).not.toHaveBeenCalled();
+    expect(mocks.updateItem).not.toHaveBeenCalled();
+    expect(mocks.setQuantity).not.toHaveBeenCalled();
+  });
+});
+
+describe('syncClassToSquare — unpublish & delete', () => {
+  it('deletes the Square catalog item and clears back-refs when class is unpublished', async () => {
+    const before = makeSnapshot(
+      true,
+      makeClassData({
+        status: 'published',
+        squareCatalogItemId: 'SQ-ITEM-1',
+        squareVariationId: 'SQ-VAR-1',
+      })
+    );
+    const after = makeSnapshot(
+      true,
+      makeClassData({
+        status: 'cancelled',
+        squareCatalogItemId: 'SQ-ITEM-1',
+        squareVariationId: 'SQ-VAR-1',
+      })
+    );
+
+    await handler(makeEvent(before, after));
+
+    expect(mocks.deleteItem).toHaveBeenCalledWith('SQ-ITEM-1');
+    expect(mocks.clearSquareSyncIds).toHaveBeenCalledWith('class-001');
+  });
+
+  it('deletes the Square catalog item when the class doc is deleted', async () => {
+    const before = makeSnapshot(
+      true,
+      makeClassData({ squareCatalogItemId: 'SQ-ITEM-1' })
+    );
+    const after = makeSnapshot(false);
+
+    await handler(makeEvent(before, after));
+
+    expect(mocks.deleteItem).toHaveBeenCalledWith('SQ-ITEM-1');
+  });
+
+  it('is a no-op when an unpublished class never had a Square mirror', async () => {
+    const before = makeSnapshot(true, makeClassData({ status: 'draft' }));
+    const after = makeSnapshot(true, makeClassData({ status: 'cancelled' }));
+
+    await handler(makeEvent(before, after));
+
+    expect(mocks.deleteItem).not.toHaveBeenCalled();
+    expect(mocks.clearSquareSyncIds).not.toHaveBeenCalled();
+  });
+});

--- a/libs/firebase/maple-functions/sync-class-to-square/src/lib/sync-class-to-square.ts
+++ b/libs/firebase/maple-functions/sync-class-to-square/src/lib/sync-class-to-square.ts
@@ -1,0 +1,273 @@
+/**
+ * Sync Class to Square Cloud Function
+ *
+ * Firestore trigger that mirrors classes to Square as catalog items so they
+ * can be rung up at in-person POS. The Square inventory quantity for the
+ * class variation tracks remaining seats — POS will refuse to ring up a
+ * sold-out class.
+ *
+ * Triggers on `classes/{classId}` writes:
+ * - Class published (create or status flip → published): create catalog
+ *   ITEM + ITEM_VARIATION + required selection MODIFIER_LIST, then seed
+ *   inventory to (capacity - currentRegistrationCount).
+ * - Class updated while still published: update name/description/price on
+ *   the existing item; reset inventory if capacity changed.
+ * - Class unpublished (published → draft/cancelled/completed) or deleted:
+ *   delete the Square catalog item and clear the back-references.
+ *
+ * Feedback-loop guard: writes triggered by `updateSquareSyncIds` /
+ * `clearSquareSyncIds` skip `updatedAt`, but the trigger fires anyway —
+ * we early-return when nothing relevant changed.
+ */
+import {
+  onDocumentWritten,
+  type Change,
+  type DocumentSnapshot,
+} from 'firebase-functions/v2/firestore';
+import { defineSecret, defineString } from 'firebase-functions/params';
+import type { Class } from '@maple/ts/domain';
+import {
+  Square,
+  SQUARE_SECRET_NAMES,
+  SQUARE_STRING_NAMES,
+} from '@maple/firebase/square';
+import {
+  ClassRepository,
+  RegistrationRepository,
+} from '@maple/firebase/database';
+
+const squareSecretParams = SQUARE_SECRET_NAMES.map((name) =>
+  defineSecret(name)
+);
+const squareStringParams = SQUARE_STRING_NAMES.map((name) =>
+  defineString(name)
+);
+
+function toDateLike(value: unknown): Date | undefined {
+  if (!value) return undefined;
+  if (value instanceof Date) return value;
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    'toDate' in value &&
+    typeof (value as { toDate: unknown }).toDate === 'function'
+  ) {
+    return (value as { toDate: () => Date }).toDate();
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    const d = new Date(value);
+    return isNaN(d.getTime()) ? undefined : d;
+  }
+  return undefined;
+}
+
+function extractClass(snapshot: DocumentSnapshot | undefined): Class | null {
+  if (!snapshot || !snapshot.exists) {
+    return null;
+  }
+  const data = snapshot.data();
+  if (!data) return null;
+
+  return {
+    id: snapshot.id,
+    ...data,
+    createdAt: toDateLike(data['createdAt']) ?? new Date(),
+    updatedAt: toDateLike(data['updatedAt']) ?? new Date(),
+  } as Class;
+}
+
+/**
+ * Did the write change anything that requires a Square sync?
+ *
+ * Without this guard the trigger feedback loops: every Square sync stamps
+ * `squareCatalogItemId`/`squareVariationId`/`squareModifierListId` back onto
+ * the class, which re-fires this trigger, which re-syncs, and so on.
+ *
+ * The Square sync IDs themselves are *not* in this list, so writes that
+ * only touch them are no-ops here.
+ */
+const SQUARE_RELEVANT_FIELDS: ReadonlyArray<keyof Class> = [
+  'name',
+  'description',
+  'priceCents',
+  'capacity',
+  'status',
+];
+
+function isSquareRelevantChange(
+  before: Class | null,
+  after: Class | null
+): boolean {
+  if (!before || !after) return true; // create or delete
+  return SQUARE_RELEVANT_FIELDS.some(
+    (field) => before[field] !== after[field]
+  );
+}
+
+export const syncClassToSquare = onDocumentWritten(
+  {
+    document: 'classes/{classId}',
+    region: 'us-east4',
+    secrets: squareSecretParams,
+  },
+  async (event) => {
+    const change: Change<DocumentSnapshot> = event.data!;
+    const before = extractClass(change.before);
+    const after = extractClass(change.after);
+
+    if (!isSquareRelevantChange(before, after)) {
+      console.log(
+        'Class write did not change Square-relevant fields, skipping sync',
+        { classId: event.params.classId }
+      );
+      return;
+    }
+
+    const secrets = Object.fromEntries(
+      squareSecretParams.map((s) => [s.name, s.value()])
+    ) as Record<(typeof SQUARE_SECRET_NAMES)[number], string>;
+    const strings = Object.fromEntries(
+      squareStringParams.map((s) => [s.name, s.value()])
+    ) as Record<(typeof SQUARE_STRING_NAMES)[number], string>;
+
+    const square = new Square(secrets, strings);
+
+    try {
+      // Case 1: class deleted — remove from Square if it was there
+      if (!after) {
+        if (before?.squareCatalogItemId) {
+          console.log('Class deleted, removing from Square', {
+            classId: event.params.classId,
+            squareItemId: before.squareCatalogItemId,
+          });
+          await square.catalogService.deleteItem(before.squareCatalogItemId);
+        }
+        return;
+      }
+
+      const becameUnpublished =
+        before?.status === 'published' && after.status !== 'published';
+
+      // Case 2: class is no longer published — tear down the Square mirror
+      if (becameUnpublished || after.status !== 'published') {
+        if (after.squareCatalogItemId) {
+          console.log(
+            'Class unpublished/non-publishable, removing Square catalog item',
+            {
+              classId: after.id,
+              squareItemId: after.squareCatalogItemId,
+              status: after.status,
+            }
+          );
+          await square.catalogService.deleteItem(after.squareCatalogItemId);
+          await ClassRepository.clearSquareSyncIds(after.id);
+        } else {
+          console.log('Class is not published and not in Square, skipping', {
+            classId: after.id,
+            status: after.status,
+          });
+        }
+        return;
+      }
+
+      // Case 3: class is published — sync (create or update)
+      const registrationCount = await RegistrationRepository.countByClassId(
+        after.id
+      );
+      const remainingCapacity = Math.max(after.capacity - registrationCount, 0);
+
+      if (!after.squareCatalogItemId || !after.squareVariationId) {
+        // No Square mirror yet — create one
+        console.log('Creating Square catalog item for published class', {
+          classId: after.id,
+          name: after.name,
+          priceCents: after.priceCents,
+          capacity: after.capacity,
+          remainingCapacity,
+        });
+
+        const created = await square.catalogService.createClassCatalogItem({
+          classId: after.id,
+          name: after.name,
+          description: after.description,
+          priceCents: after.priceCents,
+        });
+
+        await ClassRepository.updateSquareSyncIds(after.id, {
+          squareCatalogItemId: created.squareItemId,
+          squareVariationId: created.squareVariationId,
+          squareModifierListId: created.squareModifierListId,
+          squareCatalogVersion: created.squareCatalogVersion,
+        });
+
+        // Seed inventory at remainingCapacity (capacity minus existing
+        // registrations). For a brand-new class this is just `capacity`.
+        if (remainingCapacity > 0) {
+          await square.inventoryService.setQuantity({
+            squareVariationId: created.squareVariationId,
+            locationId: square.locationId,
+            quantity: remainingCapacity,
+          });
+        }
+
+        console.log('Square catalog item created', {
+          classId: after.id,
+          squareItemId: created.squareItemId,
+          squareVariationId: created.squareVariationId,
+          inventory: remainingCapacity,
+        });
+        return;
+      }
+
+      // Existing Square mirror — update name/description/price if changed,
+      // and reset inventory if capacity changed.
+      const nameChanged = before?.name !== after.name;
+      const descriptionChanged = before?.description !== after.description;
+      const priceChanged = before?.priceCents !== after.priceCents;
+      const capacityChanged = before?.capacity !== after.capacity;
+
+      if (nameChanged || descriptionChanged || priceChanged) {
+        console.log('Updating Square catalog item for class', {
+          classId: after.id,
+          nameChanged,
+          descriptionChanged,
+          priceChanged,
+        });
+        const updated = await square.catalogService.updateItem({
+          squareItemId: after.squareCatalogItemId,
+          squareCatalogVersion: after.squareCatalogVersion ?? 0,
+          name: nameChanged ? after.name : undefined,
+          description: descriptionChanged ? after.description : undefined,
+          variations: priceChanged
+            ? [
+                {
+                  squareVariationId: after.squareVariationId,
+                  priceCents: after.priceCents,
+                },
+              ]
+            : undefined,
+        });
+        await ClassRepository.updateSquareSyncIds(after.id, {
+          squareCatalogVersion: updated.squareCatalogVersion,
+        });
+      }
+
+      if (capacityChanged) {
+        console.log('Resetting Square inventory after capacity change', {
+          classId: after.id,
+          newCapacity: after.capacity,
+          remainingCapacity,
+        });
+        await square.inventoryService.setQuantity({
+          squareVariationId: after.squareVariationId,
+          locationId: square.locationId,
+          quantity: remainingCapacity,
+        });
+      }
+    } catch (error) {
+      // Don't throw — Cloud Functions retries triggers on uncaught errors,
+      // and a flapping Square API call would fan out into a tight loop.
+      console.error('Square sync error (class):', error);
+    }
+  }
+);

--- a/libs/firebase/maple-functions/sync-class-to-square/tsconfig.json
+++ b/libs/firebase/maple-functions/sync-class-to-square/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/sync-class-to-square/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/sync-class-to-square/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/libs/firebase/square/src/lib/catalog.service.spec.ts
+++ b/libs/firebase/square/src/lib/catalog.service.spec.ts
@@ -421,3 +421,138 @@ describe('CatalogService.updateItem', () => {
     expect(result.squareCatalogVersion).toBe(6);
   });
 });
+
+describe('CatalogService.createClassCatalogItem', () => {
+  let client: MockClient;
+  let service: CatalogService;
+
+  beforeEach(() => {
+    client = makeMockClient();
+    service = new CatalogService(client as unknown as SquareClient);
+  });
+
+  it('upserts a MODIFIER_LIST and ITEM (with one variation) in a single batch and returns parsed IDs', async () => {
+    client.catalog.batchUpsert.mockResolvedValue({
+      objects: [
+        { type: 'MODIFIER_LIST', id: 'SQ-MODLIST-1', version: 1n },
+        {
+          type: 'ITEM',
+          id: 'SQ-ITEM-CLASS-1',
+          version: 2n,
+          itemData: {
+            variations: [
+              {
+                type: 'ITEM_VARIATION',
+                id: 'SQ-VAR-CLASS-1',
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const result = await service.createClassCatalogItem({
+      classId: 'class-abc',
+      name: 'Sourdough Workshop',
+      description: 'Bring an apron',
+      priceCents: 4500,
+    });
+
+    // Result fields parsed correctly
+    expect(result.squareItemId).toBe('SQ-ITEM-CLASS-1');
+    expect(result.squareVariationId).toBe('SQ-VAR-CLASS-1');
+    expect(result.squareModifierListId).toBe('SQ-MODLIST-1');
+    expect(result.squareCatalogVersion).toBe(2);
+
+    // Inspect the request shape — modifier list, item, and variation
+    // must all live in one batches[0].objects so Square resolves the
+    // temp-id references between them atomically.
+    const call = client.catalog.batchUpsert.mock.calls[0][0];
+    const objects = call.batches[0].objects;
+    expect(objects).toHaveLength(2);
+
+    const modList = objects.find(
+      (o: { type: string }) => o.type === 'MODIFIER_LIST'
+    );
+    expect(modList).toBeDefined();
+    expect(modList.modifierListData.selectionType).toBe('SINGLE');
+    expect(modList.modifierListData.modifiers).toHaveLength(1);
+    expect(modList.modifierListData.modifiers[0].modifierData.name).toBe('Yes');
+
+    const item = objects.find((o: { type: string }) => o.type === 'ITEM');
+    expect(item).toBeDefined();
+    expect(item.itemData.name).toBe('Sourdough Workshop');
+    expect(item.itemData.modifierListInfo[0].modifierListId).toBe(
+      modList.id
+    );
+    expect(item.itemData.variations).toHaveLength(1);
+    expect(item.itemData.variations[0].itemVariationData.priceMoney.amount).toBe(
+      4500n
+    );
+    expect(
+      item.itemData.variations[0].itemVariationData.trackInventory
+    ).toBe(true);
+  });
+
+  it('uses the default modifier list name when none is provided', async () => {
+    client.catalog.batchUpsert.mockResolvedValue({
+      objects: [
+        { type: 'MODIFIER_LIST', id: 'M1', version: 1n },
+        {
+          type: 'ITEM',
+          id: 'I1',
+          version: 1n,
+          itemData: {
+            variations: [{ type: 'ITEM_VARIATION', id: 'V1' }],
+          },
+        },
+      ],
+    });
+
+    await service.createClassCatalogItem({
+      classId: 'class-1',
+      name: 'X',
+      priceCents: 1000,
+    });
+
+    const call = client.catalog.batchUpsert.mock.calls[0][0];
+    const modList = call.batches[0].objects.find(
+      (o: { type: string }) => o.type === 'MODIFIER_LIST'
+    );
+    expect(modList.modifierListData.name).toBe(
+      'Added customer email (required)?'
+    );
+  });
+
+  it('throws when the response is missing the ITEM or MODIFIER_LIST', async () => {
+    // Use a plain number version here — the catalog code logs the response
+    // via JSON.stringify on the error path, which can't serialize bigints.
+    // Real Square responses come back as plain JSON before the SDK has had
+    // a chance to widen any field to BigInt.
+    client.catalog.batchUpsert.mockResolvedValue({
+      objects: [{ type: 'MODIFIER_LIST', id: 'M1', version: 1 }],
+    });
+
+    await expect(
+      service.createClassCatalogItem({
+        classId: 'class-broken',
+        name: 'Broken',
+        priceCents: 100,
+      })
+    ).rejects.toThrow(/ITEM or MODIFIER_LIST missing/);
+  });
+
+  it('surfaces Square API errors', async () => {
+    client.catalog.batchUpsert.mockResolvedValue({
+      errors: [{ code: 'BAD_REQUEST', detail: 'invalid price' }],
+    });
+
+    await expect(
+      service.createClassCatalogItem({
+        classId: 'class-bad',
+        name: 'Bad',
+        priceCents: -1,
+      })
+    ).rejects.toThrow(/invalid price/);
+  });
+});

--- a/libs/firebase/square/src/lib/catalog.service.ts
+++ b/libs/firebase/square/src/lib/catalog.service.ts
@@ -142,10 +142,168 @@ export interface UpdateCatalogItemResult {
 }
 
 /**
+ * Input for creating a class catalog item
+ */
+export interface CreateClassCatalogItemInput {
+  /** Firestore class id (used to derive a deterministic idempotency key) */
+  classId: string;
+  /** Class display name (becomes the catalog item name) */
+  name: string;
+  /** Optional class description */
+  description?: string;
+  /** Class price in cents (single-variation; classes have one price) */
+  priceCents: number;
+  /**
+   * Modifier list name shown to staff at POS. Defaults to
+   * `"Added customer email (required)?"` — required selection modifier
+   * with one Yes option whose only purpose is to force staff to acknowledge
+   * customer collection before tendering. There is no native way to *enforce*
+   * email collection at in-person POS, so this is the operational nudge.
+   */
+  modifierListName?: string;
+}
+
+/**
+ * Result of creating a class catalog item
+ */
+export interface CreateClassCatalogItemResult {
+  /** Square ITEM id */
+  squareItemId: string;
+  /** Square ITEM_VARIATION id (single variation per class) */
+  squareVariationId: string;
+  /** Square MODIFIER_LIST id attached to the item */
+  squareModifierListId: string;
+  /** Catalog version of the created ITEM (for optimistic locking) */
+  squareCatalogVersion: number;
+}
+
+/**
  * Catalog service for Square API operations
  */
 export class CatalogService {
   constructor(private readonly client: SquareClient) {}
+
+  /**
+   * Create a Square catalog ITEM, ITEM_VARIATION, and required MODIFIER_LIST
+   * for a class in a single batchUpsert. The modifier list is a single-option
+   * required selection ("Yes") so staff sees a prompt at POS — the closest
+   * thing Square offers to a per-item required field at in-person checkout
+   * (text-input modifiers don't render on the POS register; selection-only
+   * modifiers do).
+   */
+  async createClassCatalogItem(
+    input: CreateClassCatalogItemInput
+  ): Promise<CreateClassCatalogItemResult> {
+    const idempotencyKey = `class-create-${input.classId}-${Date.now()}`;
+    const itemTempId = `#class-item-${input.classId}`;
+    const variationTempId = `#class-variation-${input.classId}`;
+    const modifierListTempId = `#class-modlist-${input.classId}`;
+    const modifierTempId = `#class-mod-yes-${input.classId}`;
+    const modifierListName =
+      input.modifierListName ?? 'Added customer email (required)?';
+
+    const response = await this.client.catalog.batchUpsert({
+      idempotencyKey,
+      batches: [
+        {
+          objects: [
+            {
+              type: 'MODIFIER_LIST',
+              id: modifierListTempId,
+              modifierListData: {
+                name: modifierListName,
+                selectionType: 'SINGLE',
+                modifiers: [
+                  {
+                    type: 'MODIFIER',
+                    id: modifierTempId,
+                    modifierData: {
+                      name: 'Yes',
+                      priceMoney: { amount: 0n, currency: 'USD' },
+                    },
+                  },
+                ],
+              },
+            },
+            {
+              type: 'ITEM',
+              id: itemTempId,
+              itemData: {
+                name: input.name,
+                description: input.description,
+                modifierListInfo: [
+                  {
+                    modifierListId: modifierListTempId,
+                    enabled: true,
+                    minSelectedModifiers: 1,
+                    maxSelectedModifiers: 1,
+                  },
+                ],
+                variations: [
+                  {
+                    type: 'ITEM_VARIATION',
+                    id: variationTempId,
+                    itemVariationData: {
+                      name: 'Registration',
+                      pricingType: 'FIXED_PRICING',
+                      priceMoney: {
+                        amount: BigInt(input.priceCents),
+                        currency: 'USD',
+                      },
+                      trackInventory: true,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    if (response.errors && response.errors.length > 0) {
+      const errorMessages = response.errors
+        .map((e) => e.detail || e.code || 'Unknown error')
+        .join(', ');
+      throw new Error(`Square API error: ${errorMessages}`);
+    }
+
+    const objects = response.objects || [];
+    const itemObject = objects.find(
+      (obj: Square.CatalogObject) => obj.type === 'ITEM'
+    );
+    const modListObject = objects.find(
+      (obj: Square.CatalogObject) => obj.type === 'MODIFIER_LIST'
+    );
+
+    if (!itemObject || !modListObject) {
+      console.error(
+        'Square batchUpsert response (class):',
+        JSON.stringify(response, null, 2)
+      );
+      throw new Error(
+        'Failed to create class catalog item: ITEM or MODIFIER_LIST missing'
+      );
+    }
+
+    const variation = itemObject.itemData?.variations?.[0];
+    if (!variation?.id) {
+      console.error(
+        'Square ITEM response (class):',
+        JSON.stringify(itemObject, null, 2)
+      );
+      throw new Error(
+        'Failed to create class catalog item: variation missing in response'
+      );
+    }
+
+    return {
+      squareItemId: itemObject.id!,
+      squareVariationId: variation.id,
+      squareModifierListId: modListObject.id!,
+      squareCatalogVersion: Number(itemObject.version || 0),
+    };
+  }
 
   /**
    * Create a new catalog item with one or more variations

--- a/libs/firebase/square/src/lib/orders.service.ts
+++ b/libs/firebase/square/src/lib/orders.service.ts
@@ -62,6 +62,13 @@ export interface CreateOrderInput {
   discounts?: OrderDiscountInput[];
   /** External reference ID (e.g., registration ID) */
   referenceId?: string;
+  /**
+   * Optional Square order metadata (string→string map). The web registration
+   * flow tags orders with `{ source: 'web-registration', registrationId }`
+   * so the POS webhook handler can dedup and skip them — POS-originated
+   * orders won't carry this tag.
+   */
+  metadata?: Record<string, string>;
 }
 
 /**
@@ -94,6 +101,7 @@ export class OrdersService {
       order: {
         locationId: input.locationId,
         referenceId: input.referenceId,
+        metadata: input.metadata,
         lineItems: input.lineItems.map((item) => ({
           name: item.name,
           quantity: item.quantity,

--- a/libs/ts/domain/src/lib/class.ts
+++ b/libs/ts/domain/src/lib/class.ts
@@ -96,6 +96,27 @@ export interface Class {
    */
   webflowItemId?: string;
   /**
+   * Square catalog ITEM id, set by `syncClassToSquare` after the first
+   * successful sync. Presence is the signal that this class is sellable
+   * on Square POS in person.
+   */
+  squareCatalogItemId?: string;
+  /**
+   * Square catalog ITEM_VARIATION id (one variation per class). Used to
+   * adjust inventory and to identify the line item on POS-originated orders.
+   */
+  squareVariationId?: string;
+  /**
+   * Square MODIFIER_LIST id for the "Added customer email (required)?" prompt
+   * attached to the class item. Forces staff to acknowledge customer
+   * collection before tendering at POS.
+   */
+  squareModifierListId?: string;
+  /**
+   * Square catalog version for optimistic locking on subsequent updates.
+   */
+  squareCatalogVersion?: number;
+  /**
    * Opt-in to the friend-referral program for this class. When set, every
    * confirmed registration auto-generates a single-use Discount and the
    * confirmation email includes a code the customer can share.
@@ -120,11 +141,19 @@ export interface ClassReferralDiscount {
 }
 
 /**
- * Input for creating a new class (no id, timestamps, or webflowItemId)
+ * Input for creating a new class. External-system IDs (Webflow, Square) are
+ * populated by their respective sync functions, never by the create caller.
  */
 export type CreateClassInput = Omit<
   Class,
-  'id' | 'createdAt' | 'updatedAt' | 'webflowItemId'
+  | 'id'
+  | 'createdAt'
+  | 'updatedAt'
+  | 'webflowItemId'
+  | 'squareCatalogItemId'
+  | 'squareVariationId'
+  | 'squareModifierListId'
+  | 'squareCatalogVersion'
 >;
 
 /**

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -104,6 +104,12 @@
       "@maple/firebase/maple-functions/sync-class-to-webflow": [
         "libs/firebase/maple-functions/sync-class-to-webflow/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/sync-class-to-square": [
+        "libs/firebase/maple-functions/sync-class-to-square/src/index.ts"
+      ],
+      "@maple/firebase/maple-functions/sync-class-inventory-to-square": [
+        "libs/firebase/maple-functions/sync-class-inventory-to-square/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/sync-registration-count": [
         "libs/firebase/maple-functions/sync-registration-count/src/index.ts"
       ],


### PR DESCRIPTION
PR 2 of 3 in the Square POS class-registration plan. Mirrors classes to Square so they can be rung up at in-person POS, with capacity tracked as Square inventory.

## What's in this PR

### Catalog sync — `syncClassToSquare`
Firestore trigger on `classes/{id}` (maple-square codebase). On a published class, batchUpserts a Square `ITEM` + `ITEM_VARIATION` + a required-selection `MODIFIER_LIST` titled **"Added customer email (required)?"**. Lifecycle:

- **Published create** → create catalog item, store IDs back, seed inventory at `(capacity - currentRegistrationCount)`
- **Published update** → update name/description/price; reset inventory if capacity changed
- **Unpublished or deleted** → delete the Square catalog item + clear back-refs

The MODIFIER_LIST is a single-option ("Yes") required modifier. Square offers no native way to enforce per-item required fields at in-person POS — text-input modifiers don't render on the POS register — so this selection-only modifier is the operational nudge. The **actual** safety net for missing emails will be server-side in PR 3 (admin alert + manual reconcile).

### Inventory mirror — `syncClassInventoryToSquare`
Firestore trigger on `registrations/{id}`. On any count-relevant write, recomputes the registration count and `PHYSICAL_COUNT`s the Square variation to `(capacity - count)`. PHYSICAL_COUNT is idempotent — preferred over delta-based ADJUSTMENT because two near-simultaneous registration writes can't double-decrement. Same `COUNT_RELEVANT_FIELDS` guard as `sync-registration-count` to prevent trigger churn.

### Webhook guard
The existing `inventory.count.updated` Square webhook handler now fetches the class list alongside products and **skips** any inventory event whose `catalog_object_id` matches a class variation. Without this, Square's echo of our own `setQuantity` writes would loop back through `ProductRepository.updateCachedQuantity` and corrupt the Firestore-driven mirror.

### Order metadata for PR 3 dedup
`createRegistration` now tags the Square order it creates with `metadata: { source: 'web-registration', registrationId }`. PR 3's POS webhook handler will skip any order carrying that metadata — POS-originated orders won't have it, so they become the trigger to create a registration on our side.

### Domain + repo
- `Class` gains `squareCatalogItemId`, `squareVariationId`, `squareModifierListId`, `squareCatalogVersion` (all optional).
- `ClassRepository.updateSquareSyncIds` / `clearSquareSyncIds` are bare updates with **no `updatedAt` bump** — same trigger feedback-loop guard as `updateWebflowItemId`.
- `OrdersService.createOrder` plumbs the new `metadata` param.

## Test plan
- [x] `nx run domain:test` passes
- [x] `nx run firebase-database:test` passes
- [x] CatalogService.createClassCatalogItem unit tests (request shape, default modifier name, error paths)
- [x] syncClassToSquare unit tests (4 lifecycle branches, feedback-loop guard, inventory edge cases)
- [x] syncClassInventoryToSquare unit tests (count-relevance guard, no-mirror skip, oversold clamp)
- [x] handleInventoryUpdate class-skip test added
- [x] All 4 cloud function codebases build cleanly
- [x] `nx run maple-spruce:typecheck` passes
- [x] `tools/validate-function-tsconfigs.sh` passes (13 includes in functions-square, codebase mappings consistent)
- [ ] Manual smoke (post-merge, in dev): publish a test class → verify Square catalog item appears with the modifier list; create a registration → verify Square inventory ticks down; cancel it → verify it ticks back up

## Out of scope
- POS webhook handler (PR 3) — the `order.updated` listener that turns a POS-originated Square order into a Firestore registration with `source: 'pos'` and the missing-email admin alert.

## Followup ops
After PR 3 merges and we're using POS in production, we'll want a one-time backfill that runs `syncClassToSquare` against existing published classes so they appear in Square. For now there are no published classes in production that need backfilling.