### PR TITLE
fix: wrap DiscountForm in LocalizationProvider so Create Discount opens

### DIFF
--- a/libs/react/discounts/src/lib/DiscountForm.tsx
+++ b/libs/react/discounts/src/lib/DiscountForm.tsx
@@ -18,6 +18,8 @@ import {
   InputAdornment,
 } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFnsV3';
 import type {
   Discount,
   CreateDiscountInput,
@@ -232,7 +234,8 @@ export function DiscountForm({
   );
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
       <DialogTitle>
         {discount ? 'Edit Discount' : 'Add Discount Code'}
       </DialogTitle>
@@ -489,6 +492,7 @@ export function DiscountForm({
               : 'Create'}
         </Button>
       </DialogActions>
-    </Dialog>
+      </Dialog>
+    </LocalizationProvider>
   );
 }


### PR DESCRIPTION
## Summary
- `business.mapleandsprucefolkarts.com/discounts` → **Create Discount** crashed with `MUI X: Can not find the date and time pickers localization context. It looks like you forgot to wrap your component in LocalizationProvider`.
- `DiscountForm` uses `DatePicker` (expiresAt, cutoffDate) but had no `LocalizationProvider` in the tree. The page that mounts it didn't provide one either.
- Fix: wrap the dialog with `LocalizationProvider dateAdapter={AdapterDateFns}`, matching the existing pattern in `ClassForm`, `EditLessonDialog`, `ScheduleLessonDialog`, `CalendarEventForm`, and `PeriodPicker`.

## Test plan
- [ ] On `/discounts`, click **Create Discount** → dialog opens without console error.
- [ ] Pick an `Expires at` date — calendar popover renders, value persists, validation passes.
- [ ] Switch type to **Amount before date** — `Cutoff date` picker also renders.
- [ ] Edit an existing discount — both pickers seed from saved values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)