### PR TITLE
fix: declare missing Firestore composite indexes + add CI guardrail

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -24,7 +24,7 @@ Check for a matching skill before building workflows from scratch.
 ## Path-Specific Rules
 
 Rules in `.claude/rules/` are auto-loaded when working on matching file paths:
-- `firebase-functions.md` -- Applies to `libs/firebase/maple-functions/**`, `apps/functions/**`
+- `firebase-functions.md` -- Applies to `libs/firebase/maple-functions/**`, `apps/functions/**`, `libs/firebase/database/**` (also covers Firestore composite-index guardrails)
 - `react-components.md` -- Applies to `libs/react/**`, `apps/maple-spruce/src/components/**`
 
 ---

--- a/.claude/rules/firebase-functions.md
+++ b/.claude/rules/firebase-functions.md
@@ -5,6 +5,7 @@ globs:
   - "apps/functions-calendar/**"
   - "apps/functions-square/**"
   - "apps/functions-sync/**"
+  - "libs/firebase/database/**"
 ---
 
 # Firebase Cloud Functions Rules
@@ -113,6 +114,50 @@ export const updateClass = createAdminFunction<Req, Res>(async (data) => {
 **Error helpers** (`throwInvalidArgument`, `throwNotFound`, `throwValidationError`) live in `@maple/firebase/functions` (`errors.utility.ts`). They throw typed `HttpsError` codes — prefer them over bare `throw new Error(...)` so clients can discriminate failures.
 
 **Validation must run BEFORE any external writes** (Square, Webflow, payments). Invalid data must never reach external APIs and fail halfway through.
+
+## Firestore Composite Indexes
+
+**Every `.where()` chain that requires a composite index MUST have a matching entry in `firestore.indexes.json` in the same PR that introduces it.** A 20-day production outage was caused by an undeclared agreementTemplates index in 2026-05; the CI guardrail below was added to prevent recurrence.
+
+### When a composite index is required
+
+Firestore auto-creates single-field indexes; everything below needs a composite index declared in `firestore.indexes.json`:
+
+- Two or more `.where()` filters on the same query (any combination of `==`, `!=`, `<`, `>`, etc.)
+- A `.where()` + a `.orderBy()` on a *different* field
+- `array-contains` or `array-contains-any` combined with any other filter or orderBy
+
+### The Firestore emulator does NOT enforce composite indexes
+
+Integration tests against the emulator will pass even when a query requires an index that isn't declared. A green test suite is **not** proof the query will run in prod. The only reliable verification is the analyzer (below) plus deploying to a real Firestore instance.
+
+### Run the analyzer before committing
+
+```bash
+npx tsx tools/check-firestore-indexes.ts            # exits non-zero if any required index is undeclared
+npx tsx tools/check-firestore-indexes.ts --verbose  # shows every query chain it found
+```
+
+The analyzer scans `libs/firebase/database/**/*.repository.ts`, `libs/firebase/maple-functions/**`, and `tools/`. When it finds an undeclared index, it emits the exact JSON object to paste into the `indexes` array of `firestore.indexes.json`. CI runs the same script on every PR (`build-check.yml` → `firestore-indexes` job).
+
+### Adding a new query
+
+1. Write the `.where()` / `.orderBy()` chain.
+2. Run `npx tsx tools/check-firestore-indexes.ts`.
+3. If it flags missing indexes, paste the emitted JSON object(s) into the `indexes` array in `firestore.indexes.json`.
+4. Re-run the analyzer until it passes.
+5. CI/CD applies index changes via `firebase deploy --only firestore:indexes` on merge — there is no manual deploy step.
+
+### Opt-out
+
+If the analyzer flags a query that genuinely doesn't need a declared index (rare — usually only for queries we accept will never run in prod), add this comment on the line immediately above the query:
+
+```typescript
+// firestore-index-analyzer-ignore: <reason>
+let query = db.collection('foo').where(...)
+```
+
+Prefer declaring the index over ignoring; the cost of an unused index is small, the cost of a missing one is a production outage.
 
 ## Testing
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,7 @@
-## Summary
+<!-- Describe what changed and why. Link the issue (Closes #NN) if there is one. -->
 
-<!-- Brief description of the changes -->
-
-## Changes
-
-- <!-- Change 1 -->
-- <!-- Change 2 -->
-
-## Testing
-
-- [ ] Unit tests added/updated
-- [ ] All tests pass (`npm test`)
-- [ ] Storybook stories added (if UI changes)
-
-## Checklist
-
-- [ ] Code follows project patterns (see PATTERNS-AND-PRACTICES.md)
-- [ ] No secrets or credentials committed
-- [ ] Documentation updated (if needed)
-
-<!-- Link to issue: Closes #XX -->
+<!--
+Guardrails are automated: CI runs typecheck, lint, build, unit + integration
+tests, security audit, and a Firestore-composite-index analyzer on every PR.
+Nothing to check by hand — just make sure all jobs are green.
+-->

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -75,6 +75,37 @@ jobs:
       - name: Run pnpm audit
         run: pnpm audit --audit-level=high
 
+  firestore-indexes:
+    name: Firestore Indexes
+    needs: [install]
+    runs-on: ubuntu-latest
+    if: github.repository == 'Maple-and-Spruce/maple-and-spruce'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: ${{ needs.install.outputs.cache_key }}
+
+      # Every composite-index-requiring Firestore query in repositories,
+      # Cloud Functions, and tools must have a matching entry in
+      # firestore.indexes.json. The Firestore emulator does NOT enforce
+      # composite indexes, so a green test suite is not proof the query
+      # will run in prod. See .claude/rules/firebase-functions.md.
+      - name: Check Firestore indexes
+        run: pnpm exec tsx tools/check-firestore-indexes.ts
+
   typecheck:
     name: TypeScript Check
     needs: [install]

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -104,7 +104,9 @@ jobs:
       # composite indexes, so a green test suite is not proof the query
       # will run in prod. See .claude/rules/firebase-functions.md.
       - name: Check Firestore indexes
-        run: pnpm exec tsx tools/check-firestore-indexes.ts
+        # tsx isn't a project dep — npx fetches it on demand (same pattern as
+        # integration-tests step). Other CI jobs use it via `npx tsx`.
+        run: npx tsx tools/check-firestore-indexes.ts
 
   typecheck:
     name: TypeScript Check

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,52 +1,859 @@
 {
   "indexes": [
     {
+      "collectionGroup": "agreementRequests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "expiresAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "agreementRequests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "signerEmail",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "classId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "agreementRequests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "signerEmail",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "registrationId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "classId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "agreementRequests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "signerEmail",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "classId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "registrationId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "agreementTemplates",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "name",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "agreementTemplates",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classCategoryIds",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "autoAttach",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "name",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "agreementTemplates",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classCategoryIds",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "autoAttach",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "signingRequirement",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "name",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "artists",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "status", "order": "ASCENDING" },
-        { "fieldPath": "name", "order": "ASCENDING" }
-      ]
-    },
-    {
-      "collectionGroup": "classes",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "status", "order": "ASCENDING" },
-        { "fieldPath": "firstSessionAt", "order": "ASCENDING" }
-      ]
-    },
-    {
-      "collectionGroup": "classes",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "categoryId", "order": "ASCENDING" },
-        { "fieldPath": "firstSessionAt", "order": "ASCENDING" }
-      ]
-    },
-    {
-      "collectionGroup": "classes",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "instructorId", "order": "ASCENDING" },
-        { "fieldPath": "firstSessionAt", "order": "ASCENDING" }
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "name",
+          "order": "ASCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "calendarEvents",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "public", "order": "ASCENDING" },
-        { "fieldPath": "startDateTime", "order": "ASCENDING" }
+        {
+          "fieldPath": "public",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "startDateTime",
+          "order": "ASCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "calendarEvents",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "public", "order": "ASCENDING" },
-        { "fieldPath": "type", "order": "ASCENDING" },
-        { "fieldPath": "startDateTime", "order": "ASCENDING" }
+        {
+          "fieldPath": "public",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "type",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "startDateTime",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "calendarEvents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "type",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "public",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "startDateTime",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "classes",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "categoryId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "firstSessionAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "classes",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "instructorId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "firstSessionAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "classes",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "firstSessionAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "classes",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "categoryId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "firstSessionAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "classes",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "categoryId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "instructorId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "firstSessionAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "discounts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "code",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "instructors",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "name",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "inventoryMovements",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "productId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "inventoryMovements",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "productId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "type",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "source",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "invoices",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "studentId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "lessons",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "scheduledAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "lessons",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "studentId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "teacherId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "seriesId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "scheduledAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "payouts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "artistId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "payouts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "artistId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "payouts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "artistId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "periodStart",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "periodEnd",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "products",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "artistId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "products",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "products",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "artistId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "registrations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "registrations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "registrations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "customerEmail",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "source",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "registrations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "customerEmail",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "source",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "sales",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "artistId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "soldAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "sales",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "artistId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "source",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "soldAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "sales",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "artistId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "source",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "productId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "soldAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "sales",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "productId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "artistId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "source",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "soldAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "signedAgreements",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "signerEmail",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "templateId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "signedAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "signedAgreements",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "requestId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "templateId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "signerEmail",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "signedAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "signedAgreements",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "signerEmail",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "templateId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "requestId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "signedAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "students",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "name",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "students",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "primaryTeacherId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "isHopeScholarship",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "name",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "syncConflicts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "detectedAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "syncConflicts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "productId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "type",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "detectedAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "syncConflicts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "productId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "type",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "externalState.system",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "syncConflicts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "type",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "externalState.system",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "productId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "detectedAt",
+          "order": "DESCENDING"
+        }
       ]
     }
   ],

--- a/tools/check-firestore-indexes.ts
+++ b/tools/check-firestore-indexes.ts
@@ -549,14 +549,13 @@ function findRepositoryExport(sf: ts.SourceFile): string | undefined {
 function main(): void {
   const files = listSourceFiles();
   const allChains: QueryChain[] = [];
-  /** All conditional chains, with metadata used to bind callers to them. */
+  /** Conditional chains with metadata used to bind callers to them. */
   type ConditionalChain = PartialChain & {
     sourceFile: string;
     sourceLine: number;
     /** `AgreementTemplateRepository` if this chain lives in a Repository export. */
     repositoryName?: string;
   };
-  const conditionalChains: ConditionalChain[] = [];
   /** Maps `<Name>Repository` → list of conditional chains in its file. */
   const chainsByRepository = new Map<string, ConditionalChain[]>();
   /** Maps source file path → list of conditional chains in it. */
@@ -586,7 +585,6 @@ function main(): void {
           sourceLine: line + 1,
           repositoryName,
         };
-        conditionalChains.push(cc);
         if (repositoryName) {
           const list = chainsByRepository.get(repositoryName) || [];
           list.push(cc);

--- a/tools/check-firestore-indexes.ts
+++ b/tools/check-firestore-indexes.ts
@@ -1,0 +1,737 @@
+/**
+ * Static analyzer for Firestore composite-index requirements.
+ *
+ * Walks every TS file that builds Firestore queries (repositories, Cloud
+ * Functions, admin tools) and derives which composite indexes are needed.
+ * Diffs against `firestore.indexes.json` and emits paste-ready JSON for
+ * anything missing.
+ *
+ * Why this exists: Firebase auto-creates single-field indexes, but composite
+ * indexes (multi-`.where()`, `array-contains`+anything, `.where()`+different-
+ * field `.orderBy()`) must be declared. The Firestore emulator does NOT
+ * enforce composite-index requirements, so a passing test suite is no proof
+ * that production will work. We caught a 20-day production outage because of
+ * this — see PR description / `docs/sessions/`.
+ *
+ * Usage:
+ *   npx tsx tools/check-firestore-indexes.ts            # checks, exits 1 on missing
+ *   npx tsx tools/check-firestore-indexes.ts --verbose  # shows queries it found
+ *
+ * Per-query opt-out: add a comment on the line immediately preceding the
+ * query chain:
+ *   // firestore-index-analyzer-ignore: <reason>
+ *
+ * Scope (intentional): scans queries built in
+ *   - libs/firebase/database/**\/*.repository.ts
+ *   - libs/firebase/maple-functions/**\/src/**\/*.ts (excluding *.spec.ts)
+ *   - tools/**\/*.ts (this file is excluded by name)
+ *
+ * NOT scanned: the Next.js admin app (apps/maple-spruce). Direct Firestore
+ * access from frontend is discouraged; if you add some, also add it here.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as ts from 'typescript';
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const ROOT = path.resolve(__dirname, '..');
+const INDEX_FILE = path.join(ROOT, 'firestore.indexes.json');
+const VERBOSE = process.argv.includes('--verbose');
+const SELF_PATH = path.relative(ROOT, __filename);
+
+const SCAN_DIRS = [
+  'libs/firebase/database/src/lib',
+  'libs/firebase/maple-functions',
+  'tools',
+];
+
+const SKIP_PATTERNS = [
+  /\.spec\.ts$/,
+  /\.test\.ts$/,
+  /\/dist\//,
+  /\/node_modules\//,
+  /\.next\//,
+];
+
+// Equality-style operators don't have ranges; array-contains is its own beast.
+const EQUALITY_OPS = new Set(['==', '!=', 'in', 'not-in']);
+const RANGE_OPS = new Set(['<', '<=', '>', '>=']);
+const ARRAY_OPS = new Set(['array-contains', 'array-contains-any']);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type IndexField =
+  | { fieldPath: string; order: 'ASCENDING' | 'DESCENDING' }
+  | { fieldPath: string; arrayConfig: 'CONTAINS' };
+
+interface IndexSpec {
+  collectionGroup: string;
+  queryScope: 'COLLECTION' | 'COLLECTION_GROUP';
+  fields: IndexField[];
+}
+
+interface QueryChain {
+  collection: string;
+  filters: Array<{ field: string; op: string }>;
+  orderBys: Array<{ field: string; dir: 'asc' | 'desc' }>;
+  file: string;
+  line: number;
+  ignore: boolean;
+  ignoreReason?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Discovery: walk source files
+// ---------------------------------------------------------------------------
+
+function* walk(dir: string): Generator<string> {
+  if (!fs.existsSync(dir)) return;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (SKIP_PATTERNS.some((p) => p.test(full))) continue;
+    if (entry.isDirectory()) yield* walk(full);
+    else if (entry.isFile() && full.endsWith('.ts')) yield full;
+  }
+}
+
+function listSourceFiles(): string[] {
+  const out: string[] = [];
+  for (const d of SCAN_DIRS) {
+    for (const f of walk(path.join(ROOT, d))) {
+      if (path.relative(ROOT, f) === SELF_PATH) continue;
+      out.push(f);
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// AST: pull all .collection(...).where(...).orderBy(...) chains
+// ---------------------------------------------------------------------------
+
+function getStringLit(node: ts.Node | undefined): string | undefined {
+  if (!node) return undefined;
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    return node.text;
+  }
+  if (ts.isIdentifier(node) && node.text === 'COLLECTION') return '__COLLECTION_CONST__';
+  return undefined;
+}
+
+function resolveCollectionConst(sf: ts.SourceFile): string | undefined {
+  let value: string | undefined;
+  function visit(n: ts.Node) {
+    if (
+      ts.isVariableDeclaration(n) &&
+      ts.isIdentifier(n.name) &&
+      n.name.text === 'COLLECTION' &&
+      n.initializer
+    ) {
+      if (ts.isStringLiteral(n.initializer) || ts.isNoSubstitutionTemplateLiteral(n.initializer)) {
+        value = n.initializer.text;
+      }
+    }
+    ts.forEachChild(n, visit);
+  }
+  visit(sf);
+  return value;
+}
+
+interface PartialChain {
+  collection?: string;
+  filters: Array<{ field: string; op: string }>;
+  orderBys: Array<{ field: string; dir: 'asc' | 'desc' }>;
+  startNode: ts.Node;
+  /**
+   * If this chain came from a repository's `findAll` (or similar) with
+   * conditional `query = query.where(...)` blocks, this records the optional
+   * filters keyed by the property name that gates them. Combined with helper-
+   * call extraction, it lets the analyzer derive per-helper index shapes
+   * (the only way to satisfy Firestore's strict prefix-matching when
+   * conditional fields sit between others in the chain).
+   */
+  conditionalFilters?: Map<string, { field: string; op: string }>;
+  /**
+   * Static orderBy fields applied to every code path through the chain
+   * (e.g., a trailing `query = query.orderBy('name', 'asc')`).
+   */
+  staticOrderBys?: Array<{ field: string; dir: 'asc' | 'desc' }>;
+}
+
+function extractChains(sf: ts.SourceFile): PartialChain[] {
+  const collectionConst = resolveCollectionConst(sf);
+  const chains: PartialChain[] = [];
+
+  function unwindCallChain(call: ts.CallExpression): PartialChain {
+    const chain: PartialChain = { filters: [], orderBys: [], startNode: call };
+    let node: ts.Node = call;
+    while (ts.isCallExpression(node)) {
+      const expr = node.expression;
+      if (!ts.isPropertyAccessExpression(expr)) break;
+      const method = expr.name.text;
+      const args = node.arguments;
+      if (method === 'where' && args.length >= 2) {
+        const field = getStringLit(args[0]);
+        const op =
+          ts.isStringLiteral(args[1]) || ts.isNoSubstitutionTemplateLiteral(args[1])
+            ? args[1].text
+            : '?';
+        if (field) chain.filters.unshift({ field, op });
+      } else if (method === 'orderBy' && args.length >= 1) {
+        const field = getStringLit(args[0]);
+        let dir: 'asc' | 'desc' = 'asc';
+        if (args[1] && (ts.isStringLiteral(args[1]) || ts.isNoSubstitutionTemplateLiteral(args[1]))) {
+          dir = args[1].text === 'desc' ? 'desc' : 'asc';
+        }
+        if (field) chain.orderBys.unshift({ field, dir });
+      } else if (method === 'collection' && args.length >= 1) {
+        const lit = getStringLit(args[0]);
+        if (lit === '__COLLECTION_CONST__') chain.collection = collectionConst;
+        else if (lit) chain.collection = lit;
+        break;
+      }
+      node = expr.expression;
+    }
+    return chain;
+  }
+
+  function visit(n: ts.Node) {
+    // Pick up only the OUTERMOST call expression in each chain
+    if (ts.isCallExpression(n)) {
+      const parent = n.parent;
+      const isInnerCallInChain =
+        parent &&
+        ts.isPropertyAccessExpression(parent) &&
+        parent.expression === n &&
+        parent.parent &&
+        ts.isCallExpression(parent.parent);
+      if (!isInnerCallInChain) {
+        const chain = unwindCallChain(n);
+        if (chain.collection && (chain.filters.length > 0 || chain.orderBys.length > 0)) {
+          chains.push(chain);
+        }
+      }
+    }
+    ts.forEachChild(n, visit);
+  }
+  visit(sf);
+
+  // Also pick up chains where filters span across `query = query.where(...)` reassignments
+  // by detecting a `let query = db.collection(X)` pattern and aggregating .where() / .orderBy()
+  // assignments in the same function scope.
+  chains.push(...extractReassignmentChains(sf, collectionConst));
+
+  return chains;
+}
+
+// ---------------------------------------------------------------------------
+// Handle the `let query = db.collection(X); if (filters?.foo) query = query.where(...)`
+// pattern (used in every Repository.findAll). We over-approximate by treating
+// every `query = query.where(...)` in the same function as "potentially active".
+// ---------------------------------------------------------------------------
+
+function extractReassignmentChains(
+  sf: ts.SourceFile,
+  collectionConst: string | undefined
+): PartialChain[] {
+  const chains: PartialChain[] = [];
+
+  function walkFn(fnNode: ts.Node) {
+    let collectionName: string | undefined;
+    let startNode: ts.Node | undefined;
+    const filters: Array<{ field: string; op: string }> = [];
+    const orderBys: Array<{ field: string; dir: 'asc' | 'desc' }> = [];
+    const conditionalFilters = new Map<string, { field: string; op: string }>();
+    const staticOrderBys: Array<{ field: string; dir: 'asc' | 'desc' }> = [];
+
+    function visit(n: ts.Node, insideIf: ts.IfStatement | undefined = undefined) {
+      if (
+        ts.isVariableDeclaration(n) &&
+        ts.isIdentifier(n.name) &&
+        n.initializer
+      ) {
+        const init = n.initializer;
+        if (ts.isCallExpression(init) && ts.isPropertyAccessExpression(init.expression)) {
+          const method = init.expression.name.text;
+          if (method === 'collection' && init.arguments[0]) {
+            const lit = getStringLit(init.arguments[0]);
+            if (lit === '__COLLECTION_CONST__') collectionName = collectionConst;
+            else if (lit) collectionName = lit;
+            startNode = n;
+          }
+        }
+      }
+
+      // `query = query.where(...)` or `query = query.orderBy(...)` reassignment
+      if (
+        ts.isBinaryExpression(n) &&
+        n.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        ts.isCallExpression(n.right) &&
+        ts.isPropertyAccessExpression(n.right.expression)
+      ) {
+        const method = n.right.expression.name.text;
+        const args = n.right.arguments;
+        if (method === 'where' && args.length >= 2) {
+          const field = getStringLit(args[0]);
+          const op =
+            ts.isStringLiteral(args[1]) || ts.isNoSubstitutionTemplateLiteral(args[1])
+              ? args[1].text
+              : '?';
+          if (field) {
+            filters.push({ field, op });
+            if (insideIf) {
+              const key = extractFilterKey(insideIf.expression);
+              if (key) conditionalFilters.set(key, { field, op });
+            }
+          }
+        } else if (method === 'orderBy' && args.length >= 1) {
+          const field = getStringLit(args[0]);
+          let dir: 'asc' | 'desc' = 'asc';
+          if (
+            args[1] &&
+            (ts.isStringLiteral(args[1]) || ts.isNoSubstitutionTemplateLiteral(args[1]))
+          ) {
+            dir = args[1].text === 'desc' ? 'desc' : 'asc';
+          }
+          if (field) {
+            orderBys.push({ field, dir });
+            if (!insideIf) staticOrderBys.push({ field, dir });
+          }
+        }
+      }
+
+      if (ts.isIfStatement(n)) {
+        ts.forEachChild(n.thenStatement, (c) => visit(c, n));
+        if (n.elseStatement) ts.forEachChild(n.elseStatement, (c) => visit(c, insideIf));
+        return;
+      }
+
+      ts.forEachChild(n, (c) => visit(c, insideIf));
+    }
+    visit(fnNode);
+
+    if (collectionName && (filters.length > 0 || orderBys.length > 0)) {
+      chains.push({
+        collection: collectionName,
+        filters,
+        orderBys,
+        startNode: startNode || fnNode,
+        conditionalFilters: conditionalFilters.size > 0 ? conditionalFilters : undefined,
+        staticOrderBys: staticOrderBys.length > 0 ? staticOrderBys : undefined,
+      });
+    }
+  }
+
+  /**
+   * Pull the property key out of an `if (filters?.foo)` / `if (filters?.foo !== undefined)` condition.
+   * Returns 'foo' or undefined.
+   */
+  function extractFilterKey(cond: ts.Expression): string | undefined {
+    let expr: ts.Expression = cond;
+    if (ts.isBinaryExpression(expr)) {
+      // `filters?.foo !== undefined` etc — pull the left side
+      expr = expr.left;
+    }
+    if (ts.isPropertyAccessExpression(expr)) return expr.name.text;
+    if (ts.isPropertyAccessChain(expr)) return expr.name.text;
+    return undefined;
+  }
+
+  function findFunctions(n: ts.Node) {
+    if (
+      ts.isFunctionDeclaration(n) ||
+      ts.isFunctionExpression(n) ||
+      ts.isArrowFunction(n) ||
+      ts.isMethodDeclaration(n) ||
+      // Object literal methods: `{ async findAll() {...} }` and `{ findAll: async () => {...} }`
+      (ts.isPropertyAssignment(n) && (ts.isFunctionExpression(n.initializer) || ts.isArrowFunction(n.initializer))) ||
+      ts.isShorthandPropertyAssignment(n)
+    ) {
+      walkFn(n);
+    }
+    ts.forEachChild(n, findFunctions);
+  }
+  findFunctions(sf);
+
+  return chains;
+}
+
+// ---------------------------------------------------------------------------
+// Detect ignore comment immediately preceding a chain
+// ---------------------------------------------------------------------------
+
+function getIgnoreComment(sf: ts.SourceFile, pos: number): string | undefined {
+  const text = sf.getFullText();
+  // Find the last `// firestore-index-analyzer-ignore: ...` before `pos` on a preceding line
+  const before = text.slice(0, pos);
+  const lastNL = before.lastIndexOf('\n');
+  const startOfLine = lastNL + 1;
+  // The "line" containing `pos` starts at startOfLine. We want comments on preceding lines.
+  // Look up to 5 lines back for the ignore marker.
+  const window = text.slice(Math.max(0, startOfLine - 1000), pos);
+  const m = window.match(/\/\/\s*firestore-index-analyzer-ignore(?::\s*([^\n]*))?\s*\n[^\n]*$/);
+  return m ? (m[1] || '(no reason given)') : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Decide whether a chain needs a composite index, and what shape
+// ---------------------------------------------------------------------------
+
+/**
+ * Firestore composite-index rules in plain terms:
+ *  - A single `.where()` with no `.orderBy()` on a different field: no composite needed.
+ *  - 2+ `.where()` calls: composite needed.
+ *  - `.where()` + `.orderBy()` on a different field: composite needed.
+ *  - Any `array-contains` / `array-contains-any` + any other filter/orderBy: composite needed.
+ *  - Range/inequality on a different field than `.orderBy()`: usually composite needed (we conservatively flag).
+ */
+function needsCompositeIndex(chain: PartialChain): boolean {
+  const filterCount = chain.filters.length;
+  const orderByCount = chain.orderBys.length;
+  const hasArray = chain.filters.some((f) => ARRAY_OPS.has(f.op));
+
+  if (filterCount === 0 && orderByCount <= 1) return false;
+  if (filterCount >= 2) return true;
+  if (hasArray && (filterCount + orderByCount) >= 2) return true;
+  if (filterCount === 1 && orderByCount >= 1) {
+    const filterField = chain.filters[0].field;
+    return chain.orderBys.some((o) => o.field !== filterField);
+  }
+  if (filterCount === 0 && orderByCount >= 2) return true;
+  return false;
+}
+
+/**
+ * Build the index shape Firestore wants. Field order:
+ *   1. array-contains field (if any)
+ *   2. equality / range fields, in source order
+ *   3. orderBy fields, in source order
+ */
+function deriveIndexFields(chain: PartialChain): IndexField[] {
+  const fields: IndexField[] = [];
+  const seen = new Set<string>();
+
+  for (const f of chain.filters) {
+    if (ARRAY_OPS.has(f.op)) {
+      fields.push({ fieldPath: f.field, arrayConfig: 'CONTAINS' });
+      seen.add(f.field);
+    }
+  }
+  for (const f of chain.filters) {
+    if (!ARRAY_OPS.has(f.op) && !seen.has(f.field)) {
+      fields.push({ fieldPath: f.field, order: 'ASCENDING' });
+      seen.add(f.field);
+    }
+  }
+  for (const o of chain.orderBys) {
+    if (seen.has(o.field)) continue;
+    fields.push({
+      fieldPath: o.field,
+      order: o.dir === 'desc' ? 'DESCENDING' : 'ASCENDING',
+    });
+    seen.add(o.field);
+  }
+  return fields;
+}
+
+// ---------------------------------------------------------------------------
+// Load declared indexes
+// ---------------------------------------------------------------------------
+
+function loadDeclared(): IndexSpec[] {
+  const raw = JSON.parse(fs.readFileSync(INDEX_FILE, 'utf8'));
+  return (raw.indexes || []) as IndexSpec[];
+}
+
+function normalize(spec: { collectionGroup: string; fields: IndexField[] }): string {
+  const parts = spec.fields.map((f) => {
+    if ('arrayConfig' in f) return `${f.fieldPath}:CONTAINS`;
+    return `${f.fieldPath}:${f.order}`;
+  });
+  return `${spec.collectionGroup}|${parts.join(',')}`;
+}
+
+/**
+ * Returns true if `declared` covers `required`. A declared index covers a
+ * required index when the declared field sequence STARTS WITH the required
+ * sequence (Firestore prefix-matches).
+ */
+function coversRequired(declared: IndexSpec, required: IndexSpec): boolean {
+  if (declared.collectionGroup !== required.collectionGroup) return false;
+  if (required.fields.length > declared.fields.length) return false;
+  for (let i = 0; i < required.fields.length; i++) {
+    const a = required.fields[i];
+    const b = declared.fields[i];
+    if (a.fieldPath !== b.fieldPath) return false;
+    if ('arrayConfig' in a && !('arrayConfig' in b)) return false;
+    if ('order' in a && 'order' in b && a.order !== b.order) return false;
+    if ('arrayConfig' in a && 'arrayConfig' in b && a.arrayConfig !== b.arrayConfig) return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+/**
+ * Find every call expression in the file that passes an object literal as
+ * the first arg. Used to discover the actual filter combinations a helper
+ * (or external caller) passes to `findAll`-style methods.
+ *
+ * Returns: list of { methodName, keys, location }
+ */
+function findLiteralArgCalls(sf: ts.SourceFile): Array<{
+  methodName: string;
+  keys: string[];
+  line: number;
+  caller: string;
+}> {
+  const out: Array<{ methodName: string; keys: string[]; line: number; caller: string }> = [];
+
+  function visit(n: ts.Node) {
+    if (
+      ts.isCallExpression(n) &&
+      ts.isPropertyAccessExpression(n.expression) &&
+      n.arguments.length >= 1 &&
+      ts.isObjectLiteralExpression(n.arguments[0])
+    ) {
+      const methodName = n.expression.name.text;
+      const obj = n.arguments[0];
+      const keys: string[] = [];
+      for (const prop of obj.properties) {
+        if (
+          (ts.isPropertyAssignment(prop) || ts.isShorthandPropertyAssignment(prop)) &&
+          ts.isIdentifier(prop.name)
+        ) {
+          keys.push(prop.name.text);
+        }
+      }
+      if (keys.length > 0) {
+        const { line } = sf.getLineAndCharacterOfPosition(n.getStart(sf));
+        // Caller chain text for the diagnostic ("ThisRepo.findAll", "this.findAll", etc)
+        const left = n.expression.expression.getText(sf);
+        out.push({ methodName, keys, line: line + 1, caller: `${left}.${methodName}` });
+      }
+    }
+    ts.forEachChild(n, visit);
+  }
+  visit(sf);
+  return out;
+}
+
+/**
+ * Find the `<Name>Repository = { ... }` export in a file and return its name.
+ */
+function findRepositoryExport(sf: ts.SourceFile): string | undefined {
+  let name: string | undefined;
+  function visit(n: ts.Node) {
+    if (
+      ts.isVariableDeclaration(n) &&
+      ts.isIdentifier(n.name) &&
+      n.name.text.endsWith('Repository') &&
+      n.initializer &&
+      ts.isObjectLiteralExpression(n.initializer)
+    ) {
+      name = n.name.text;
+    }
+    ts.forEachChild(n, visit);
+  }
+  visit(sf);
+  return name;
+}
+
+function main(): void {
+  const files = listSourceFiles();
+  const allChains: QueryChain[] = [];
+  /** All conditional chains, with metadata used to bind callers to them. */
+  type ConditionalChain = PartialChain & {
+    sourceFile: string;
+    sourceLine: number;
+    /** `AgreementTemplateRepository` if this chain lives in a Repository export. */
+    repositoryName?: string;
+  };
+  const conditionalChains: ConditionalChain[] = [];
+  /** Maps `<Name>Repository` → list of conditional chains in its file. */
+  const chainsByRepository = new Map<string, ConditionalChain[]>();
+  /** Maps source file path → list of conditional chains in it. */
+  const chainsByFile = new Map<string, ConditionalChain[]>();
+
+  for (const file of files) {
+    const text = fs.readFileSync(file, 'utf8');
+    const sf = ts.createSourceFile(file, text, ts.ScriptTarget.ES2022, true);
+    const repositoryName = findRepositoryExport(sf);
+    const chains = extractChains(sf);
+    for (const c of chains) {
+      const { line } = sf.getLineAndCharacterOfPosition(c.startNode.getStart(sf));
+      const ignoreReason = getIgnoreComment(sf, c.startNode.getStart(sf));
+      allChains.push({
+        collection: c.collection!,
+        filters: c.filters,
+        orderBys: c.orderBys,
+        file: path.relative(ROOT, file),
+        line: line + 1,
+        ignore: ignoreReason !== undefined,
+        ignoreReason,
+      });
+      if (c.conditionalFilters && !ignoreReason) {
+        const cc: ConditionalChain = {
+          ...c,
+          sourceFile: path.relative(ROOT, file),
+          sourceLine: line + 1,
+          repositoryName,
+        };
+        conditionalChains.push(cc);
+        if (repositoryName) {
+          const list = chainsByRepository.get(repositoryName) || [];
+          list.push(cc);
+          chainsByRepository.set(repositoryName, list);
+        }
+        const flist = chainsByFile.get(cc.sourceFile) || [];
+        flist.push(cc);
+        chainsByFile.set(cc.sourceFile, flist);
+      }
+    }
+  }
+
+  // Pass 2: scan literal-argument calls site-by-site and emit a precise index
+  // for each invocation that hits a chain with conditional filters. We bind
+  // calls to chains by repository name:
+  //   `AgreementTemplateRepository.findAll({...})` → chain in agreement-template.repository.ts
+  //   `this.findAll({...})`                        → chain in the SAME file
+  const perCallSiteRequirements: Array<{ spec: IndexSpec; chain: QueryChain }> = [];
+  for (const file of files) {
+    const relFile = path.relative(ROOT, file);
+    const text = fs.readFileSync(file, 'utf8');
+    const sf = ts.createSourceFile(file, text, ts.ScriptTarget.ES2022, true);
+    const calls = findLiteralArgCalls(sf);
+    for (const call of calls) {
+      // Identify the target repository / file based on the call receiver.
+      const receiver = call.caller.split('.')[0]; // e.g., "AgreementTemplateRepository" or "this"
+      let candidates: ConditionalChain[] = [];
+      if (receiver === 'this') {
+        candidates = chainsByFile.get(relFile) || [];
+      } else if (receiver.endsWith('Repository')) {
+        candidates = chainsByRepository.get(receiver) || [];
+      } else {
+        continue; // not a recognized repository call
+      }
+      for (const cc of candidates) {
+        if (!cc.conditionalFilters) continue;
+        const matchedKeys = call.keys.filter((k) => cc.conditionalFilters!.has(k));
+        if (matchedKeys.length === 0) continue;
+        // Keys not present in conditionalFilters are not a where() — they may
+        // be static config (e.g., `limit`, `upcoming` that's filtered in-memory).
+        // We tolerate foreign keys; only matched keys contribute to the index.
+        const activeFilters = matchedKeys.map((k) => cc.conditionalFilters!.get(k)!);
+        const synthChain: PartialChain = {
+          collection: cc.collection,
+          filters: activeFilters,
+          orderBys: cc.staticOrderBys || [],
+          startNode: cc.startNode,
+        };
+        if (!needsCompositeIndex(synthChain)) continue;
+        const fields = deriveIndexFields(synthChain);
+        perCallSiteRequirements.push({
+          spec: { collectionGroup: cc.collection!, queryScope: 'COLLECTION', fields },
+          chain: {
+            collection: cc.collection!,
+            filters: activeFilters,
+            orderBys: synthChain.orderBys,
+            file: relFile,
+            line: call.line,
+            ignore: false,
+            ignoreReason: `${call.caller}({ ${call.keys.join(', ')} }) → ${cc.sourceFile}:${cc.sourceLine}`,
+          },
+        });
+      }
+    }
+  }
+
+  const declared = loadDeclared();
+  const required: Array<{ spec: IndexSpec; chain: QueryChain }> = [];
+
+  for (const chain of allChains) {
+    if (chain.ignore) continue;
+    if (!needsCompositeIndex(chain as unknown as PartialChain)) continue;
+    const fields = deriveIndexFields(chain as unknown as PartialChain);
+    required.push({
+      spec: {
+        collectionGroup: chain.collection,
+        queryScope: 'COLLECTION',
+        fields,
+      },
+      chain,
+    });
+  }
+
+  // Merge in the per-call-site requirements (often a subset / different
+  // ordering than the worst-case chain index).
+  for (const r of perCallSiteRequirements) required.push(r);
+
+  // Step 1: drop any required index already covered by a declared one.
+  const stillNeeded = required.filter(
+    (r) => !declared.some((d) => coversRequired(d, r.spec))
+  );
+
+  // Step 2: among the remaining, consolidate prefix-coverable entries — if
+  // index B is a prefix of index A, A covers B and B is redundant. Keep the
+  // longest distinct shapes.
+  const byKey = new Map<string, typeof required[number]>();
+  for (const r of stillNeeded) {
+    const key = normalize(r.spec);
+    if (!byKey.has(key)) byKey.set(key, r);
+  }
+  const distinct = [...byKey.values()];
+  const missing: typeof required = [];
+  for (const r of distinct) {
+    const coveredByOther = distinct.some(
+      (other) => other !== r && coversRequired(other.spec, r.spec)
+    );
+    if (!coveredByOther) missing.push(r);
+  }
+
+  if (VERBOSE) {
+    console.log(`Scanned ${files.length} files, found ${allChains.length} query chains.\n`);
+    console.log(`Composite-index-requiring chains: ${required.length}\n`);
+    for (const r of required) {
+      console.log(`  ${r.chain.file}:${r.chain.line}  ${r.chain.collection}`);
+      console.log(`    filters: ${r.chain.filters.map((f) => `${f.field} ${f.op}`).join(', ') || '(none)'}`);
+      console.log(`    orderBy: ${r.chain.orderBys.map((o) => `${o.field} ${o.dir}`).join(', ') || '(none)'}`);
+    }
+    console.log();
+  }
+
+  if (missing.length === 0) {
+    console.log(`✓ All ${required.length} composite-index-requiring queries are covered by firestore.indexes.json.`);
+    return;
+  }
+
+  console.error(
+    `✗ ${missing.length} Firestore composite index(es) are missing from firestore.indexes.json.\n`
+  );
+  console.error('Add the following entries to the "indexes" array in firestore.indexes.json:\n');
+
+  for (const m of missing) {
+    console.error(`  // Required by ${m.chain.file}:${m.chain.line}`);
+    const entry = JSON.stringify(m.spec, null, 2)
+      .split('\n')
+      .map((l) => '  ' + l)
+      .join('\n');
+    console.error(entry + ',');
+    console.error('');
+  }
+
+  console.error('\nIf a flagged query is intentionally bypassing the analyzer (dynamic shape we');
+  console.error('accept won\'t hit prod, etc.), add this comment above the query:');
+  console.error('  // firestore-index-analyzer-ignore: <reason>\n');
+
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## What

Declares 40 previously-undeclared Firestore composite indexes and adds a static-analysis CI check that prevents the same class of bug from shipping again.

## Why

A ~20-day production outage (2026-04-21 → 2026-05-11) silently broke every web class registration on the Stained Glass classes. The cause: PR #343 added `signingRequirement` to the `findRequiredForCategory` query on `agreementTemplates`, which made the composite index requirement 5 fields wide, but the corresponding index was never declared in `firestore.indexes.json`. Every registration on a class with a `categoryId` died on the `HttpsError` before payment ran. Sue Collins's "I registered but you can't find me" support thread today is one example; the Cloud Function logs show at least 6 distinct customer-facing failed attempts across the window.

The Firestore emulator does NOT enforce composite indexes, so the integration test suite happily ran. There was no signal until real users hit it in prod.

## How

**1. `firestore.indexes.json` (+40 indexes)** — derived from a static analysis of every `.where()` / `.orderBy()` chain in `libs/firebase/database`, `libs/firebase/maple-functions`, and `tools/`. Includes both the agreement-templates indexes that caused the outage (4-field and 5-field) plus 38 others that would have eventually failed the same way. Distribution:

| Collection | Indexes |
|---|---|
| classes, agreementRequests, registrations, sales, syncConflicts | 4-5 each |
| agreementTemplates, calendarEvents, payouts, products, signedAgreements | 3 each |
| inventoryMovements, lessons, students | 2 each |
| artists, discounts, instructors, invoices | 1 each |

Total: **46 declared** (up from 6). Well under Firestore's 200-index-per-database limit.

**2. `tools/check-firestore-indexes.ts` (new)** — TypeScript static analyzer that:
- Walks `*.repository.ts` files, Cloud Function source, and tools/
- Flattens method-chain `.where()` / `.orderBy()` calls **and** the `query = query.where(...)` reassignment pattern used by every Repository's `findAll`
- For each conditional `findAll`, scans all literal-argument call sites (`AgreementTemplateRepository.findAll({...})`, `this.findAll({...})`) and emits a precise index for that specific filter combination — necessary because Firestore's strict prefix-matching means a worst-case 5-field index does **not** serve a 4-field subset query when the missing field sits in the middle. (This was the agreement-templates outage.)
- Diffs against `firestore.indexes.json` with proper prefix-coverage logic
- Emits paste-ready JSON for any missing entry
- Supports `// firestore-index-analyzer-ignore: <reason>` for genuine false positives

Verified by deleting the agreement-templates 5-field index and confirming the analyzer fails with the exact missing-index JSON.

**3. CI wiring** — new `firestore-indexes` job in `build-check.yml`. Runs on every PR.

**4. `.claude/rules/firebase-functions.md`** — new "Firestore Composite Indexes" section explaining when an index is required, why the emulator doesn't catch it, and how to use the analyzer. Glob expanded to also auto-load when editing `libs/firebase/database/**` so future Claude sessions see the rule when adding a query.

**5. `.github/PULL_REQUEST_TEMPLATE.md`** — stripped from a multi-section checklist to a one-liner. Vibe-coding workflow doesn't honor manual checklists; guardrails are now CI-enforced.

## Followups

- [ ] One-time Cloud Logging alert for `"requires an index"` errors as a backstop in case the analyzer ever misses something. Suggested one-time setup:
  ```bash
  gcloud logging metrics create firestore-index-missing \
    --description='Firestore composite index missing — alerts on missed index declarations' \
    --log-filter='"requires an index"' \
    --project=maple-and-spruce
  ```
  Then create an alert policy on that metric (notify katie@ + david@). Doing this in console rather than Terraforming it.
- [ ] Audit Sue Collins's class registration manually (separate, in-progress).