### PR TITLE
fix: Register button shows loading state immediately on click

### DIFF
--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.spec.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.spec.tsx
@@ -50,6 +50,12 @@ vi.mock('@maple/react/agreements', () => ({
 // Google Pay / Apple Pay token events from outside the component.
 let capturedDigitalWalletTokenCallback: ((token: string) => void) | undefined;
 
+// Allow individual tests to override how the mocked tokenize function
+// behaves (e.g. to keep the promise pending and simulate Square's SDK
+// taking a moment to produce a nonce). Default is an instant resolve.
+let mockTokenizeImpl: () => Promise<string> = () =>
+  Promise.resolve('test-nonce');
+
 // Mock SquareCardForm — the real one loads Square's Web Payments SDK
 // from a CDN, which isn't available in jsdom. We emulate the minimum
 // surface the parent depends on: signalling ready, exposing a tokenize
@@ -67,7 +73,7 @@ vi.mock('./SquareCardForm', () => ({
     afterCardContent?: React.ReactNode;
   }) => {
     useEffect(() => {
-      onTokenizeRef(() => Promise.resolve('test-nonce'));
+      onTokenizeRef(() => mockTokenizeImpl());
       onReady?.();
     }, [onReady, onTokenizeRef]);
     useEffect(() => {
@@ -111,6 +117,7 @@ const mockRegistrationResponse = {
 describe('RegistrationCheckoutForm submit flow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockTokenizeImpl = () => Promise.resolve('test-nonce');
   });
 
   // @testing-library/react v13+ auto-registers cleanup only when Vitest
@@ -205,6 +212,112 @@ describe('RegistrationCheckoutForm submit flow', () => {
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+  });
+
+  it('flips the Register button to its loading state while Square tokenization is still pending', async () => {
+    const user = userEvent.setup();
+
+    // Square's tokenize call is the first await in the click handler. Hold
+    // its promise pending so we can observe the button state *before* the
+    // backend onSubmit is ever reached.
+    let resolveTokenize!: (nonce: string) => void;
+    mockTokenizeImpl = () =>
+      new Promise<string>((resolve) => {
+        resolveTokenize = resolve;
+      });
+
+    const onSubmit = vi.fn().mockResolvedValue(mockRegistrationResponse);
+    const onCalculateCost = vi.fn().mockResolvedValue(mockCostResponse);
+    const onSuccess = vi.fn();
+
+    render(
+      <RegistrationCheckoutForm
+        publicClass={mockPublicClass}
+        squareApplicationId="test-app"
+        squareLocationId="test-loc"
+        onCalculateCost={onCalculateCost}
+        onSubmit={onSubmit}
+        onSuccess={onSuccess}
+      />
+    );
+
+    const registerButton = await screen.findByRole('button', {
+      name: /Register & Pay/,
+    });
+    await waitFor(() => expect(registerButton).toBeEnabled());
+
+    fireEvent.change(screen.getByLabelText(/Full Name/), {
+      target: { value: 'Jane Doe' },
+    });
+    fireEvent.change(screen.getByLabelText(/Email Address/), {
+      target: { value: 'jane@example.com' },
+    });
+
+    await user.click(registerButton);
+
+    // While tokenize is still pending, the button must already show its
+    // loading state — that's the regression this test guards against.
+    const processingButton = await screen.findByRole('button', {
+      name: /Processing/,
+    });
+    expect(processingButton).toBeDisabled();
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    // Resolve tokenize → onSubmit runs → onSuccess fires.
+    await act(async () => {
+      resolveTokenize('square-nonce');
+    });
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ paymentNonce: 'square-nonce' })
+    );
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+  });
+
+  it('restores the Register button to its default state when the backend call fails', async () => {
+    const user = userEvent.setup();
+
+    const onSubmit = vi
+      .fn()
+      .mockRejectedValue(new Error('Payment declined by issuer'));
+    const onCalculateCost = vi.fn().mockResolvedValue(mockCostResponse);
+    const onSuccess = vi.fn();
+
+    render(
+      <RegistrationCheckoutForm
+        publicClass={mockPublicClass}
+        squareApplicationId="test-app"
+        squareLocationId="test-loc"
+        onCalculateCost={onCalculateCost}
+        onSubmit={onSubmit}
+        onSuccess={onSuccess}
+      />
+    );
+
+    const registerButton = await screen.findByRole('button', {
+      name: /Register & Pay/,
+    });
+    await waitFor(() => expect(registerButton).toBeEnabled());
+
+    fireEvent.change(screen.getByLabelText(/Full Name/), {
+      target: { value: 'Jane Doe' },
+    });
+    fireEvent.change(screen.getByLabelText(/Email Address/), {
+      target: { value: 'jane@example.com' },
+    });
+
+    await user.click(registerButton);
+
+    // After the rejection, the button must flip back from "Processing..."
+    // to its default label so the user can correct + retry.
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /Register & Pay/ })
+      ).toBeEnabled();
+    });
+    expect(screen.getByText(/Payment declined by issuer/)).toBeInTheDocument();
+    expect(onSuccess).not.toHaveBeenCalled();
   });
 
   it('disables the Register button immediately on click and ignores repeat clicks while the backend is cold-starting', async () => {

--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
@@ -337,8 +337,62 @@ export function RegistrationCheckoutForm({
   }, [quantity, discountCode, calculateCost]);
 
   /**
-   * Submit the registration with a given payment nonce.
-   * Shared by the card form submit, Google Pay callback, and Apple Pay popup.
+   * Run the registration API call and onSuccess callback for a given nonce.
+   * Assumes the caller has already flipped `isSubmitting` to true and will
+   * clear it in their own finally block. Throws on backend error so the
+   * caller can map it to `submitError`.
+   */
+  const performSubmit = useCallback(
+    async (nonce: string) => {
+      const agreementsData = hasRequiredAgreements
+        ? Array.from(signedAgreements.value.values())
+        : undefined;
+
+      const result = await onSubmit({
+        classId: publicClass.id,
+        customerEmail: customerEmail.value.trim(),
+        customerName: customerName.value.trim(),
+        customerPhone: customerPhone.value.trim() || undefined,
+        quantity: quantity.value,
+        additionalAttendees:
+          additionalAttendeesPayload.value.length > 0
+            ? additionalAttendeesPayload.value
+            : undefined,
+        discountCode: discountCode.value.trim() || undefined,
+        notes: notes.value.trim() || undefined,
+        paymentNonce: nonce,
+        agreements: agreementsData,
+      });
+
+      onSuccess({
+        confirmationNumber: result.confirmationNumber,
+        customerName: customerName.value.trim(),
+        customerEmail: customerEmail.value.trim(),
+        pricePaidCents: result.registration.pricePaidCents,
+        quantity: quantity.value,
+        agreementsSigned: result.agreementsSigned,
+      });
+    },
+    [
+      customerName,
+      customerEmail,
+      customerPhone,
+      quantity,
+      additionalAttendeesPayload,
+      discountCode,
+      notes,
+      publicClass.id,
+      onSubmit,
+      onSuccess,
+      hasRequiredAgreements,
+      signedAgreements,
+    ]
+  );
+
+  /**
+   * Submit with a nonce that arrived from outside the card form (Google Pay
+   * or Apple Pay popup). These flows don't go through `handleSubmit`, so this
+   * wrapper handles the validation guard and `isSubmitting` toggle itself.
    */
   const submitWithNonce = useCallback(
     async (nonce: string) => {
@@ -352,35 +406,7 @@ export function RegistrationCheckoutForm({
       submitError.value = null;
 
       try {
-        // Collect signed agreement data if any
-        const agreementsData = hasRequiredAgreements
-          ? Array.from(signedAgreements.value.values())
-          : undefined;
-
-        const result = await onSubmit({
-          classId: publicClass.id,
-          customerEmail: customerEmail.value.trim(),
-          customerName: customerName.value.trim(),
-          customerPhone: customerPhone.value.trim() || undefined,
-          quantity: quantity.value,
-          additionalAttendees:
-            additionalAttendeesPayload.value.length > 0
-              ? additionalAttendeesPayload.value
-              : undefined,
-          discountCode: discountCode.value.trim() || undefined,
-          notes: notes.value.trim() || undefined,
-          paymentNonce: nonce,
-          agreements: agreementsData,
-        });
-
-        onSuccess({
-          confirmationNumber: result.confirmationNumber,
-          customerName: customerName.value.trim(),
-          customerEmail: customerEmail.value.trim(),
-          pricePaidCents: result.registration.pricePaidCents,
-          quantity: quantity.value,
-          agreementsSigned: result.agreementsSigned,
-        });
+        await performSubmit(nonce);
       } catch (error) {
         submitError.value = extractErrorMessage(error);
       } finally {
@@ -388,23 +414,12 @@ export function RegistrationCheckoutForm({
       }
     },
     [
-      customerName,
-      customerEmail,
-      customerPhone,
-      quantity,
-      additionalAttendeesPayload,
-      discountCode,
-      notes,
-      publicClass.id,
-      onSubmit,
-      onSuccess,
       isSubmitting,
       submitError,
       showValidationErrors,
       isValid,
-      hasRequiredAgreements,
-      signedAgreements,
       allAgreementsSigned,
+      performSubmit,
     ]
   );
 
@@ -428,12 +443,15 @@ export function RegistrationCheckoutForm({
     if (isSubmitting.value) return;
 
     showValidationErrors.value = true;
-    if (!isValid.value) {
-      return;
-    }
+    if (!isValid.value) return;
+    if (!allAgreementsSigned.value) return;
 
+    // Flip the submitting state BEFORE awaiting Square tokenization. The
+    // tokenize call can take a noticeable moment, and without this the
+    // button stays in its default state until the network round-trip
+    // completes, leaving the user wondering whether their click registered.
+    isSubmitting.value = true;
     submitError.value = null;
-
 
     try {
       if (!tokenizeRef.current) {
@@ -443,12 +461,20 @@ export function RegistrationCheckoutForm({
       }
 
       const nonce = await tokenizeRef.current();
-      await submitWithNonce(nonce);
+      await performSubmit(nonce);
     } catch (error) {
       submitError.value = extractErrorMessage(error);
+    } finally {
       isSubmitting.value = false;
     }
-  }, [isSubmitting, submitError, showValidationErrors, isValid, submitWithNonce]);
+  }, [
+    isSubmitting,
+    submitError,
+    showValidationErrors,
+    isValid,
+    allAgreementsSigned,
+    performSubmit,
+  ]);
 
   // ============================================================
   // APPLE PAY POPUP


### PR DESCRIPTION
## Summary
- `handleSubmit` flipped `isSubmitting` only after awaiting `tokenizeRef.current()`, so the button sat in its default \"Register & Pay\" state during Square's tokenize round-trip — users had no feedback that their click registered.
- Move the `isSubmitting = true` flip to the top of `handleSubmit` (after the validation guard) so it takes effect synchronously on click.
- Split the shared submit body into a `performSubmit` helper so `handleSubmit` can call it directly without re-entering the `isSubmitting` early-return guard inside `submitWithNonce` (which is still used by the Google Pay / Apple Pay flows).
- `finally` blocks in both flows still clear `isSubmitting` on failure, so a rejected tokenize/onSubmit returns the button to its default state.

## Test plan
- [x] `vitest run libs/react/registrations/src/lib/RegistrationCheckoutForm.spec.tsx` — 8/8 pass
- [x] New test: button flips to \"Processing\" while Square tokenize is still pending (the regression this fixes)
- [x] New test: button returns to \"Register & Pay\" and enables after a rejected `onSubmit`
- [x] Existing cold-start test continues to pass (still blocks duplicate charges on repeat clicks)
- [ ] Manual: click Register on a real class — spinner appears immediately, not after the Square round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)