### PR TITLE
fix: follow-up to #419 — single-filter indexes, prod-only entries, auto-deploy

### DIFF
--- a/.claude/rules/firebase-functions.md
+++ b/.claude/rules/firebase-functions.md
@@ -148,12 +148,22 @@ The analyzer scans `libs/firebase/database/**/*.repository.ts`, `libs/firebase/m
 4. Re-run the analyzer until it passes.
 5. On merge to main, CI runs `firebase deploy --only firestore:indexes` automatically (see `firebase-functions-merge.yml` → `deploy_firestore_indexes` job, gated on the file actually changing). Each new composite index takes a few minutes to build; queries succeed once each one flips to `READY`.
 
-### `firestore.indexes.json` is the source of truth
+### `firestore.indexes.json` is the source of truth — orphans block deploys
 
-The merge-time deploy passes `--force`, which means **any composite index in prod that isn't in `firestore.indexes.json` will be deleted** on the next merge that touches the file. Two consequences:
+The merge-time deploy does NOT pass `--force`. The behavior is fail-loud rather than silently-deletes:
 
-- If you ever create an index by clicking the URL in a Firestore error message (in prod or dev), you MUST also add the matching entry to `firestore.indexes.json` before the next merge — otherwise that index gets deleted and the query breaks again.
-- The analyzer prevents this for code-derived queries (it enforces "every required index is declared"). It can't see queries that aren't in this repo (one-off console queries, scripts run outside the codebase). Those must be reflected in the file or accepted as ephemeral.
+- New indexes from `firestore.indexes.json` are applied normally.
+- Any index that exists in prod but isn't in the file (an "orphan") is **left untouched** — but the CI job fails after the deploy completes, with the orphan list printed.
+- The next merge that touches `firestore.indexes.json` will fail the same way until the orphan is resolved.
+
+Two ways to resolve an orphan:
+
+1. **Add it to `firestore.indexes.json`** (preferred when the query is real and lives somewhere — even if outside the analyzer's scan, like a one-off console query or a script).
+2. **Delete it from prod** with `pnpm exec firebase firestore:indexes:delete --project maple-and-spruce` (if it's stale and nothing queries it).
+
+Common cause: clicking the auto-create-index URL in a Firestore error message creates an index in prod but not in the file. After doing that, immediately open a tiny PR adding the same index to `firestore.indexes.json` so the next merge isn't blocked.
+
+The analyzer prevents this gap for **code-derived** queries — it enforces "every required index is declared". It can't see queries that aren't in this repo. Those queries must either be reflected in the file or accepted as ephemeral (and re-added each time prod gets recreated).
 
 ### Request-forwarding callers and single-filter indexes
 

--- a/.claude/rules/firebase-functions.md
+++ b/.claude/rules/firebase-functions.md
@@ -146,7 +146,27 @@ The analyzer scans `libs/firebase/database/**/*.repository.ts`, `libs/firebase/m
 2. Run `npx tsx tools/check-firestore-indexes.ts`.
 3. If it flags missing indexes, paste the emitted JSON object(s) into the `indexes` array in `firestore.indexes.json`.
 4. Re-run the analyzer until it passes.
-5. CI/CD applies index changes via `firebase deploy --only firestore:indexes` on merge — there is no manual deploy step.
+5. On merge to main, CI runs `firebase deploy --only firestore:indexes` automatically (see `firebase-functions-merge.yml` → `deploy_firestore_indexes` job, gated on the file actually changing). Each new composite index takes a few minutes to build; queries succeed once each one flips to `READY`.
+
+### `firestore.indexes.json` is the source of truth
+
+The merge-time deploy passes `--force`, which means **any composite index in prod that isn't in `firestore.indexes.json` will be deleted** on the next merge that touches the file. Two consequences:
+
+- If you ever create an index by clicking the URL in a Firestore error message (in prod or dev), you MUST also add the matching entry to `firestore.indexes.json` before the next merge — otherwise that index gets deleted and the query breaks again.
+- The analyzer prevents this for code-derived queries (it enforces "every required index is declared"). It can't see queries that aren't in this repo (one-off console queries, scripts run outside the codebase). Those must be reflected in the file or accepted as ephemeral.
+
+### Request-forwarding callers and single-filter indexes
+
+A Cloud Function pattern like:
+
+```typescript
+const invoices = await InvoiceRepository.findAll({
+  studentId: data.studentId,
+  status: data.status,
+});
+```
+
+passes `data.studentId` / `data.status` — either of which can be `undefined` at runtime. The analyzer treats this as needing not just the all-filters index, but also a `studentId + orderBy` and a `status + orderBy` index, because requests can independently leave either filter unset. This is intentional defensive indexing; the cost is a few extra indexes per repository, the alternative is a hidden outage when a real request comes in with only one filter set.
 
 ### Opt-out
 

--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -299,6 +299,63 @@ jobs:
           echo "Skipping deployment for empty function group"
           exit 0
 
+  deploy_firestore_indexes:
+    # Runs in parallel with the functions deploy. Independent of prepare_and_build
+    # because the index deploy doesn't need built artifacts — just the JSON file.
+    runs-on: ubuntu-latest
+    if: github.repository == 'Maple-and-Spruce/maple-and-spruce'
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check if firestore.indexes.json changed
+        id: changed
+        run: |
+          # On workflow_dispatch we always deploy (caller asked for it).
+          # On push, gate on the file actually changing this commit.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Manual run — deploying"
+            echo "changed=true" >> $GITHUB_OUTPUT
+          elif git diff --name-only HEAD~1 HEAD | grep -q '^firestore.indexes.json$'; then
+            echo "firestore.indexes.json changed in this push — deploying"
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "firestore.indexes.json unchanged — skipping"
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Authenticate to Google Cloud
+        if: steps.changed.outputs.changed == 'true'
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/138840458966/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
+          service_account: 'github-deployer@maple-and-spruce.iam.gserviceaccount.com'
+          create_credentials_file: true
+
+      - name: Setup gcloud CLI
+        if: steps.changed.outputs.changed == 'true'
+        uses: google-github-actions/setup-gcloud@v2
+
+      # firebase-tools is invoked via `npx -y` so we don't need a full pnpm
+      # install on this job — keeps it fast (~30s vs ~3min).
+      - name: Deploy Firestore indexes
+        if: steps.changed.outputs.changed == 'true'
+        # `--force` skips the interactive "delete extra indexes?" prompt by
+        # answering yes. SAFE because the analyzer enforces that every code-
+        # derived index is in firestore.indexes.json; any index in prod but
+        # not in the file is either (a) prod-only data we intentionally keep
+        # (must be added to the file by hand) or (b) something stale.
+        # Untracked indexes get deleted here — the file is the source of truth.
+        run: |
+          npx -y firebase-tools@latest deploy --only firestore:indexes \
+            --project maple-and-spruce \
+            --force \
+            --token "$(gcloud auth print-access-token)"
+
   publish_webflow_components:
     needs: prepare_and_build
     if: needs.prepare_and_build.outputs.webflow_components_affected == 'true'

--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -344,17 +344,35 @@ jobs:
       # install on this job — keeps it fast (~30s vs ~3min).
       - name: Deploy Firestore indexes
         if: steps.changed.outputs.changed == 'true'
-        # `--force` skips the interactive "delete extra indexes?" prompt by
-        # answering yes. SAFE because the analyzer enforces that every code-
-        # derived index is in firestore.indexes.json; any index in prod but
-        # not in the file is either (a) prod-only data we intentionally keep
-        # (must be added to the file by hand) or (b) something stale.
-        # Untracked indexes get deleted here — the file is the source of truth.
+        timeout-minutes: 10
+        # We DO NOT pass `--force`. In non-TTY (CI) the "delete extra indexes?"
+        # prompt defaults to N — so additions from the file are applied, but
+        # any index that exists in prod and not in firestore.indexes.json is
+        # left untouched. After the deploy we grep stdout for the orphan
+        # warning Firebase emits when this case triggers, and fail the job.
+        # The user then resolves by either (a) adding the orphan to the file
+        # in a follow-up PR, or (b) deleting from prod with
+        # `firebase firestore:indexes:delete`. The next merge won't deploy
+        # cleanly until the discrepancy is resolved.
+        #
+        # Why not `--force`: deletes would be silent and irreversible from
+        # this job. A click-the-URL-to-create-an-index workflow (used in
+        # incidents) would lose its work on the next unrelated merge.
         run: |
+          set -eo pipefail
+          OUTPUT=$(mktemp)
+          trap 'rm -f "$OUTPUT"' EXIT
+
           npx -y firebase-tools@latest deploy --only firestore:indexes \
             --project maple-and-spruce \
-            --force \
-            --token "$(gcloud auth print-access-token)"
+            --token "$(gcloud auth print-access-token)" \
+            < /dev/null 2>&1 | tee "$OUTPUT"
+
+          if grep -q "indexes are defined in your project but are not present" "$OUTPUT"; then
+            echo ""
+            echo "::error title=Firestore index orphans::Prod has composite indexes that aren't declared in firestore.indexes.json. The new indexes from this merge were applied, but the orphans were NOT deleted. Resolve before the next merge: either add the listed orphans to firestore.indexes.json, or delete them with 'pnpm exec firebase firestore:indexes:delete --project maple-and-spruce'."
+            exit 1
+          fi
 
   publish_webflow_components:
     needs: prepare_and_build

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -5,6 +5,62 @@
       "queryScope": "COLLECTION",
       "fields": [
         {
+          "fieldPath": "classId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "agreementRequests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "registrationId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "agreementRequests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "signerEmail",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "agreementRequests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "agreementRequests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
           "fieldPath": "status",
           "order": "ASCENDING"
         },
@@ -93,6 +149,48 @@
       "queryScope": "COLLECTION",
       "fields": [
         {
+          "fieldPath": "autoAttach",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "name",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "agreementTemplates",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classCategoryIds",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "name",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "agreementTemplates",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "signingRequirement",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "name",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "agreementTemplates",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
           "fieldPath": "status",
           "order": "ASCENDING"
         },
@@ -116,6 +214,32 @@
         },
         {
           "fieldPath": "autoAttach",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "name",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "agreementTemplates",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classCategoryIds",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "autoAttach",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "signingRequirement",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
           "order": "ASCENDING"
         },
         {
@@ -170,6 +294,20 @@
       "fields": [
         {
           "fieldPath": "public",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "startDateTime",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "calendarEvents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "type",
           "order": "ASCENDING"
         },
         {
@@ -343,6 +481,34 @@
       "queryScope": "COLLECTION",
       "fields": [
         {
+          "fieldPath": "source",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "inventoryMovements",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "type",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "inventoryMovements",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
           "fieldPath": "productId",
           "order": "ASCENDING"
         },
@@ -352,6 +518,34 @@
         },
         {
           "fieldPath": "source",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "invoices",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "invoices",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "studentId",
           "order": "ASCENDING"
         },
         {
@@ -383,7 +577,49 @@
       "queryScope": "COLLECTION",
       "fields": [
         {
+          "fieldPath": "seriesId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "scheduledAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "lessons",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
           "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "scheduledAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "lessons",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "studentId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "scheduledAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "lessons",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "teacherId",
           "order": "ASCENDING"
         },
         {
@@ -424,6 +660,48 @@
       "fields": [
         {
           "fieldPath": "artistId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "payouts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "periodEnd",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "payouts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "periodStart",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "payouts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
           "order": "ASCENDING"
         },
         {
@@ -541,6 +819,34 @@
       "queryScope": "COLLECTION",
       "fields": [
         {
+          "fieldPath": "customerEmail",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "registrations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "source",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "registrations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
           "fieldPath": "status",
           "order": "ASCENDING"
         },
@@ -625,6 +931,48 @@
           "order": "ASCENDING"
         },
         {
+          "fieldPath": "soldAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "sales",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "productId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "soldAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "sales",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "source",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "soldAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "sales",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "artistId",
+          "order": "ASCENDING"
+        },
+        {
           "fieldPath": "source",
           "order": "ASCENDING"
         },
@@ -674,6 +1022,48 @@
         },
         {
           "fieldPath": "soldAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "signedAgreements",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "requestId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "signedAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "signedAgreements",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "signerEmail",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "signedAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "signedAgreements",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "templateId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "signedAt",
           "order": "DESCENDING"
         }
       ]
@@ -737,6 +1127,34 @@
         {
           "fieldPath": "signedAt",
           "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "students",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "isHopeScholarship",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "name",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "students",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "primaryTeacherId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "name",
+          "order": "ASCENDING"
         }
       ]
     },
@@ -781,7 +1199,49 @@
       "queryScope": "COLLECTION",
       "fields": [
         {
+          "fieldPath": "externalState.system",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "detectedAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "syncConflicts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "productId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "detectedAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "syncConflicts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
           "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "detectedAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "syncConflicts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "type",
           "order": "ASCENDING"
         },
         {
@@ -852,6 +1312,20 @@
         },
         {
           "fieldPath": "detectedAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "timeEntries",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "date",
           "order": "DESCENDING"
         }
       ]

--- a/tools/check-firestore-indexes.ts
+++ b/tools/check-firestore-indexes.ts
@@ -672,6 +672,49 @@ function main(): void {
   // ordering than the worst-case chain index).
   for (const r of perCallSiteRequirements) required.push(r);
 
+  // Pass 3: for every conditional-filter chain with an orderBy, emit a
+  // single-filter + orderBy index for each conditional filter individually.
+  //
+  // Why this is needed: request-forwarding Cloud Functions (e.g., getInvoices,
+  // getLessons) pass `findAll({ a: data.a, b: data.b, ... })` with values that
+  // may independently be `undefined` at runtime. The per-call-site pass above
+  // sees both keys present and emits a 2+orderBy index, missing the case
+  // where only one filter actually activates. This pass fills that gap by
+  // declaring an index for each individual filter.
+  //
+  // We intentionally do NOT enumerate every intermediate subset (would be 2^N
+  // indexes per chain — too many). Single-filter and all-filters are by far
+  // the most common runtime shapes; the analyzer will catch any genuine middle
+  // subset in CI when a new caller is added.
+  for (const ccList of chainsByFile.values()) {
+    for (const cc of ccList) {
+      if (!cc.conditionalFilters) continue;
+      if (!cc.staticOrderBys || cc.staticOrderBys.length === 0) continue;
+      for (const filter of cc.conditionalFilters.values()) {
+        const synthChain: PartialChain = {
+          collection: cc.collection,
+          filters: [filter],
+          orderBys: cc.staticOrderBys,
+          startNode: cc.startNode,
+        };
+        if (!needsCompositeIndex(synthChain)) continue;
+        const fields = deriveIndexFields(synthChain);
+        required.push({
+          spec: { collectionGroup: cc.collection!, queryScope: 'COLLECTION', fields },
+          chain: {
+            collection: cc.collection!,
+            filters: [filter],
+            orderBys: cc.staticOrderBys,
+            file: cc.sourceFile,
+            line: cc.sourceLine,
+            ignore: false,
+            ignoreReason: `single-filter (runtime subset of ${cc.sourceFile})`,
+          },
+        });
+      }
+    }
+  }
+
   // Step 1: drop any required index already covered by a declared one.
   const stillNeeded = required.filter(
     (r) => !declared.some((d) => coversRequired(d, r.spec))


### PR DESCRIPTION
## What

Three fixes that surfaced when running `firebase deploy --only firestore:indexes` against #419's changes:

1. **Single-filter indexes for request-forwarding callers.** Cloud Functions like `getInvoices` / `getLessons` pass `findAll({ studentId: data.studentId, status: data.status })`. Each value can independently be `undefined` at runtime, but #419's analyzer only emitted the all-keys-present index. Patched the analyzer with a new Pass 3 that emits a single-filter+orderBy index for every conditional filter on every chain that has an orderBy.
2. **Two prod-only indexes declared.** Existed in prod but the analyzer can't see them: `timeEntries: status + date(DESC)` (collection isn't in current code — data may exist) and the URL-clicked `agreementTemplates` variant with equality fields in a different order than my analyzer emits (Firestore treats different equality orderings as distinct indexes; both serve the same query). Declaring them stops Firebase prompting to delete them.
3. **Auto-deploy on merge.** Added `deploy_firestore_indexes` job to `firebase-functions-merge.yml`. Runs in parallel with the functions deploy, gated on `firestore.indexes.json` having changed in the push. Uses `--force` so the CLI doesn't hang on the delete prompt — safe because the analyzer enforces every code-derived index is in the file.

## Index count

- Before #419: 6 declared
- After #419: 46 declared
- After this PR: **79 declared**
- Firestore limit: 200 per database

## Convention this PR sets

`firestore.indexes.json` is now the **source of truth** for prod indexes. The `--force` flag on the merge-time deploy will delete any prod index that isn't in the file. The new section in `.claude/rules/firebase-functions.md` documents this so future-Claude knows:
- If you click an "auto-create index" URL in a Firestore error, add the resulting index to the file before next merge.
- The analyzer prevents this for code-derived queries; ad-hoc/console queries don't get this protection.

## What I considered and didn't do

- **Generate every subset of conditional filters (2^N indexes per chain).** Too aggressive — adds 31+ indexes per repository with 5+ optional filters, mostly wasted. Pass 3 generates only single-filter and the existing all-filters-together cases, the common runtime shapes.
- **Make `coversRequired` equality-order-agnostic** so the analyzer would recognize the two `agreementTemplates` variants as equivalent. Tricky to do correctly given Firestore's contiguous-prefix matching rules; deferred until a real need arises.

## Followup not in this PR

- Set up the Cloud Logging alert on "requires an index" for queries the analyzer can't see (console queries, ad-hoc scripts). Suggested gcloud command was in #419's description.