### PR TITLE
fix: registration cost off-by-one when adding/removing attendees

### DIFF
--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.spec.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.spec.tsx
@@ -527,3 +527,105 @@ describe('RegistrationCheckoutForm — digital wallet + agreements', () => {
     await waitFor(() => expect(registerButton).toBeEnabled());
   });
 });
+
+// ============================================================
+// Quantity recalculation when attendees are added / removed
+//
+// Regression: PR #417 introduced a multi-attendee flow that called
+// `calculateCost(quantity.value + 1)` after pushing a new attendee
+// into the signal. Because `quantity` is a computed of
+// `additionalAttendees.length + 1`, reading it after the write
+// already reflects the new total — the +1 double-counted and the
+// backend returned cost for N+1 people while the UI displayed N.
+// Customers were overcharged by one ticket. These tests lock in
+// the corrected behaviour.
+// ============================================================
+describe('RegistrationCheckoutForm — attendee quantity recalculation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('recalculates cost with the new total (not total+1) when an attendee is added', async () => {
+    const user = userEvent.setup();
+
+    const onCalculateCost = vi.fn().mockResolvedValue(mockCostResponse);
+
+    render(
+      <RegistrationCheckoutForm
+        publicClass={mockPublicClass}
+        squareApplicationId="test-app"
+        squareLocationId="test-loc"
+        onCalculateCost={onCalculateCost}
+        onSubmit={vi.fn()}
+        onSuccess={vi.fn()}
+      />
+    );
+
+    // Initial mount fires onCalculateCost with quantity 1.
+    await waitFor(() =>
+      expect(onCalculateCost).toHaveBeenCalledWith('class-1', 1, undefined)
+    );
+
+    await user.click(
+      screen.getByRole('button', { name: /Add another person/ })
+    );
+
+    // Adding one attendee → 2 people total, not 3.
+    await waitFor(() =>
+      expect(onCalculateCost).toHaveBeenLastCalledWith('class-1', 2, undefined)
+    );
+
+    await user.click(
+      screen.getByRole('button', { name: /Add another person/ })
+    );
+
+    // Adding a second attendee → 3 people total, not 4.
+    await waitFor(() =>
+      expect(onCalculateCost).toHaveBeenLastCalledWith('class-1', 3, undefined)
+    );
+  });
+
+  it('recalculates cost with the new total (not total-1) when an attendee is removed', async () => {
+    const user = userEvent.setup();
+
+    const onCalculateCost = vi.fn().mockResolvedValue(mockCostResponse);
+
+    render(
+      <RegistrationCheckoutForm
+        publicClass={mockPublicClass}
+        squareApplicationId="test-app"
+        squareLocationId="test-loc"
+        onCalculateCost={onCalculateCost}
+        onSubmit={vi.fn()}
+        onSuccess={vi.fn()}
+      />
+    );
+
+    await waitFor(() =>
+      expect(onCalculateCost).toHaveBeenCalledWith('class-1', 1, undefined)
+    );
+
+    // Add two attendees so we can remove one.
+    await user.click(
+      screen.getByRole('button', { name: /Add another person/ })
+    );
+    await user.click(
+      screen.getByRole('button', { name: /Add another person/ })
+    );
+    await waitFor(() =>
+      expect(onCalculateCost).toHaveBeenLastCalledWith('class-1', 3, undefined)
+    );
+
+    // Remove the first attendee → 2 people total, not 1.
+    await user.click(
+      screen.getByRole('button', { name: /Remove additional person 1/ })
+    );
+    await waitFor(() =>
+      expect(onCalculateCost).toHaveBeenLastCalledWith('class-1', 2, undefined)
+    );
+  });
+});

--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
@@ -297,7 +297,9 @@ export function RegistrationCheckoutForm({
         { nameRevealed: false, sendConfirmation: false, name: '', email: '' },
       ];
     });
-    calculateCost(quantity.value + 1, discountCode.value);
+    // `quantity` is computed from additionalAttendees.length, so reading it
+    // after the batch already reflects the new total — no +1 offset.
+    calculateCost(quantity.value, discountCode.value);
   }, [
     additionalAttendees,
     calculateCost,
@@ -315,7 +317,7 @@ export function RegistrationCheckoutForm({
           (_, i) => i !== index
         );
       });
-      calculateCost(quantity.value - 1, discountCode.value);
+      calculateCost(quantity.value, discountCode.value);
     },
     [additionalAttendees, calculateCost, discountCode, quantity, quantityWarning]
   );


### PR DESCRIPTION
## Summary

- Customers were overcharged by one ticket whenever they added an additional attendee. The cost summary correctly displayed `2 x \$100.00` but the totals reflected 3 people (e.g. \$300 subtotal, \$318 with tax instead of \$212).
- Root cause: `handleAddAttendee` / `handleRemoveAttendee` in `RegistrationCheckoutForm.tsx` called `calculateCost(quantity.value + 1, …)` and `calculateCost(quantity.value - 1, …)` *after* mutating `additionalAttendees`. Because `quantity` is `useComputed(() => 1 + additionalAttendees.value.length)`, the read already reflected the new total — the manual offset double-counted.
- Fix: pass `quantity.value` directly to `calculateCost` in both handlers.
- Adds two regression tests asserting the args of `onCalculateCost` after add and after remove.

Introduced in #417 (multi-attendee class registration).

## Test plan

- [x] `npx vitest run --config libs/react/registrations/vitest.config.ts` — all 19 tests pass, including the 2 new ones
- [ ] Manual: load the registration page, add an attendee, confirm `2 x \$100.00 = \$200.00` (not \$300)
- [ ] Manual: add 2 attendees, remove one, confirm cost summary shows `2 x` totals
- [ ] Manual: apply a discount code with multiple attendees, confirm the discount maths off the correct subtotal

🤖 Generated with [Claude Code](https://claude.com/claude-code)