### PR TITLE
feat: list registered attendees in purchaser confirmation email

### DIFF
--- a/apps/functions-integration-tests-square/src/create-registration.spec.ts
+++ b/apps/functions-integration-tests-square/src/create-registration.spec.ts
@@ -195,6 +195,13 @@ describe('createRegistration', () => {
 
       expect(registrantMail?.template?.name).toBe('registration-confirmation');
       expect(registrantMail?.template?.data?.extrasWithoutEmailCount).toBe(1);
+      // Full attendee roster (primary purchaser first, then additional
+      // attendees) is included so the registrant can see who they signed up.
+      expect(registrantMail?.template?.data?.attendees).toEqual([
+        { name: 'Pat Registrant', email: 'registrant@test.com' },
+        { name: 'Alice Friend', email: 'alice@test.com' },
+        { name: 'Bob Friend' },
+      ]);
 
       expect(attendeeMail?.template?.name).toBe(
         'registration-confirmation-attendee'

--- a/libs/firebase/maple-functions/create-registration/src/lib/create-registration.ts
+++ b/libs/firebase/maple-functions/create-registration/src/lib/create-registration.ts
@@ -717,6 +717,18 @@ export const createRegistration = Functions.endpoint
         const extrasWithoutEmailCount =
           additionalAttendees.length - attendeesWithEmail.length;
 
+        // Full roster shown in the registrant's confirmation: primary
+        // purchaser first, then each additional attendee they entered.
+        const attendees = [
+          { name: data.customerName, email: data.customerEmail },
+          ...additionalAttendees
+            .map((a) => ({
+              name: a.name?.trim() || undefined,
+              email: a.email?.trim() || undefined,
+            }))
+            .filter((a) => a.name || a.email),
+        ];
+
         await db.collection('mail').add({
           to: data.customerEmail,
           template: {
@@ -749,6 +761,7 @@ export const createRegistration = Functions.endpoint
                   : undefined,
               extrasWithoutEmailNoun:
                 extrasWithoutEmailCount === 1 ? 'friend' : 'friends',
+              attendees,
             },
           },
         });

--- a/tools/seed-email-templates.ts
+++ b/tools/seed-email-templates.ts
@@ -106,6 +106,18 @@ const registrationConfirmationHtml = `<!DOCTYPE html>
       </tr>
     </table>
 
+    {{#if attendees}}
+    <h3 style="color: #4A3728; font-size: 18px; margin: 24px 0 8px;">Registered attendees</h3>
+    <table class="detail-table">
+      {{#each attendees}}
+      <tr>
+        <td class="label">{{#if name}}{{name}}{{else}}(no name){{/if}}</td>
+        <td>{{#if email}}{{email}}{{else}}<span style="color: #999;">no email provided</span>{{/if}}</td>
+      </tr>
+      {{/each}}
+    </table>
+    {{/if}}
+
     {{#if receiptUrl}}
     <p><a href="{{receiptUrl}}" style="color: #6B7B5E; font-weight: bold;">View Payment Receipt</a></p>
     {{/if}}


### PR DESCRIPTION
## Summary
- Adds a **Registered attendees** table to the primary purchaser's `registration-confirmation` email — primary purchaser first, then each additional attendee they entered.
- Each row shows the attendee's name (or `(no name)`) and email (or a muted "no email provided" hint), so the registrant can verify the roster at a glance and know which friends still need a manual reminder.
- Updates the matching integration-test assertion to lock in the `attendees` array contract.

## Post-merge step
The Handlebars template lives in Firestore (Trigger Email extension), so the new section won't render until templates are re-seeded:

```
npx tsx tools/seed-email-templates.ts --prod
```

## Test plan
- [ ] Run `./tools/run-integration-tests.sh square` and confirm the multi-attendee `createRegistration` spec passes.
- [ ] After merge + re-seed: place a test registration with `quantity=3`, one additional attendee with email and one without, and verify the new "Registered attendees" block renders in the purchaser's email with the no-email hint on the second row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)