### PR TITLE
feat: server-side lead attribution via Tally webhook → GA4 + Meta CAPI

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -32,3 +32,16 @@ GOOGLE_CALENDAR_ADHOC_ICS_URL=
 # Class Reminders
 # Google Business Profile review shortlink used in the day-of class reminder email.
 GOOGLE_REVIEW_URL=https://g.page/r/CVjnXa8bifPBEBM/review
+
+# Lead attribution (Tally → GA4 + Meta CAPI)
+# Defaults match the production stream / pixel. Dev events currently land
+# in the same GA4 + Meta destinations as prod — see
+# docs/guides/tally-lead-webhook-setup.md "Dev / prod isolation" for the
+# separate-pixel option. These must be set (even to default values) or
+# the Firebase emulator prompts via stdin for each defineString param
+# and the boot hangs in CI.
+GA4_MEASUREMENT_ID=G-TY0E9X31V6
+META_PIXEL_ID=1625932185289127
+GA4_BASE_URL=https://www.google-analytics.com
+META_CAPI_BASE_URL=https://graph.facebook.com
+META_CAPI_API_VERSION=v20.0

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -359,7 +359,13 @@ jobs:
 
           # maple-core: Etsy mock server URL + fake secrets
           echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions/.env
-          printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions/.secret.local
+          # Tally lead webhook → GA4 + Meta CAPI mock servers
+          echo "GA4_BASE_URL=http://localhost:9995" >> dist/apps/functions/.env
+          echo "META_CAPI_BASE_URL=http://localhost:9994" >> dist/apps/functions/.env
+          echo "GA4_MEASUREMENT_ID=G-TEST-MOCK" >> dist/apps/functions/.env
+          echo "META_PIXEL_ID=test-pixel-id" >> dist/apps/functions/.env
+          echo "META_CAPI_API_VERSION=v20.0" >> dist/apps/functions/.env
+          printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\nTALLY_WEBHOOK_SECRET=test-tally-secret\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions/.secret.local
 
           # maple-square: Square mock server URL + fake secrets
           echo "SQUARE_BASE_URL=http://localhost:9997" >> dist/apps/functions-square/.env
@@ -378,13 +384,17 @@ jobs:
           # parallel invocations try to download tsx simultaneously
           npx tsx --version
 
-          # Start per-service mock HTTP servers (Square, Webflow, Etsy)
+          # Start per-service mock HTTP servers (Square, Webflow, Etsy, GA4, Meta CAPI)
           SQUARE_MOCK_SERVER_PORT=9997 npx tsx libs/firebase/square-test-mock-server/start.ts &
           SQUARE_MOCK_PID=$!
           WEBFLOW_MOCK_SERVER_PORT=9996 npx tsx libs/firebase/webflow-test-mock-server/start.ts &
           WEBFLOW_MOCK_PID=$!
           ETSY_MOCK_SERVER_PORT=9998 npx tsx libs/firebase/etsy-test-mock-server/start.ts &
           ETSY_MOCK_PID=$!
+          GA4_MOCK_SERVER_PORT=9995 npx tsx libs/firebase/ga4-test-mock-server/start.ts &
+          GA4_MOCK_PID=$!
+          META_CAPI_MOCK_SERVER_PORT=9994 npx tsx libs/firebase/meta-capi-test-mock-server/start.ts &
+          META_CAPI_MOCK_PID=$!
           sleep 2
 
           # Run the suites assigned to this matrix group
@@ -395,6 +405,8 @@ jobs:
           kill $SQUARE_MOCK_PID 2>/dev/null || true
           kill $WEBFLOW_MOCK_PID 2>/dev/null || true
           kill $ETSY_MOCK_PID 2>/dev/null || true
+          kill $GA4_MOCK_PID 2>/dev/null || true
+          kill $META_CAPI_MOCK_PID 2>/dev/null || true
           exit $EXIT_CODE
 
   integration-tests-result:

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -516,7 +516,9 @@ jobs:
 
           # maple-core: Etsy mock server URL + fake secrets
           echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions/.env
-          printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions/.secret.local
+          # tallyLeadWebhook (maple-core) declares these defineSecret params;
+          # without them the emulator silently waits on stdin for each one.
+          printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\nTALLY_WEBHOOK_SECRET=test-tally-secret\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions/.secret.local
 
           # maple-square: real Square sandbox (no SQUARE_BASE_URL → SDK
           # uses its built-in sandbox endpoint). Etsy still mocked.

--- a/apps/functions-integration-tests-tally-lead-webhook/project.json
+++ b/apps/functions-integration-tests-tally-lead-webhook/project.json
@@ -1,0 +1,21 @@
+{
+  "name": "functions-integration-tests-tally-lead-webhook",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/functions-integration-tests-tally-lead-webhook/src",
+  "projectType": "application",
+  "tags": ["type:e2e"],
+  "implicitDependencies": [
+    "firebase-maple-functions-tally-lead-webhook",
+    "firebase-integration-test-utils",
+    "firebase-ga4-test-mock-server",
+    "firebase-meta-capi-test-mock-server"
+  ],
+  "targets": {
+    "test": {
+      "executor": "@nx/vitest:test",
+      "options": {
+        "config": "apps/functions-integration-tests-tally-lead-webhook/vitest.config.ts"
+      }
+    }
+  }
+}

--- a/apps/functions-integration-tests-tally-lead-webhook/src/tally-lead-webhook.spec.ts
+++ b/apps/functions-integration-tests-tally-lead-webhook/src/tally-lead-webhook.spec.ts
@@ -1,0 +1,377 @@
+/**
+ * Integration tests for the tallyLeadWebhook Cloud Function.
+ *
+ * Exercises the deployed onRequest endpoint through the Functions emulator
+ * with GA4 and Meta CAPI traffic redirected to the per-service mock
+ * servers. Verifies:
+ *   - HMAC signature gate (401 on mismatch, no downstream calls)
+ *   - Vest validation gate (400 on missing email, no downstream calls)
+ *   - Happy path fan-out to both endpoints with the right payload
+ *   - Single-channel resilience: if either downstream fails, the other
+ *     still fires and Tally still gets a 200 ack
+ *   - Tally retry semantics — duplicate submissions hit both endpoints
+ *     twice (we don't deduplicate on the server)
+ */
+import { createHmac, createHash } from 'crypto';
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { EMULATOR_CONFIG } from '@maple/firebase/integration-test-utils';
+
+// Must match what tools/run-integration-tests.sh writes to .secret.local
+const TALLY_SECRET = 'test-tally-secret';
+const META_PIXEL_ID = 'test-pixel-id';
+
+const WEBHOOK_URL = `${EMULATOR_CONFIG.functionsHost}/${EMULATOR_CONFIG.projectId}/${EMULATOR_CONFIG.region}/tallyLeadWebhook`;
+const GA4_MOCK_URL = EMULATOR_CONFIG.ga4MockServerUrl;
+const META_MOCK_URL = EMULATOR_CONFIG.metaCapiMockServerUrl;
+
+interface TallyHiddenField {
+  label: string;
+  type: string;
+  value: string;
+}
+
+function tallyPayload(overrides: {
+  email?: string | null;
+  hidden?: Partial<{
+    gaClientId: string;
+    fbp: string;
+    fbc: string;
+    utmSource: string;
+    utmMedium: string;
+    utmCampaign: string;
+    utmContent: string;
+    utmTerm: string;
+    referrer: string;
+    landingPage: string;
+  }>;
+} = {}): Record<string, unknown> {
+  const h = overrides.hidden ?? {};
+  const fields: TallyHiddenField[] = [];
+
+  if (overrides.email !== null) {
+    fields.push({
+      label: 'Email',
+      type: 'INPUT_EMAIL',
+      value: overrides.email ?? 'lead@example.com',
+    });
+  }
+
+  const hiddenMap: Array<[string, string | undefined]> = [
+    ['_ga_client_id', h.gaClientId],
+    ['_fbp', h.fbp],
+    ['_fbc', h.fbc],
+    ['utm_source', h.utmSource],
+    ['utm_medium', h.utmMedium],
+    ['utm_campaign', h.utmCampaign],
+    ['utm_content', h.utmContent],
+    ['utm_term', h.utmTerm],
+    ['referrer', h.referrer],
+    ['landing_page', h.landingPage],
+  ];
+
+  for (const [label, value] of hiddenMap) {
+    fields.push({
+      label,
+      type: 'HIDDEN_FIELDS',
+      value: value ?? '',
+    });
+  }
+
+  return {
+    eventId: `evt-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    eventType: 'FORM_RESPONSE',
+    createdAt: new Date().toISOString(),
+    data: {
+      submissionId: `sub-${Date.now()}`,
+      formId: 'test-form',
+      fields,
+    },
+  };
+}
+
+function signBody(rawBody: string, secret: string): string {
+  return createHmac('sha256', secret).update(rawBody).digest('base64');
+}
+
+function hashEmail(email: string): string {
+  return createHash('sha256').update(email.trim().toLowerCase()).digest('hex');
+}
+
+async function postWebhook(options: {
+  body: unknown;
+  signature?: string;
+  signWith?: string;
+  userAgent?: string;
+}): Promise<{ status: number; body: unknown }> {
+  const raw = JSON.stringify(options.body);
+  const signature =
+    options.signature ??
+    (options.signWith ? signBody(raw, options.signWith) : undefined);
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (signature) headers['tally-signature'] = signature;
+  if (options.userAgent) headers['User-Agent'] = options.userAgent;
+
+  const response = await fetch(WEBHOOK_URL, {
+    method: 'POST',
+    headers,
+    body: raw,
+  });
+
+  const text = await response.text();
+  let parsed: unknown = text;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    /* keep raw text */
+  }
+  return { status: response.status, body: parsed };
+}
+
+interface RecordedRequest {
+  method: string;
+  path: string;
+  query: Record<string, string>;
+  pixelId?: string;
+  apiVersion?: string;
+  headers: Record<string, string | string[] | undefined>;
+  body: unknown;
+}
+
+async function resetMocks(): Promise<void> {
+  await Promise.all([
+    fetch(`${GA4_MOCK_URL}/_mock/reset`, { method: 'POST' }),
+    fetch(`${META_MOCK_URL}/_mock/reset`, { method: 'POST' }),
+  ]);
+}
+
+async function setGa4Failure(status: number | null): Promise<void> {
+  await fetch(`${GA4_MOCK_URL}/_mock/failure-status`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status }),
+  });
+}
+
+async function setMetaFailure(status: number | null): Promise<void> {
+  await fetch(`${META_MOCK_URL}/_mock/failure-status`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status }),
+  });
+}
+
+async function getGa4Requests(): Promise<RecordedRequest[]> {
+  const res = await fetch(`${GA4_MOCK_URL}/_mock/requests`);
+  const json = (await res.json()) as { requests: RecordedRequest[] };
+  return json.requests.filter((r) => r.path.startsWith('/mp/collect'));
+}
+
+async function getMetaRequests(): Promise<RecordedRequest[]> {
+  const res = await fetch(`${META_MOCK_URL}/_mock/requests`);
+  const json = (await res.json()) as { requests: RecordedRequest[] };
+  return json.requests.filter((r) => /^\/v\d+\.\d+\/[^/]+\/events$/.test(r.path));
+}
+
+describe('tallyLeadWebhook', () => {
+  beforeAll(async () => {
+    await resetMocks();
+  });
+
+  beforeEach(async () => {
+    await resetMocks();
+  });
+
+  describe('Signature verification', () => {
+    it('rejects requests with no signature header', async () => {
+      const result = await postWebhook({
+        body: tallyPayload(),
+      });
+      expect(result.status).toBe(401);
+      expect(await getGa4Requests()).toHaveLength(0);
+      expect(await getMetaRequests()).toHaveLength(0);
+    });
+
+    it('rejects requests with a wrong signature', async () => {
+      const result = await postWebhook({
+        body: tallyPayload(),
+        signature: 'not-the-right-signature',
+      });
+      expect(result.status).toBe(401);
+      expect(await getGa4Requests()).toHaveLength(0);
+      expect(await getMetaRequests()).toHaveLength(0);
+    });
+
+    it('rejects requests signed with the wrong secret', async () => {
+      const result = await postWebhook({
+        body: tallyPayload(),
+        signWith: 'wrong-secret',
+      });
+      expect(result.status).toBe(401);
+      expect(await getGa4Requests()).toHaveLength(0);
+      expect(await getMetaRequests()).toHaveLength(0);
+    });
+  });
+
+  describe('Payload validation', () => {
+    it('returns 400 and skips downstream calls when email is missing', async () => {
+      const result = await postWebhook({
+        body: tallyPayload({ email: null }),
+        signWith: TALLY_SECRET,
+      });
+      expect(result.status).toBe(400);
+      expect((result.body as { error?: string }).error).toBe(
+        'Invalid lead payload'
+      );
+      expect(await getGa4Requests()).toHaveLength(0);
+      expect(await getMetaRequests()).toHaveLength(0);
+    });
+  });
+
+  describe('Happy path fan-out', () => {
+    it('fires generate_lead to GA4 and Lead to Meta CAPI with attribution context', async () => {
+      const payload = tallyPayload({
+        email: 'Lead@Example.COM',
+        hidden: {
+          gaClientId: '1234567890.0987654321',
+          fbp: 'fb.1.1700000000000.1234567890',
+          fbc: 'fb.1.1700000000000.AbCdEfGhIj',
+          utmSource: 'instagram',
+          utmMedium: 'social',
+          utmCampaign: 'spring-classes',
+          referrer: 'https://www.instagram.com/',
+          landingPage: 'https://mapleandsprucewv.com/classes',
+        },
+      });
+
+      const result = await postWebhook({
+        body: payload,
+        signWith: TALLY_SECRET,
+        userAgent: 'TestAgent/1.0',
+      });
+
+      expect(result.status).toBe(200);
+      expect((result.body as { ga4?: string }).ga4).toBe('fulfilled');
+      expect((result.body as { meta?: string }).meta).toBe('fulfilled');
+
+      const ga4Requests = await getGa4Requests();
+      expect(ga4Requests).toHaveLength(1);
+      const ga4 = ga4Requests[0];
+      expect(ga4.method).toBe('POST');
+      expect(ga4.query['measurement_id']).toBe('G-TEST-MOCK');
+      expect(ga4.query['api_secret']).toBe('test-ga4-secret');
+      const ga4Body = ga4.body as {
+        client_id: string;
+        events: Array<{ name: string; params: Record<string, string> }>;
+      };
+      expect(ga4Body.client_id).toBe('1234567890.0987654321');
+      expect(ga4Body.events[0].name).toBe('generate_lead');
+      expect(ga4Body.events[0].params).toMatchObject({
+        source: 'instagram',
+        medium: 'social',
+        campaign: 'spring-classes',
+        page_referrer: 'https://www.instagram.com/',
+        page_location: 'https://mapleandsprucewv.com/classes',
+      });
+
+      const metaRequests = await getMetaRequests();
+      expect(metaRequests).toHaveLength(1);
+      const meta = metaRequests[0];
+      expect(meta.apiVersion).toBe('v20.0');
+      expect(meta.pixelId).toBe(META_PIXEL_ID);
+      expect(meta.query['access_token']).toBe('test-meta-token');
+      const metaBody = meta.body as {
+        data: Array<{
+          event_name: string;
+          action_source: string;
+          event_source_url?: string;
+          user_data: Record<string, unknown>;
+          custom_data: Record<string, unknown>;
+        }>;
+      };
+      const event = metaBody.data[0];
+      expect(event.event_name).toBe('Lead');
+      expect(event.action_source).toBe('website');
+      expect(event.event_source_url).toBe(
+        'https://mapleandsprucewv.com/classes'
+      );
+      // Lowercased + SHA-256 hashed email
+      expect((event.user_data['em'] as string[])[0]).toBe(
+        hashEmail('Lead@Example.COM')
+      );
+      expect(event.user_data['fbp']).toBe('fb.1.1700000000000.1234567890');
+      expect(event.user_data['fbc']).toBe('fb.1.1700000000000.AbCdEfGhIj');
+      expect(event.user_data['client_user_agent']).toBe('TestAgent/1.0');
+      expect(event.custom_data).toMatchObject({
+        utm_source: 'instagram',
+        utm_medium: 'social',
+        utm_campaign: 'spring-classes',
+      });
+    });
+
+    it('fires both calls even without attribution cookies (minimal payload)', async () => {
+      const result = await postWebhook({
+        body: tallyPayload({ email: 'minimal@example.com' }),
+        signWith: TALLY_SECRET,
+      });
+      expect(result.status).toBe(200);
+      expect(await getGa4Requests()).toHaveLength(1);
+      expect(await getMetaRequests()).toHaveLength(1);
+    });
+  });
+
+  describe('Partial-failure resilience', () => {
+    it('returns 200 with meta=fulfilled when GA4 fails', async () => {
+      await setGa4Failure(500);
+      try {
+        const result = await postWebhook({
+          body: tallyPayload(),
+          signWith: TALLY_SECRET,
+        });
+        expect(result.status).toBe(200);
+        expect((result.body as { ga4?: string }).ga4).toBe('rejected');
+        expect((result.body as { meta?: string }).meta).toBe('fulfilled');
+        expect(await getGa4Requests()).toHaveLength(1); // attempted
+        expect(await getMetaRequests()).toHaveLength(1); // succeeded
+      } finally {
+        await setGa4Failure(null);
+      }
+    });
+
+    it('returns 200 with ga4=fulfilled when Meta CAPI fails', async () => {
+      await setMetaFailure(500);
+      try {
+        const result = await postWebhook({
+          body: tallyPayload(),
+          signWith: TALLY_SECRET,
+        });
+        expect(result.status).toBe(200);
+        expect((result.body as { ga4?: string }).ga4).toBe('fulfilled');
+        expect((result.body as { meta?: string }).meta).toBe('rejected');
+        expect(await getGa4Requests()).toHaveLength(1); // succeeded
+        expect(await getMetaRequests()).toHaveLength(1); // attempted
+      } finally {
+        await setMetaFailure(null);
+      }
+    });
+  });
+
+  describe('Tally retry semantics', () => {
+    // Tally retries on 5xx. The function does not deduplicate by
+    // submissionId, so two deliveries of the same submission fire both
+    // downstream calls twice. This is documented behavior: GA4 and Meta
+    // tolerate occasional duplicates, and the alternative (storing
+    // dedupe state) introduces a Firestore write on the hot path.
+    it('processes duplicate submissions independently', async () => {
+      const payload = tallyPayload({ email: 'dupe@example.com' });
+      const r1 = await postWebhook({ body: payload, signWith: TALLY_SECRET });
+      const r2 = await postWebhook({ body: payload, signWith: TALLY_SECRET });
+      expect(r1.status).toBe(200);
+      expect(r2.status).toBe(200);
+      expect(await getGa4Requests()).toHaveLength(2);
+      expect(await getMetaRequests()).toHaveLength(2);
+    });
+  });
+});

--- a/apps/functions-integration-tests-tally-lead-webhook/tsconfig.json
+++ b/apps/functions-integration-tests-tally-lead-webhook/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/apps/functions-integration-tests-tally-lead-webhook/tsconfig.spec.json
+++ b/apps/functions-integration-tests-tally-lead-webhook/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "types": ["vitest/globals", "node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/functions-integration-tests-tally-lead-webhook/vitest.config.ts
+++ b/apps/functions-integration-tests-tally-lead-webhook/vitest.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@maple/firebase/integration-test-utils': path.resolve(
+        __dirname,
+        '../../libs/firebase/integration-test-utils/src/index.ts'
+      ),
+      '@maple/firebase/ga4-test-mock-server': path.resolve(
+        __dirname,
+        '../../libs/firebase/ga4-test-mock-server/src/index.ts'
+      ),
+      '@maple/firebase/meta-capi-test-mock-server': path.resolve(
+        __dirname,
+        '../../libs/firebase/meta-capi-test-mock-server/src/index.ts'
+      ),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    root: path.resolve(__dirname),
+    include: ['src/**/*.spec.ts'],
+    setupFiles: ['../../libs/firebase/integration-test-utils/src/lib/setup.ts'],
+    testTimeout: 30000,
+    hookTimeout: 30000,
+    fileParallelism: false,
+    sequence: {
+      concurrent: false,
+    },
+  },
+});

--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -200,3 +200,6 @@ export { getPayouts } from '@maple/firebase/maple-functions/get-payouts';
 export { listUsers } from '@maple/firebase/maple-functions/list-users';
 export { grantAdminRole } from '@maple/firebase/maple-functions/grant-admin-role';
 export { revokeAdminRole } from '@maple/firebase/maple-functions/revoke-admin-role';
+
+// Lead attribution (Tally newsletter signups → GA4 Measurement Protocol + Meta CAPI)
+export { tallyLeadWebhook } from '@maple/firebase/maple-functions/tally-lead-webhook';

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -111,6 +111,7 @@
     "../../libs/firebase/maple-functions/list-users/**/*.ts",
     "../../libs/firebase/maple-functions/grant-admin-role/**/*.ts",
     "../../libs/firebase/maple-functions/revoke-admin-role/**/*.ts",
+    "../../libs/firebase/maple-functions/tally-lead-webhook/**/*.ts",
     "../../libs/firebase/database/src/**/*.ts",
     "../../libs/firebase/functions/src/**/*.ts",
     "../../libs/ts/domain/src/**/*.ts",

--- a/docs/guides/tally-lead-webhook-setup.md
+++ b/docs/guides/tally-lead-webhook-setup.md
@@ -1,0 +1,246 @@
+# Tally Lead Webhook Setup
+
+End-to-end setup for the `tallyLeadWebhook` Cloud Function — the server-side
+replacement for Tally's paid GA4 / Meta Pixel integrations. The function
+itself is in `libs/firebase/maple-functions/tally-lead-webhook/`. This guide
+covers the manual configuration the function depends on:
+
+1. Generate the GA4 Measurement Protocol API secret
+2. Generate the Meta Conversions API access token
+3. Set Firebase secrets and (optional) string overrides
+4. Configure the Tally form: hidden fields + webhook + signing secret
+5. Add the Webflow page snippet that populates hidden fields from cookies
+
+You only need to do this once per environment (dev + prod). Re-do it any
+time the GA4 stream or Meta pixel changes.
+
+---
+
+## What this fixes
+
+- **GA4** showed zero `generate_lead` key events attributed to any
+  source/medium because Tally never fires the event in the browser.
+- **Meta** only saw browser-side Pixel `Lead` events, which iOS drops in
+  attribution.
+
+The function listens to the Tally form's webhook, validates the HMAC
+signature, pulls attribution context out of hidden fields, and fans out
+to GA4 Measurement Protocol (`generate_lead`) and Meta CAPI (`Lead`) in
+parallel. Tally retries 5xx, so we always 200 once the payload is
+validated; if either downstream fails, the other still runs.
+
+---
+
+## 1. Generate the GA4 Measurement Protocol API secret
+
+1. Open GA4 → **Admin** → under the property, **Data Streams**.
+2. Click the web stream for `mapleandsprucewv.com`.
+3. Scroll to **Events** → **Measurement Protocol API secrets** →
+   **Create**.
+4. Nickname it `tally-lead-webhook`. Copy the secret value — you cannot
+   view it again.
+
+The Measurement ID from the same stream (looks like `G-XXXXXXXXXX`) is
+the GA4 destination. The function defaults to `G-TY0E9X31V6`; override
+via the `GA4_MEASUREMENT_ID` Firebase string param if the production
+stream changes.
+
+## 2. Generate the Meta Conversions API access token
+
+1. Open Meta **Events Manager** → select the `mapleandsprucewv.com`
+   pixel (id `1625932185289127`).
+2. **Settings** → **Conversions API** → **Generate access token**.
+3. Copy the token immediately — Events Manager hides it after the first
+   view.
+
+Pixel id and API version are configurable via `META_PIXEL_ID` and
+`META_CAPI_API_VERSION` string params (defaults: `1625932185289127`,
+`v20.0`). The function constructs the URL as
+`/{META_CAPI_API_VERSION}/{META_PIXEL_ID}/events`.
+
+## 3. Set the Firebase secrets
+
+Run from a fresh terminal where `firebase login` succeeded — pasting
+secrets while screen-sharing or with a clipboard manager open is a quick
+way to leak them.
+
+```bash
+# Dev project
+firebase use maple-and-spruce-dev
+firebase functions:secrets:set TALLY_WEBHOOK_SECRET   # paste the value from Tally (step 4)
+firebase functions:secrets:set GA4_API_SECRET         # value from step 1
+firebase functions:secrets:set META_CAPI_TOKEN        # value from step 2
+
+# Prod project
+firebase use maple-and-spruce
+firebase functions:secrets:set TALLY_WEBHOOK_SECRET
+firebase functions:secrets:set GA4_API_SECRET
+firebase functions:secrets:set META_CAPI_TOKEN
+```
+
+The function reads them at runtime via `defineSecret` and only mounts
+them when the request actually invokes the function, so adding the
+secrets does not require a redeploy of the entire codebase.
+
+## 4. Configure the Tally form
+
+The newsletter form lives in workspace `mJJjAd`. Open the form in
+Tally's editor (the one wired into the `/newsletter` page on Webflow —
+not the contact form).
+
+### Hidden fields
+
+Add the following **Hidden fields** (Form settings → Hidden fields).
+Labels must match exactly — the webhook extracts values by label.
+
+| Label | Populated by | Notes |
+|---|---|---|
+| `_ga_client_id` | JS snippet (step 5) | From the `_ga` cookie. GA4 stitches the lead to the existing session when this is present. |
+| `_fbp` | JS snippet | First-party Meta browser cookie. |
+| `_fbc` | JS snippet | Meta click id; only set when the visitor arrived from a Meta ad. |
+| `utm_source` | URL param (Tally auto-populates) | Plus `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`. |
+| `utm_medium` | URL param | |
+| `utm_campaign` | URL param | |
+| `utm_content` | URL param | |
+| `utm_term` | URL param | |
+| `referrer` | JS snippet | `document.referrer` at form load. |
+| `landing_page` | JS snippet | `window.location.href` at form load. |
+
+Tally's URL parameter mapping is "Settings → Get values from URL"; the
+five `utm_*` fields plug straight in if you name them identically to the
+query params. Hidden fields default to empty string when no value is
+supplied — that is fine, the function treats empty as "no value".
+
+### Webhook + signing secret
+
+1. **Integrations** → **Webhooks** → **Connect**.
+2. Endpoint URL:
+   - Dev: `https://us-east4-maple-and-spruce-dev.cloudfunctions.net/tallyLeadWebhook`
+   - Prod: `https://us-east4-maple-and-spruce.cloudfunctions.net/tallyLeadWebhook`
+3. **Signing secret** → click "Add a signing secret" and paste a strong
+   random string (this is the value you put into `TALLY_WEBHOOK_SECRET`
+   in step 3 — it must match exactly).
+
+The function verifies `tally-signature` against
+`HMAC-SHA256(rawBody, secret)` (base64). A signature mismatch returns
+401 and no downstream call is made.
+
+## 5. Webflow page snippet
+
+The hidden fields above only fire if something writes to the iframe
+before submit. Add this snippet to the Webflow page that embeds the
+Tally form. Use **Webflow Designer → page settings → Inside `<head>`
+tag** (or a Custom Code block at the bottom of the page body):
+
+```html
+<script>
+  // Populate Tally hidden fields with GA / Meta cookies + page context.
+  //
+  // Works with Tally's inline embed (the form is rendered as an iframe
+  // hosted at tally.so). We listen for the iframe's "Tally.LoadedForm"
+  // postMessage and inject a `?fieldName=value` query string back into
+  // the iframe src — Tally reads URL params into the matching hidden
+  // fields automatically.
+  (function () {
+    function readCookie(name) {
+      var match = document.cookie.match(
+        new RegExp('(?:^|;\\s*)' + name + '=([^;]*)')
+      );
+      return match ? decodeURIComponent(match[1]) : '';
+    }
+
+    // The `_ga` cookie value looks like `GA1.2.<clientId>` — GA4 wants
+    // just the trailing clientId portion as `client_id`.
+    function gaClientId() {
+      var raw = readCookie('_ga');
+      if (!raw) return '';
+      var parts = raw.split('.');
+      // Last two segments concatenated with a dot ARE the client id.
+      if (parts.length < 4) return '';
+      return parts[2] + '.' + parts[3];
+    }
+
+    var params = {
+      _ga_client_id: gaClientId(),
+      _fbp: readCookie('_fbp'),
+      _fbc: readCookie('_fbc'),
+      referrer: document.referrer || '',
+      landing_page: window.location.href,
+    };
+
+    function appendParams(srcUrl) {
+      var url = new URL(srcUrl, window.location.origin);
+      Object.keys(params).forEach(function (key) {
+        if (params[key]) url.searchParams.set(key, params[key]);
+      });
+      return url.toString();
+    }
+
+    // Tally posts a "Tally.LoadedForm" message once the iframe is ready.
+    window.addEventListener('message', function (event) {
+      if (
+        !event.data ||
+        typeof event.data !== 'object' ||
+        event.data.type !== 'Tally.LoadedForm'
+      ) {
+        return;
+      }
+      var iframes = document.querySelectorAll('iframe[src*="tally.so"]');
+      iframes.forEach(function (iframe) {
+        if (!iframe.dataset.tallyParamsApplied) {
+          iframe.dataset.tallyParamsApplied = '1';
+          iframe.src = appendParams(iframe.src);
+        }
+      });
+    });
+  })();
+</script>
+```
+
+UTM params are auto-passed by Tally when they exist in the page URL,
+so the snippet does not need to forward them.
+
+Once published, open the page in an incognito window with a UTM
+appended (e.g. `?utm_source=test&utm_medium=manual`), submit the form
+with a test email, and check:
+
+- GA4 → **Realtime** → events should show `generate_lead` within ~30s.
+- Meta Events Manager → **Test events** (with the Test Event Code set
+  on the request body if you want to filter) shows a `Lead` event.
+
+---
+
+## Local testing
+
+The function is covered by `apps/functions-integration-tests-tally-lead-webhook/`,
+which redirects GA4 and Meta CAPI traffic to per-service mock servers
+in `libs/firebase/ga4-test-mock-server/` and
+`libs/firebase/meta-capi-test-mock-server/`. Run the suite with:
+
+```bash
+./tools/run-integration-tests.sh tally-lead-webhook
+```
+
+The mock servers expose `/_mock/reset`, `/_mock/requests`, and
+`/_mock/failure-status` for tests to control state without restarting
+the process.
+
+## Tally retries
+
+Tally retries 5xx but not 4xx, and the function does not deduplicate by
+`submissionId`. A delivery + retry will produce two GA4 events and two
+Meta events. Both platforms tolerate occasional duplicates, and the
+alternative (Firestore write to dedupe) adds a hot-path round trip
+without a real attribution benefit. If we ever see significant
+duplicate volume in GA4, the dedupe key to use is
+`payload.data.submissionId`.
+
+## Operational notes
+
+- The function is in the **maple-core** codebase. It has no heavy SDK
+  dependencies — just `crypto`, `fetch`, and the Vest validation suite
+  shared with the rest of the app.
+- Region `us-east4`, concurrency `80`, memory `256MiB`. Cold start is
+  small because the codebase is core.
+- If GA4 / Meta credentials are rotated, only `firebase functions:secrets:set`
+  is needed; no redeploy.

--- a/docs/guides/tally-lead-webhook-setup.md
+++ b/docs/guides/tally-lead-webhook-setup.md
@@ -235,6 +235,61 @@ without a real attribution benefit. If we ever see significant
 duplicate volume in GA4, the dedupe key to use is
 `payload.data.submissionId`.
 
+## Dev / prod isolation
+
+By default, the dev and prod Firebase projects both point at the **same**
+production GA4 stream (`G-TY0E9X31V6`) and Meta pixel
+(`1625932185289127`). Tokens are separate but destinations are not — so
+dev test submissions land in production attribution and (worse) feed
+Meta's ad-delivery algorithm if you ever optimize a campaign for the
+`Lead` event.
+
+Three ways to handle this, in order of how much work they are:
+
+1. **Do nothing** — at low test volume the noise is rounding-error. Fine
+   to defer until you actually start running Meta Lead-optimization
+   campaigns.
+2. **Separate dev pixel + dev GA4 stream** — best long-term setup,
+   ~15 minutes:
+   - Events Manager → Datasets → **Connect data** → create a pixel
+     called "Maple & Spruce — Dev"; copy its ID.
+   - Add the new pixel as a "Use events dataset" asset on the existing
+     `Conversions API System User` (Business Settings → System users →
+     Assigned assets → Add). The existing CAPI token will now write to
+     either pixel based on the URL.
+   - GA4 → Admin → Data Streams → Add stream for a dev hostname; copy
+     the new Measurement ID; create a fresh Measurement Protocol API
+     secret on it.
+   - The function reads `GA4_MEASUREMENT_ID` and `META_PIXEL_ID` as
+     `defineString` params with prod defaults baked into the code.
+     Override for dev by adding the project-scoped `.env.maple-and-spruce-dev`
+     file at the functions codebase root (`apps/functions/.env.maple-and-spruce-dev`)
+     — Firebase auto-loads it on deploy to the dev project, and prod
+     deploys keep the hard-coded defaults:
+
+     ```ini
+     # apps/functions/.env.maple-and-spruce-dev
+     GA4_MEASUREMENT_ID=G-DEVXXXXXX
+     META_PIXEL_ID=9999999999999999
+     ```
+
+     Then rotate the dev `GA4_API_SECRET` to the new stream's secret
+     (the existing Meta CAPI token works against any pixel its system
+     user has access to, so no token rotation needed there):
+
+     ```bash
+     firebase use maple-and-spruce-dev
+     firebase functions:secrets:set GA4_API_SECRET   # paste dev secret
+     ```
+3. **`test_event_code` for interactive validation only** — Meta's
+   Events Manager → Test events tab shows a code like `TEST14336` that
+   excludes events from production attribution. **Don't** bake it into
+   the dev env: per Meta's docs, the code rotates each time the tab is
+   opened and expires on inactivity, so a stale code silently re-enters
+   production attribution. Useful for sitting in front of Events
+   Manager and watching events arrive in real-time during a debug
+   session, not for a persistent dev environment.
+
 ## Operational notes
 
 - The function is in the **maple-core** codebase. It has no heavy SDK

--- a/docs/reference/deployed-functions.md
+++ b/docs/reference/deployed-functions.md
@@ -91,6 +91,9 @@ Core CRUD operations, auth, triggers, and admin functions. No heavy third-party 
 - `healthCheck`
 - `getSyncConflicts`, `getSyncConflictSummary`
 
+### Lead attribution (Tally → GA4 + Meta CAPI)
+- `tallyLeadWebhook` — HTTP endpoint (Tally newsletter-signup webhook). Verifies `tally-signature` HMAC, extracts hidden fields, fans out to GA4 Measurement Protocol (`generate_lead`) and Meta Conversions API (`Lead`). _(concurrency: 80, memory: 256MiB.)_ Manual setup: `docs/guides/tally-lead-webhook-setup.md`.
+
 ---
 
 ## Codebase: `maple-calendar` (`apps/functions-calendar/`)

--- a/libs/firebase/ga4-test-mock-server/project.json
+++ b/libs/firebase/ga4-test-mock-server/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-ga4-test-mock-server",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/ga4-test-mock-server/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:test-util"],
+  "targets": {}
+}

--- a/libs/firebase/ga4-test-mock-server/src/index.ts
+++ b/libs/firebase/ga4-test-mock-server/src/index.ts
@@ -1,0 +1,6 @@
+export {
+  Ga4MockServer,
+  createGa4MockServer,
+  type Ga4MockInstance,
+  type RecordedRequest,
+} from './lib/ga4-mock-server';

--- a/libs/firebase/ga4-test-mock-server/src/lib/ga4-mock-server.ts
+++ b/libs/firebase/ga4-test-mock-server/src/lib/ga4-mock-server.ts
@@ -1,0 +1,165 @@
+/**
+ * Standalone GA4 Measurement Protocol mock HTTP server.
+ *
+ * Serves the `POST /mp/collect` endpoint used by the tally-lead-webhook
+ * function. The real GA4 endpoint always answers 200 (or 204 with a tiny
+ * empty body) regardless of payload content, so the mock mirrors that
+ * shape and just records what was sent so tests can assert on it.
+ *
+ * Per-service mock server, parallel to libs/firebase/{square,webflow,etsy}-test-mock-server.
+ */
+import http from 'http';
+
+export interface RecordedRequest {
+  method: string;
+  path: string;
+  query: Record<string, string>;
+  headers: Record<string, string | string[] | undefined>;
+  body: unknown;
+  timestamp: Date;
+}
+
+export interface Ga4MockInstance {
+  server: Ga4MockServer;
+  reset: () => void;
+}
+
+export class Ga4MockServer {
+  private server: http.Server | null = null;
+  private _requests: RecordedRequest[] = [];
+  /**
+   * When set, `/mp/collect` responds with this status instead of 200.
+   * Tests use this to simulate downstream failures.
+   */
+  failureStatus: number | null = null;
+
+  get requests(): readonly RecordedRequest[] {
+    return this._requests;
+  }
+
+  /** Requests recorded against `/mp/collect`. */
+  getCollectRequests(): RecordedRequest[] {
+    return this._requests.filter((r) => r.path.startsWith('/mp/collect'));
+  }
+
+  clearRequests(): void {
+    this._requests = [];
+  }
+
+  async start(port: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.server = http.createServer(async (req, res) => {
+        const body = await readBody(req);
+        const method = req.method?.toUpperCase() ?? 'GET';
+        const url = req.url ?? '/';
+        const [path, queryString = ''] = url.split('?');
+        const query: Record<string, string> = {};
+        if (queryString) {
+          for (const pair of queryString.split('&')) {
+            const [k, v = ''] = pair.split('=');
+            if (k) query[decodeURIComponent(k)] = decodeURIComponent(v);
+          }
+        }
+
+        this._requests.push({
+          method,
+          path,
+          query,
+          headers: req.headers,
+          body,
+          timestamp: new Date(),
+        });
+
+        if (method === 'POST' && path === '/mp/collect') {
+          if (this.failureStatus) {
+            res.writeHead(this.failureStatus, {
+              'Content-Type': 'application/json',
+            });
+            res.end(JSON.stringify({ error: 'simulated GA4 failure' }));
+            return;
+          }
+          // Real GA4 returns 204 with no body. JSON 200 is also accepted and
+          // a little easier to spot in test output.
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true }));
+          return;
+        }
+
+        // Test-control endpoints under /_mock/* — the mock server runs in
+        // its own process, so tests need an HTTP surface to inspect state
+        // and toggle failure mode.
+        if (method === 'POST' && path === '/_mock/reset') {
+          this.clearRequests();
+          this.failureStatus = null;
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true }));
+          return;
+        }
+        if (method === 'GET' && path === '/_mock/requests') {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ requests: this._requests }));
+          return;
+        }
+        if (method === 'POST' && path === '/_mock/failure-status') {
+          const status = (body as { status?: number } | undefined)?.status;
+          this.failureStatus = typeof status === 'number' ? status : null;
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true, failureStatus: this.failureStatus }));
+          return;
+        }
+
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            error: 'GA4 mock server: no route matched',
+            method,
+            path,
+          })
+        );
+      });
+
+      this.server.on('error', reject);
+      this.server.listen(port, () => resolve());
+    });
+  }
+
+  async stop(): Promise<void> {
+    return new Promise((resolve) => {
+      if (this.server) {
+        this.server.close(() => resolve());
+      } else {
+        resolve();
+      }
+    });
+  }
+}
+
+export function createGa4MockServer(): Ga4MockInstance {
+  const server = new Ga4MockServer();
+  return {
+    server,
+    reset: () => {
+      server.clearRequests();
+      server.failureStatus = null;
+    },
+  };
+}
+
+function readBody(req: http.IncomingMessage): Promise<unknown> {
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString();
+      if (!raw) {
+        resolve(undefined);
+        return;
+      }
+      try {
+        resolve(JSON.parse(raw));
+      } catch {
+        resolve(raw);
+      }
+    });
+  });
+}

--- a/libs/firebase/ga4-test-mock-server/start.ts
+++ b/libs/firebase/ga4-test-mock-server/start.ts
@@ -1,0 +1,32 @@
+/**
+ * Standalone script to start the GA4 mock server for integration tests.
+ *
+ * Usage: npx tsx libs/firebase/ga4-test-mock-server/start.ts
+ *
+ * Starts on port 9995 (or GA4_MOCK_SERVER_PORT env var).
+ */
+import { createGa4MockServer } from './src/lib/ga4-mock-server.js';
+
+const port = parseInt(process.env['GA4_MOCK_SERVER_PORT'] ?? '9995', 10);
+const mock = createGa4MockServer();
+
+async function main(): Promise<void> {
+  await mock.server.start(port);
+  console.log(`GA4 mock server running on http://localhost:${port}`);
+  console.log('Routes: POST /mp/collect');
+
+  process.on('SIGINT', async () => {
+    await mock.server.stop();
+    process.exit(0);
+  });
+
+  process.on('SIGTERM', async () => {
+    await mock.server.stop();
+    process.exit(0);
+  });
+}
+
+main().catch((err) => {
+  console.error('Failed to start GA4 mock server:', err);
+  process.exit(1);
+});

--- a/libs/firebase/ga4-test-mock-server/tsconfig.json
+++ b/libs/firebase/ga4-test-mock-server/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/ga4-test-mock-server/tsconfig.lib.json
+++ b/libs/firebase/ga4-test-mock-server/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/integration-test-utils/src/lib/utils/emulator-config.ts
+++ b/libs/firebase/integration-test-utils/src/lib/utils/emulator-config.ts
@@ -7,6 +7,8 @@ const ORIGIN_PORT = 3000 + OFFSET;
 const SQUARE_MOCK_SERVER_PORT = 9997 + OFFSET;
 const WEBFLOW_MOCK_SERVER_PORT = 9996 + OFFSET;
 const ETSY_MOCK_SERVER_PORT = 9998 + OFFSET;
+const GA4_MOCK_SERVER_PORT = 9995 + OFFSET;
+const META_CAPI_MOCK_SERVER_PORT = 9994 + OFFSET;
 
 export const EMULATOR_CONFIG = {
   projectId: 'maple-and-spruce-dev',
@@ -21,6 +23,10 @@ export const EMULATOR_CONFIG = {
   webflowMockServerUrl: `http://localhost:${WEBFLOW_MOCK_SERVER_PORT}`,
   /** Dedicated Etsy mock server */
   etsyMockServerUrl: `http://localhost:${ETSY_MOCK_SERVER_PORT}`,
+  /** GA4 Measurement Protocol mock server */
+  ga4MockServerUrl: `http://localhost:${GA4_MOCK_SERVER_PORT}`,
+  /** Meta Conversions API mock server */
+  metaCapiMockServerUrl: `http://localhost:${META_CAPI_MOCK_SERVER_PORT}`,
   portOffset: OFFSET,
 } as const;
 

--- a/libs/firebase/maple-functions/tally-lead-webhook/project.json
+++ b/libs/firebase/maple-functions/tally-lead-webhook/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-tally-lead-webhook",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/tally-lead-webhook/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/tally-lead-webhook/src/index.ts
+++ b/libs/firebase/maple-functions/tally-lead-webhook/src/index.ts
@@ -1,0 +1,1 @@
+export { tallyLeadWebhook } from './lib/tally-lead-webhook';

--- a/libs/firebase/maple-functions/tally-lead-webhook/src/lib/tally-lead-webhook.ts
+++ b/libs/firebase/maple-functions/tally-lead-webhook/src/lib/tally-lead-webhook.ts
@@ -1,0 +1,326 @@
+/**
+ * Tally newsletter-signup webhook → GA4 Measurement Protocol + Meta Conversions API.
+ *
+ * Tally's free tier supports webhooks but charges for native GA4 / Meta Pixel
+ * integrations. This function replicates both server-side: it verifies the
+ * Tally signature, pulls the attribution context out of the submission's
+ * hidden fields, and fires `generate_lead` (GA4) and `Lead` (Meta CAPI) in
+ * parallel.
+ *
+ * Why server-side:
+ * - The Tally → MailerLite flow never fires `generate_lead` in the browser,
+ *   so GA4 attributes zero lead key-events to any source/medium.
+ * - Meta only sees browser-side Pixel events, which iOS attribution drops.
+ *
+ * Tally retries 5xx, so we always answer 200 once we've validated the
+ * payload. Downstream failures are logged but never block the ack — one
+ * channel succeeding still beats zero.
+ *
+ * @see https://tally.so/help/webhooks
+ * @see https://developers.google.com/analytics/devguides/collection/protocol/ga4
+ * @see https://developers.facebook.com/docs/marketing-api/conversions-api
+ */
+import { onRequest } from 'firebase-functions/v2/https';
+import { defineSecret, defineString } from 'firebase-functions/params';
+import { createHmac, createHash, timingSafeEqual } from 'crypto';
+import {
+  tallyLeadValidation,
+  type TallyLeadValidationInput,
+} from '@maple/ts/validation';
+
+const tallyWebhookSecret = defineSecret('TALLY_WEBHOOK_SECRET');
+const ga4ApiSecret = defineSecret('GA4_API_SECRET');
+const metaCapiToken = defineSecret('META_CAPI_TOKEN');
+
+const ga4MeasurementId = defineString('GA4_MEASUREMENT_ID', {
+  default: 'G-TY0E9X31V6',
+});
+const metaPixelId = defineString('META_PIXEL_ID', {
+  default: '1625932185289127',
+});
+const ga4BaseUrl = defineString('GA4_BASE_URL', {
+  default: 'https://www.google-analytics.com',
+});
+const metaCapiBaseUrl = defineString('META_CAPI_BASE_URL', {
+  default: 'https://graph.facebook.com',
+});
+const metaCapiApiVersion = defineString('META_CAPI_API_VERSION', {
+  default: 'v20.0',
+});
+
+interface TallyField {
+  key?: string;
+  label?: string;
+  type?: string;
+  value?: unknown;
+}
+
+interface TallyWebhookPayload {
+  eventId?: string;
+  eventType?: string;
+  data?: {
+    submissionId?: string;
+    formId?: string;
+    fields?: TallyField[];
+  };
+}
+
+/**
+ * Tally signs each webhook with HMAC-SHA256 (base64) of the raw body using
+ * the secret configured in the Tally form's webhook settings. Constant-time
+ * compare so a timing side-channel can't be used to guess the signature.
+ */
+function verifySignature(
+  rawBody: string,
+  signature: string | undefined,
+  secret: string
+): boolean {
+  if (!signature || !secret) return false;
+  const expected = createHmac('sha256', secret)
+    .update(rawBody)
+    .digest('base64');
+  const a = Buffer.from(signature);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+function stringValue(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+  if (typeof value === 'number') return String(value);
+  return undefined;
+}
+
+function findFieldValue(
+  fields: TallyField[],
+  label: string
+): string | undefined {
+  for (const f of fields) {
+    if (f.label === label) {
+      const v = stringValue(f.value);
+      if (v) return v;
+    }
+  }
+  return undefined;
+}
+
+function findEmail(fields: TallyField[]): string | undefined {
+  // Prefer the typed email field — robust to label tweaks in the Tally form.
+  for (const f of fields) {
+    if (f.type === 'INPUT_EMAIL') {
+      const v = stringValue(f.value);
+      if (v) return v;
+    }
+  }
+  return findFieldValue(fields, 'Email');
+}
+
+export function extractLead(
+  payload: TallyWebhookPayload
+): TallyLeadValidationInput {
+  const fields = payload.data?.fields ?? [];
+  return {
+    email: findEmail(fields),
+    gaClientId: findFieldValue(fields, '_ga_client_id'),
+    fbp: findFieldValue(fields, '_fbp'),
+    fbc: findFieldValue(fields, '_fbc'),
+    utmSource: findFieldValue(fields, 'utm_source'),
+    utmMedium: findFieldValue(fields, 'utm_medium'),
+    utmCampaign: findFieldValue(fields, 'utm_campaign'),
+    utmContent: findFieldValue(fields, 'utm_content'),
+    utmTerm: findFieldValue(fields, 'utm_term'),
+    referrer: findFieldValue(fields, 'referrer'),
+    landingPage: findFieldValue(fields, 'landing_page'),
+  };
+}
+
+async function sendGa4Event(
+  lead: TallyLeadValidationInput,
+  config: { baseUrl: string; measurementId: string; apiSecret: string }
+): Promise<void> {
+  const url = `${config.baseUrl}/mp/collect?measurement_id=${encodeURIComponent(
+    config.measurementId
+  )}&api_secret=${encodeURIComponent(config.apiSecret)}`;
+
+  // GA4 requires a client_id. When the page-side snippet captured the `_ga`
+  // cookie, sessions stitch together; otherwise we fall back to a synthetic
+  // server id so the event still lands.
+  const clientId =
+    lead.gaClientId ||
+    `server.${Date.now()}.${Math.floor(Math.random() * 1e10)}`;
+
+  const params: Record<string, string> = {};
+  if (lead.utmSource) params['source'] = lead.utmSource;
+  if (lead.utmMedium) params['medium'] = lead.utmMedium;
+  if (lead.utmCampaign) params['campaign'] = lead.utmCampaign;
+  if (lead.utmContent) params['content'] = lead.utmContent;
+  if (lead.utmTerm) params['term'] = lead.utmTerm;
+  if (lead.referrer) params['page_referrer'] = lead.referrer;
+  if (lead.landingPage) params['page_location'] = lead.landingPage;
+
+  const body = {
+    client_id: clientId,
+    events: [{ name: 'generate_lead', params }],
+  };
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`GA4 ${response.status}: ${text}`);
+  }
+}
+
+function hashEmail(email: string): string {
+  return createHash('sha256').update(email.trim().toLowerCase()).digest('hex');
+}
+
+async function sendMetaCapiEvent(
+  lead: TallyLeadValidationInput,
+  ctx: { ip?: string; userAgent?: string },
+  config: {
+    baseUrl: string;
+    apiVersion: string;
+    pixelId: string;
+    accessToken: string;
+  }
+): Promise<void> {
+  if (!lead.email) {
+    throw new Error('Cannot send Meta CAPI Lead without an email');
+  }
+
+  const url = `${config.baseUrl}/${config.apiVersion}/${encodeURIComponent(
+    config.pixelId
+  )}/events?access_token=${encodeURIComponent(config.accessToken)}`;
+
+  const userData: Record<string, unknown> = {
+    em: [hashEmail(lead.email)],
+  };
+  if (lead.fbp) userData['fbp'] = lead.fbp;
+  if (lead.fbc) userData['fbc'] = lead.fbc;
+  if (ctx.ip) userData['client_ip_address'] = ctx.ip;
+  if (ctx.userAgent) userData['client_user_agent'] = ctx.userAgent;
+
+  const customData: Record<string, unknown> = {};
+  if (lead.utmSource) customData['utm_source'] = lead.utmSource;
+  if (lead.utmMedium) customData['utm_medium'] = lead.utmMedium;
+  if (lead.utmCampaign) customData['utm_campaign'] = lead.utmCampaign;
+  if (lead.utmContent) customData['utm_content'] = lead.utmContent;
+  if (lead.utmTerm) customData['utm_term'] = lead.utmTerm;
+
+  const event: Record<string, unknown> = {
+    event_name: 'Lead',
+    event_time: Math.floor(Date.now() / 1000),
+    action_source: 'website',
+    user_data: userData,
+    custom_data: customData,
+  };
+  if (lead.landingPage) event['event_source_url'] = lead.landingPage;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ data: [event] }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`Meta CAPI ${response.status}: ${text}`);
+  }
+}
+
+export const tallyLeadWebhook = onRequest(
+  {
+    region: 'us-east4',
+    memory: '256MiB',
+    concurrency: 80,
+    secrets: [tallyWebhookSecret, ga4ApiSecret, metaCapiToken],
+  },
+  async (request, response) => {
+    if (request.method !== 'POST') {
+      response.status(405).send('Method not allowed');
+      return;
+    }
+
+    // Firebase Functions v2 exposes the raw bytes as `rawBody`. We have to
+    // verify the signature against those exact bytes — re-stringifying
+    // `request.body` would change key order / whitespace and break HMAC.
+    const rawBuffer = (request as unknown as { rawBody?: Buffer }).rawBody;
+    const rawBody = rawBuffer
+      ? rawBuffer.toString('utf8')
+      : typeof request.body === 'string'
+      ? request.body
+      : JSON.stringify(request.body ?? {});
+
+    const signature =
+      (request.headers['tally-signature'] as string | undefined) ??
+      (request.headers['x-tally-signature'] as string | undefined);
+
+    if (!verifySignature(rawBody, signature, tallyWebhookSecret.value())) {
+      console.warn('Tally webhook signature verification failed');
+      response.status(401).send('Invalid signature');
+      return;
+    }
+
+    let payload: TallyWebhookPayload;
+    try {
+      payload =
+        typeof request.body === 'object' && request.body !== null
+          ? (request.body as TallyWebhookPayload)
+          : (JSON.parse(rawBody) as TallyWebhookPayload);
+    } catch (err) {
+      console.warn('Tally webhook payload could not be parsed', err);
+      response.status(400).json({ error: 'Invalid JSON payload' });
+      return;
+    }
+
+    const lead = extractLead(payload);
+    const validation = tallyLeadValidation(lead);
+    if (validation.hasErrors()) {
+      const errors = validation.getErrors();
+      console.warn('Tally webhook lead validation failed', errors);
+      response.status(400).json({ error: 'Invalid lead payload', errors });
+      return;
+    }
+
+    const ctx = {
+      ip: typeof request.ip === 'string' ? request.ip : undefined,
+      userAgent: request.headers['user-agent'] as string | undefined,
+    };
+
+    const [ga4Result, metaResult] = await Promise.allSettled([
+      sendGa4Event(lead, {
+        baseUrl: ga4BaseUrl.value(),
+        measurementId: ga4MeasurementId.value(),
+        apiSecret: ga4ApiSecret.value(),
+      }),
+      sendMetaCapiEvent(lead, ctx, {
+        baseUrl: metaCapiBaseUrl.value(),
+        apiVersion: metaCapiApiVersion.value(),
+        pixelId: metaPixelId.value(),
+        accessToken: metaCapiToken.value(),
+      }),
+    ]);
+
+    if (ga4Result.status === 'rejected') {
+      console.error('GA4 Measurement Protocol call failed', ga4Result.reason);
+    }
+    if (metaResult.status === 'rejected') {
+      console.error('Meta CAPI call failed', metaResult.reason);
+    }
+
+    response.status(200).json({
+      received: true,
+      ga4: ga4Result.status,
+      meta: metaResult.status,
+      submissionId: payload.data?.submissionId,
+    });
+  }
+);

--- a/libs/firebase/maple-functions/tally-lead-webhook/tsconfig.json
+++ b/libs/firebase/maple-functions/tally-lead-webhook/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/tally-lead-webhook/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/tally-lead-webhook/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/meta-capi-test-mock-server/project.json
+++ b/libs/firebase/meta-capi-test-mock-server/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-meta-capi-test-mock-server",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/meta-capi-test-mock-server/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:test-util"],
+  "targets": {}
+}

--- a/libs/firebase/meta-capi-test-mock-server/src/index.ts
+++ b/libs/firebase/meta-capi-test-mock-server/src/index.ts
@@ -1,0 +1,6 @@
+export {
+  MetaCapiMockServer,
+  createMetaCapiMockServer,
+  type MetaCapiMockInstance,
+  type RecordedRequest,
+} from './lib/meta-capi-mock-server';

--- a/libs/firebase/meta-capi-test-mock-server/src/lib/meta-capi-mock-server.ts
+++ b/libs/firebase/meta-capi-test-mock-server/src/lib/meta-capi-mock-server.ts
@@ -1,0 +1,179 @@
+/**
+ * Standalone Meta Conversions API mock HTTP server.
+ *
+ * Serves `POST /<apiVersion>/<pixelId>/events` for the tally-lead-webhook
+ * function. The real Meta CAPI returns a JSON body with `events_received`
+ * and a `fbtrace_id`; the mock returns the same shape so the function
+ * code path is exercised end-to-end.
+ *
+ * Per-service mock server, parallel to libs/firebase/{square,webflow,etsy}-test-mock-server.
+ */
+import http from 'http';
+
+export interface RecordedRequest {
+  method: string;
+  path: string;
+  query: Record<string, string>;
+  pixelId?: string;
+  apiVersion?: string;
+  headers: Record<string, string | string[] | undefined>;
+  body: unknown;
+  timestamp: Date;
+}
+
+export interface MetaCapiMockInstance {
+  server: MetaCapiMockServer;
+  reset: () => void;
+}
+
+const EVENTS_PATH_PATTERN = /^\/(v\d+\.\d+)\/([^/]+)\/events$/;
+
+export class MetaCapiMockServer {
+  private server: http.Server | null = null;
+  private _requests: RecordedRequest[] = [];
+  /**
+   * When set, the events endpoint responds with this status instead of 200.
+   * Tests use this to simulate downstream failures.
+   */
+  failureStatus: number | null = null;
+
+  get requests(): readonly RecordedRequest[] {
+    return this._requests;
+  }
+
+  /** Requests recorded against any /v{N}.{N}/{pixel}/events path. */
+  getEventsRequests(): RecordedRequest[] {
+    return this._requests.filter((r) => EVENTS_PATH_PATTERN.test(r.path));
+  }
+
+  clearRequests(): void {
+    this._requests = [];
+  }
+
+  async start(port: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.server = http.createServer(async (req, res) => {
+        const body = await readBody(req);
+        const method = req.method?.toUpperCase() ?? 'GET';
+        const url = req.url ?? '/';
+        const [path, queryString = ''] = url.split('?');
+        const query: Record<string, string> = {};
+        if (queryString) {
+          for (const pair of queryString.split('&')) {
+            const [k, v = ''] = pair.split('=');
+            if (k) query[decodeURIComponent(k)] = decodeURIComponent(v);
+          }
+        }
+
+        const match = EVENTS_PATH_PATTERN.exec(path);
+
+        this._requests.push({
+          method,
+          path,
+          query,
+          apiVersion: match?.[1],
+          pixelId: match?.[2],
+          headers: req.headers,
+          body,
+          timestamp: new Date(),
+        });
+
+        if (method === 'POST' && match) {
+          if (this.failureStatus) {
+            res.writeHead(this.failureStatus, {
+              'Content-Type': 'application/json',
+            });
+            res.end(
+              JSON.stringify({
+                error: { message: 'simulated Meta CAPI failure' },
+              })
+            );
+            return;
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(
+            JSON.stringify({
+              events_received: 1,
+              messages: [],
+              fbtrace_id: 'mock-fbtrace-id',
+            })
+          );
+          return;
+        }
+
+        // Test-control endpoints under /_mock/* — see ga4-mock-server for rationale.
+        if (method === 'POST' && path === '/_mock/reset') {
+          this.clearRequests();
+          this.failureStatus = null;
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true }));
+          return;
+        }
+        if (method === 'GET' && path === '/_mock/requests') {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ requests: this._requests }));
+          return;
+        }
+        if (method === 'POST' && path === '/_mock/failure-status') {
+          const status = (body as { status?: number } | undefined)?.status;
+          this.failureStatus = typeof status === 'number' ? status : null;
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true, failureStatus: this.failureStatus }));
+          return;
+        }
+
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            error: 'Meta CAPI mock server: no route matched',
+            method,
+            path,
+          })
+        );
+      });
+
+      this.server.on('error', reject);
+      this.server.listen(port, () => resolve());
+    });
+  }
+
+  async stop(): Promise<void> {
+    return new Promise((resolve) => {
+      if (this.server) {
+        this.server.close(() => resolve());
+      } else {
+        resolve();
+      }
+    });
+  }
+}
+
+export function createMetaCapiMockServer(): MetaCapiMockInstance {
+  const server = new MetaCapiMockServer();
+  return {
+    server,
+    reset: () => {
+      server.clearRequests();
+      server.failureStatus = null;
+    },
+  };
+}
+
+function readBody(req: http.IncomingMessage): Promise<unknown> {
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString();
+      if (!raw) {
+        resolve(undefined);
+        return;
+      }
+      try {
+        resolve(JSON.parse(raw));
+      } catch {
+        resolve(raw);
+      }
+    });
+  });
+}

--- a/libs/firebase/meta-capi-test-mock-server/start.ts
+++ b/libs/firebase/meta-capi-test-mock-server/start.ts
@@ -1,0 +1,35 @@
+/**
+ * Standalone script to start the Meta CAPI mock server for integration tests.
+ *
+ * Usage: npx tsx libs/firebase/meta-capi-test-mock-server/start.ts
+ *
+ * Starts on port 9994 (or META_CAPI_MOCK_SERVER_PORT env var).
+ */
+import { createMetaCapiMockServer } from './src/lib/meta-capi-mock-server.js';
+
+const port = parseInt(
+  process.env['META_CAPI_MOCK_SERVER_PORT'] ?? '9994',
+  10
+);
+const mock = createMetaCapiMockServer();
+
+async function main(): Promise<void> {
+  await mock.server.start(port);
+  console.log(`Meta CAPI mock server running on http://localhost:${port}`);
+  console.log('Routes: POST /v{N.N}/{pixelId}/events');
+
+  process.on('SIGINT', async () => {
+    await mock.server.stop();
+    process.exit(0);
+  });
+
+  process.on('SIGTERM', async () => {
+    await mock.server.stop();
+    process.exit(0);
+  });
+}
+
+main().catch((err) => {
+  console.error('Failed to start Meta CAPI mock server:', err);
+  process.exit(1);
+});

--- a/libs/firebase/meta-capi-test-mock-server/tsconfig.json
+++ b/libs/firebase/meta-capi-test-mock-server/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/meta-capi-test-mock-server/tsconfig.lib.json
+++ b/libs/firebase/meta-capi-test-mock-server/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/ts/validation/src/lib/index.ts
+++ b/libs/ts/validation/src/lib/index.ts
@@ -63,3 +63,9 @@ export {
   DEFAULT_IMAGE_MAX_BYTES,
   type ImageUploadValidationInput,
 } from './image-upload.validation';
+
+// Lead attribution (Tally → GA4 + Meta CAPI)
+export {
+  tallyLeadValidation,
+  type TallyLeadValidationInput,
+} from './tally-lead.validation';

--- a/libs/ts/validation/src/lib/tally-lead.validation.spec.ts
+++ b/libs/ts/validation/src/lib/tally-lead.validation.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { tallyLeadValidation } from './tally-lead.validation';
+
+describe('tallyLeadValidation', () => {
+  it('passes with just an email', () => {
+    const result = tallyLeadValidation({ email: 'hello@example.com' });
+    expect(result.isValid()).toBe(true);
+  });
+
+  it('passes with email plus full attribution context', () => {
+    const result = tallyLeadValidation({
+      email: 'hello@example.com',
+      gaClientId: '1234567890.0987654321',
+      fbp: 'fb.1.1700000000000.1234567890',
+      fbc: 'fb.1.1700000000000.AbCdEfGhIj',
+      utmSource: 'instagram',
+      utmMedium: 'social',
+      utmCampaign: 'spring-classes',
+      referrer: 'https://www.instagram.com/',
+      landingPage: 'https://mapleandsprucewv.com/classes',
+    });
+    expect(result.isValid()).toBe(true);
+  });
+
+  it('fails when email is missing', () => {
+    const result = tallyLeadValidation({});
+    expect(result.isValid()).toBe(false);
+    expect(result.getErrors('email')).toContain('Email is required');
+  });
+
+  it('fails when email is blank', () => {
+    const result = tallyLeadValidation({ email: '   ' });
+    expect(result.isValid()).toBe(false);
+    expect(result.getErrors('email')).toContain('Email is required');
+  });
+
+  it('fails when email is malformed', () => {
+    const result = tallyLeadValidation({ email: 'not-an-email' });
+    expect(result.isValid()).toBe(false);
+    expect(result.getErrors('email')).toContain('Email must be valid');
+  });
+});

--- a/libs/ts/validation/src/lib/tally-lead.validation.ts
+++ b/libs/ts/validation/src/lib/tally-lead.validation.ts
@@ -1,0 +1,40 @@
+/**
+ * Tally lead webhook validation suite
+ *
+ * Vest validation for the payload extracted from a Tally newsletter-signup
+ * submission. Email is the only hard requirement — every other field is
+ * optional context for downstream attribution.
+ */
+import { staticSuite, test, enforce, only } from 'vest';
+
+export interface TallyLeadValidationInput {
+  email?: string;
+  gaClientId?: string;
+  fbp?: string;
+  fbc?: string;
+  utmSource?: string;
+  utmMedium?: string;
+  utmCampaign?: string;
+  utmContent?: string;
+  utmTerm?: string;
+  referrer?: string;
+  landingPage?: string;
+}
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const tallyLeadValidation = staticSuite(
+  (data: TallyLeadValidationInput, field?: string | string[]) => {
+    only(field);
+
+    test('email', 'Email is required', () => {
+      enforce(data.email).isNotBlank();
+    });
+
+    test('email', 'Email must be valid', () => {
+      if (data.email) {
+        enforce(EMAIL_PATTERN.test(data.email)).isTruthy();
+      }
+    });
+  }
+);

--- a/tools/run-integration-tests.sh
+++ b/tools/run-integration-tests.sh
@@ -29,15 +29,17 @@ UI_PORT=$((4000 + OFFSET))
 SQUARE_MOCK_SERVER_PORT=$((9997 + OFFSET))
 WEBFLOW_MOCK_SERVER_PORT=$((9996 + OFFSET))
 ETSY_MOCK_SERVER_PORT=$((9998 + OFFSET))
+GA4_MOCK_SERVER_PORT=$((9995 + OFFSET))
+META_CAPI_MOCK_SERVER_PORT=$((9994 + OFFSET))
 
 if [ "$OFFSET" != "0" ]; then
-  echo "Using EMULATOR_PORT_OFFSET=$OFFSET -> functions:$FUNCTIONS_PORT, firestore:$FIRESTORE_PORT, auth:$AUTH_PORT, ui:$UI_PORT, square-mock:$SQUARE_MOCK_SERVER_PORT, webflow-mock:$WEBFLOW_MOCK_SERVER_PORT, etsy-mock:$ETSY_MOCK_SERVER_PORT"
+  echo "Using EMULATOR_PORT_OFFSET=$OFFSET -> functions:$FUNCTIONS_PORT, firestore:$FIRESTORE_PORT, auth:$AUTH_PORT, ui:$UI_PORT, square-mock:$SQUARE_MOCK_SERVER_PORT, webflow-mock:$WEBFLOW_MOCK_SERVER_PORT, etsy-mock:$ETSY_MOCK_SERVER_PORT, ga4-mock:$GA4_MOCK_SERVER_PORT, meta-capi-mock:$META_CAPI_MOCK_SERVER_PORT"
 fi
 
 # ---------------------------------------------------------------------------
 # 1. Kill stale processes on OUR ports only (leave other worktrees alone)
 # ---------------------------------------------------------------------------
-for port in "$SQUARE_MOCK_SERVER_PORT" "$WEBFLOW_MOCK_SERVER_PORT" "$ETSY_MOCK_SERVER_PORT" "$FUNCTIONS_PORT" "$FIRESTORE_PORT" "$AUTH_PORT" "$UI_PORT"; do
+for port in "$SQUARE_MOCK_SERVER_PORT" "$WEBFLOW_MOCK_SERVER_PORT" "$ETSY_MOCK_SERVER_PORT" "$GA4_MOCK_SERVER_PORT" "$META_CAPI_MOCK_SERVER_PORT" "$FUNCTIONS_PORT" "$FIRESTORE_PORT" "$AUTH_PORT" "$UI_PORT"; do
   lsof -ti:"$port" 2>/dev/null | xargs kill -9 2>/dev/null || true
 done
 sleep 1
@@ -71,7 +73,13 @@ done
 
 # maple-core: Etsy mock server URL + fake secrets (for listEtsyListings, getEtsyTemplates)
 echo "ETSY_API_BASE=http://localhost:$ETSY_MOCK_SERVER_PORT/v3/application" >> dist/apps/functions/.env
-printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions/.secret.local
+# Tally lead webhook → GA4 + Meta CAPI mock servers
+echo "GA4_BASE_URL=http://localhost:$GA4_MOCK_SERVER_PORT" >> dist/apps/functions/.env
+echo "META_CAPI_BASE_URL=http://localhost:$META_CAPI_MOCK_SERVER_PORT" >> dist/apps/functions/.env
+echo "GA4_MEASUREMENT_ID=G-TEST-MOCK" >> dist/apps/functions/.env
+echo "META_PIXEL_ID=test-pixel-id" >> dist/apps/functions/.env
+echo "META_CAPI_API_VERSION=v20.0" >> dist/apps/functions/.env
+printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\nTALLY_WEBHOOK_SECRET=test-tally-secret\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions/.secret.local
 
 # maple-square: Square mock server URL + fake secrets
 echo "SQUARE_BASE_URL=http://localhost:$SQUARE_MOCK_SERVER_PORT" >> dist/apps/functions-square/.env
@@ -85,7 +93,7 @@ echo "ETSY_TOKEN_URL=http://localhost:$ETSY_MOCK_SERVER_PORT/v3/public/oauth/tok
 printf "WEBFLOW_API_TOKEN=mock-token\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions-sync/.secret.local
 
 # ---------------------------------------------------------------------------
-# 4. Start per-service mock HTTP servers (Square, Webflow, Etsy)
+# 4. Start per-service mock HTTP servers (Square, Webflow, Etsy, GA4, Meta CAPI)
 # ---------------------------------------------------------------------------
 # Pre-warm npx tsx cache to avoid race condition when parallel invocations
 # try to download tsx simultaneously
@@ -102,6 +110,14 @@ WEBFLOW_MOCK_PID=$!
 echo "Starting Etsy mock server on :$ETSY_MOCK_SERVER_PORT..."
 ETSY_MOCK_SERVER_PORT="$ETSY_MOCK_SERVER_PORT" npx tsx libs/firebase/etsy-test-mock-server/start.ts &
 ETSY_MOCK_PID=$!
+
+echo "Starting GA4 mock server on :$GA4_MOCK_SERVER_PORT..."
+GA4_MOCK_SERVER_PORT="$GA4_MOCK_SERVER_PORT" npx tsx libs/firebase/ga4-test-mock-server/start.ts &
+GA4_MOCK_PID=$!
+
+echo "Starting Meta CAPI mock server on :$META_CAPI_MOCK_SERVER_PORT..."
+META_CAPI_MOCK_SERVER_PORT="$META_CAPI_MOCK_SERVER_PORT" npx tsx libs/firebase/meta-capi-test-mock-server/start.ts &
+META_CAPI_MOCK_PID=$!
 sleep 2
 
 # ---------------------------------------------------------------------------
@@ -151,6 +167,8 @@ EMULATOR_PORT_OFFSET="$OFFSET" npx firebase --config "$FIREBASE_CONFIG_FILE" emu
 kill $SQUARE_MOCK_PID 2>/dev/null || true
 kill $WEBFLOW_MOCK_PID 2>/dev/null || true
 kill $ETSY_MOCK_PID 2>/dev/null || true
+kill $GA4_MOCK_PID 2>/dev/null || true
+kill $META_CAPI_MOCK_PID 2>/dev/null || true
 
 if [ $EXIT_CODE -eq 0 ]; then
   echo ""

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -459,6 +459,15 @@
       "@maple/firebase/maple-functions/revoke-admin-role": [
         "libs/firebase/maple-functions/revoke-admin-role/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/tally-lead-webhook": [
+        "libs/firebase/maple-functions/tally-lead-webhook/src/index.ts"
+      ],
+      "@maple/firebase/ga4-test-mock-server": [
+        "libs/firebase/ga4-test-mock-server/src/index.ts"
+      ],
+      "@maple/firebase/meta-capi-test-mock-server": [
+        "libs/firebase/meta-capi-test-mock-server/src/index.ts"
+      ],
       "@maple/react/users": ["libs/react/users/src/index.ts"],
       "@/*": ["apps/maple-spruce/src/*"]
     }


### PR DESCRIPTION
## Summary
- New `tallyLeadWebhook` Cloud Function in the **maple-core** codebase — verifies the Tally HMAC signature, pulls attribution context out of hidden fields, fans out to GA4 Measurement Protocol (`generate_lead`) and Meta Conversions API (`Lead`) in parallel via `Promise.allSettled`. Always 200s for Tally; downstream failures are logged but never block the ack.
- Vest validation suite in `@maple/ts/validation` enforces email is present before any external call.
- Per-service mock servers for GA4 (`libs/firebase/ga4-test-mock-server/`) and Meta CAPI (`libs/firebase/meta-capi-test-mock-server/`) matching the Square / Webflow / Etsy mock pattern — each runs in its own process and exposes `/_mock/{reset,requests,failure-status}` for test inspection.
- Integration suite `apps/functions-integration-tests-tally-lead-webhook/` (9 tests) covers signature gate (401), validation gate (400), happy-path fan-out, single-channel resilience when either downstream fails, and Tally retry semantics. Wired into `tools/run-integration-tests.sh` and `.github/workflows/build-check.yml`.
- `docs/guides/tally-lead-webhook-setup.md` walks through the manual config that has to happen alongside the deploy: GA4 API secret, Meta CAPI token, Firebase secrets, Tally form hidden fields + signing secret, and the Webflow page JS snippet that pulls `_ga` / `_fbp` / `_fbc` / referrer / current URL into the Tally iframe.

### Why
GA4 currently shows 0 lead key-events attributed to any source/medium because Tally → MailerLite never fires `generate_lead` in the browser. Meta only sees browser Pixel events, which iOS drops in attribution. This webhook fixes both server-side and replaces Tally's $30/mo native integrations.

## Manual follow-up (must happen before the function is useful)
1. Generate the **GA4 Measurement Protocol API secret** (GA4 Admin → Data Streams → web stream → Measurement Protocol API secrets).
2. Generate the **Meta CAPI access token** (Events Manager → Settings → Conversions API → Generate access token).
3. `firebase functions:secrets:set` for `TALLY_WEBHOOK_SECRET`, `GA4_API_SECRET`, `META_CAPI_TOKEN` (per project).
4. In Tally: add the hidden fields listed in the doc, point the webhook at the deployed function URL, and paste the signing secret.
5. In Webflow: add the JS snippet from the doc to the page that embeds the Tally form.

All five are documented step-by-step in `docs/guides/tally-lead-webhook-setup.md`.

## Test plan
- [x] `pnpm exec nx run functions:build` — succeeds, no new bundle bloat
- [x] `./tools/validate-function-tsconfigs.sh` — passes
- [x] `npx tsx tools/check-firestore-indexes.ts` — passes (no new indexes needed)
- [x] `pnpm exec vitest run libs/ts/validation` — 472 tests pass, including 5 new for `tallyLeadValidation`
- [x] `./tools/run-integration-tests.sh tally-lead-webhook` — 9/9 tests pass against the Firebase emulator + GA4/Meta mock servers
- [ ] CI integration matrix picks up the new suite automatically (`functions-integration-tests-tally-lead-webhook`)
- [ ] After merge + secrets set: send a real Tally test submission and confirm `generate_lead` in GA4 Realtime + `Lead` in Meta Test Events

🤖 Generated with [Claude Code](https://claude.com/claude-code)