### PR TITLE
perf: parallelize deploys across codebases

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -169,8 +169,15 @@ jobs:
           CODEBASES_JSON=$(printf '%s\n' "${AFFECTED_CODEBASES_SET[@]}" | sort -u | jq -R . | jq -sc .)
           echo "affected_codebases=$CODEBASES_JSON" >> $GITHUB_OUTPUT
 
-          # Group functions by codebase, then split into batches of 5
-          GROUP_SIZE=5
+          # One matrix entry per codebase. Firebase deploys functions
+          # within a codebase serially regardless of how we batch them
+          # (a single `firebase deploy` command iterates through them),
+          # but DIFFERENT codebases are independent and safe to deploy
+          # in parallel. Earlier this was GROUP_SIZE=5 with max-parallel:1,
+          # which produced ~22 sequential batches and ~60 min of wall time
+          # per side. One entry per codebase + max-parallel:4 collapses
+          # that to ~4 parallel deploys.
+          GROUP_SIZE=10000
           VALID_GROUPS=()
 
           for CODEBASE in "${!CODEBASE_FUNCTIONS[@]}"; do
@@ -264,7 +271,12 @@ jobs:
       contents: read
       id-token: write
     strategy:
-      max-parallel: 1
+      # max-parallel = number of Firebase codebases. The matrix is now
+      # one entry per codebase (see prepare_and_build's GROUP_SIZE
+      # comment), so this caps concurrent deploys at one per codebase,
+      # which is the safe upper bound — concurrent deploys within a
+      # codebase race on Firebase's "deployment in progress" check.
+      max-parallel: 4
       matrix: ${{ fromJson(needs.prepare_and_build.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
@@ -481,7 +493,12 @@ jobs:
       contents: read
       id-token: write
     strategy:
-      max-parallel: 1
+      # max-parallel = number of Firebase codebases. The matrix is now
+      # one entry per codebase (see prepare_and_build's GROUP_SIZE
+      # comment), so this caps concurrent deploys at one per codebase,
+      # which is the safe upper bound — concurrent deploys within a
+      # codebase race on Firebase's "deployment in progress" check.
+      max-parallel: 4
       matrix: ${{ fromJson(needs.prepare_and_build.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Phase 2's dev+prod functions deploys ran serially (\`max-parallel: 1\`) with 5 functions per matrix batch, producing ~22 sequential entries per side and ~60 minutes of wall time. Total merge pipeline ran ~2h.

This collapses the matrix to **one entry per Firebase codebase** (\`maple-core\` / \`maple-calendar\` / \`maple-square\` / \`maple-sync\`) and bumps \`max-parallel\` to 4. Functions within a codebase still deploy serially inside a single \`firebase deploy --only functions:codebase:a,b,c,…\` command — that's Firebase's natural serialization. **Different** codebases are independent and safe to run in parallel.

## Why this is safe

The concurrency hazard for \`firebase deploy\` is two simultaneous deploys touching the same codebase — Firebase rejects the second with \"deployment in progress.\" The matrix is now one entry **per codebase**, so up to 4 concurrent deploys is the safe upper bound: each one operates on a different codebase, no shared state.

## Expected impact

| | Before | After |
|---|---|---|
| dev functions deploy | ~60 min serial | ~15-20 min parallel |
| prod functions deploy | ~60 min serial | ~15-20 min parallel |
| **total merge pipeline** | **~2h** | **~40-50 min** |

The parallel time is bounded by the slowest single codebase (\`maple-core\` has the most functions).

## Implementation

Tiny diff:
- \`GROUP_SIZE\` bumped from 5 to 10000 in \`prepare_and_build\` so the existing batching loop produces one entry per codebase instead of ~22.
- \`max-parallel\` bumped from 1 to 4 on both \`deploy_functions_dev\` and \`deploy_functions_prod\` strategy blocks.

## Test plan

- [ ] PR-time CI passes (it doesn't exercise the matrix shape; the change only takes effect at merge time)
- [ ] On next merge to main, observe that \`deploy_functions_dev\` shows ≤4 matrix entries and they overlap in time. Wall-clock should be ~15-20 min for dev+prod each, not ~60 min.
- [ ] If a codebase has many concurrent deploys racing (shouldn't happen with this matrix shape), watch for Firebase \"deployment already in progress\" errors in the deploy step logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)