### PR TITLE
feat: Phase 3 — manual approval gate before prod deploys

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -1,20 +1,26 @@
 name: Deploy on merge
 
-# Phase 2 pipeline ("known-good dev"):
+# Pipeline ("known-good dev" + manual prod approval):
 #
 #   merge to main
 #     ├── prepare_and_build  (compute affected, build artifacts)
 #     ├── deploy_functions_dev   (deploy affected functions → maple-and-spruce-dev)
 #     ├── deploy_harness_dev     (build + deploy harness → maple-spruce-registration-test)
-#     ├── e2e_dev                (Playwright → deployed dev URL; GATES prod)
+#     ├── e2e_dev                (Playwright → deployed dev URL)
 #     │     │
-#     │     ├── deploy_functions_prod        (only if e2e_dev passed)
-#     │     ├── publish_webflow_components   (only if e2e_dev passed)
-#     │     └── deploy_vercel_prod           (only if e2e_dev passed)
+#     │     └── approve_prod  ← MANUAL APPROVAL via `production` Environment
+#     │            │
+#     │            ├── deploy_functions_prod        (only if approve_prod passed)
+#     │            ├── publish_webflow_components   (only if approve_prod passed)
+#     │            └── deploy_vercel_prod           (only if approve_prod passed)
 #     │
 #     └── deploy_firestore_indexes_prod  (independent — index changes don't block on E2E
 #                                          because they take minutes to build and are
 #                                          additive; analyzer enforces declaration at PR)
+#
+# Setup: a "production" GitHub Environment must exist in repo Settings →
+# Environments, with at least one required reviewer. Without it, approve_prod
+# auto-passes (any user counts as approver) — defeating the purpose.
 #
 # Per-feature-branch dev deploys are gone — the old
 # firebase-functions-dev.yml has been deleted. Dev is the post-merge
@@ -469,10 +475,26 @@ jobs:
             apps/registration-e2e/test-results/
           retention-days: 7
 
+  approve_prod:
+    # Phase 3 manual gate: every prod-side job depends on this, and this
+    # job uses the `production` Environment which is configured (in repo
+    # Settings → Environments) with required reviewers. GitHub pauses
+    # the job until a reviewer clicks "Review pending deployments".
+    #
+    # A single gate covers all three prod jobs (functions, webflow,
+    # vercel) — one approval click unlocks the whole prod side.
+    needs: e2e_dev
+    if: needs.e2e_dev.result == 'success'
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Approved for production deploy
+        run: echo "Production deploys unlocked by approver — proceeding."
+
   deploy_functions_prod:
-    needs: [prepare_and_build, e2e_dev]
+    needs: [prepare_and_build, approve_prod]
     if: >-
-      needs.e2e_dev.result == 'success' &&
+      needs.approve_prod.result == 'success' &&
       needs.prepare_and_build.outputs.has_changes == 'true' &&
       needs.prepare_and_build.outputs.matrix != '' &&
       toJson(fromJson(needs.prepare_and_build.outputs.matrix).include) != '[]'
@@ -623,12 +645,12 @@ jobs:
           fi
 
   publish_webflow_components:
-    needs: [prepare_and_build, e2e_dev]
-    # Gate the webflow-components publish on E2E because the published
-    # bundle becomes the live widget — if the dev E2E fails on the new
-    # widget code, we don't want it propagating to the live Webflow site.
+    needs: [prepare_and_build, approve_prod]
+    # Gate the webflow-components publish on the manual approval (which
+    # itself depends on E2E passing). The published bundle becomes the
+    # live widget, so it's treated as a prod-side action.
     if: >-
-      needs.e2e_dev.result == 'success' &&
+      needs.approve_prod.result == 'success' &&
       needs.prepare_and_build.outputs.webflow_components_affected == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -662,10 +684,11 @@ jobs:
   deploy_vercel_prod:
     # Vercel's auto-deploy-on-main is disabled via vercel.json
     # (git.deploymentEnabled.main = false). Prod promotion happens here,
-    # gated on the same E2E that gates Firebase prod. PR previews still
-    # auto-deploy from Vercel because the disable only covers `main`.
-    needs: e2e_dev
-    if: needs.e2e_dev.result == 'success'
+    # gated on the manual approval (which itself requires E2E success).
+    # PR previews still auto-deploy from Vercel because the disable only
+    # covers `main`.
+    needs: approve_prod
+    if: needs.approve_prod.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/docs/architecture/ci-cd.md
+++ b/docs/architecture/ci-cd.md
@@ -30,22 +30,25 @@ All CI workflows use `pnpm/action-setup@v4` which reads the version from `packag
 
 **Workflow**: `.github/workflows/firebase-functions-merge.yml` — the only deploy pipeline. Per-branch dev deploys (`firebase-functions-dev.yml`) were removed in Phase 2 (#TBD); dev is a post-merge-only environment now.
 
-**Pipeline shape (Phase 2 — "known-good dev")**:
+**Pipeline shape**:
 
 ```
 merge to main
   ├── prepare_and_build  (build affected codebases, upload artifacts)
   ├── deploy_functions_dev   → maple-and-spruce-dev
   ├── deploy_harness_dev     → maple-spruce-registration-test.web.app
-  └── e2e_dev (registration Playwright suite vs deployed dev) ← GATE
-       ├── deploy_functions_prod        → maple-and-spruce
-       ├── publish_webflow_components   → Webflow library share
-       └── deploy_vercel_prod           → maple-spruce on Vercel
+  └── e2e_dev (registration Playwright suite vs deployed dev)
+       └── approve_prod  ← MANUAL APPROVAL via `production` Environment
+            ├── deploy_functions_prod        → maple-and-spruce
+            ├── publish_webflow_components   → Webflow library share
+            └── deploy_vercel_prod           → maple-spruce on Vercel
 
   + deploy_firestore_indexes  (independent — runs in parallel with everything)
 ```
 
-**The gate**: `e2e_dev` must pass before any prod-facing job runs. If it fails, prod functions stay on the previous deploy, the Webflow widget library isn't re-shared, and Vercel doesn't promote.
+**Two gates**:
+1. **`e2e_dev`** must pass — the suite hits deployed dev callables + dev Firestore. Failures here mean prod stays on the previous deploy.
+2. **`approve_prod`** requires a human to click "Review pending deployments" in the GitHub UI. Uses the `production` Environment (Settings → Environments) which has required reviewers configured. One approval unlocks all three prod jobs.
 
 **Why Firestore indexes don't gate**: index additions are forward-compatible (queries work without them, just slower or with a "missing index" error). Index builds take minutes server-side after the deploy submits the spec, so gating E2E on index readiness would add a lot of wall-clock without catching anything new. The PR-time analyzer (`tools/check-firestore-indexes.ts`) enforces declaration; that's the load-bearing check.
 
@@ -56,6 +59,17 @@ merge to main
 - Prod: `github-deployer@maple-and-spruce.iam.gserviceaccount.com`
 
 **Region**: All functions deploy to `us-east4` (Northern Virginia)
+
+### Required GitHub Environment
+
+A `production` Environment must exist (Settings → Environments → New environment). Without it, `approve_prod` auto-passes for any actor — defeating the gate.
+
+Configure:
+- **Required reviewers**: at minimum the repo owner. Multiple is fine — any one can approve.
+- **Wait timer**: leave at 0 (the dev E2E is already the substantive check).
+- **Deployment branches**: restrict to `main` only.
+
+Optional but recommended: move `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` from repo-level secrets to Environment secrets scoped to `production`. That way only post-approval runs can read them.
 
 ### Required secrets
 


### PR DESCRIPTION
## Summary

Adds the manual approval gate on top of the Phase 2 dev-E2E gate. After \`e2e_dev\` passes, a new \`approve_prod\` job uses GitHub's \`production\` Environment to pause for a human review. One approval click unlocks all three prod-side jobs (\`deploy_functions_prod\`, \`publish_webflow_components\`, \`deploy_vercel_prod\`).

\`\`\`
merge to main
  └── deploy_functions_dev + deploy_harness_dev + e2e_dev
       └── approve_prod  ← MANUAL APPROVAL via \`production\` Environment
            ├── deploy_functions_prod
            ├── publish_webflow_components
            └── deploy_vercel_prod
\`\`\`

## Required setup before this merges

In repo **Settings → Environments → New environment**, create one named \`production\` with:

- **Required reviewers**: at minimum yourself. Without this, the gate auto-passes and the PR is a no-op.
- **Deployment branches**: restrict to \`main\` only.
- **Wait timer**: leave at 0 — the dev E2E is the substantive check; this gate is just \"do I want to ship this right now?\"

**Optional but recommended**: move \`VERCEL_TOKEN\`, \`VERCEL_ORG_ID\`, \`VERCEL_PROJECT_ID\` from repo-level secrets to Environment secrets scoped to \`production\`. That way only post-approval runs can read them — a defense-in-depth move that makes \"someone bypassed the gate\" detectable in the audit log.

## Failure mode if you forget to configure the Environment

GitHub's default behavior for an Environment with no required reviewers is: the job auto-passes for any actor. So this PR alone doesn't add safety — the Environment config does. The workflow comment calls this out explicitly so a future-you doesn't see \"approve_prod\" in the YAML and assume it's gating.

## Conflicts with #431 and #432

Both touch \`firebase-functions-merge.yml\` but at different lines:
- #431: the deploy STEP shell command
- #432: GROUP_SIZE constant + max-parallel value
- This PR: \`needs:\` lines on prod jobs + new \`approve_prod\` job

Merge order matters but conflicts are mechanical. I'll rebase whichever lands second.

## Test plan

- [ ] CI passes
- [ ] Configure the \`production\` Environment per above
- [ ] On next merge: workflow run shows \`approve_prod\` as \"Waiting for review\" — click \"Review pending deployments\" → \"Approve and deploy\" — prod jobs run
- [ ] Sanity-check: if you don't approve, prod jobs stay queued indefinitely (you can cancel the run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)