### PR TITLE
feat: real Square sandbox in registration E2E (PR check + dev)

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -6,6 +6,10 @@ ALLOWED_ORIGINS=http://localhost:3000,http://localhost:4200,http://127.0.0.1:300
 SQUARE_ENV=LOCAL
 # Sandbox location ID from Square Developer Dashboard
 SQUARE_LOCATION_ID=LW0MMBZ5721QY
+# Sandbox application ID — used by the *browser* Square Web Payments
+# SDK (not by Cloud Functions). Public by design: every page that
+# renders the payment form ships this to clients.
+SQUARE_APPLICATION_ID=sandbox-sq0idb-gAg2gnLYZ-5b2uXajUfZLA
 # WV sales tax rate (6% state rate)
 SALES_TAX_RATE=6.0
 

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -427,18 +427,23 @@ jobs:
           fi
 
   registration-e2e:
-    # Phase-1 FE→BE end-to-end: drives the production RegistrationWidget
+    # PR-time FE→BE end-to-end: drives the production RegistrationWidget
     # (mounted in apps/registration-test-harness) against the local
-    # Firebase emulator. Catches bugs neither the Storybook interaction
-    # tests nor the cloud-function integration tests can see — i.e. the
-    # arg-shape contract between the form and the callable, and the
-    # render contract between the cost-calc response and the cost
-    # summary. The same suite is reused in Phase 2 against the deployed
-    # dev project; the only difference is HARNESS_BASE_URL.
+    # Firebase emulator with the PR's own cloud-function code, the real
+    # Square sandbox, and HTTP mock servers for Webflow + Etsy (no real
+    # sandbox exists for those). Catches bugs neither the Storybook
+    # interaction tests nor the cloud-function integration tests can
+    # see: the arg-shape contract between the form and the callable,
+    # the cost-summary render contract, AND the Square tokenize →
+    # createRegistration → success flow against actual Square infra.
+    #
+    # The same spec set is reused post-merge against deployed dev
+    # (see firebase-functions-merge.yml :: e2e_dev) — that's the
+    # "real-everything including Webflow/Etsy" gate before prod.
     name: Registration E2E
     needs: [install]
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     if: github.repository == 'Maple-and-Spruce/maple-and-spruce'
     steps:
       - uses: actions/checkout@v4
@@ -470,9 +475,9 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Build function codebases
-        # All four are required because firebase.json declares them all;
-        # the emulator refuses to boot if any source dir is missing,
-        # even if the test only exercises maple-core functions.
+        # All four are required: createRegistration lives in maple-square,
+        # the Firestore-trigger sync functions live in maple-sync, and
+        # firebase.json declares all four source dirs.
         run: |
           pnpm exec nx run functions:build
           pnpm exec nx run functions-square:build
@@ -480,48 +485,77 @@ jobs:
           pnpm exec nx run functions-calendar:build
 
       - name: Create emulator .env
-        # Same shape as the integration-tests job — every codebase
-        # needs ALL project-level params or the emulator silently hangs
-        # on a stdin prompt. The Phase-1 E2E doesn't actually exercise
-        # Square / Webflow / Etsy paths but the emulator still loads
-        # those codebases at boot.
+        # Mirrors the integration-tests job, with one critical difference:
+        # we DON'T set SQUARE_BASE_URL so the SDK uses its built-in
+        # sandbox base URL (connect.squareupsandbox.com) and we feed it
+        # the real sandbox access token from repo secrets. Webflow and
+        # Etsy still hit local mock servers because there's no usable
+        # sandbox for either.
         #
         # ALLOWED_ORIGINS is extended with the harness origin
-        # (127.0.0.1:4173). Without this every callable comes back as
-        # `permission-denied` — the function CORS middleware returns
-        # 403 for any origin not in the allowlist, which the Firebase
-        # SDK maps to permission-denied.
+        # (127.0.0.1:4173) so the function CORS middleware doesn't
+        # turn callables into permission-denied.
+        env:
+          SQUARE_SANDBOX_ACCESS_TOKEN: ${{ secrets.SQUARE_SANDBOX_ACCESS_TOKEN }}
         run: |
           for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar; do
             grep -v '^#' .env.dev | grep -v '^$' > "$dir/.env"
           done
-          echo "ETSY_API_BASE=http://localhost:99999/v3/application" >> dist/apps/functions/.env
-          printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions/.secret.local
-          printf "SQUARE_ACCESS_TOKEN=mock-token\nSQUARE_WEBHOOK_SIGNATURE_KEY=mock-key\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions-square/.secret.local
-          printf "WEBFLOW_API_TOKEN=mock-token\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions-sync/.secret.local
 
-          # Point the Webflow / Etsy SDKs at a closed local port so the
-          # Firestore triggers that fire from the seed (syncClassToWebflow,
-          # etc.) fail fast with ECONNREFUSED instead of round-tripping to
-          # api.webflow.com / api.etsy.com with the fake tokens. Removes
-          # ~700ms of noise per run and stops every CI invocation from
-          # generating an outbound auth-failure on a third-party API.
-          echo "WEBFLOW_BASE_URL=http://127.0.0.1:1" >> dist/apps/functions-sync/.env
-          echo "ETSY_API_BASE=http://127.0.0.1:1" >> dist/apps/functions-sync/.env
-          echo "ETSY_TOKEN_URL=http://127.0.0.1:1" >> dist/apps/functions-sync/.env
+          # maple-core: Etsy mock server URL + fake secrets
+          echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions/.env
+          printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions/.secret.local
+
+          # maple-square: real Square sandbox (no SQUARE_BASE_URL → SDK
+          # uses its built-in sandbox endpoint). Etsy still mocked.
+          echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions-square/.env
+          printf "SQUARE_ACCESS_TOKEN=%s\nSQUARE_WEBHOOK_SIGNATURE_KEY=mock-key\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" "$SQUARE_SANDBOX_ACCESS_TOKEN" > dist/apps/functions-square/.secret.local
+
+          # maple-sync: Webflow + Etsy mock servers
+          echo "WEBFLOW_BASE_URL=http://localhost:9996" >> dist/apps/functions-sync/.env
+          echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions-sync/.env
+          echo "ETSY_TOKEN_URL=http://localhost:9998/v3/public/oauth/token" >> dist/apps/functions-sync/.env
+          printf "WEBFLOW_API_TOKEN=mock-token\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions-sync/.secret.local
 
           for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar; do
             EXISTING=$(grep '^ALLOWED_ORIGINS=' "$dir/.env" | head -1 | cut -d= -f2-)
             echo "ALLOWED_ORIGINS=$EXISTING,http://127.0.0.1:4173,http://localhost:4173" >> "$dir/.env"
           done
 
-      - name: Run Playwright against emulator
-        # firebase emulators:exec handles emulator lifecycle (boot →
-        # run → teardown). Playwright's webServer config inside the
-        # nx target boots the Vite test harness on 127.0.0.1:4173.
+      - name: Start mock servers (Webflow + Etsy)
+        # Square is intentionally NOT mocked — the spec exercises real
+        # tokenization against Square sandbox. Webflow and Etsy don't
+        # have a usable sandbox so we keep the in-repo mock servers.
         run: |
+          # Pre-warm npx tsx cache (matches integration-tests pattern)
+          npx tsx --version
+
+          WEBFLOW_MOCK_SERVER_PORT=9996 npx tsx libs/firebase/webflow-test-mock-server/start.ts &
+          echo "WEBFLOW_MOCK_PID=$!" >> $GITHUB_ENV
+          ETSY_MOCK_SERVER_PORT=9998 npx tsx libs/firebase/etsy-test-mock-server/start.ts &
+          echo "ETSY_MOCK_PID=$!" >> $GITHUB_ENV
+          sleep 2
+
+      - name: Run Playwright against emulator
+        # firebase emulators:exec handles emulator lifecycle. Playwright's
+        # webServer config (in playwright.config.ts) boots the Vite
+        # harness on 127.0.0.1:4173 with VITE_SQUARE_APPLICATION_ID /
+        # VITE_SQUARE_LOCATION_ID picked up from process.env via
+        # vite.config.ts. The IDs are extracted from .env.dev (public —
+        # they ship to browsers) so the workflow doesn't fork that
+        # source of truth.
+        run: |
+          export VITE_SQUARE_APPLICATION_ID=$(grep '^SQUARE_APPLICATION_ID=' .env.dev | cut -d= -f2-)
+          export VITE_SQUARE_LOCATION_ID=$(grep '^SQUARE_LOCATION_ID=' .env.dev | cut -d= -f2-)
+
           npx firebase emulators:exec --project=dev --only auth,firestore,functions \
             "pnpm exec nx run registration-e2e:e2e"
+
+      - name: Stop mock servers
+        if: always()
+        run: |
+          kill "$WEBFLOW_MOCK_PID" 2>/dev/null || true
+          kill "$ETSY_MOCK_PID" 2>/dev/null || true
 
       - name: Upload Playwright report on failure
         if: failure()

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -557,12 +557,27 @@ jobs:
           kill "$WEBFLOW_MOCK_PID" 2>/dev/null || true
           kill "$ETSY_MOCK_PID" 2>/dev/null || true
 
-      - name: Upload Playwright report on failure
+      - name: Locate Playwright report paths
+        if: failure()
+        # The HTML reporter's output path depends on Playwright's resolved
+        # cwd, which has been surprising under nx (the path differs from
+        # what `cwd: apps/registration-e2e` in project.json suggests).
+        # Find both report + raw test-results wherever they ended up.
+        run: |
+          find . -type d \( -name 'playwright-report' -o -name 'test-results' \) \
+            -not -path '*/node_modules/*' -not -path '*/.next/*' \
+            -print
+
+      - name: Upload Playwright artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report-registration-e2e
-          path: apps/registration-e2e/playwright-report
+          # Tar everything under either dir name anywhere in the tree so
+          # we don't lose traces/screenshots to a path mismatch again.
+          path: |
+            **/playwright-report/**
+            **/test-results/**
           if-no-files-found: ignore
           retention-days: 7
 

--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -412,9 +412,15 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build harness for dev
+        # Square sandbox IDs are sourced from .env.dev (public — they
+        # ship to every browser that opens the form anyway) so the
+        # workflow doesn't fork that source of truth.
         env:
           VITE_TARGET_ENV: dev
-        run: pnpm exec nx build registration-test-harness
+        run: |
+          export VITE_SQUARE_APPLICATION_ID=$(grep '^SQUARE_APPLICATION_ID=' .env.dev | cut -d= -f2-)
+          export VITE_SQUARE_LOCATION_ID=$(grep '^SQUARE_LOCATION_ID=' .env.dev | cut -d= -f2-)
+          pnpm exec nx build registration-test-harness
 
       - name: Ensure Hosting site exists
         # Idempotent — the first deploy after the site is created

--- a/apps/registration-e2e/playwright.config.ts
+++ b/apps/registration-e2e/playwright.config.ts
@@ -28,7 +28,12 @@ const baseURL =
   process.env['HARNESS_BASE_URL'] ??
   (target === 'dev'
     ? DEFAULT_DEV_HARNESS_URL
-    : `http://127.0.0.1:${harnessPort}`);
+    : // Use `localhost` (not `127.0.0.1`) — Square's Web Payments SDK
+      // allows localhost as a secure-context exception but rejects raw
+      // IPs with "Web Payments SDK can only be embedded on sites that
+      // use HTTPS." Both resolve to the same loopback so Vite (bound
+      // to localhost) accepts either.
+      `http://localhost:${harnessPort}`);
 
 export default defineConfig({
   testDir: './src',

--- a/apps/registration-e2e/playwright.config.ts
+++ b/apps/registration-e2e/playwright.config.ts
@@ -4,16 +4,18 @@ import { workspaceRoot } from '@nx/devkit';
 /**
  * Registration E2E config — runs the same specs against either:
  *
- * - `E2E_TARGET=emulator` (default) — Phase 1: harness on local Vite
- *   server, callables on local Firebase emulator. Boots the harness
- *   itself via the `webServer` block. Pair with `firebase emulators:exec`
- *   (see `tools/run-registration-e2e.sh`).
+ * - `E2E_TARGET=emulator` (default) — PR check: harness on local Vite
+ *   server, callables on local Firebase emulator with the PR's own
+ *   code, real Square sandbox, and HTTP mock servers for Webflow +
+ *   Etsy. Boots the harness itself via the `webServer` block. Pair
+ *   with `firebase emulators:exec` (see `tools/run-registration-e2e.sh`).
  *
- * - `E2E_TARGET=dev` — Phase 2: harness on the deployed Firebase
- *   Hosting site `maple-spruce-registration-test`, callables on the
- *   deployed `maple-and-spruce-dev` project. No `webServer`; baseURL
- *   points at the deployed harness URL. Seed runs against real
- *   Firestore via Admin SDK (Application Default Credentials).
+ * - `E2E_TARGET=dev` — post-merge gate: harness on the deployed
+ *   Firebase Hosting site `maple-spruce-registration-test`, callables
+ *   on the deployed `maple-and-spruce-dev` project, real Square
+ *   sandbox, real Webflow + Etsy dev integrations. No `webServer`;
+ *   baseURL points at the deployed harness URL. Seed runs against
+ *   real Firestore via Admin SDK (Application Default Credentials).
  */
 const target = process.env['E2E_TARGET'] ?? 'emulator';
 const offset = Number.parseInt(process.env['EMULATOR_PORT_OFFSET'] ?? '0', 10);
@@ -41,6 +43,7 @@ export default defineConfig({
     ? [['html', { open: 'never' }], ['list']]
     : 'list',
   globalSetup: require.resolve('./src/global-setup.ts'),
+  globalTeardown: require.resolve('./src/global-teardown.ts'),
   // Deployed-dev callables can cold-start past the 30s default,
   // especially on the very first request after a deploy.
   timeout: target === 'dev' ? 60_000 : 30_000,

--- a/apps/registration-e2e/src/global-setup.ts
+++ b/apps/registration-e2e/src/global-setup.ts
@@ -5,18 +5,24 @@
  * - default / `emulator` — seed the local Firestore emulator via REST
  *   (full wipe + reseed, fast and isolated).
  * - `dev` — seed the deployed `maple-and-spruce-dev` project via the
- *   Admin SDK. Overwrites the same deterministic IDs each run rather
- *   than wiping the collection (we don't want to nuke dev data that
- *   isn't ours).
+ *   Admin SDK. Idempotent: writes specific doc IDs without wiping the
+ *   collection (we don't want to nuke dev data that isn't ours).
+ *
+ * The class doc gets a UUID-suffixed ID per run so concurrent runs
+ * (or sequential runs that haven't been torn down yet) don't collide.
+ * The ID is published via process.env.TEST_CLASS_ID so the spec and
+ * teardown can pick it up. Discounts keep deterministic IDs because
+ * the specs reference them by *code* (`SAVE10`, `TENOFF`), not doc ID.
  *
  * Same fixture set in both modes (shared from
  * `@maple/firebase/integration-test-utils`) so the spec assertions
  * don't have to know which backend they're running against.
  */
+import { randomUUID } from 'node:crypto';
+
 import {
   clearFirestoreEmulator,
   setFirestoreDoc,
-  CLASS_IDS,
   PUBLISHED_CLASS,
   DISCOUNT_IDS,
   PERCENT_DISCOUNT,
@@ -25,10 +31,10 @@ import {
 
 import { seedDev } from './seed-dev';
 
-async function seedEmulator(): Promise<void> {
+async function seedEmulator(classId: string): Promise<void> {
   await clearFirestoreEmulator();
   await Promise.all([
-    setFirestoreDoc('classes', CLASS_IDS.published, PUBLISHED_CLASS),
+    setFirestoreDoc('classes', classId, PUBLISHED_CLASS),
     setFirestoreDoc('discounts', DISCOUNT_IDS.percent, PERCENT_DISCOUNT),
     setFirestoreDoc('discounts', DISCOUNT_IDS.amount, AMOUNT_DISCOUNT),
   ]);
@@ -36,16 +42,23 @@ async function seedEmulator(): Promise<void> {
 
 async function globalSetup(): Promise<void> {
   const target = process.env['E2E_TARGET'] ?? 'emulator';
-  console.log(`[e2e] Seeding fixtures for target=${target}…`);
+  const classId = `test-class-${randomUUID()}`;
+
+  // Publish the dynamic ID so workers + globalTeardown can read it.
+  // process.env mutations in globalSetup propagate to spawned Playwright
+  // workers because Playwright forwards parent env at spawn time.
+  process.env['TEST_CLASS_ID'] = classId;
+
+  console.log(`[e2e] Seeding fixtures for target=${target}, classId=${classId}…`);
 
   if (target === 'dev') {
-    await seedDev();
+    await seedDev(classId);
   } else {
-    await seedEmulator();
+    await seedEmulator(classId);
   }
 
   console.log(
-    `[e2e] Seeded class=${CLASS_IDS.published}, discounts=[${DISCOUNT_IDS.percent}, ${DISCOUNT_IDS.amount}]`
+    `[e2e] Seeded class=${classId}, discounts=[${DISCOUNT_IDS.percent}, ${DISCOUNT_IDS.amount}]`
   );
 }
 

--- a/apps/registration-e2e/src/global-teardown.ts
+++ b/apps/registration-e2e/src/global-teardown.ts
@@ -1,0 +1,43 @@
+/**
+ * Playwright globalTeardown: clean up seeded test data after the run.
+ *
+ * Emulator mode: nothing to do — the emulator process exits with the
+ * job, taking all Firestore state with it.
+ *
+ * Dev mode: delete the seeded class + any registrations the Pay-flow
+ * specs created against it. Without this, every run accumulates real
+ * Firestore docs and Square sandbox orders against the same merchant.
+ * Discount fixtures are intentionally left alone (stable, idempotent
+ * across runs).
+ *
+ * Idempotent — runs even if globalSetup failed half-way. The class ID
+ * is read from process.env.TEST_CLASS_ID; if unset (setup never ran),
+ * teardown no-ops.
+ */
+import { teardownDev } from './seed-dev';
+
+async function globalTeardown(): Promise<void> {
+  const target = process.env['E2E_TARGET'] ?? 'emulator';
+  const classId = process.env['TEST_CLASS_ID'];
+
+  if (target !== 'dev') {
+    return;
+  }
+
+  if (!classId) {
+    console.warn('[e2e] No TEST_CLASS_ID in env — skipping dev teardown');
+    return;
+  }
+
+  console.log(`[e2e] Tearing down dev fixtures for classId=${classId}…`);
+  try {
+    await teardownDev(classId);
+    console.log(`[e2e] Removed class=${classId} + any registrations`);
+  } catch (err) {
+    // Don't fail the whole job on a teardown hiccup — the test result
+    // is the signal. Surface the error so it's visible in the log.
+    console.error('[e2e] teardown failed (continuing):', err);
+  }
+}
+
+export default globalTeardown;

--- a/apps/registration-e2e/src/registration.spec.ts
+++ b/apps/registration-e2e/src/registration.spec.ts
@@ -4,12 +4,19 @@
  * Runs against the `registration-test-harness` Vite app, which mounts
  * the production `RegistrationWidget`. The same specs cover two
  * targets, picked by `E2E_TARGET`:
- *   - emulator (default) — local Vite harness + local Firebase emulator
- *   - dev                — deployed harness + deployed maple-and-spruce-dev
+ *   - emulator (default) — PR check: local Vite harness + local
+ *     Firebase emulator (PR's code) + real Square sandbox + HTTP mock
+ *     servers for Webflow / Etsy (no usable sandbox for either).
+ *   - dev               — post-merge gate: deployed harness + deployed
+ *     maple-and-spruce-dev + real Square sandbox + real Webflow / Etsy
+ *     dev integrations.
  *
  * Seeded fixtures come from `@maple/firebase/integration-test-utils`
- * via `global-setup.ts` so the spec assertions don't care which
- * backend is on the other side.
+ * via `global-setup.ts`. The class doc ID is generated per-run (UUID)
+ * and propagated through `process.env.TEST_CLASS_ID` so concurrent
+ * runs and the post-run teardown can attribute writes to the right
+ * suite. Discount fixtures keep deterministic IDs because the specs
+ * reference them by *code* (`SAVE10`, `TENOFF`), not doc ID.
  *
  * Why these tests exist:
  * - Storybook interaction tests mock `onCalculateCost`; they cannot
@@ -20,16 +27,33 @@
  * - Real Firestore enforces composite indexes; the emulator does not.
  *   The dev target catches missing indexes that emulator E2E silently
  *   passes.
- *
- * Scope: load → attendee management → cost recalc → discount apply.
- * Square tokenization is intentionally out of scope (the "Register &
- * Pay" button stays disabled until the Square Web Payments SDK marks
- * the card form ready, which requires real sandbox credentials).
+ * - Square Web Payments SDK + tokenize → createRegistration is the
+ *   highest-stakes single flow in the app; the Pay-flow specs below
+ *   exercise it against real Square sandbox infra so an SDK upgrade
+ *   or a Square API breaking change surfaces as a red CI run.
  */
-import { test, expect, Page } from '@playwright/test';
+import { test, expect, Page, FrameLocator } from '@playwright/test';
 
-const CLASS_ID = 'test-class-published';
+const CLASS_ID = process.env['TEST_CLASS_ID'];
+if (!CLASS_ID) {
+  throw new Error(
+    'TEST_CLASS_ID missing — globalSetup must run before specs to seed and publish the per-run class doc ID.'
+  );
+}
+
 const PRICE_LABEL = '$45.00'; // PUBLISHED_CLASS.priceCents = 4500
+
+// Square sandbox test card numbers. The full reference lives at
+// https://developer.squareup.com/docs/devtools/sandbox/payments. Visa
+// number → approved; the decline number triggers a `GENERIC_DECLINE`
+// from the Payments API.
+const SANDBOX_CARD_SUCCESS = '4111 1111 1111 1111';
+const SANDBOX_CARD_DECLINE = '4000 0000 0000 0002';
+// Any future expiration / any 3-digit CVV / any valid US ZIP — Square
+// doesn't validate these beyond format in sandbox.
+const SANDBOX_EXP = '12/30';
+const SANDBOX_CVV = '111';
+const SANDBOX_ZIP = '26554';
 
 async function openWidget(page: Page) {
   await page.goto(`/?classId=${CLASS_ID}`);
@@ -133,3 +157,134 @@ test('an invalid discount code is silently ignored', async ({ page }) => {
   // The base cost still reads as before the failed apply.
   await expect(page.getByText(`1 x ${PRICE_LABEL}`)).toBeVisible();
 });
+
+// ---------------------------------------------------------------------
+// Pay-flow specs — drive the real Square Web Payments SDK in sandbox
+// mode. These cost ~one sandbox tokenize + one sandbox order/payment
+// roundtrip each (sandbox is free). Bumped timeout: tokenize + payments
+// API roundtrip is 3-6s end to end, longer on a cold callable.
+// ---------------------------------------------------------------------
+
+test.describe('Pay flow', () => {
+  test.setTimeout(120_000);
+
+  test('completes a successful registration with a sandbox card', async ({
+    page,
+  }) => {
+    await openWidget(page);
+
+    await fillCustomerInfo(page, {
+      name: 'E2E Tester',
+      email: `e2e+${Date.now()}@maplespruce.test`,
+    });
+
+    await fillSquareCard(page, {
+      number: SANDBOX_CARD_SUCCESS,
+      exp: SANDBOX_EXP,
+      cvv: SANDBOX_CVV,
+      zip: SANDBOX_ZIP,
+    });
+
+    // Wait for SDK readiness — Pay button stays disabled until
+    // SquareCardForm.onReady fires (cardRef.current set).
+    const payButton = page.getByRole('button', {
+      name: /Register & Pay \$/,
+    });
+    await expect(payButton).toBeEnabled({ timeout: 30_000 });
+    await payButton.click();
+
+    // Success view shows "You're Registered!" + confirmation number +
+    // "$XX.XX paid". Asserting both proves: tokenize succeeded → token
+    // reached createRegistration → Square sandbox charged → Firestore
+    // registration doc written → widget transitioned to confirmed.
+    await expect(page.getByText(/You're Registered/i)).toBeVisible({
+      timeout: 60_000,
+    });
+    await expect(page.getByText('$47.70 paid')).toBeVisible();
+  });
+
+  test('surfaces a payment error when the sandbox card is declined', async ({
+    page,
+  }) => {
+    await openWidget(page);
+
+    await fillCustomerInfo(page, {
+      name: 'E2E Decline Tester',
+      email: `e2e-decline+${Date.now()}@maplespruce.test`,
+    });
+
+    await fillSquareCard(page, {
+      number: SANDBOX_CARD_DECLINE,
+      exp: SANDBOX_EXP,
+      cvv: SANDBOX_CVV,
+      zip: SANDBOX_ZIP,
+    });
+
+    const payButton = page.getByRole('button', {
+      name: /Register & Pay \$/,
+    });
+    await expect(payButton).toBeEnabled({ timeout: 30_000 });
+    await payButton.click();
+
+    // Success view must NOT render — the user stays on the form with
+    // a visible error. Don't pin to a specific error string (Square
+    // wording changes) but require an alert and the absence of the
+    // success header.
+    await expect(page.getByRole('alert')).toBeVisible({ timeout: 60_000 });
+    await expect(page.getByText(/You're Registered/i)).not.toBeVisible();
+  });
+});
+
+async function fillCustomerInfo(
+  page: Page,
+  { name, email }: { name: string; email: string }
+) {
+  await page.getByLabel('Full Name').fill(name);
+  await page.getByLabel('Email Address').fill(email);
+}
+
+/**
+ * Drive Square's Web Payments SDK card form.
+ *
+ * The SDK renders four separate iframes inside `#square-card-container`
+ * (one per field, for PCI scope reduction). Each iframe contains a
+ * single `<input>` we can locate by placeholder text — that's the most
+ * stable selector across SDK versions, since Square's internal element
+ * names include UUIDs.
+ *
+ * If a future SDK update changes placeholder copy, this helper is the
+ * one place to update.
+ */
+async function fillSquareCard(
+  page: Page,
+  card: { number: string; exp: string; cvv: string; zip: string }
+) {
+  const container = page.locator('#square-card-container');
+  // Wait for at least one iframe to mount.
+  await expect(container.locator('iframe').first()).toBeVisible({
+    timeout: 30_000,
+  });
+
+  const fields = [
+    { placeholder: /card number/i, value: card.number },
+    { placeholder: /(MM ?\/ ?YY|expiration)/i, value: card.exp },
+    { placeholder: /CVV|CVC/i, value: card.cvv },
+    { placeholder: /(ZIP|postal)/i, value: card.zip },
+  ];
+
+  // Each frame holds exactly one of the four fields. Iterate the
+  // mounted iframes and match by placeholder content.
+  const frameElements = await container.locator('iframe').all();
+  for (const frameEl of frameElements) {
+    const name = await frameEl.getAttribute('name');
+    if (!name) continue;
+    const frame: FrameLocator = page.frameLocator(`iframe[name="${name}"]`);
+    for (const field of fields) {
+      const input = frame.getByPlaceholder(field.placeholder);
+      if ((await input.count()) > 0) {
+        await input.fill(field.value);
+        break;
+      }
+    }
+  }
+}

--- a/apps/registration-e2e/src/registration.spec.ts
+++ b/apps/registration-e2e/src/registration.spec.ts
@@ -185,13 +185,9 @@ test.describe('Pay flow', () => {
       zip: SANDBOX_ZIP,
     });
 
-    // Wait for SDK readiness — Pay button stays disabled until
-    // SquareCardForm.onReady fires (cardRef.current set).
-    const payButton = page.getByRole('button', {
-      name: /Register & Pay \$/,
-    });
-    await expect(payButton).toBeEnabled({ timeout: 30_000 });
-    await payButton.click();
+    await page
+      .getByRole('button', { name: /Register & Pay \$/ })
+      .click();
 
     // Success view shows "You're Registered!" + confirmation number +
     // "$XX.XX paid". Asserting both proves: tokenize succeeded → token
@@ -220,11 +216,9 @@ test.describe('Pay flow', () => {
       zip: SANDBOX_ZIP,
     });
 
-    const payButton = page.getByRole('button', {
-      name: /Register & Pay \$/,
-    });
-    await expect(payButton).toBeEnabled({ timeout: 30_000 });
-    await payButton.click();
+    await page
+      .getByRole('button', { name: /Register & Pay \$/ })
+      .click();
 
     // Success view must NOT render — the user stays on the form with
     // a visible error. Don't pin to a specific error string (Square
@@ -246,45 +240,75 @@ async function fillCustomerInfo(
 /**
  * Drive Square's Web Payments SDK card form.
  *
- * The SDK renders four separate iframes inside `#square-card-container`
- * (one per field, for PCI scope reduction). Each iframe contains a
- * single `<input>` we can locate by placeholder text — that's the most
- * stable selector across SDK versions, since Square's internal element
- * names include UUIDs.
+ * Strategy: wait for the Pay button to become enabled (proves the SDK
+ * loaded, `payments()` succeeded, `card.attach()` resolved, and
+ * SquareCardForm.onReady fired). At that point the iframe(s) under
+ * `#square-card-container` MUST exist. If it never enables, dump the
+ * page content + any visible alerts so the failure has a real cause
+ * in the log instead of just "iframe not found."
  *
- * If a future SDK update changes placeholder copy, this helper is the
- * one place to update.
+ * Field selectors use HTML `autocomplete` attributes (`cc-number`,
+ * `cc-exp`, `cc-csc`, `postal-code`) — these are the stable, browser-
+ * level identifiers for credit card fields and survive Square SDK
+ * minor-version churn better than placeholder copy or DOM `name`s.
  */
 async function fillSquareCard(
   page: Page,
   card: { number: string; exp: string; cvv: string; zip: string }
 ) {
-  const container = page.locator('#square-card-container');
-  // Wait for at least one iframe to mount.
-  await expect(container.locator('iframe').first()).toBeVisible({
-    timeout: 30_000,
-  });
+  const payButton = page.getByRole('button', { name: /Register & Pay \$/ });
+  const alert = page.getByRole('alert');
 
-  const fields = [
-    { placeholder: /card number/i, value: card.number },
-    { placeholder: /(MM ?\/ ?YY|expiration)/i, value: card.exp },
-    { placeholder: /CVV|CVC/i, value: card.cvv },
-    { placeholder: /(ZIP|postal)/i, value: card.zip },
+  try {
+    await expect(payButton).toBeEnabled({ timeout: 45_000 });
+  } catch (err) {
+    const alertText = (await alert.count())
+      ? await alert.allInnerTexts()
+      : ['(no alert visible)'];
+    const bodyText = await page
+      .locator('body')
+      .innerText()
+      .catch(() => '(could not read body)');
+    throw new Error(
+      `Pay button never enabled — SDK likely failed to initialize.\nAlerts: ${JSON.stringify(alertText)}\nPage text (first 600 chars):\n${bodyText.slice(0, 600)}`
+    );
+  }
+
+  // Single frame OR multi-frame: try each iframe under the container
+  // and fill whichever input is present.
+  const iframeNames = await page
+    .locator('#square-card-container iframe')
+    .evaluateAll((els) =>
+      (els as HTMLIFrameElement[]).map((el) => el.getAttribute('name') ?? '')
+    );
+
+  const fillers: Array<[selector: string, value: string]> = [
+    ['input[autocomplete="cc-number"]', card.number],
+    ['input[autocomplete="cc-exp"]', card.exp],
+    ['input[autocomplete="cc-csc"]', card.cvv],
+    ['input[autocomplete="postal-code"]', card.zip],
   ];
+  const filled = new Set<string>();
 
-  // Each frame holds exactly one of the four fields. Iterate the
-  // mounted iframes and match by placeholder content.
-  const frameElements = await container.locator('iframe').all();
-  for (const frameEl of frameElements) {
-    const name = await frameEl.getAttribute('name');
+  for (const name of iframeNames) {
     if (!name) continue;
     const frame: FrameLocator = page.frameLocator(`iframe[name="${name}"]`);
-    for (const field of fields) {
-      const input = frame.getByPlaceholder(field.placeholder);
+    for (const [selector, value] of fillers) {
+      if (filled.has(selector)) continue;
+      const input = frame.locator(selector);
       if ((await input.count()) > 0) {
-        await input.fill(field.value);
-        break;
+        await input.fill(value);
+        filled.add(selector);
       }
     }
+  }
+
+  if (filled.size < fillers.length) {
+    const missing = fillers
+      .filter(([sel]) => !filled.has(sel))
+      .map(([sel]) => sel);
+    throw new Error(
+      `fillSquareCard: did not find input selectors ${JSON.stringify(missing)} in any iframe (saw frames=${JSON.stringify(iframeNames)})`
+    );
   }
 }

--- a/apps/registration-e2e/src/registration.spec.ts
+++ b/apps/registration-e2e/src/registration.spec.ts
@@ -262,15 +262,18 @@ async function fillSquareCard(
   try {
     await expect(payButton).toBeEnabled({ timeout: 45_000 });
   } catch (err) {
+    const original = err instanceof Error ? err.message : String(err);
     const alertText = (await alert.count())
       ? await alert.allInnerTexts()
       : ['(no alert visible)'];
     const bodyText = await page
       .locator('body')
       .innerText()
-      .catch(() => '(could not read body)');
+      .catch((readErr: unknown) =>
+        `(could not read body: ${readErr instanceof Error ? readErr.message : String(readErr)})`
+      );
     throw new Error(
-      `Pay button never enabled — SDK likely failed to initialize.\nAlerts: ${JSON.stringify(alertText)}\nPage text (first 600 chars):\n${bodyText.slice(0, 600)}`
+      `Pay button never enabled — SDK likely failed to initialize.\nOriginal wait error: ${original}\nAlerts: ${JSON.stringify(alertText)}\nPage text (first 600 chars):\n${bodyText.slice(0, 600)}`
     );
   }
 

--- a/apps/registration-e2e/src/seed-dev.ts
+++ b/apps/registration-e2e/src/seed-dev.ts
@@ -7,17 +7,15 @@
  * google-github-actions/auth, or `gcloud auth application-default
  * login` locally).
  *
- * Idempotent: re-running overwrites the same doc IDs. The fixture
- * IDs are deterministic (`test-class-published`, etc.) so the
- * Webflow sync triggers find/update the same CMS item each run
- * rather than accumulating new ones — and because dev syncs with
- * isDev=true, those items are CMS drafts, never published to the
- * live site (see libs/firebase/maple-functions/sync-class-to-webflow).
+ * The class doc ID is unique per run (generated in globalSetup) so
+ * concurrent CI runs can't collide and the Pay-flow registrations
+ * created during the suite can be cleanly attributed/deleted. Discount
+ * fixtures use deterministic IDs and are simply overwritten each run
+ * — they're stable code fixtures, not per-run data.
  */
 import { initializeApp, getApps } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 import {
-  CLASS_IDS,
   PUBLISHED_CLASS,
   DISCOUNT_IDS,
   PERCENT_DISCOUNT,
@@ -37,11 +35,32 @@ function getAdminDb() {
   return getFirestore();
 }
 
-export async function seedDev(): Promise<void> {
+export async function seedDev(classId: string): Promise<void> {
   const db = getAdminDb();
   await Promise.all([
-    db.collection('classes').doc(CLASS_IDS.published).set(PUBLISHED_CLASS),
+    db.collection('classes').doc(classId).set(PUBLISHED_CLASS),
     db.collection('discounts').doc(DISCOUNT_IDS.percent).set(PERCENT_DISCOUNT),
     db.collection('discounts').doc(DISCOUNT_IDS.amount).set(AMOUNT_DISCOUNT),
   ]);
+}
+
+/**
+ * Remove the seeded class plus any registrations it accumulated during
+ * the run. Discount fixtures are left alone — they're stable. Idempotent:
+ * missing docs are silently ignored by Firestore.
+ *
+ * The registration cleanup matters: Pay-flow specs create real Square
+ * sandbox orders + Firestore registration docs. Without this they'd
+ * pile up in dev indefinitely.
+ */
+export async function teardownDev(classId: string): Promise<void> {
+  const db = getAdminDb();
+
+  const regs = await db
+    .collection('registrations')
+    .where('classId', '==', classId)
+    .get();
+  await Promise.all(regs.docs.map((d) => d.ref.delete()));
+
+  await db.collection('classes').doc(classId).delete();
 }

--- a/apps/registration-test-harness/src/main.tsx
+++ b/apps/registration-test-harness/src/main.tsx
@@ -1,14 +1,11 @@
 /**
  * Registration test harness — minimal Vite app that mounts the
  * production `RegistrationWidget` against either local Firebase
- * emulators (Phase 1) or the deployed dev project (Phase 2).
+ * emulators (PR-check) or the deployed dev project (post-merge).
  *
  * Used by `apps/registration-e2e/` Playwright tests to exercise the
- * full FE→BE wiring (widget → callable → Firestore) end-to-end, the
- * same way a customer hits it in production. Catches the class of bug
- * that unit tests miss: arg shape between the form and the cloud
- * function, and the contract between the cost-calc response and the
- * cost summary render.
+ * full FE→BE wiring (widget → callable → Firestore + Square sandbox)
+ * end-to-end, the same way a customer hits it in production.
  *
  * Selecting which class to load:
  *   ?classId=<id>       — required (seeded ahead of time)
@@ -17,8 +14,12 @@
  *   VITE_TARGET_ENV=emulator (default) — 127.0.0.1 functions emulator
  *   VITE_TARGET_ENV=dev               — deployed maple-and-spruce-dev
  *
- * Square credentials are intentionally fake. The current E2E suite
- * stops short of Square tokenization.
+ * Square sandbox creds (both browser-public — not secrets):
+ *   VITE_SQUARE_APPLICATION_ID — sandbox app ID from Square Developer
+ *   VITE_SQUARE_LOCATION_ID    — sandbox location ID
+ * Sourced from `.env.dev` at build time and forwarded through
+ * vite.config.ts's `define` block (see build-check.yml +
+ * firebase-functions-merge.yml).
  */
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -45,6 +46,12 @@ const port = Number.parseInt(
   globalThis as { __MAPLE_FUNCTIONS_EMULATOR_PORT__?: number }
 ).__MAPLE_FUNCTIONS_EMULATOR_PORT__ = port;
 
+// Real sandbox creds — the SDK loads from sandbox.web.squarecdn.com
+// (see SquareCardForm.tsx; any env !== 'prod' selects sandbox), and
+// the IDs below bind tokenization to our merchant.
+const squareApplicationId = import.meta.env['VITE_SQUARE_APPLICATION_ID'];
+const squareLocationId = import.meta.env['VITE_SQUARE_LOCATION_ID'];
+
 function App() {
   const params = new URLSearchParams(window.location.search);
   const classId = params.get('classId') ?? '';
@@ -64,12 +71,25 @@ function App() {
     );
   }
 
+  if (!squareApplicationId || !squareLocationId) {
+    return (
+      <div style={{ padding: 24, fontFamily: 'system-ui' }}>
+        <h2>Missing Square sandbox credentials</h2>
+        <p>
+          The harness build did not receive{' '}
+          <code>VITE_SQUARE_APPLICATION_ID</code> /{' '}
+          <code>VITE_SQUARE_LOCATION_ID</code>. Check the workflow that
+          built this bundle.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <>
       {/* Small banner so a human visiting the deployed harness can tell
-          which backend it's pointing at. Phase 2 ships this to a public
-          Firebase Hosting URL; without the banner, it would be ambiguous
-          whether you're hitting dev or an emulator. */}
+          which backend it's pointing at. Without the banner it would be
+          ambiguous whether you're hitting dev or an emulator. */}
       <div
         data-testid="harness-banner"
         style={{
@@ -84,11 +104,8 @@ function App() {
       </div>
       <RegistrationWidget
         classId={classId}
-        // Square Web Payments SDK requires non-empty IDs to initialise.
-        // These are sandbox-formatted dummies — the form renders, but
-        // tokenization is never exercised by the current E2E suite.
-        squareAppId="sandbox-sq0idb-0000000000000000000000"
-        squareLocationId="L00000000000"
+        squareAppId={squareApplicationId}
+        squareLocationId={squareLocationId}
         env={targetEnv}
         showDigitalWallets="hide"
       />

--- a/apps/registration-test-harness/vite.config.ts
+++ b/apps/registration-test-harness/vite.config.ts
@@ -21,6 +21,8 @@ const offset = Number.parseInt(process.env['EMULATOR_PORT_OFFSET'] ?? '0', 10);
 const harnessPort = 4173 + offset;
 const functionsPort = 5001 + offset;
 const targetEnv = process.env['VITE_TARGET_ENV'] ?? 'emulator';
+const squareApplicationId = process.env['VITE_SQUARE_APPLICATION_ID'] ?? '';
+const squareLocationId = process.env['VITE_SQUARE_LOCATION_ID'] ?? '';
 
 export default defineConfig({
   root: __dirname,
@@ -40,10 +42,17 @@ export default defineConfig({
     strictPort: true,
     host: '127.0.0.1',
   },
+  // Forward selected process.env values into the client bundle. Vite's
+  // automatic VITE_*-from-.env loading doesn't read process.env, so
+  // anything CI sets must be mirrored explicitly here.
   define: {
     'import.meta.env.VITE_FUNCTIONS_EMULATOR_PORT': JSON.stringify(
       String(functionsPort)
     ),
     'import.meta.env.VITE_TARGET_ENV': JSON.stringify(targetEnv),
+    'import.meta.env.VITE_SQUARE_APPLICATION_ID':
+      JSON.stringify(squareApplicationId),
+    'import.meta.env.VITE_SQUARE_LOCATION_ID':
+      JSON.stringify(squareLocationId),
   },
 });

--- a/apps/registration-test-harness/vite.config.ts
+++ b/apps/registration-test-harness/vite.config.ts
@@ -32,15 +32,19 @@ export default defineConfig({
       projects: [resolve(__dirname, '../../tsconfig.base.json')],
     }),
   ],
+  // Bind to `localhost` (not 127.0.0.1) — Square's Web Payments SDK
+  // explicitly allows `localhost` as a secure-context exception, but
+  // raw IPs (127.0.0.1) trip its "HTTPS required" rejection even
+  // though Chromium considers both equivalent.
   server: {
     port: harnessPort,
     strictPort: true,
-    host: '127.0.0.1',
+    host: 'localhost',
   },
   preview: {
     port: harnessPort,
     strictPort: true,
-    host: '127.0.0.1',
+    host: 'localhost',
   },
   // Forward selected process.env values into the client bundle. Vite's
   // automatic VITE_*-from-.env loading doesn't read process.env, so


### PR DESCRIPTION
## Summary

PR-check registration-e2e was running with the entire Pay flow out of scope (header: "Square tokenization is intentionally out of scope") and a closed-port `WEBFLOW_BASE_URL` workaround to silence the sync trigger's stack traces. Both go away here.

**PR-check:** emulator loads the PR's own cloud-function code, Square server SDK + browser Web Payments SDK both point at real Square sandbox, Webflow + Etsy use the existing in-repo HTTP mock servers (no usable sandbox for either).

**Post-merge `e2e_dev` (unchanged job, already wired):** deployed dev backend + real Square sandbox + real Webflow/Etsy dev — remains the prod-deploy gate.

Both jobs now drive the same spec set, which adds:
- Pay happy-path: tokenize sandbox `4111…` via real Square Web Payments SDK → `createRegistration` → assert success view + `$47.70 paid`
- Pay decline: sandbox `4000…0002` → assert alert + no success view

## Per-run isolation

- Class doc gets a UUID-suffixed ID per run (`test-class-${uuid}`), published via `process.env.TEST_CLASS_ID`. Discount fixtures keep deterministic IDs (specs reference codes, not doc IDs).
- New `globalTeardown` deletes the seeded class + any registrations the Pay flow created in dev. Emulator mode is a no-op (emulator exits with the job).

## Plumbing

- `.env.dev` gains `SQUARE_APPLICATION_ID` (public sandbox app ID — ships to every browser, not a secret)
- `vite.config.ts` forwards `VITE_SQUARE_APPLICATION_ID` / `_LOCATION_ID` into the bundle via `define`; `main.tsx` reads them and renders an error banner if missing
- `registration-e2e` job adds Webflow + Etsy mock servers (mirrors the integration-tests pattern)
- `deploy_harness_dev` now also passes the Vite Square vars so the deployed harness uses real sandbox creds

## Secret required (already added)

`SQUARE_SANDBOX_ACCESS_TOKEN` in repo Actions secrets.

## Test plan

- [ ] Registration E2E (PR check) green
- [ ] Six existing specs (cost summary, attendees, discounts) all pass against new emulator-with-real-Square setup
- [ ] Pay success spec: sandbox 4111… → success view + `\$47.70 paid`
- [ ] Pay decline spec: sandbox 4000…0002 → alert visible, success view absent
- [ ] After merge: `e2e_dev` against deployed dev passes the same suite
- [ ] After `e2e_dev`: no orphan `test-class-*` docs in dev Firestore (teardown ran)

🤖 Generated with [Claude Code](https://claude.com/claude-code)