### PR TITLE
fix(ci): unblock prod deploy by setting defineString defaults in .env.prod

### DIFF
--- a/.env.prod
+++ b/.env.prod
@@ -29,3 +29,13 @@ GOOGLE_CALENDAR_ADHOC_ICS_URL=
 # Class Reminders
 # Google Business Profile review shortlink used in the day-of class reminder email.
 GOOGLE_REVIEW_URL=https://g.page/r/CVjnXa8bifPBEBM/review
+
+# Lead attribution (Tally → GA4 + Meta CAPI)
+# Must be set even though defineString defaults match — without these the
+# Firebase deploy-time function discovery prompts via stdin for each param
+# and hangs the CI job.
+GA4_MEASUREMENT_ID=G-TY0E9X31V6
+META_PIXEL_ID=1625932185289127
+GA4_BASE_URL=https://www.google-analytics.com
+META_CAPI_BASE_URL=https://graph.facebook.com
+META_CAPI_API_VERSION=v20.0


### PR DESCRIPTION
Same root cause as the \`.env.dev\` fix in #429. Firebase's deploy-time function discovery prompts via stdin for any \`defineString\` param not present in the env file — even when there's a default in code. The dev fix landed but the prod equivalent didn't, so the latest **Deploy on merge** run failed with a 2-minute hang at \`Serving at port 8135\`:

\`\`\`
i  functions: Loading and analyzing source code for codebase maple-core to determine what to deploy
Serving at port 8135
[hang until job timeout]
\`\`\`

Values mirror the production GA4 stream and Meta pixel, matching the code-level defaults in \`libs/firebase/maple-functions/tally-lead-webhook/src/lib/tally-lead-webhook.ts\`.

Until this merges, **\`tallyLeadWebhook\` is not deployed to the prod project** (and any other prod deploys are blocked too).

## Test plan
- [ ] CI **Deploy on merge** workflow succeeds after this merges
- [ ] \`gcloud functions describe tallyLeadWebhook --project=maple-and-spruce --region=us-east4\` confirms the function exists post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)