### PR TITLE
chore: document defineSecret/defineString deploy requirements (forces prod redeploy)

### DIFF
--- a/libs/firebase/maple-functions/tally-lead-webhook/src/lib/tally-lead-webhook.ts
+++ b/libs/firebase/maple-functions/tally-lead-webhook/src/lib/tally-lead-webhook.ts
@@ -28,6 +28,11 @@ import {
   type TallyLeadValidationInput,
 } from '@maple/ts/validation';
 
+// Secrets are set per-project via `firebase functions:secrets:set` and
+// are required to be present for the function to deploy successfully.
+// String params (below) MUST also have matching entries in .env.dev /
+// .env.prod — Firebase prompts via stdin for any unset param during
+// deploy-time function discovery, even when there's a default in code.
 const tallyWebhookSecret = defineSecret('TALLY_WEBHOOK_SECRET');
 const ga4ApiSecret = defineSecret('GA4_API_SECRET');
 const metaCapiToken = defineSecret('META_CAPI_TOKEN');


### PR DESCRIPTION
The prod deploy of \`tallyLeadWebhook\` never completed — the original #429 attempt hung on missing \`.env.prod\` params, and the env-file fix in #436 was Nx-invisible (file-not-source) so the function wasn't re-included in the deploy set. Today \`tallyLeadWebhook\` exists in dev but 404s in prod.

This adds a 5-line comment block above the \`defineSecret\` / \`defineString\` declarations — useful documentation in its own right (the deploy-time stdin-prompt gotcha is non-obvious and bit me twice), and a meaningful source change that Nx affected will pick up on merge, triggering a prod deploy of the function.

## Test plan
- [ ] After merge, \`gcloud functions describe tallyLeadWebhook --project=maple-and-spruce --region=us-east4 --gen2\` returns the function (currently 404)
- [ ] \`curl -X POST -H "tally-signature: bogus" https://us-east4-maple-and-spruce.cloudfunctions.net/tallyLeadWebhook\` returns \`401 Invalid signature\` (currently 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)