### PR TITLE
chore: monthly check-pnpm-overrides workflow

### DIFF
--- a/.github/workflows/check-pnpm-overrides.yml
+++ b/.github/workflows/check-pnpm-overrides.yml
@@ -1,0 +1,32 @@
+name: Check pnpm overrides
+
+on:
+  schedule:
+    - cron: '0 9 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-overrides:
+    name: Check pnpm overrides
+    runs-on: ubuntu-latest
+    if: github.repository == 'Maple-and-Spruce/maple-and-spruce'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Check overrides
+        uses: mfranzke/check-pnpm-overrides@v0.0

--- a/docs/guides/dependency-overrides.md
+++ b/docs/guides/dependency-overrides.md
@@ -77,6 +77,12 @@ Overrides should be reviewed periodically (e.g., when updating Nx or other major
 - When `pnpm audit` reports no vulnerabilities — some overrides may be redundant
 - At least once per quarter
 
+## Automation
+
+- **New vulnerabilities** — Dependabot alerts are enabled at the repo level. When an alert fires, assign it to an AI agent from the Security → Dependabot tab (or the Agents tab). The agent reads this guide and opens a draft PR with either a top-level update or a scoped override.
+- **Stale overrides** — `.github/workflows/check-pnpm-overrides.yml` runs monthly. It temporarily removes each entry, re-runs `pnpm audit`, and opens a PR if any override is no longer needed.
+- **CI belt-and-suspenders** — the `security` job in `build-check.yml` keeps running `pnpm audit --audit-level=high` on every PR so a regression can't merge unnoticed.
+
 ## Notes
 
 - `overridesComments` is not a pnpm feature — it's a documentation convention stored as a sibling key. pnpm ignores unknown keys under `pnpm`.


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/check-pnpm-overrides.yml` — `mfranzke/check-pnpm-overrides` on a monthly cron (1st of the month, 9am UTC) plus `workflow_dispatch`. Opens a PR if any `pnpm.overrides` entry is no longer needed.
- Updates `docs/guides/dependency-overrides.md` to document the full automation: Dependabot alerts → agent-assigned PRs for new vulns, this workflow for stale-override cleanup, the existing CI audit as the regression guardrail.

## Manual repo settings still needed
1. **Settings → Code security → Dependabot alerts**: enable (likely already on).
2. **Settings → Actions → General → Workflow permissions**: tick *Allow GitHub Actions to create and approve pull requests* (required by `check-pnpm-overrides`).
3. When a Dependabot alert fires, assign it to an AI agent from the Security or Agents tab — the agent reads `docs/guides/dependency-overrides.md` and follows the update-or-override flow.

## Test plan
- [ ] Verify the workflow appears in Actions and can be triggered via `workflow_dispatch`.
- [ ] Run it once manually and confirm it either reports "all overrides still needed" or opens a cleanup PR.
- [ ] Confirm Dependabot alerts page lists the existing `@vitest/browser` / `tmp` advisories, and that the *Assign to agent* control is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)