### PR TITLE
fix: defer Square catalog sync to async worker (root cause of webhook 504s)

### DIFF
--- a/apps/functions-square/src/index.ts
+++ b/apps/functions-square/src/index.ts
@@ -20,6 +20,11 @@ export { uploadProductImage } from '@maple/firebase/maple-functions/upload-produ
 // Square webhook (HTTP endpoint, not callable)
 export { squareWebhook } from '@maple/firebase/maple-functions/square-webhook';
 
+// Async catalog sync worker (Firestore-triggered, debounced via lease).
+// Decoupled from squareWebhook so the webhook can ack within Square's
+// 10-second delivery deadline; the heavy O(catalog) sync runs here.
+export { processCatalogSyncRequest } from '@maple/firebase/maple-functions/process-catalog-sync-request';
+
 // Registration operations (Square payments)
 export { createRegistration } from '@maple/firebase/maple-functions/create-registration';
 export { cancelRegistration } from '@maple/firebase/maple-functions/cancel-registration';

--- a/apps/functions-square/tsconfig.app.json
+++ b/apps/functions-square/tsconfig.app.json
@@ -10,6 +10,7 @@
     "../../libs/firebase/maple-functions/update-product/**/*.ts",
     "../../libs/firebase/maple-functions/upload-product-image/**/*.ts",
     "../../libs/firebase/maple-functions/square-webhook/**/*.ts",
+    "../../libs/firebase/maple-functions/process-catalog-sync-request/**/*.ts",
     "../../libs/firebase/maple-functions/create-registration/**/*.ts",
     "../../libs/firebase/maple-functions/cancel-registration/**/*.ts",
     "../../libs/firebase/maple-functions/detect-sync-conflicts/**/*.ts",

--- a/docs/reference/deployed-functions.md
+++ b/docs/reference/deployed-functions.md
@@ -117,7 +117,8 @@ Square SDK integration for payments, catalog management, and sync conflict resol
 - `createProduct`, `updateProduct`, `uploadProductImage`
 
 ### Square webhook
-- `squareWebhook` — HTTP endpoint _(memory: 512MiB, concurrency: 10)_
+- `squareWebhook` — HTTP endpoint _(memory: 512MiB, concurrency: 10)_. For `catalog.version.updated` events, the handler just bumps the singleton `catalogSyncRequests/pending` doc and acks 200 within Square's 10-second delivery timeout; the actual catalog re-sync runs in `processCatalogSyncRequest`. Inventory and invoice events run inline (fast).
+- `processCatalogSyncRequest` — Firestore trigger on `catalogSyncRequests/pending` _(memory: 512MiB, timeout: 540s)_. Lease-based: a burst of N catalog webhooks collapses to a single downstream sync. Reads all Firestore products + all Square catalog items, parallelizes image-URL fetches (concurrency 8), and reconciles.
 
 ### Registration operations (Square payments)
 - `createRegistration`, `cancelRegistration`

--- a/function-codebases.json
+++ b/function-codebases.json
@@ -16,6 +16,7 @@
     "firebase-maple-functions-update-product": "maple-square",
     "firebase-maple-functions-upload-product-image": "maple-square",
     "firebase-maple-functions-square-webhook": "maple-square",
+    "firebase-maple-functions-process-catalog-sync-request": "maple-square",
     "firebase-maple-functions-create-registration": "maple-square",
     "firebase-maple-functions-cancel-registration": "maple-square",
     "firebase-maple-functions-detect-sync-conflicts": "maple-square",

--- a/libs/firebase/database/src/index.ts
+++ b/libs/firebase/database/src/index.ts
@@ -43,6 +43,11 @@ export {
   type CalendarEventFilters,
 } from './lib/calendar-event.repository';
 export { CalendarEmbedConfigRepository } from './lib/calendar-embed-config.repository';
+export {
+  CatalogSyncRequestRepository,
+  LEASE_TTL_MS,
+  type CatalogSyncRequest,
+} from './lib/catalog-sync-request.repository';
 
 // Phase 5: Sales & Inventory
 export {

--- a/libs/firebase/database/src/lib/catalog-sync-request.repository.ts
+++ b/libs/firebase/database/src/lib/catalog-sync-request.repository.ts
@@ -1,0 +1,148 @@
+/**
+ * Catalog Sync Request Repository
+ *
+ * Singleton document at `catalogSyncRequests/pending` that coordinates
+ * deferred catalog syncs from Square webhooks. The webhook handler must
+ * ack within Square's 10-second timeout, so it just bumps `requestedAt`
+ * here and returns 200. A Firestore-triggered function (`processCatalog
+ * SyncRequest`) drains the request asynchronously.
+ *
+ * Lease semantics let a burst of N webhook events collapse to a single
+ * downstream sync: only the first trigger to claim the lease runs the
+ * work, the rest exit fast. After a sync completes, the running=false
+ * write re-fires the trigger; if any further requests arrived during
+ * the sync (requestedAt > processedAt), the next invocation picks them
+ * up. Otherwise it exits.
+ *
+ * The lease has a TTL so a crashed processor doesn't permanently block
+ * later syncs.
+ */
+import admin from 'firebase-admin';
+import { db, toDate } from './utilities/database.config';
+
+const COLLECTION = 'catalogSyncRequests';
+const DOC_ID = 'pending';
+
+/** A stale lease is one whose holder hasn't checked in within this window. */
+export const LEASE_TTL_MS = 5 * 60 * 1000;
+
+export interface CatalogSyncRequest {
+  requestedAt?: Date;
+  processedAt?: Date;
+  running: boolean;
+  lastStartedAt?: Date;
+  lastResult?: string;
+  lastError?: string;
+}
+
+function docToRequest(
+  doc: FirebaseFirestore.DocumentSnapshot
+): CatalogSyncRequest {
+  if (!doc.exists) {
+    return { running: false };
+  }
+  const data = doc.data()!;
+  return {
+    requestedAt: data['requestedAt'] ? toDate(data['requestedAt']) : undefined,
+    processedAt: data['processedAt'] ? toDate(data['processedAt']) : undefined,
+    running: Boolean(data['running']),
+    lastStartedAt: data['lastStartedAt']
+      ? toDate(data['lastStartedAt'])
+      : undefined,
+    lastResult: data['lastResult'],
+    lastError: data['lastError'],
+  };
+}
+
+function docRef(): FirebaseFirestore.DocumentReference {
+  return db.collection(COLLECTION).doc(DOC_ID);
+}
+
+export const CatalogSyncRequestRepository = {
+  /**
+   * Called by the webhook handler. Bumps `requestedAt` to the current
+   * server time; merges so we don't clobber lease/processed state.
+   */
+  async requestRefresh(): Promise<void> {
+    await docRef().set(
+      { requestedAt: admin.firestore.FieldValue.serverTimestamp() },
+      { merge: true }
+    );
+  },
+
+  /**
+   * Atomic lease acquisition. Returns true if the caller now holds the
+   * lease and should run the sync, false otherwise. Re-checks every
+   * condition inside the transaction so two concurrent triggers can't
+   * both think they own the lease.
+   */
+  async tryClaimLease(now: Date = new Date()): Promise<boolean> {
+    return db.runTransaction(async (tx) => {
+      const snap = await tx.get(docRef());
+      const cur = docToRequest(snap);
+
+      // Lease in flight and not stale → bail
+      if (
+        cur.running &&
+        cur.lastStartedAt &&
+        now.getTime() - cur.lastStartedAt.getTime() < LEASE_TTL_MS
+      ) {
+        return false;
+      }
+
+      // Nothing new to do
+      if (
+        cur.processedAt &&
+        cur.requestedAt &&
+        cur.processedAt.getTime() >= cur.requestedAt.getTime()
+      ) {
+        return false;
+      }
+
+      // No request ever recorded → nothing to do
+      if (!cur.requestedAt) {
+        return false;
+      }
+
+      tx.set(
+        snap.ref,
+        {
+          running: true,
+          lastStartedAt: admin.firestore.FieldValue.serverTimestamp(),
+          lastError: admin.firestore.FieldValue.delete(),
+        },
+        { merge: true }
+      );
+      return true;
+    });
+  },
+
+  /** Release the lease and record success. */
+  async markCompleted(summary: string): Promise<void> {
+    await docRef().set(
+      {
+        running: false,
+        processedAt: admin.firestore.FieldValue.serverTimestamp(),
+        lastResult: summary,
+      },
+      { merge: true }
+    );
+  },
+
+  /** Release the lease and record failure (does not advance processedAt). */
+  async markFailed(error: string): Promise<void> {
+    await docRef().set(
+      {
+        running: false,
+        lastError: error,
+      },
+      { merge: true }
+    );
+  },
+
+  /** Read current state (used by the trigger to make a cheap pre-claim check). */
+  async getCurrent(): Promise<CatalogSyncRequest> {
+    const snap = await docRef().get();
+    return docToRequest(snap);
+  },
+};

--- a/libs/firebase/maple-functions/process-catalog-sync-request/eslint.config.mjs
+++ b/libs/firebase/maple-functions/process-catalog-sync-request/eslint.config.mjs
@@ -1,0 +1,3 @@
+import baseConfig from '../../../../eslint.config.mjs';
+
+export default [...baseConfig];

--- a/libs/firebase/maple-functions/process-catalog-sync-request/project.json
+++ b/libs/firebase/maple-functions/process-catalog-sync-request/project.json
@@ -1,0 +1,15 @@
+{
+  "name": "firebase-maple-functions-process-catalog-sync-request",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/process-catalog-sync-request/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "test": {
+      "executor": "@nx/vitest:test",
+      "options": {
+        "config": "libs/firebase/maple-functions/process-catalog-sync-request/vitest.config.ts"
+      }
+    }
+  }
+}

--- a/libs/firebase/maple-functions/process-catalog-sync-request/src/index.ts
+++ b/libs/firebase/maple-functions/process-catalog-sync-request/src/index.ts
@@ -1,0 +1,1 @@
+export { processCatalogSyncRequest } from './lib/process-catalog-sync-request';

--- a/libs/firebase/maple-functions/process-catalog-sync-request/src/lib/process-catalog-sync-request.spec.ts
+++ b/libs/firebase/maple-functions/process-catalog-sync-request/src/lib/process-catalog-sync-request.spec.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Tests for processCatalogSyncRequest.
+ *
+ * Two concerns:
+ *  1. Lease coordination — N rapid triggers must collapse to one
+ *     downstream sync (the 5/16 burst that produced 269 504s).
+ *  2. Catalog sync correctness — same input/output as the old inline
+ *     handleCatalogUpdate batch path.
+ */
+
+const mocks = vi.hoisted(() => ({
+  onDocumentWritten: vi.fn(),
+  // CatalogSyncRequestRepository
+  tryClaimLease: vi.fn(),
+  markCompleted: vi.fn(),
+  markFailed: vi.fn(),
+  getCurrent: vi.fn(),
+  // ProductRepository
+  productFindAll: vi.fn(),
+  updateSquareCache: vi.fn(),
+  createProduct: vi.fn(),
+  // Square catalog service
+  listItems: vi.fn(),
+  getItemImageUrl: vi.fn(),
+}));
+
+vi.mock('firebase-functions/v2/firestore', () => ({
+  onDocumentWritten: vi.fn((config, handler) => {
+    mocks.onDocumentWritten(config, handler);
+    return handler;
+  }),
+}));
+
+vi.mock('firebase-functions/params', () => ({
+  defineSecret: vi.fn((name: string) => ({ name, value: () => `mock-${name}` })),
+  defineString: vi.fn((name: string) => ({ name, value: () => `mock-${name}` })),
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  CatalogSyncRequestRepository: {
+    tryClaimLease: mocks.tryClaimLease,
+    markCompleted: mocks.markCompleted,
+    markFailed: mocks.markFailed,
+    getCurrent: mocks.getCurrent,
+  },
+  ProductRepository: {
+    findAll: mocks.productFindAll,
+    updateSquareCache: mocks.updateSquareCache,
+    create: mocks.createProduct,
+  },
+}));
+
+vi.mock('@maple/firebase/square', () => ({
+  Square: class MockSquare {
+    locationId = 'LW0MMBZ';
+    catalogService = {
+      listItems: mocks.listItems,
+      getItemImageUrl: mocks.getItemImageUrl,
+    };
+  },
+  SQUARE_SECRET_NAMES: ['SQUARE_ACCESS_TOKEN'] as const,
+  SQUARE_STRING_NAMES: ['SQUARE_LOCATION_ID'] as const,
+}));
+
+// Import after mocks
+import { processCatalogSyncRequest } from './process-catalog-sync-request';
+
+type Handler = (event: unknown) => Promise<void>;
+const handler = processCatalogSyncRequest as unknown as Handler;
+
+function makeEvent(after?: Record<string, unknown>): unknown {
+  return {
+    data: {
+      after: {
+        data: () => after,
+        ref: { id: 'pending' },
+      },
+    },
+    params: {},
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default safe state — caller can override.
+  mocks.getCurrent.mockResolvedValue({
+    running: false,
+    requestedAt: new Date(2026, 5, 7, 12, 0, 0),
+    processedAt: undefined,
+  });
+  mocks.productFindAll.mockResolvedValue([]);
+  mocks.listItems.mockResolvedValue([]);
+});
+
+describe('processCatalogSyncRequest — lease coordination', () => {
+  it('exits without claiming when doc is deleted (no after data)', async () => {
+    await handler(makeEvent(undefined));
+    expect(mocks.tryClaimLease).not.toHaveBeenCalled();
+    expect(mocks.listItems).not.toHaveBeenCalled();
+  });
+
+  it('exits without claiming when processedAt >= requestedAt', async () => {
+    const t = new Date(2026, 5, 7, 12, 0, 0);
+    mocks.getCurrent.mockResolvedValue({
+      running: false,
+      requestedAt: t,
+      processedAt: t,
+    });
+    await handler(makeEvent({ requestedAt: t, processedAt: t, running: false }));
+    expect(mocks.tryClaimLease).not.toHaveBeenCalled();
+  });
+
+  it('exits when tryClaimLease returns false (another worker holds it)', async () => {
+    mocks.tryClaimLease.mockResolvedValue(false);
+    await handler(makeEvent({ requestedAt: new Date(), running: true }));
+    expect(mocks.listItems).not.toHaveBeenCalled();
+    expect(mocks.markCompleted).not.toHaveBeenCalled();
+  });
+
+  it('runs sync exactly once when lease is claimed, then marks completed', async () => {
+    mocks.tryClaimLease.mockResolvedValue(true);
+    mocks.productFindAll.mockResolvedValue([]);
+    mocks.listItems.mockResolvedValue([]);
+
+    await handler(makeEvent({ requestedAt: new Date(), running: false }));
+
+    expect(mocks.tryClaimLease).toHaveBeenCalledTimes(1);
+    expect(mocks.listItems).toHaveBeenCalledTimes(1);
+    expect(mocks.markCompleted).toHaveBeenCalledTimes(1);
+    expect(mocks.markFailed).not.toHaveBeenCalled();
+  });
+
+  it('marks failed and re-throws when the sync errors', async () => {
+    mocks.tryClaimLease.mockResolvedValue(true);
+    mocks.listItems.mockRejectedValue(new Error('Square 500'));
+
+    await expect(
+      handler(makeEvent({ requestedAt: new Date(), running: false }))
+    ).rejects.toThrow('Square 500');
+
+    expect(mocks.markFailed).toHaveBeenCalledTimes(1);
+    expect(mocks.markCompleted).not.toHaveBeenCalled();
+  });
+
+  it('50 concurrent triggers result in exactly one sync (burst → one)', async () => {
+    // Simulate a 50-event burst: the first invocation claims the lease,
+    // the other 49 see it held and exit fast. tryClaimLease returns true
+    // exactly once.
+    let claimedOnce = false;
+    mocks.tryClaimLease.mockImplementation(async () => {
+      if (claimedOnce) return false;
+      claimedOnce = true;
+      return true;
+    });
+    mocks.productFindAll.mockResolvedValue([]);
+    mocks.listItems.mockResolvedValue([]);
+
+    const event = makeEvent({ requestedAt: new Date(), running: false });
+    await Promise.all(
+      Array.from({ length: 50 }, () => handler(event))
+    );
+
+    expect(mocks.listItems).toHaveBeenCalledTimes(1);
+    expect(mocks.markCompleted).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('processCatalogSyncRequest — catalog sync correctness', () => {
+  beforeEach(() => {
+    mocks.tryClaimLease.mockResolvedValue(true);
+  });
+
+  it('updates tracked products and creates drafts for new Square items', async () => {
+    mocks.productFindAll.mockResolvedValue([
+      {
+        id: 'prod-1',
+        squareItemId: 'ITEM_A',
+        squareCache: {
+          name: 'A',
+          description: 'a',
+          priceCents: 100,
+          sku: 'A',
+          imageUrl: '',
+        },
+      },
+    ]);
+    mocks.listItems.mockResolvedValue([
+      {
+        id: 'ITEM_A',
+        type: 'ITEM',
+        version: 2,
+        itemData: {
+          name: 'A updated',
+          variations: [
+            {
+              id: 'VAR_A',
+              itemVariationData: { sku: 'A', priceMoney: { amount: 150n } },
+            },
+          ],
+        },
+      },
+      {
+        id: 'ITEM_B',
+        type: 'ITEM',
+        version: 1,
+        itemData: {
+          name: 'B new',
+          variations: [
+            {
+              id: 'VAR_B',
+              itemVariationData: { sku: 'B', priceMoney: { amount: 200n } },
+            },
+          ],
+        },
+      },
+    ]);
+    mocks.getItemImageUrl.mockResolvedValue('image.jpg');
+    mocks.createProduct.mockResolvedValue({ id: 'prod-new' });
+
+    await handler(makeEvent({ requestedAt: new Date(), running: false }));
+
+    expect(mocks.updateSquareCache).toHaveBeenCalled();
+    expect(mocks.createProduct).toHaveBeenCalled();
+    expect(mocks.markCompleted).toHaveBeenCalledWith(
+      expect.stringContaining('scanned 2')
+    );
+  });
+
+  it('skips non-ITEM catalog objects', async () => {
+    mocks.listItems.mockResolvedValue([
+      { id: 'CAT_1', type: 'CATEGORY' },
+      { id: 'TAX_1', type: 'TAX' },
+    ]);
+
+    await handler(makeEvent({ requestedAt: new Date(), running: false }));
+
+    expect(mocks.createProduct).not.toHaveBeenCalled();
+    expect(mocks.updateSquareCache).not.toHaveBeenCalled();
+    expect(mocks.markCompleted).toHaveBeenCalledWith(
+      expect.stringContaining('scanned 2')
+    );
+  });
+
+  it('parallelizes image fetches (concurrent calls to getItemImageUrl)', async () => {
+    const ids = Array.from({ length: 10 }, (_, i) => `ITEM_${i}`);
+    mocks.listItems.mockResolvedValue(
+      ids.map((id) => ({
+        id,
+        type: 'ITEM',
+        version: 1,
+        itemData: {
+          name: id,
+          variations: [
+            {
+              id: `VAR_${id}`,
+              itemVariationData: { sku: id, priceMoney: { amount: 100n } },
+            },
+          ],
+        },
+      }))
+    );
+    mocks.getItemImageUrl.mockResolvedValue('img');
+    mocks.createProduct.mockResolvedValue({ id: 'new' });
+
+    await handler(makeEvent({ requestedAt: new Date(), running: false }));
+
+    expect(mocks.getItemImageUrl).toHaveBeenCalledTimes(10);
+  });
+});

--- a/libs/firebase/maple-functions/process-catalog-sync-request/src/lib/process-catalog-sync-request.ts
+++ b/libs/firebase/maple-functions/process-catalog-sync-request/src/lib/process-catalog-sync-request.ts
@@ -1,0 +1,260 @@
+/**
+ * Process Catalog Sync Request
+ *
+ * Firestore-triggered worker for the singleton `catalogSyncRequests/
+ * pending` doc. The Square webhook (`squareWebhook`) records each
+ * `catalog.version.updated` event by bumping `requestedAt` on this
+ * doc; this trigger drains the request asynchronously so the webhook
+ * itself can ack inside Square's 10-second timeout.
+ *
+ * Coordination is lease-based via
+ * `CatalogSyncRequestRepository.tryClaimLease()`:
+ *
+ * - A burst of N webhook events upserts the doc N times, firing this
+ *   trigger N times. Only the first claim succeeds; the rest exit fast.
+ * - On completion, the running=false write re-fires the trigger. If
+ *   new requests arrived during the sync (requestedAt > processedAt
+ *   at that moment), the next invocation runs a single catch-up sync.
+ *   Otherwise it exits.
+ *
+ * The actual sync mirrors what the old inline webhook handler did:
+ * fetch all tracked products + all Square catalog items, then update
+ * existing products and create drafts for new items. Image-URL fetches
+ * are parallelized so the wall time scales with Square's rate limits,
+ * not with catalog size.
+ */
+import { onDocumentWritten } from 'firebase-functions/v2/firestore';
+import { defineSecret, defineString } from 'firebase-functions/params';
+import {
+  CatalogSyncRequestRepository,
+  ProductRepository,
+} from '@maple/firebase/database';
+import {
+  Square,
+  SQUARE_SECRET_NAMES,
+  SQUARE_STRING_NAMES,
+} from '@maple/firebase/square';
+
+const squareSecretParams = SQUARE_SECRET_NAMES.map((name) => defineSecret(name));
+const squareStringParams = SQUARE_STRING_NAMES.map((name) => defineString(name));
+
+/** Concurrency cap on parallel image-URL fetches against Square. */
+const IMAGE_FETCH_CONCURRENCY = 8;
+
+interface SyncSummary {
+  scanned: number;
+  updated: number;
+  created: number;
+  skipped: number;
+}
+
+async function fetchImageUrl(
+  squareItemId: string,
+  square: Square
+): Promise<string | undefined> {
+  try {
+    const imageUrl = await square.catalogService.getItemImageUrl(squareItemId);
+    return imageUrl || undefined;
+  } catch (err) {
+    console.warn(`[process-catalog-sync] image fetch failed for ${squareItemId}:`, err);
+    return undefined;
+  }
+}
+
+/**
+ * Run image-URL fetches in batches of N concurrent. Returns a Map keyed
+ * by Square item id so callers can look up results without re-running.
+ */
+async function fetchImageUrlsConcurrent(
+  squareItemIds: string[],
+  square: Square
+): Promise<Map<string, string | undefined>> {
+  const out = new Map<string, string | undefined>();
+  for (let i = 0; i < squareItemIds.length; i += IMAGE_FETCH_CONCURRENCY) {
+    const chunk = squareItemIds.slice(i, i + IMAGE_FETCH_CONCURRENCY);
+    const results = await Promise.all(
+      chunk.map((id) => fetchImageUrl(id, square))
+    );
+    chunk.forEach((id, idx) => out.set(id, results[idx]));
+  }
+  return out;
+}
+
+async function runCatalogSync(square: Square): Promise<SyncSummary> {
+  const products = await ProductRepository.findAll();
+  const trackedSquareItemIds = new Set(
+    products.filter((p) => p.squareItemId).map((p) => p.squareItemId!)
+  );
+
+  const squareItems = await square.catalogService.listItems();
+
+  console.log(
+    `[process-catalog-sync] firestore=${products.length} (tracked=${trackedSquareItemIds.size}) square=${squareItems.length}`
+  );
+
+  // Pre-fetch all image URLs in parallel before iterating.
+  const itemIdsForImages = squareItems
+    .filter((o) => o.type === 'ITEM' && o.id)
+    .map((o) => o.id!);
+  const imageUrls = await fetchImageUrlsConcurrent(itemIdsForImages, square);
+
+  let updated = 0;
+  let created = 0;
+  let skipped = 0;
+
+  for (const catalogObject of squareItems) {
+    if (catalogObject.type !== 'ITEM' || !catalogObject.id) {
+      skipped++;
+      continue;
+    }
+
+    const itemData = catalogObject.itemData;
+    const variation = itemData?.variations?.[0];
+    const variationData = (variation as {
+      itemVariationData?: {
+        sku?: string;
+        priceMoney?: { amount?: bigint };
+      };
+    })?.itemVariationData;
+
+    const imageUrl = imageUrls.get(catalogObject.id);
+
+    if (trackedSquareItemIds.has(catalogObject.id)) {
+      const product = products.find((p) => p.squareItemId === catalogObject.id);
+      if (!product) {
+        skipped++;
+        continue;
+      }
+      try {
+        await ProductRepository.updateSquareCache(
+          product.id,
+          {
+            name: itemData?.name ?? product.squareCache.name,
+            description:
+              itemData?.description ?? product.squareCache.description,
+            priceCents: variationData?.priceMoney?.amount
+              ? Number(variationData.priceMoney.amount)
+              : product.squareCache.priceCents,
+            sku: variationData?.sku ?? product.squareCache.sku,
+            imageUrl: imageUrl ?? product.squareCache.imageUrl,
+          },
+          Number(catalogObject.version || 0)
+        );
+        updated++;
+      } catch (err) {
+        console.warn(
+          `[process-catalog-sync] update failed for ${product.id}:`,
+          err
+        );
+        skipped++;
+      }
+      continue;
+    }
+
+    // New item in Square — create a draft (artistId left blank for manual assignment).
+    if (!variation) {
+      skipped++;
+      continue;
+    }
+    try {
+      const newProduct = await ProductRepository.create(
+        {
+          artistId: '',
+          name: itemData?.name ?? 'Unnamed Product',
+          description: itemData?.description ?? undefined,
+          priceCents: variationData?.priceMoney?.amount
+            ? Number(variationData.priceMoney.amount)
+            : 0,
+          quantity: 0,
+          status: 'draft',
+        },
+        {
+          squareItemId: catalogObject.id,
+          squareVariationId: variation.id!,
+          squareCatalogVersion: Number(catalogObject.version || 0),
+          squareLocationId: square.locationId,
+          sku: variationData?.sku ?? '',
+          variations: [
+            {
+              variantId: 'var_compat',
+              squareVariationId: variation.id!,
+              sku: variationData?.sku ?? '',
+            },
+          ],
+        }
+      );
+      if (imageUrl) {
+        await ProductRepository.updateSquareCache(newProduct.id, { imageUrl });
+      }
+      created++;
+    } catch (err) {
+      console.warn(
+        `[process-catalog-sync] create failed for Square item ${catalogObject.id}:`,
+        err
+      );
+      skipped++;
+    }
+  }
+
+  return { scanned: squareItems.length, updated, created, skipped };
+}
+
+export const processCatalogSyncRequest = onDocumentWritten(
+  {
+    document: 'catalogSyncRequests/pending',
+    region: 'us-east4',
+    memory: '512MiB',
+    // Long timeout: this can take a few minutes on a large catalog. Square
+    // doesn't wait on this — only the webhook ack matters.
+    timeoutSeconds: 540,
+    secrets: squareSecretParams,
+  },
+  async (event) => {
+    const after = event.data?.after.data();
+    if (!after) {
+      // Doc deleted — nothing to do.
+      return;
+    }
+
+    // Cheap pre-check before opening a transaction. Lease in-flight or
+    // nothing new to process → exit fast.
+    const cur = await CatalogSyncRequestRepository.getCurrent();
+    if (
+      cur.processedAt &&
+      cur.requestedAt &&
+      cur.processedAt.getTime() >= cur.requestedAt.getTime()
+    ) {
+      return;
+    }
+
+    const claimed = await CatalogSyncRequestRepository.tryClaimLease();
+    if (!claimed) {
+      // Either another invocation grabbed the lease, or there's nothing
+      // to do. Either way, this trigger is done.
+      return;
+    }
+
+    const secrets = Object.fromEntries(
+      squareSecretParams.map((s) => [s.name, s.value()])
+    ) as Record<(typeof SQUARE_SECRET_NAMES)[number], string>;
+
+    const strings = Object.fromEntries(
+      squareStringParams.map((s) => [s.name, s.value()])
+    ) as Record<(typeof SQUARE_STRING_NAMES)[number], string>;
+
+    const square = new Square(secrets, strings);
+
+    try {
+      const summary = await runCatalogSync(square);
+      const details = `scanned ${summary.scanned}, updated ${summary.updated}, created ${summary.created}, skipped ${summary.skipped}`;
+      await CatalogSyncRequestRepository.markCompleted(details);
+      console.log(`[process-catalog-sync] done: ${details}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error('[process-catalog-sync] sync failed:', message);
+      await CatalogSyncRequestRepository.markFailed(message);
+      // Re-throw so the function reports failure to Cloud Functions logs.
+      throw err;
+    }
+  }
+);

--- a/libs/firebase/maple-functions/process-catalog-sync-request/tsconfig.json
+++ b/libs/firebase/maple-functions/process-catalog-sync-request/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/process-catalog-sync-request/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/process-catalog-sync-request/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/process-catalog-sync-request/vitest.config.ts
+++ b/libs/firebase/maple-functions/process-catalog-sync-request/vitest.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  root: __dirname,
+  test: {
+    name: 'firebase-maple-functions-process-catalog-sync-request',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov', 'json-summary', 'json'],
+      reportsDirectory:
+        '../../../../coverage/libs/firebase/maple-functions/process-catalog-sync-request',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.spec.ts', 'src/index.ts'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@maple/ts/domain': resolve(__dirname, '../../../ts/domain/src/index.ts'),
+      '@maple/firebase/database': resolve(__dirname, '../../../firebase/database/src/index.ts'),
+      '@maple/firebase/square': resolve(__dirname, '../../../firebase/square/src/index.ts'),
+      '@maple/firebase/functions': resolve(__dirname, '../../../firebase/functions/src/index.ts'),
+    },
+  },
+});

--- a/libs/firebase/maple-functions/square-webhook/src/lib/square-webhook.spec.ts
+++ b/libs/firebase/maple-functions/square-webhook/src/lib/square-webhook.spec.ts
@@ -17,14 +17,11 @@ const mocks = vi.hoisted(() => {
     createProduct: vi.fn(),
     findBySquareInvoiceId: vi.fn(),
     markPaidBySquareWebhook: vi.fn(),
-    // Square catalogService
-    getItem: vi.fn(),
-    listItems: vi.fn(),
-    getItemImageUrl: vi.fn(),
+    requestRefresh: vi.fn(),
   };
 });
 
-// Mock ProductRepository + InvoiceRepository
+// Mock ProductRepository + InvoiceRepository + CatalogSyncRequestRepository
 vi.mock('@maple/firebase/database', () => ({
   ProductRepository: {
     findAll: mocks.findAll,
@@ -37,13 +34,9 @@ vi.mock('@maple/firebase/database', () => ({
     findBySquareInvoiceId: mocks.findBySquareInvoiceId,
     markPaidBySquareWebhook: mocks.markPaidBySquareWebhook,
   },
-}));
-
-// Mock Square module (not used in inventory handler but needed for imports)
-vi.mock('@maple/firebase/square', () => ({
-  Square: vi.fn(),
-  SQUARE_SECRET_NAMES: ['SQUARE_ACCESS_TOKEN'],
-  SQUARE_STRING_NAMES: ['SQUARE_LOCATION_ID'],
+  CatalogSyncRequestRepository: {
+    requestRefresh: mocks.requestRefresh,
+  },
 }));
 
 // Mock firebase-functions params
@@ -369,376 +362,32 @@ describe('Square Webhook - invoice.payment_made handler', () => {
   });
 });
 
-describe('Square Webhook - handleCatalogUpdate', () => {
+describe('Square Webhook - handleCatalogUpdate (enqueue path)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  const makeCatalogEvent = (catalogObjectId?: string) => ({
-    merchant_id: 'ML1TB2DX6N1B0',
-    type: 'catalog.version.updated' as const,
-    event_id: 'evt-cat',
-    created_at: '2026-04-23T14:00:00Z',
-    data: {
-      type: 'catalog_item',
-      id: catalogObjectId ?? '',
-    },
+  // The catalog handler no longer performs a sync inline — it bumps the
+  // singleton `catalogSyncRequests/pending` doc and returns. The actual
+  // sync runs in `processCatalogSyncRequest` (separate cloud function).
+  // Tests for the sync work itself live in
+  // `process-catalog-sync-request.spec.ts`.
+
+  it('enqueues a sync request and returns immediately', async () => {
+    mocks.requestRefresh.mockResolvedValue(undefined);
+
+    const { handleCatalogUpdate } = await import('./square-webhook');
+    const result = await handleCatalogUpdate();
+
+    expect(mocks.requestRefresh).toHaveBeenCalledTimes(1);
+    expect(result.action).toBe('enqueued');
   });
 
-  const makeSquare = () => ({
-    locationId: 'LW0MMBZ',
-    catalogService: {
-      getItem: mocks.getItem,
-      listItems: mocks.listItems,
-      getItemImageUrl: mocks.getItemImageUrl,
-    },
-  });
+  it('propagates Firestore errors so the webhook returns 500 and Square retries', async () => {
+    mocks.requestRefresh.mockRejectedValue(new Error('Firestore unavailable'));
 
-  describe('single-item path', () => {
-    it('updates an existing product when the catalog item is already tracked', async () => {
-      const existing = {
-        id: 'prod-1',
-        squareItemId: 'ITEM_1',
-        squareCache: {
-          name: 'Old name',
-          description: 'Old desc',
-          priceCents: 1000,
-          sku: 'OLD-SKU',
-          imageUrl: 'old.jpg',
-        },
-      };
-      mocks.findBySquareItemId.mockResolvedValue(existing);
-      mocks.getItem.mockResolvedValue({
-        id: 'ITEM_1',
-        type: 'ITEM',
-        version: 42,
-        itemData: {
-          name: 'New name',
-          description: 'New desc',
-          variations: [
-            {
-              id: 'VAR_1',
-              itemVariationData: {
-                sku: 'NEW-SKU',
-                priceMoney: { amount: 2500n },
-              },
-            },
-          ],
-        },
-      });
-      mocks.getItemImageUrl.mockResolvedValue('new.jpg');
-      mocks.updateSquareCache.mockResolvedValue(undefined);
-
-      const { handleCatalogUpdate } = await import('./square-webhook');
-      const result = await handleCatalogUpdate(
-        makeCatalogEvent('ITEM_1'),
-        makeSquare() as unknown as Parameters<typeof handleCatalogUpdate>[1]
-      );
-
-      expect(mocks.updateSquareCache).toHaveBeenCalledWith(
-        'prod-1',
-        expect.objectContaining({
-          name: 'New name',
-          description: 'New desc',
-          priceCents: 2500,
-          sku: 'NEW-SKU',
-          imageUrl: 'new.jpg',
-        }),
-        42
-      );
-      expect(result.action).toBe('updated');
-    });
-
-    it('creates a draft product when the catalog item is new', async () => {
-      mocks.findBySquareItemId.mockResolvedValue(undefined);
-      mocks.getItem.mockResolvedValue({
-        id: 'ITEM_NEW',
-        type: 'ITEM',
-        version: 1,
-        itemData: {
-          name: 'Brand new',
-          description: 'desc',
-          variations: [
-            {
-              id: 'VAR_NEW',
-              itemVariationData: {
-                sku: 'SKU-NEW',
-                priceMoney: { amount: 5000n },
-              },
-            },
-          ],
-        },
-      });
-      mocks.getItemImageUrl.mockResolvedValue(undefined);
-      mocks.createProduct.mockResolvedValue({ id: 'prod-new' });
-
-      const { handleCatalogUpdate } = await import('./square-webhook');
-      const result = await handleCatalogUpdate(
-        makeCatalogEvent('ITEM_NEW'),
-        makeSquare() as unknown as Parameters<typeof handleCatalogUpdate>[1]
-      );
-
-      expect(mocks.createProduct).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'Brand new',
-          status: 'draft',
-          priceCents: 5000,
-        }),
-        expect.objectContaining({
-          squareItemId: 'ITEM_NEW',
-          squareVariationId: 'VAR_NEW',
-          sku: 'SKU-NEW',
-        })
-      );
-      expect(result.action).toBe('created');
-    });
-
-    it('skips a single-item update when the catalog object is not an ITEM', async () => {
-      mocks.getItem.mockResolvedValue({
-        id: 'CAT_1',
-        type: 'CATEGORY',
-      });
-
-      const { handleCatalogUpdate } = await import('./square-webhook');
-      const result = await handleCatalogUpdate(
-        makeCatalogEvent('CAT_1'),
-        makeSquare() as unknown as Parameters<typeof handleCatalogUpdate>[1]
-      );
-
-      expect(result.action).toBe('skipped');
-      expect(result.details).toMatch(/non-ITEM/);
-    });
-
-    it('skips when the catalog object is not found in Square (deleted)', async () => {
-      mocks.getItem.mockResolvedValue(undefined);
-
-      const { handleCatalogUpdate } = await import('./square-webhook');
-      const result = await handleCatalogUpdate(
-        makeCatalogEvent('ITEM_GONE'),
-        makeSquare() as unknown as Parameters<typeof handleCatalogUpdate>[1]
-      );
-
-      expect(result.action).toBe('skipped');
-      expect(result.details).toMatch(/not found/);
-    });
-
-    it('skips when a new item has no variation', async () => {
-      mocks.findBySquareItemId.mockResolvedValue(undefined);
-      mocks.getItem.mockResolvedValue({
-        id: 'ITEM_NO_VAR',
-        type: 'ITEM',
-        itemData: { name: 'No variation', variations: [] },
-      });
-
-      const { handleCatalogUpdate } = await import('./square-webhook');
-      const result = await handleCatalogUpdate(
-        makeCatalogEvent('ITEM_NO_VAR'),
-        makeSquare() as unknown as Parameters<typeof handleCatalogUpdate>[1]
-      );
-
-      expect(mocks.createProduct).not.toHaveBeenCalled();
-      expect(result.action).toBe('skipped');
-    });
-  });
-
-  describe('batch path (no catalogObjectId — version bump)', () => {
-    it('syncs every Square item, updating tracked + creating new', async () => {
-      mocks.findAll.mockResolvedValue([
-        {
-          id: 'prod-1',
-          squareItemId: 'ITEM_A',
-          squareCache: {
-            name: 'A',
-            description: 'a',
-            priceCents: 100,
-            sku: 'A',
-            imageUrl: '',
-          },
-        },
-      ]);
-      mocks.listItems.mockResolvedValue([
-        {
-          id: 'ITEM_A',
-          type: 'ITEM',
-          version: 2,
-          itemData: {
-            name: 'A updated',
-            variations: [
-              {
-                id: 'VAR_A',
-                itemVariationData: {
-                  sku: 'A',
-                  priceMoney: { amount: 150n },
-                },
-              },
-            ],
-          },
-        },
-        {
-          id: 'ITEM_B',
-          type: 'ITEM',
-          version: 1,
-          itemData: {
-            name: 'B new',
-            variations: [
-              {
-                id: 'VAR_B',
-                itemVariationData: {
-                  sku: 'B',
-                  priceMoney: { amount: 200n },
-                },
-              },
-            ],
-          },
-        },
-      ]);
-      mocks.getItemImageUrl.mockResolvedValue('image.jpg');
-      mocks.updateSquareCache.mockResolvedValue(undefined);
-      mocks.createProduct.mockResolvedValue({ id: 'prod-new' });
-
-      const { handleCatalogUpdate } = await import('./square-webhook');
-      const result = await handleCatalogUpdate(
-        makeCatalogEvent(undefined),
-        makeSquare() as unknown as Parameters<typeof handleCatalogUpdate>[1]
-      );
-
-      expect(mocks.updateSquareCache).toHaveBeenCalled(); // prod-1 updated
-      expect(mocks.createProduct).toHaveBeenCalled(); // ITEM_B created as new product
-      expect(result.action).toBe('synced');
-    });
-
-    it('ignores non-ITEM catalog objects during batch sync', async () => {
-      mocks.findAll.mockResolvedValue([]);
-      mocks.listItems.mockResolvedValue([
-        { id: 'CAT_1', type: 'CATEGORY' },
-        { id: 'TAX_1', type: 'TAX' },
-      ]);
-
-      const { handleCatalogUpdate } = await import('./square-webhook');
-      const result = await handleCatalogUpdate(
-        makeCatalogEvent(undefined),
-        makeSquare() as unknown as Parameters<typeof handleCatalogUpdate>[1]
-      );
-
-      expect(mocks.createProduct).not.toHaveBeenCalled();
-      expect(mocks.updateSquareCache).not.toHaveBeenCalled();
-      expect(result.action).toBe('synced');
-    });
-
-    it('skips Square items with no variation during batch sync', async () => {
-      mocks.findAll.mockResolvedValue([]);
-      mocks.listItems.mockResolvedValue([
-        {
-          id: 'ITEM_X',
-          type: 'ITEM',
-          itemData: { name: 'X', variations: [] },
-        },
-      ]);
-
-      const { handleCatalogUpdate } = await import('./square-webhook');
-      const result = await handleCatalogUpdate(
-        makeCatalogEvent(undefined),
-        makeSquare() as unknown as Parameters<typeof handleCatalogUpdate>[1]
-      );
-
-      expect(mocks.createProduct).not.toHaveBeenCalled();
-      expect(result.action).toBe('synced');
-    });
-
-    it('logs and skips when updateSquareCache throws (degrades gracefully)', async () => {
-      mocks.findAll.mockResolvedValue([
-        {
-          id: 'prod-1',
-          squareItemId: 'ITEM_A',
-          squareCache: { name: 'A', priceCents: 100, sku: 'A', imageUrl: '' },
-        },
-      ]);
-      mocks.listItems.mockResolvedValue([
-        {
-          id: 'ITEM_A',
-          type: 'ITEM',
-          version: 2,
-          itemData: {
-            name: 'A',
-            variations: [
-              {
-                id: 'VAR_A',
-                itemVariationData: { sku: 'A', priceMoney: { amount: 150n } },
-              },
-            ],
-          },
-        },
-      ]);
-      mocks.getItemImageUrl.mockResolvedValue('image.jpg');
-      mocks.updateSquareCache.mockRejectedValueOnce(new Error('Firestore down'));
-
-      const { handleCatalogUpdate } = await import('./square-webhook');
-      const result = await handleCatalogUpdate(
-        makeCatalogEvent(undefined),
-        makeSquare() as unknown as Parameters<typeof handleCatalogUpdate>[1]
-      );
-
-      // Failure is caught internally — the trigger still returns 'synced' to
-      // ack the webhook (we don't want Square to retry forever).
-      expect(result.action).toBe('synced');
-    });
-
-    it('logs and skips when createProduct throws during batch path', async () => {
-      mocks.findAll.mockResolvedValue([]);
-      mocks.listItems.mockResolvedValue([
-        {
-          id: 'ITEM_NEW',
-          type: 'ITEM',
-          itemData: {
-            name: 'Z',
-            variations: [
-              {
-                id: 'VAR_Z',
-                itemVariationData: { sku: 'Z', priceMoney: { amount: 10n } },
-              },
-            ],
-          },
-        },
-      ]);
-      mocks.createProduct.mockRejectedValueOnce(new Error('create failed'));
-
-      const { handleCatalogUpdate } = await import('./square-webhook');
-      const result = await handleCatalogUpdate(
-        makeCatalogEvent(undefined),
-        makeSquare() as unknown as Parameters<typeof handleCatalogUpdate>[1]
-      );
-
-      expect(result.action).toBe('synced');
-    });
-  });
-
-  describe('image fetch edge cases', () => {
-    it('falls back to undefined image URL when getItemImageUrl throws', async () => {
-      mocks.findBySquareItemId.mockResolvedValue(undefined);
-      mocks.getItem.mockResolvedValue({
-        id: 'ITEM_1',
-        type: 'ITEM',
-        itemData: {
-          name: 'no-image',
-          variations: [
-            {
-              id: 'VAR_1',
-              itemVariationData: { sku: 'X', priceMoney: { amount: 100n } },
-            },
-          ],
-        },
-      });
-      mocks.getItemImageUrl.mockRejectedValueOnce(new Error('image 404'));
-      mocks.createProduct.mockResolvedValue({ id: 'prod-new' });
-
-      const { handleCatalogUpdate } = await import('./square-webhook');
-      const result = await handleCatalogUpdate(
-        makeCatalogEvent('ITEM_1'),
-        makeSquare() as unknown as Parameters<typeof handleCatalogUpdate>[1]
-      );
-
-      expect(result.action).toBe('created');
-    });
+    const { handleCatalogUpdate } = await import('./square-webhook');
+    await expect(handleCatalogUpdate()).rejects.toThrow('Firestore unavailable');
   });
 });
 

--- a/libs/firebase/maple-functions/square-webhook/src/lib/square-webhook.ts
+++ b/libs/firebase/maple-functions/square-webhook/src/lib/square-webhook.ts
@@ -2,33 +2,29 @@
  * Square Webhook Handler
  *
  * Handles incoming webhooks from Square for:
- * - catalog.version.updated: Item created/updated in Square
- * - inventory.count.updated: Inventory quantity changed
- *
- * Webhooks allow us to sync changes made directly in Square
- * (POS, Dashboard) back to our Firestore records.
+ * - catalog.version.updated: a catalog edit happened in Square. The
+ *   actual catalog re-sync runs asynchronously in
+ *   `processCatalogSyncRequest`; this handler just records a request
+ *   and returns 200 well within Square's 10-second delivery timeout.
+ *   See `CatalogSyncRequestRepository`.
+ * - inventory.count.updated: targeted per-variation update; fast
+ *   enough to run inline.
+ * - invoice.payment_made: single-record status flip; inline.
  *
  * With separate Firebase projects, each project has its own webhook signature key:
  * - maple-and-spruce-dev: sandbox webhook signature key
  * - maple-and-spruce: production webhook signature key
  *
- * IMPORTANT: This function uses inline secret definitions to avoid cold start delays.
- * Secrets are defined in the onRequest options, NOT at module level.
- *
  * @see https://developer.squareup.com/docs/webhooks/overview
  */
 import { onRequest } from 'firebase-functions/v2/https';
-import { defineSecret, defineString } from 'firebase-functions/params';
+import { defineSecret } from 'firebase-functions/params';
 import { createHmac } from 'crypto';
 import {
+  CatalogSyncRequestRepository,
   InvoiceRepository,
   ProductRepository,
 } from '@maple/firebase/database';
-import {
-  Square,
-  SQUARE_SECRET_NAMES,
-  SQUARE_STRING_NAMES,
-} from '@maple/firebase/square';
 import { FirebaseProject } from '@maple/firebase/functions';
 
 // Webhook event types we handle
@@ -75,236 +71,24 @@ function verifySignature(
 }
 
 /**
- * Extract the primary image URL from a catalog item
- *
- * Images are stored as separate CatalogImage objects referenced by imageIds.
- * We fetch the first (primary) image to get its URL.
- */
-async function extractImageUrl(
-  squareItemId: string,
-  square: Square
-): Promise<string | undefined> {
-  try {
-    const imageUrl = await square.catalogService.getItemImageUrl(squareItemId);
-    return imageUrl || undefined;
-  } catch (err) {
-    console.warn('Failed to fetch image URL:', err);
-    return undefined;
-  }
-}
-
-/**
  * Handle catalog.version.updated webhook
  *
- * Fired when a catalog item is created or updated in Square.
- * We need to sync the changes to our Firestore record.
+ * Square sends this every time the catalog version changes — for bulk
+ * POS or Dashboard edits, that's a burst of events in seconds. The
+ * actual re-sync is O(catalog size) and far exceeds Square's 10-second
+ * delivery deadline, so we defer: bump the singleton request doc and
+ * let the Firestore-triggered processor coalesce + run the work.
  */
-export async function handleCatalogUpdate(
-  event: WebhookEvent,
-  square: Square
-): Promise<{ action: string; details: string }> {
-  const catalogObjectId = event.data.id;
-
-  // catalog.version.updated events don't include a specific item ID
-  // They notify that the catalog version changed (batch update)
-  // We need to refresh all tracked products AND discover new ones
-  if (!catalogObjectId) {
-    console.log('Batch catalog update - syncing all items from Square');
-
-    // Fetch all products we track
-    const products = await ProductRepository.findAll();
-    const trackedSquareItemIds = new Set(
-      products.filter(p => p.squareItemId).map(p => p.squareItemId!)
-    );
-
-    console.log(`Found ${products.length} products in Firestore, ${trackedSquareItemIds.size} with Square IDs`);
-
-    // Fetch all items from Square catalog
-    const squareItems = await square.catalogService.listItems();
-    console.log(`Found ${squareItems.length} items in Square catalog`);
-
-    let updatedCount = 0;
-    let createdCount = 0;
-
-    for (const catalogObject of squareItems) {
-      if (catalogObject.type !== 'ITEM' || !catalogObject.id) {
-        continue;
-      }
-
-      const itemData = catalogObject.itemData;
-      const variation = itemData?.variations?.[0];
-      const variationData = (variation as { itemVariationData?: {
-        sku?: string;
-        priceMoney?: { amount?: bigint };
-      } })?.itemVariationData;
-
-      // Extract image URL from catalog item
-      const imageUrl = catalogObject.id ? await extractImageUrl(catalogObject.id, square) : undefined;
-
-      if (trackedSquareItemIds.has(catalogObject.id)) {
-        // Update existing product
-        const product = products.find(p => p.squareItemId === catalogObject.id);
-        if (product) {
-          try {
-            await ProductRepository.updateSquareCache(
-              product.id,
-              {
-                name: itemData?.name ?? product.squareCache.name,
-                description: itemData?.description ?? product.squareCache.description,
-                priceCents: variationData?.priceMoney?.amount
-                  ? Number(variationData.priceMoney.amount)
-                  : product.squareCache.priceCents,
-                sku: variationData?.sku ?? product.squareCache.sku,
-                imageUrl: imageUrl ?? product.squareCache.imageUrl,
-              },
-              Number(catalogObject.version || 0)
-            );
-            updatedCount++;
-          } catch (err) {
-            console.warn(`Failed to refresh product ${product.id}:`, err);
-          }
-        }
-      } else {
-        // Create new product from Square item
-        if (!variation) {
-          console.warn(`Skipping Square item ${catalogObject.id} - no variation`);
-          continue;
-        }
-
-        try {
-          const newProduct = await ProductRepository.create(
-            {
-              artistId: '', // Needs to be assigned manually
-              name: itemData?.name ?? 'Unnamed Product',
-              description: itemData?.description ?? undefined,
-              priceCents: variationData?.priceMoney?.amount
-                ? Number(variationData.priceMoney.amount)
-                : 0,
-              quantity: 0, // Will be updated by inventory webhook
-              status: 'draft', // Draft until artist is assigned
-            },
-            {
-              squareItemId: catalogObject.id,
-              squareVariationId: variation.id!,
-              squareCatalogVersion: Number(catalogObject.version || 0),
-              squareLocationId: square.locationId,
-              sku: variationData?.sku ?? '',
-              variations: [{ variantId: 'var_compat', squareVariationId: variation.id!, sku: variationData?.sku ?? '' }],
-            }
-          );
-          // Update image URL if available (create doesn't support imageUrl directly)
-          if (imageUrl) {
-            await ProductRepository.updateSquareCache(newProduct.id, { imageUrl });
-          }
-          console.log(`Created new product ${newProduct.id} from Square item ${catalogObject.id}`);
-          createdCount++;
-        } catch (err) {
-          console.warn(`Failed to create product from Square item ${catalogObject.id}:`, err);
-        }
-      }
-    }
-
-    return {
-      action: 'synced',
-      details: `Synced catalog: updated ${updatedCount}, created ${createdCount} from ${squareItems.length} Square items`,
-    };
-  }
-
-  // Fetch the full catalog object from Square
-  const catalogObject = await square.catalogService.getItem(catalogObjectId);
-
-  if (!catalogObject) {
-    return {
-      action: 'skipped',
-      details: `Catalog object ${catalogObjectId} not found in Square (may have been deleted)`,
-    };
-  }
-
-  // Only handle ITEM types (not categories, taxes, etc.)
-  if (catalogObject.type !== 'ITEM') {
-    return {
-      action: 'skipped',
-      details: `Skipping non-ITEM catalog object type: ${catalogObject.type}`,
-    };
-  }
-
-  // Check if we have this item in Firestore
-  const existingProduct = await ProductRepository.findBySquareItemId(catalogObjectId);
-
-  // Extract variation data - it's nested as CatalogObject with itemVariationData
-  const itemData = catalogObject.itemData;
-  const variation = itemData?.variations?.[0];
-  // Access itemVariationData from the variation object (typed as CatalogObject but has this property)
-  const variationData = (variation as { itemVariationData?: {
-    sku?: string;
-    priceMoney?: { amount?: bigint };
-  } })?.itemVariationData;
-
-  // Extract image URL from catalog item
-  const imageUrl = catalogObject.id ? await extractImageUrl(catalogObject.id, square) : undefined;
-
-  if (existingProduct) {
-    // Update existing product's cache
-    await ProductRepository.updateSquareCache(
-      existingProduct.id,
-      {
-        name: itemData?.name ?? existingProduct.squareCache.name,
-        description: itemData?.description ?? existingProduct.squareCache.description,
-        priceCents: variationData?.priceMoney?.amount
-          ? Number(variationData.priceMoney.amount)
-          : existingProduct.squareCache.priceCents,
-        sku: variationData?.sku ?? existingProduct.squareCache.sku,
-        imageUrl: imageUrl ?? existingProduct.squareCache.imageUrl,
-      },
-      Number(catalogObject.version || 0)
-    );
-
-    return {
-      action: 'updated',
-      details: `Updated product ${existingProduct.id} from Square item ${catalogObjectId}`,
-    };
-  } else {
-    // New item created in Square - create a placeholder in Firestore
-    // Note: This won't have an artistId, so it will need to be assigned manually
-    if (!variation) {
-      return {
-        action: 'skipped',
-        details: `Catalog item ${catalogObjectId} has no variation`,
-      };
-    }
-
-    // Create a draft product that needs artist assignment
-    const product = await ProductRepository.create(
-      {
-        artistId: '', // Needs to be assigned manually
-        name: itemData?.name ?? 'Unnamed Product',
-        description: itemData?.description ?? undefined,
-        priceCents: variationData?.priceMoney?.amount
-          ? Number(variationData.priceMoney.amount)
-          : 0,
-        quantity: 0, // Will be updated by inventory webhook
-        status: 'draft', // Draft until artist is assigned
-      },
-      {
-        squareItemId: catalogObject.id!,
-        squareVariationId: variation.id!,
-        squareCatalogVersion: Number(catalogObject.version || 0),
-        squareLocationId: square.locationId,
-        sku: variationData?.sku ?? '',
-        variations: [{ variantId: 'var_compat', squareVariationId: variation.id!, sku: variationData?.sku ?? '' }],
-      }
-    );
-
-    // Update image URL if available (create doesn't support imageUrl directly)
-    if (imageUrl) {
-      await ProductRepository.updateSquareCache(product.id, { imageUrl });
-    }
-
-    return {
-      action: 'created',
-      details: `Created draft product ${product.id} from Square item ${catalogObjectId} (needs artist assignment)`,
-    };
-  }
+export async function handleCatalogUpdate(): Promise<{
+  action: string;
+  details: string;
+}> {
+  await CatalogSyncRequestRepository.requestRefresh();
+  return {
+    action: 'enqueued',
+    details:
+      'catalogSyncRequests/pending bumped; processCatalogSyncRequest will run the sync',
+  };
 }
 
 /**
@@ -444,11 +228,9 @@ export async function handleInvoicePaymentMade(
   };
 }
 
-// Define secrets INLINE in the function options to avoid cold start delays
-// These are NOT defined at module level - they are created when the function is registered
+// Webhook signature key is the only secret we need here. Catalog sync
+// (which needs full Square credentials) runs in processCatalogSyncRequest.
 const webhookSignatureKey = defineSecret('SQUARE_WEBHOOK_SIGNATURE_KEY');
-const squareSecretParams = SQUARE_SECRET_NAMES.map((name) => defineSecret(name));
-const squareStringParams = SQUARE_STRING_NAMES.map((name) => defineString(name));
 
 /**
  * Square webhook endpoint
@@ -465,7 +247,7 @@ export const squareWebhook = onRequest(
     region: 'us-east4',
     memory: '512MiB',
     concurrency: 10,
-    secrets: [webhookSignatureKey, ...squareSecretParams],
+    secrets: [webhookSignatureKey],
   },
   async (request, response) => {
     // Only accept POST
@@ -503,23 +285,12 @@ export const squareWebhook = onRequest(
       const event = request.body as WebhookEvent;
       console.log(`Received Square webhook: ${event.type} (${event.event_id})`);
 
-      // Build Square client for API calls - secrets accessed at runtime
-      const secrets = Object.fromEntries(
-        squareSecretParams.map((s) => [s.name, s.value()])
-      ) as Record<(typeof SQUARE_SECRET_NAMES)[number], string>;
-
-      const strings = Object.fromEntries(
-        squareStringParams.map((s) => [s.name, s.value()])
-      ) as Record<(typeof SQUARE_STRING_NAMES)[number], string>;
-
-      const square = new Square(secrets, strings);
-
       // Handle the event based on type
       let result: { action: string; details: string };
 
       switch (event.type) {
         case 'catalog.version.updated':
-          result = await handleCatalogUpdate(event, square);
+          result = await handleCatalogUpdate();
           break;
 
         case 'inventory.count.updated':

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -84,6 +84,9 @@
       "@maple/firebase/maple-functions/square-webhook": [
         "libs/firebase/maple-functions/square-webhook/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/process-catalog-sync-request": [
+        "libs/firebase/maple-functions/process-catalog-sync-request/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/sync-invoice-to-square": [
         "libs/firebase/maple-functions/sync-invoice-to-square/src/index.ts"
       ],


### PR DESCRIPTION
## Summary

Square's webhook delivery timeout is **10 seconds**. Our `handleCatalogUpdate` was doing a full O(N) catalog re-sync (86 items × serial image-URL fetch + Firestore write per item) on every `catalog.version.updated` event, which took 30–60+ seconds. Result:

- **269 × 504 timeouts** on 2026-05-16 when a POS bulk operation produced a burst of events
- **100% of recent production deliveries** logged as 504 in Square's webhook dashboard, even when our function eventually returned 200
- Square's "Your webhook is being unreliable" email that prompted this investigation

This PR decouples the ack from the work:

- **`squareWebhook` for `catalog.version.updated`**: just upserts the singleton `catalogSyncRequests/pending` doc and returns 200. Well under 10s, no Square SDK on the hot path.
- **New `processCatalogSyncRequest` Firestore trigger**: drains the request. Lease-based coordinator collapses bursts — N concurrent triggers collapse to exactly one downstream sync. Image URL fetches are parallelized (concurrency 8). 540s timeout, runs as long as needed since Square isn't waiting.
- **New `CatalogSyncRequestRepository`**: owns the lease/state transitions with a transaction-guarded `tryClaimLease()` so two triggers can't both think they own the lease. Stale leases (>5 min) are reclaimable so a crashed processor doesn't permanently block.
- Inventory and invoice handlers stay inline (already fast enough).

## Verification done

- Cloud Logging confirmed the failure mode: 269 × 504 + 55 × 500 on 5/16, all `Square Connect v2` user agent, latency pegged at 59.994s (cold function timeout).
- 100% of real `catalog.version.updated` events on 5/31 hit the batch-resync branch (data.id is empty/falsy in real Square payloads, despite the original code assuming otherwise).
- Squared the diagnosis against Square's docs: 10s delivery timeout, `http_timeout` retry reason. https://developer.squareup.com/docs/webhooks/troubleshooting

## What's next (not in this PR)

- Replay catalog/inventory events missed between 2026-05-16 and now using Square's Events API. The user wants to handle this in a follow-up once the bleeding stops.
- Existing webhook signature path (`JSON.stringify(request.body)`) is unchanged — it works in practice (5/30, 5/31 successes confirmed), but is fragile. Worth a future hardening pass with `request.rawBody`.

## Test plan

- [x] Unit tests pass: `firebase-maple-functions-square-webhook` (27/27) and `firebase-maple-functions-process-catalog-sync-request` (9/9)
- [x] `tsc -p apps/functions-square/tsconfig.app.json --noEmit` succeeds
- [x] `tools/validate-function-tsconfigs.sh` passes
- [x] `tools/check-firestore-indexes.ts` passes (new collection is a singleton doc — no composite indexes needed)
- [x] ESLint clean (warnings only, matching existing patterns)
- [ ] Once merged: send a test event from Square Dashboard → should return 200 quickly; check `catalogSyncRequests/pending` doc populated; check `processCatalogSyncRequest` ran in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)