### PR TITLE
fix(ci): pass --repo to gh label create in alert workflow

### DIFF
--- a/.github/workflows/dependabot-alert-to-claude.yml
+++ b/.github/workflows/dependabot-alert-to-claude.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          gh label create dependabot-alert --color B60205 --description "Filed by dependabot-alert-to-claude workflow" --force >/dev/null
+          gh label create dependabot-alert --repo "$REPO" --color B60205 --description "Filed by dependabot-alert-to-claude workflow" --force >/dev/null
 
           alerts=$(gh api "repos/$REPO/dependabot/alerts?state=open&severity=high,critical&per_page=100" \
             --jq '.[] | @base64')


### PR DESCRIPTION
## Summary
Fixes the dependabot-alert-to-claude workflow that failed its first manual dispatch — `gh label create` had no checkout to read repo from, so it tried git and exited 128. Adding `--repo "$REPO"` keeps it in pure-API mode (matches how `gh issue create` is already called).

## Test plan
- [ ] Merge, then re-run `gh workflow run dependabot-alert-to-claude.yml`
- [ ] Confirm it opens issues for the existing `@vitest/browser` + `tmp` alerts