### PR TITLE
fix(ci): use DEPENDABOT_READ_TOKEN PAT for alert listing

### DIFF
--- a/.github/workflows/dependabot-alert-to-claude.yml
+++ b/.github/workflows/dependabot-alert-to-claude.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   issues: write
-  security-events: read
 
 jobs:
   open-issues:
@@ -18,13 +17,15 @@ jobs:
       - name: Open one issue per unhandled alert
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPENDABOT_READ_TOKEN: ${{ secrets.DEPENDABOT_READ_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
           gh label create dependabot-alert --repo "$REPO" --color B60205 --description "Filed by dependabot-alert-to-claude workflow" --force >/dev/null
 
-          alerts=$(gh api "repos/$REPO/dependabot/alerts?state=open&severity=high,critical&per_page=100" \
+          alerts=$(GH_TOKEN="$DEPENDABOT_READ_TOKEN" gh api \
+            "repos/$REPO/dependabot/alerts?state=open&severity=high,critical&per_page=100" \
             --jq '.[] | @base64')
 
           if [[ -z "$alerts" ]]; then


### PR DESCRIPTION
## Summary
Default `GITHUB_TOKEN` can't read Dependabot alerts (no `dependabot_alerts:read` scope on the workflow token — [docs](https://docs.github.com/en/rest/dependabot/alerts)), so the alerts API returned 403. A fine-grained PAT scoped to *Dependabot alerts: Read-only* on this repo is now stored as `DEPENDABOT_READ_TOKEN`.

Only the alerts API call uses the PAT; `gh label create` and `gh issue create` still use the default `GITHUB_TOKEN`.

## Test plan
- [ ] Merge and re-run `gh workflow run dependabot-alert-to-claude.yml`
- [ ] Confirm it opens issues for the existing `@vitest/browser` + `tmp` alerts
- [ ] Confirm `claude.yml` fires on the new issues and Claude opens a fix PR