### PR TITLE
feat(functions): client-driven warmup for cold callables

### DIFF
--- a/.claude/rules/firebase-functions.md
+++ b/.claude/rules/firebase-functions.md
@@ -64,6 +64,25 @@ Functions.endpoint
   .handle<Req, Res>(async (data) => { ... });
 ```
 
+## Warmup
+
+Every function built through `Functions.endpoint.handle()` automatically accepts a warmup sentinel — clients can boot a cold instance ahead of a real call without the function author opting in.
+
+The intercept lives in `functions.utility.ts` and short-circuits before auth, validator, role check, uniqueness checks, and the handler. CORS is still enforced.
+
+**Client (from the Webflow widget or any callable consumer):**
+
+```typescript
+import { warmup } from '../lib/warmup';
+
+// Fire-and-forget on widget mount for downstream calls the user will trigger soon
+warmup(functions, 'calculateRegistrationCost', 'createRegistration');
+```
+
+**When to warm**: downstream functions that aren't called on first paint — e.g. functions invoked after the user types in a form or clicks a button. For first-paint functions (called immediately on mount), warmup is too late; use env-gated `minInstances: 1` instead.
+
+**Don't**: schedule a recurring Cloud Scheduler ping to keep functions warm 24/7. That bills idle time when no users are visiting. Warmup should be driven by user presence on the page.
+
 ## Input Validation
 
 Cloud functions that mutate entities **MUST** validate input using the shared Vest suites from `@maple/ts/validation`. Suites are declared with `staticSuite` (never `create`) so they're pure functions — no retained state across invocations, safe to call from warm cloud function containers without `.reset()`.

--- a/apps/webflow-components/src/lib/warmup.ts
+++ b/apps/webflow-components/src/lib/warmup.ts
@@ -1,0 +1,27 @@
+import { httpsCallable, type Functions } from 'firebase/functions';
+
+/**
+ * Pre-warm one or more callable Cloud Functions by sending a sentinel
+ * request that boots the container without running auth, validation,
+ * or the handler.
+ *
+ * Fire and forget on widget mount for downstream functions the user
+ * is about to invoke. By the time they act, the instance is warm.
+ *
+ * Server-side support lives in `Functions.endpoint.handle()` — every
+ * function built through the shared builder gets warmup support for
+ * free; no per-function opt-in needed.
+ *
+ * @example
+ *   warmup(functions, 'calculateRegistrationCost', 'createRegistration');
+ */
+export function warmup(
+  functions: Functions,
+  ...functionNames: string[]
+): Promise<void> {
+  return Promise.all(
+    functionNames.map((name) =>
+      httpsCallable(functions, name)({ __warmup: true }).catch(() => undefined)
+    )
+  ).then(() => undefined);
+}

--- a/libs/firebase/functions/src/lib/functions.utility.spec.ts
+++ b/libs/firebase/functions/src/lib/functions.utility.spec.ts
@@ -559,6 +559,132 @@ describe('Functions.endpoint (chain + handle)', () => {
     });
   });
 
+  describe('warmup sentinel', () => {
+    it('short-circuits with 200 { warm: true } and skips the handler', async () => {
+      const handler = vi.fn();
+      const endpoint = Functions.endpoint.handle(handler);
+
+      const res = await invoke(
+        endpoint,
+        makeReq({ body: { data: { __warmup: true } } })
+      );
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual({ data: { warm: true } });
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('accepts unwrapped { __warmup: true } body too', async () => {
+      const handler = vi.fn();
+      const endpoint = Functions.endpoint.handle(handler);
+
+      const res = await invoke(
+        endpoint,
+        makeReq({ body: { __warmup: true } })
+      );
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual({ data: { warm: true } });
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('bypasses required auth — anonymous warmup is allowed', async () => {
+      const handler = vi.fn();
+      const endpoint = Functions.endpoint.requiringAuth().handle(handler);
+
+      const res = await invoke(
+        endpoint,
+        makeReq({ body: { data: { __warmup: true } } })
+      );
+
+      expect(res.statusCode).toBe(200);
+      expect(mocks.verifyIdToken).not.toHaveBeenCalled();
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('bypasses required role check', async () => {
+      const handler = vi.fn();
+      const endpoint = Functions.endpoint
+        .requiringRole(Role.Admin)
+        .handle(handler);
+
+      const res = await invoke(
+        endpoint,
+        makeReq({ body: { data: { __warmup: true } } })
+      );
+
+      expect(res.statusCode).toBe(200);
+      expect(mocks.hasRole).not.toHaveBeenCalled();
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('bypasses validator — warmup body is not a real request', async () => {
+      const handler = vi.fn();
+      const validator = vi.fn(() => ({
+        isValid: () => false,
+        getErrors: () => ({ name: ['required'] }),
+      }));
+      const endpoint = Functions.endpoint.validating(validator).handle(handler);
+
+      const res = await invoke(
+        endpoint,
+        makeReq({ body: { data: { __warmup: true } } })
+      );
+
+      expect(res.statusCode).toBe(200);
+      expect(validator).not.toHaveBeenCalled();
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('bypasses uniqueness checks', async () => {
+      const handler = vi.fn();
+      const exists = vi.fn().mockResolvedValue(true);
+      const endpoint = Functions.endpoint
+        .ensuringUnique<{ email: string }>({ field: 'email', exists })
+        .handle(handler);
+
+      const res = await invoke(
+        endpoint,
+        makeReq({ body: { data: { __warmup: true } } })
+      );
+
+      expect(res.statusCode).toBe(200);
+      expect(exists).not.toHaveBeenCalled();
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('still enforces CORS — warmup from a disallowed origin is rejected', async () => {
+      const handler = vi.fn();
+      const endpoint = Functions.endpoint.handle(handler);
+
+      const res = await invoke(
+        endpoint,
+        makeReq({
+          body: { data: { __warmup: true } },
+          headers: { origin: 'https://evil.test' },
+        })
+      );
+
+      expect(res.statusCode).toBe(403);
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('does NOT short-circuit when __warmup is not strictly true', async () => {
+      const handler = vi.fn(async () => ({ ok: true }));
+      const endpoint = Functions.endpoint.handle(handler);
+
+      const res = await invoke(
+        endpoint,
+        // truthy but not === true; treated as a real request payload
+        makeReq({ body: { data: { __warmup: 'yes' } } })
+      );
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual({ data: { ok: true } });
+      expect(handler).toHaveBeenCalled();
+    });
+  });
+
   it('chain composition: validating + ensuringUnique runs validator first', async () => {
     const handler = vi.fn();
     const validator = vi.fn(() => ({

--- a/libs/firebase/functions/src/lib/functions.utility.ts
+++ b/libs/firebase/functions/src/lib/functions.utility.ts
@@ -459,6 +459,19 @@ class FunctionBuilder<
         // Handle CORS
         corsMiddleware(req, res, async () => {
           try {
+            // Warmup short-circuit. A request body of `{ __warmup: true }`
+            // (sent as `{ data: { __warmup: true } }` by httpsCallable)
+            // boots this function instance without running auth, validation,
+            // or the handler. Lets clients pre-warm cold endpoints from the
+            // UI in the background while the user is reading the page.
+            const rawBody = (req.body?.data ?? req.body ?? {}) as {
+              __warmup?: unknown;
+            };
+            if (rawBody && rawBody.__warmup === true) {
+              res.status(200).json({ data: { warm: true } });
+              return;
+            }
+
             // Verify auth token if present
             const auth = await verifyAuthToken(req);
             const context: FunctionContext = {


### PR DESCRIPTION
## Summary

- Every function built through `Functions.endpoint.handle()` now accepts a `__warmup: true` sentinel that short-circuits with `{ data: { warm: true } }`, booting the container without running auth, validator, role check, uniqueness checks, or the handler. Function authors stay oblivious; no per-function opt-in.
- New client helper `warmup(functions, ...names)` in `apps/webflow-components/src/lib/warmup.ts` — fire-and-forget on widget mount to pre-warm cold downstream endpoints.
- CORS still enforced (a warmup from a disallowed origin returns 403). The intercept lives inside the CORS-passed handler block, before any other check.

## Motivation

While auditing the dev project's Firebase bill, the registration hot path showed `getPublicClass` was the only function kept warm — `calculateRegistrationCost` and `createRegistration` cold-start on first use after a quiet period. `minInstances=1` on every hot-path function would solve cold starts but burns ~\$1.50/mo per warmed function. Client-driven warmup lets us pay for warmth only when there's actually a user on the page.

Strategy this PR enables:

| Function | Strategy |
|---|---|
| First-paint (called on mount) | `minInstances=1` in prod (warmup is too late) |
| Downstream (after user interaction) | `warmup()` on widget mount, no `minInstances` |

A follow-up PR will wire `RegistrationWidget` to warm `calculateRegistrationCost` + `createRegistration` on mount, and env-gate `minInstances=1` on `getRequiredAgreementsForClass`.

## Test plan

- [x] `nx run firebase-functions:test` — 41 tests pass, 8 new
- [x] Warmup bypasses required auth, role, validator, uniqueness checks
- [x] Warmup with strictly-truthy non-true value (`'yes'`) does NOT short-circuit (treated as a real request)
- [x] Warmup from disallowed origin still rejected (CORS enforced)
- [x] `nx run firebase-functions:lint` — 0 errors
- [ ] Verify in dev after merge: fire a warmup from console against a cold function, confirm it boots without 401/403/500

🤖 Generated with [Claude Code](https://claude.com/claude-code)