### PR TITLE
fix(ci): create alert issues with PAT so claude.yml triggers

### DIFF
--- a/.github/workflows/dependabot-alert-to-claude.yml
+++ b/.github/workflows/dependabot-alert-to-claude.yml
@@ -16,15 +16,14 @@ jobs:
     steps:
       - name: Open one issue per unhandled alert
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEPENDABOT_READ_TOKEN: ${{ secrets.DEPENDABOT_READ_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_READ_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
           gh label create dependabot-alert --repo "$REPO" --color B60205 --description "Filed by dependabot-alert-to-claude workflow" --force >/dev/null
 
-          alerts=$(GH_TOKEN="$DEPENDABOT_READ_TOKEN" gh api \
+          alerts=$(gh api \
             "repos/$REPO/dependabot/alerts?state=open&severity=high,critical&per_page=100" \
             --jq '.[] | @base64')
 


### PR DESCRIPTION
## Summary
The auto-filed Dependabot-alert issues from PR #446 land successfully, but `claude.yml` was never firing on them — turned out to be the documented GHA limitation that issues created by `GITHUB_TOKEN` don't trigger downstream workflows (prevents workflow loops).

With `DEPENDABOT_READ_TOKEN` now also granted **Issues: Read and write**, the whole step can authenticate as the PAT identity. Issues created that way appear authored by the user, are not filtered, and trigger `claude.yml`'s `issues: opened` event automatically.

## Test plan
- [ ] Merge, close issues #447 and #448, re-run `gh workflow run dependabot-alert-to-claude.yml`
- [ ] Confirm new issues are opened and `claude.yml` fires automatically (no manual `@claude` comment needed)