### PR TITLE
chore(deps): override tmp >=0.2.6 (fixes GHSA-ph9p-34f9-6g65)

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,14 @@
     "libs/**",
     "apps/*"
   ],
+  "pnpm": {
+    "overrides": {
+      "tmp": ">=0.2.6"
+    },
+    "overridesComments": {
+      "tmp": "GHSA-ph9p-34f9-6g65 — Path Traversal via unsanitized prefix/postfix. Pulled in by firebase-tools (^0.2.3) and nx. Fixed in 0.2.6. Added 2026-06-07"
+    }
+  },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",


### PR DESCRIPTION
Resolves #448.

Authored by [Claude](https://github.com/apps/claude) via the dependabot-alert-to-claude → claude.yml flow.

## Summary
Adds a scoped `pnpm.overrides` entry forcing `tmp >= 0.2.6` and a matching `overridesComments` documentation entry. `tmp` is a transitive dev dep pulled in by `firebase-tools` and `nx`; neither has released a version that bumps it, so the override is the right tool per `docs/guides/dependency-overrides.md`.

Advisory: [GHSA-ph9p-34f9-6g65](https://github.com/advisories/GHSA-ph9p-34f9-6g65) — path traversal via unsanitized prefix/postfix.