### PR TITLE
feat(registration): warm downstream callables, keep agreements warm

### DIFF
--- a/apps/webflow-components/src/RegistrationWidget.tsx
+++ b/apps/webflow-components/src/RegistrationWidget.tsx
@@ -46,6 +46,7 @@ import {
   trackPurchaseClass,
   trackViewClass,
 } from './lib/class-analytics';
+import { warmup } from './lib/warmup';
 
 
 /**
@@ -403,6 +404,12 @@ export function RegistrationWidget({
       setState({ status: 'error', message: 'No class ID provided.' });
       return;
     }
+
+    // Pre-warm downstream callables the user will hit shortly (discount
+    // recalc + Pay submit). The page-mount fetches above can't benefit
+    // from warmup — they fire too early — but these typically run 5–60s
+    // later, by which point the warmup ping has spun their container up.
+    warmup(functions, 'calculateRegistrationCost', 'createRegistration');
 
     const fetchClass = async () => {
       setState({ status: 'loading' });

--- a/libs/firebase/maple-functions/get-required-agreements-for-class/src/lib/get-required-agreements-for-class.spec.ts
+++ b/libs/firebase/maple-functions/get-required-agreements-for-class/src/lib/get-required-agreements-for-class.spec.ts
@@ -21,14 +21,20 @@ vi.mock('@maple/firebase/database', () => ({
   },
 }));
 
-// Mock firebase/functions to extract the handler
-vi.mock('@maple/firebase/functions', () => ({
-  createPublicFunction: (handler: (data: unknown) => unknown) => handler,
-}));
+// Mock firebase/functions — the Functions.endpoint chain returns the
+// handler directly so the test can invoke it without spinning up the
+// Functions request machinery.
+vi.mock('@maple/firebase/functions', () => {
+  const chain = {
+    withOptions: () => chain,
+    handle: (handler: (data: unknown) => unknown) => handler,
+  };
+  return { Functions: { endpoint: chain } };
+});
 
 import { getRequiredAgreementsForClass } from './get-required-agreements-for-class';
 
-// The export is the handler function itself (createPublicFunction mock returns it)
+// The export is the handler function itself (handle() mock returns it)
 const handler = getRequiredAgreementsForClass as unknown as (
   data: { classId?: string }
 ) => Promise<{ agreements: unknown[] }>;

--- a/libs/firebase/maple-functions/get-required-agreements-for-class/src/lib/get-required-agreements-for-class.ts
+++ b/libs/firebase/maple-functions/get-required-agreements-for-class/src/lib/get-required-agreements-for-class.ts
@@ -6,7 +6,7 @@
  * Used by the Webflow registration widget to show inline signing.
  * Deployed to us-east4 via CI/CD pipeline.
  */
-import { createPublicFunction } from '@maple/firebase/functions';
+import { Functions } from '@maple/firebase/functions';
 import {
   ClassRepository,
   AgreementTemplateRepository,
@@ -16,33 +16,40 @@ import type {
   GetRequiredAgreementsForClassResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getRequiredAgreementsForClass = createPublicFunction<
-  GetRequiredAgreementsForClassRequest,
-  GetRequiredAgreementsForClassResponse
->(async (data) => {
-  if (!data.classId) {
-    throw new Error('Class ID is required');
-  }
+// Keep warm in prod only — fires in the same Promise.all as getPublicClass
+// on widget mount, so a cold start here negates the warm getPublicClass.
+const minInstances =
+  process.env['GCLOUD_PROJECT'] === 'maple-and-spruce' ? 1 : 0;
 
-  const classEntity = await ClassRepository.findById(data.classId);
-  if (!classEntity) {
-    throw new Error(`Class not found: ${data.classId}`);
-  }
+export const getRequiredAgreementsForClass = Functions.endpoint
+  .withOptions({ minInstances, concurrency: 80 })
+  .handle<
+    GetRequiredAgreementsForClassRequest,
+    GetRequiredAgreementsForClassResponse
+  >(async (data) => {
+    if (!data.classId) {
+      throw new Error('Class ID is required');
+    }
 
-  if (!classEntity.categoryId) {
-    return { agreements: [] };
-  }
+    const classEntity = await ClassRepository.findById(data.classId);
+    if (!classEntity) {
+      throw new Error(`Class not found: ${data.classId}`);
+    }
 
-  const templates = await AgreementTemplateRepository.findRequiredForCategory(
-    classEntity.categoryId
-  );
+    if (!classEntity.categoryId) {
+      return { agreements: [] };
+    }
 
-  return {
-    agreements: templates.map((template) => ({
-      templateId: template.id,
-      templateName: template.name,
-      sections: template.sections,
-      supportsMinor: template.supportsMinor,
-    })),
-  };
-});
+    const templates = await AgreementTemplateRepository.findRequiredForCategory(
+      classEntity.categoryId
+    );
+
+    return {
+      agreements: templates.map((template) => ({
+        templateId: template.id,
+        templateName: template.name,
+        sections: template.sections,
+        supportsMinor: template.supportsMinor,
+      })),
+    };
+  });


### PR DESCRIPTION
## Summary

- `RegistrationWidget` calls `warmup(functions, 'calculateRegistrationCost', 'createRegistration')` on mount — fire-and-forget so the instances are warm by the time the user changes quantity, types a discount code, or clicks Pay. Uses the warmup mechanism shipped in #449.
- `getRequiredAgreementsForClass` migrates from the legacy `createPublicFunction` wrapper to the `Functions.endpoint` chain and picks up env-gated `minInstances=1` (prod only), mirroring `get-public-class.ts:22-26`.

## Why warm `getRequiredAgreementsForClass` instead of warming it via the client?

It runs in the same `Promise.all` as `getPublicClass` on widget mount (RegistrationWidget.tsx:421-426). A `warmup()` ping fired on mount lands too late — the real call goes out at the same moment. Page-load latency is `max(getPublicClass, getRequiredAgreementsForClass)`, so leaving one cold would negate the warm sibling. ~\$1.50/mo to close that gap (or \$0 if it stays under the 450K GiB-s/mo Cloud Run free tier alongside `getPublicClass`).

## Strategy summary

| Function | Strategy | Why |
|---|---|---|
| `getPublicClass` | `minInstances=1` in prod (already) | Page-mount; warmup too late |
| `getRequiredAgreementsForClass` | **`minInstances=1` in prod (this PR)** | Same Promise.all as above |
| `calculateRegistrationCost` | **warmup on mount (this PR)** | Runs ~5–60s after mount |
| `createRegistration` | **warmup on mount (this PR)** | Runs after user clicks Pay |
| `getRelatedPublicClasses` | nothing | Below the fold |

## Test plan

- [x] `nx run firebase-maple-functions-get-required-agreements-for-class:test` — 5/5 pass after updating the spec mock from `createPublicFunction` to the `Functions.endpoint` chain shape
- [x] `nx run firebase-maple-functions-get-required-agreements-for-class:lint` — 0 errors
- [x] Typecheck `apps/webflow-components` — clean
- [ ] After merge: open Webflow class registration page, confirm warmup pings appear in Cloud Run logs and registration flow is smooth on first visit after idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)