### PR TITLE
fix(mail): skip confirmation + reminder emails for E2E test recipients

### DIFF
--- a/libs/firebase/functions/src/lib/email.utility.ts
+++ b/libs/firebase/functions/src/lib/email.utility.ts
@@ -1,0 +1,22 @@
+/**
+ * Recipients used by the registration E2E suite (`apps/registration-e2e`).
+ *
+ * The Pay-flow specs run against the deployed dev project, whose
+ * `firestore-send-email` extension delivers via real Gmail SMTP. Test
+ * recipients use the reserved `.test` TLD and an `e2e+...` localpart, so
+ * any function that queues mail must skip those recipients — otherwise
+ * every post-merge run produces a real NXDOMAIN bounce back to the
+ * configured From address.
+ *
+ * Tests should keep using `e2e+...@maplespruce.test` / `e2e-decline+...`
+ * patterns; production traffic will never match.
+ */
+export function isE2ETestEmail(email: string | undefined): boolean {
+  if (!email) return false;
+  const lower = email.trim().toLowerCase();
+  return (
+    lower.endsWith('@maplespruce.test') ||
+    lower.startsWith('e2e+') ||
+    lower.startsWith('e2e-decline+')
+  );
+}

--- a/libs/firebase/functions/src/lib/index.ts
+++ b/libs/firebase/functions/src/lib/index.ts
@@ -59,3 +59,6 @@ export {
   type EnvironmentMode,
   type FirebaseProjectId,
 } from './environment.utility';
+
+// Email utilities
+export { isE2ETestEmail } from './email.utility';

--- a/libs/firebase/maple-functions/create-registration/src/lib/create-registration.ts
+++ b/libs/firebase/maple-functions/create-registration/src/lib/create-registration.ts
@@ -20,7 +20,7 @@
  * Deployed to us-east4 via CI/CD pipeline.
  */
 import admin from 'firebase-admin';
-import { Functions } from '@maple/firebase/functions';
+import { Functions, isE2ETestEmail } from '@maple/firebase/functions';
 import {
   ClassRepository,
   DiscountRepository,
@@ -688,8 +688,19 @@ export const createRegistration = Functions.endpoint
         }
       }
 
-      // 10. Write to mail collection for confirmation emails
-      try {
+      // 10. Write to mail collection for confirmation emails.
+      // The registration-e2e Pay-flow specs run against the deployed dev
+      // project, whose Send Email extension delivers via real Gmail SMTP.
+      // Test recipients use a non-routable `.test` TLD, so without this
+      // guard every post-merge run produces a real NXDOMAIN bounce back
+      // to the configured From address.
+      const skipMail = isE2ETestEmail(data.customerEmail);
+      if (skipMail) {
+        console.log(
+          `Skipping confirmation email queue for E2E test recipient ${data.customerEmail}`
+        );
+      }
+      if (!skipMail) try {
         const formatCurrency = (cents: number): string =>
           `$${(cents / 100).toFixed(2)}`;
 

--- a/libs/firebase/maple-functions/send-class-reminders/src/lib/send-class-reminders.ts
+++ b/libs/firebase/maple-functions/send-class-reminders/src/lib/send-class-reminders.ts
@@ -39,7 +39,7 @@
 import admin from 'firebase-admin';
 import { onSchedule } from 'firebase-functions/v2/scheduler';
 import { defineString } from 'firebase-functions/params';
-import { Functions, Role } from '@maple/firebase/functions';
+import { Functions, Role, isE2ETestEmail } from '@maple/firebase/functions';
 import {
   ClassRepository,
   InstructorRepository,
@@ -281,6 +281,15 @@ export async function runSendClassReminders(
       }
       if (hasReminderForSession(reg, sessionIso)) {
         skippedAlreadySent += 1;
+        continue;
+      }
+      // Skip dev-DB rows created by the registration-e2e suite — the
+      // dev project's Send Email extension uses real Gmail SMTP and
+      // would NXDOMAIN-bounce against the `.test` TLD recipients.
+      if (isE2ETestEmail(reg.customerEmail)) {
+        console.log(
+          `[sendClassReminders] Skipping E2E test registration ${reg.id} (${reg.customerEmail})`
+        );
         continue;
       }
 


### PR DESCRIPTION
## Summary

- Stop the post-merge `dev`-target registration E2E suite from queueing real Gmail-SMTP emails to `e2e+…@maplespruce.test` recipients, which were producing NXDOMAIN bounces back to `katie@`.
- Add a small `isE2ETestEmail` helper in `@maple/firebase/functions` and gate both `createRegistration` (registrant + per-attendee mail writes) and `sendClassReminders` (covers test rows already accumulated in the dev DB) on it.

## Why

The Pay-flow specs in `apps/registration-e2e/src/registration.spec.ts` use `e2e+${Date.now()}@maplespruce.test` recipients. The deployed `maple-and-spruce-dev` project has the `firestore-send-email` extension installed and sending via real Gmail — every successful run delivered a confirmation email, Gmail tried to resolve the `.test` TLD, and the bounce came back to the configured From address. `send-class-reminders` would do the same thing for any test registration still sitting in the dev DB whenever its session date rolls around.

Integration tests use `@example.com` / `@test.com` and don't match the pattern, so existing mail-count assertions in `apps/functions-integration-tests-registration` are unaffected.

## Test plan

- [x] Lint passes for `firebase-maple-functions-create-registration`, `firebase-maple-functions-send-class-reminders`, `firebase-functions`
- [x] `functions` codebase builds (transitive typecheck)
- [ ] Post-merge E2E run produces no bounce email back to katie@

🤖 Generated with [Claude Code](https://claude.com/claude-code)