### PR TITLE
docs: teach the agent to commit the lockfile after overrides

### DIFF
--- a/.github/workflows/dependabot-alert-to-claude.yml
+++ b/.github/workflows/dependabot-alert-to-claude.yml
@@ -59,7 +59,11 @@ jobs:
           - Advisory: [$ghsa]($url)
           - Summary: $summary
 
-          Try updating the top-level dependency first; only fall back to a scoped \`pnpm.overrides\` entry if no parent release ships a fixed version. Add the matching \`overridesComments\` entry when you add an override. Open a draft PR.
+          Steps:
+          1. Try updating the top-level dependency first (\`pnpm update <pkg>\`).
+          2. Only fall back to a scoped \`pnpm.overrides\` entry if no parent release ships a fix; add a matching \`overridesComments\` entry with the GHSA ID, parent packages, and date.
+          3. **Run \`pnpm install\` and commit both \`package.json\` AND \`pnpm-lock.yaml\`** in the same PR. CI and Vercel use \`--frozen-lockfile\` and will reject overrides that aren't recorded in the lockfile.
+          4. Open a draft PR.
           EOF
           )
 

--- a/docs/guides/dependency-overrides.md
+++ b/docs/guides/dependency-overrides.md
@@ -31,8 +31,9 @@ When an override is necessary:
    - A brief description of the vulnerability
    - Which top-level package(s) pull in the vulnerable transitive dep
    - The date added (e.g., `Added 2026-04-01`)
-3. Run `pnpm install` to apply
-4. Run `pnpm audit --audit-level=high` to verify
+3. Run `pnpm install` to apply the override and regenerate `pnpm-lock.yaml`
+4. **Commit BOTH `package.json` AND `pnpm-lock.yaml` in the same PR.** CI and Vercel install with `--frozen-lockfile`; a `pnpm.overrides` change with no matching lockfile update will fail with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` before any code runs.
+5. Run `pnpm audit --audit-level=high` to verify
 
 ### Override syntax
 


### PR DESCRIPTION
## Summary
Closes the gap that broke PR #452: Claude added a `pnpm.overrides` entry but didn't run `pnpm install` / commit `pnpm-lock.yaml`. Vercel and CI install with `--frozen-lockfile` and rejected the deploy with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`.

The guide previously said *"Run \`pnpm install\` to apply"* but never said *"commit the lockfile"*. Fixed in two places where the agent looks for instructions:

- **`docs/guides/dependency-overrides.md`** — numbered step calls out the `--frozen-lockfile` behavior and the specific error string (searchable for future debugging).
- **`.github/workflows/dependabot-alert-to-claude.yml`** — the auto-filed issue body now has 4 numbered steps with the lockfile commit as its own step. The agent sees this in its initial prompt rather than having to find it in the linked guide.

## Test plan
- [ ] Merge.
- [ ] On the next dispatched alert (or test run), confirm Claude commits both `package.json` AND `pnpm-lock.yaml`.