### PR TITLE
chore(deps): override tmp >=0.2.6 (fixes GHSA-ph9p-34f9-6g65)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,7 @@ overrides:
   brace-expansion@>=5.0.0 <5.0.6: '>=5.0.6'
   ws@>=8.0.0 <8.20.1: '>=8.20.1'
   path-to-regexp@>=2: '>=8.4.0'
+  tmp: '>=0.2.6'
 
 importers:
 
@@ -10222,8 +10223,8 @@ packages:
     resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
     hasBin: true
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   to-buffer@1.2.2:
@@ -18387,7 +18388,7 @@ snapshots:
       superstatic: 10.0.0(encoding@0.1.13)
       tar: 7.5.13
       tcp-port-used: 1.0.2
-      tmp: 0.2.5
+      tmp: 0.2.7
       triple-beam: 1.4.1
       universal-analytics: 0.5.3
       update-notifier-cjs: 5.1.7(encoding@0.1.13)
@@ -20393,7 +20394,7 @@ snapshots:
       smol-toml: 1.6.1
       string-width: 4.2.3
       tar-stream: 2.2.0
-      tmp: 0.2.5
+      tmp: 0.2.7
       tree-kill: 1.2.2
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
@@ -22574,7 +22575,7 @@ snapshots:
     dependencies:
       tldts-core: 7.0.28
 
-  tmp@0.2.5: {}
+  tmp@0.2.7: {}
 
   to-buffer@1.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -90,3 +90,7 @@ overrides:
   ws@>=8.0.0 <8.20.1: '>=8.20.1'
   # path-to-regexp override
   path-to-regexp@>=2: '>=8.4.0'
+  # GHSA-ph9p-34f9-6g65: tmp Path Traversal via unsanitized prefix/postfix
+  # enables directory escape (patched in 0.2.6). Transitive dep of
+  # firebase-tools and nx. Added 2026-06-07.
+  tmp: '>=0.2.6'


### PR DESCRIPTION
Resolves #456.

Authored by [Claude](https://github.com/apps/claude) via the dependabot-alert-to-claude → claude.yml flow. Second attempt at the tmp fix after #452 was closed for missing the lockfile update.

## Summary
Adds a `tmp >=0.2.6` override in `pnpm-workspace.yaml` (alongside the existing brace-expansion / ws / path-to-regexp overrides) plus the regenerated `pnpm-lock.yaml`. Inline comment captures the GHSA, summary, parent packages, and date.

Resolved `tmp` version: `0.2.5` → `0.2.7` (latest patched).

Advisory: [GHSA-ph9p-34f9-6g65](https://github.com/advisories/GHSA-ph9p-34f9-6g65) — path traversal via unsanitized prefix/postfix.

## Notes
- Claude correctly put this in `pnpm-workspace.yaml` rather than `package.json#pnpm.overrides` — the docs guide still says `package.json`. Worth a follow-up to update `docs/guides/dependency-overrides.md` to reflect the actual repo pattern.