### PR TITLE
docs: overrides live in pnpm-workspace.yaml, not package.json

### DIFF
--- a/docs/guides/dependency-overrides.md
+++ b/docs/guides/dependency-overrides.md
@@ -1,6 +1,6 @@
 # Dependency Override Management
 
-How to handle `pnpm audit` vulnerabilities and maintain `pnpm.overrides` in `package.json`.
+How to handle `pnpm audit` vulnerabilities and maintain the `overrides:` block in `pnpm-workspace.yaml`.
 
 ---
 
@@ -23,35 +23,35 @@ Always try to fix vulnerabilities by updating direct dependencies before adding 
 
 ## Adding an Override
 
-When an override is necessary:
+Overrides live in `pnpm-workspace.yaml` under the top-level `overrides:` key (pnpm v10+ convention — not in `package.json`). When an override is necessary:
 
-1. Add the override to `pnpm.overrides` in `package.json`
-2. Add a comment entry to `pnpm.overridesComments` with:
+1. Add the override entry under `overrides:` in `pnpm-workspace.yaml`
+2. Add one or more `#` comment lines **immediately above** the entry with:
    - The advisory ID (e.g., `GHSA-xxxx-xxxx-xxxx`)
    - A brief description of the vulnerability
    - Which top-level package(s) pull in the vulnerable transitive dep
    - The date added (e.g., `Added 2026-04-01`)
 3. Run `pnpm install` to apply the override and regenerate `pnpm-lock.yaml`
-4. **Commit BOTH `package.json` AND `pnpm-lock.yaml` in the same PR.** CI and Vercel install with `--frozen-lockfile`; a `pnpm.overrides` change with no matching lockfile update will fail with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` before any code runs.
+4. **Commit BOTH `pnpm-workspace.yaml` AND `pnpm-lock.yaml` in the same PR.** CI and Vercel install with `--frozen-lockfile`; an `overrides:` change with no matching lockfile update will fail with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` before any code runs.
 5. Run `pnpm audit --audit-level=high` to verify
 
 ### Override syntax
 
-```jsonc
-{
-  "pnpm": {
-    "overrides": {
-      // Simple: override all versions
-      "lodash": ">=4.18.0",
-      // Scoped: only override specific version ranges
-      "picomatch@>=4.0.0": ">=4.0.4",
-      "brace-expansion@^5": ">=5.0.5"
-    }
-  }
-}
+```yaml
+overrides:
+  # GHSA-xxxx-xxxx-xxxx: short summary of the vuln. Transitive dep of <parent
+  # packages>. Added YYYY-MM-DD.
+  lodash: '>=4.18.0'
+
+  # GHSA-yyyy-yyyy-yyyy: only the 5.x line is vulnerable; pin to the patched
+  # 5.x release rather than bumping to 6.x. Transitive dep of <parents>. Added YYYY-MM-DD.
+  brace-expansion@^5: '>=5.0.5'
+
+  # GHSA-zzzz-zzzz-zzzz: only a narrow version range is vulnerable. Added YYYY-MM-DD.
+  picomatch@>=4.0.0 <4.0.4: '>=4.0.4'
 ```
 
-Use scoped overrides (`pkg@range`) when the package appears across multiple major version ranges and only some are vulnerable.
+Use scoped overrides (`pkg@<range>`) when only some version ranges are vulnerable; use a bare `pkg:` entry when every resolved version needs the bump.
 
 ## Cleaning Up Overrides
 
@@ -59,7 +59,7 @@ Overrides should be reviewed periodically (e.g., when updating Nx or other major
 
 1. **Check if the override is still needed**:
    ```bash
-   # Temporarily remove the override from package.json, then:
+   # Temporarily remove the entry (and its comment) from pnpm-workspace.yaml, then:
    pnpm install
    pnpm audit --audit-level=high
    ```
@@ -68,8 +68,8 @@ Overrides should be reviewed periodically (e.g., when updating Nx or other major
    pnpm why <overridden-package>
    # If all resolved versions are already safe, the override can be removed
    ```
-3. **Remove the override AND its comment** from both `overrides` and `overridesComments`
-4. Run `pnpm install && pnpm audit` to confirm
+3. **Remove the override entry AND its `#` comment lines** from `pnpm-workspace.yaml`
+4. Run `pnpm install && pnpm audit` to confirm; commit both `pnpm-workspace.yaml` and `pnpm-lock.yaml`
 
 ### When to review
 
@@ -80,12 +80,13 @@ Overrides should be reviewed periodically (e.g., when updating Nx or other major
 
 ## Automation
 
-- **New vulnerabilities** — Dependabot alerts are enabled at the repo level. When an alert fires, assign it to an AI agent from the Security → Dependabot tab (or the Agents tab). The agent reads this guide and opens a draft PR with either a top-level update or a scoped override.
+- **New vulnerabilities** — Dependabot alerts are enabled at the repo level. `.github/workflows/dependabot-alert-to-claude.yml` runs daily and files an `@claude`-tagged issue per new high+critical alert; `.github/workflows/claude.yml` picks the issue up and opens a draft PR following this guide.
 - **Stale overrides** — `.github/workflows/check-pnpm-overrides.yml` runs monthly. It temporarily removes each entry, re-runs `pnpm audit`, and opens a PR if any override is no longer needed.
 - **CI belt-and-suspenders** — the `security` job in `build-check.yml` keeps running `pnpm audit --audit-level=high` on every PR so a regression can't merge unnoticed.
 
 ## Notes
 
-- `overridesComments` is not a pnpm feature — it's a documentation convention stored as a sibling key. pnpm ignores unknown keys under `pnpm`.
+- The `overrides:` key in `pnpm-workspace.yaml` is the supported location in pnpm v10+. The older `pnpm.overrides` block in `package.json` is **not** used in this repo.
+- Comments live as `#` YAML lines directly above each entry (no separate `overridesComments` map — that was the package.json-era convention).
 - All current overrides are for **transitive dev dependencies** — they don't affect the production bundle deployed to Firebase.
 - Prefer `>=` minimum version over exact pinning so patches flow through naturally.


### PR DESCRIPTION
## Summary
Rewrites `docs/guides/dependency-overrides.md` to match where overrides actually live in this repo: under the top-level `overrides:` key in `pnpm-workspace.yaml`, with `#` YAML comments inline above each entry. The old guide pointed at `package.json#pnpm.overrides` + a parallel `pnpm.overridesComments` map — that layout isn't used here.

## Why now
When Claude wrote PR #457 (tmp override) it correctly placed the entry in `pnpm-workspace.yaml` even though the guide said `package.json` — it figured the actual convention out from reading existing overrides. The next agent shouldn't have to re-derive that; the prompt should match reality from the start.

## What changed
- Intro + "Adding an Override" steps point at `pnpm-workspace.yaml`
- Lockfile-commit instruction now says "commit both `pnpm-workspace.yaml` AND `pnpm-lock.yaml`"
- Override syntax example switched from JSONC to YAML with the `# GHSA-…` comment style we actually use
- Cleanup section updated to match
- Automation section names the actual workflow files (`dependabot-alert-to-claude.yml`, `claude.yml`, `check-pnpm-overrides.yml`)
- Removed the `overridesComments` note from the Notes section (it was a package.json-era convention)

## Test plan
- [ ] After merge, on the next real Dependabot alert (or a `gh workflow run dependabot-alert-to-claude.yml` test), confirm Claude's PR puts the override in `pnpm-workspace.yaml` with the inline comment format on first try.