### PR TITLE
test(warmup): integration + unit coverage; harden sync-throw

### DIFF
--- a/apps/functions-integration-tests-utility/src/utility-functions.spec.ts
+++ b/apps/functions-integration-tests-utility/src/utility-functions.spec.ts
@@ -49,6 +49,58 @@ describe('Utility Functions', () => {
     });
   });
 
+  describe('warmup sentinel (Functions.endpoint.handle())', () => {
+    // The shared function builder accepts `{ __warmup: true }` and returns
+    // 200 + { warm: true } without running auth, validator, or the handler.
+    // These tests assert the contract over a real HTTP layer (emulator),
+    // complementing the unit tests in functions.utility.spec.ts.
+
+    it('returns 200 + { warm: true } against a public endpoint', async () => {
+      const result = await callFunction<
+        { __warmup: true },
+        { warm: boolean }
+      >({
+        functionName: 'healthCheck',
+        data: { __warmup: true },
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.data).toEqual({ warm: true });
+    });
+
+    it('bypasses required auth — no idToken needed', async () => {
+      // checkAdminStatus normally returns 401 without an idToken (see test
+      // below). With the warmup sentinel it must short-circuit BEFORE the
+      // auth check and return 200 even anonymously.
+      const result = await callFunction<
+        { __warmup: true },
+        { warm: boolean }
+      >({
+        functionName: 'checkAdminStatus',
+        data: { __warmup: true },
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.data).toEqual({ warm: true });
+    });
+
+    it('does not short-circuit when __warmup is not strictly true', async () => {
+      // A real `healthCheck` payload that happens to carry a truthy-but-not-
+      // true `__warmup` should run the real handler, not the warmup branch.
+      const result = await callFunction<
+        { __warmup: string },
+        { status: string; timestamp: string }
+      >({
+        functionName: 'healthCheck',
+        data: { __warmup: 'yes' },
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.data?.status).toBe('ok');
+      expect(result.data?.timestamp).toBeDefined();
+    });
+  });
+
   describe('checkAdminStatus', () => {
     it('should reject unauthenticated requests', async () => {
       const result = await callFunction({

--- a/apps/webflow-components/src/lib/warmup.spec.ts
+++ b/apps/webflow-components/src/lib/warmup.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  httpsCallable: vi.fn(),
+}));
+
+vi.mock('firebase/functions', () => ({
+  httpsCallable: mocks.httpsCallable,
+}));
+
+import { warmup } from './warmup';
+
+// `functions` is opaque to `warmup` — it's just passed through to
+// httpsCallable, which is mocked. Any value works.
+const fakeFunctions = {} as never;
+
+describe('warmup() resilience — must never block or break the caller', () => {
+  // The widget fires `warmup(functions, …)` on mount without awaiting it.
+  // If any failure mode here escaped as an unhandled rejection or a thrown
+  // error, the registration flow would break for users on a cold endpoint
+  // or a network blip. These tests assert the helper is bulletproof.
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves even when one callable rejects', async () => {
+    mocks.httpsCallable.mockImplementation((_fns: unknown, name: string) => {
+      if (name === 'fnA') return () => Promise.reject(new Error('boom'));
+      return () => Promise.resolve({ data: { warm: true } });
+    });
+
+    await expect(warmup(fakeFunctions, 'fnA', 'fnB')).resolves.toBeUndefined();
+  });
+
+  it('resolves when all callables reject', async () => {
+    mocks.httpsCallable.mockReturnValue(() =>
+      Promise.reject(new Error('network down'))
+    );
+
+    await expect(warmup(fakeFunctions, 'fnA', 'fnB', 'fnC')).resolves.toBeUndefined();
+  });
+
+  it('resolves when httpsCallable throws synchronously', async () => {
+    // E.g. if Firebase SDK initialization failed mid-flight, httpsCallable
+    // itself could throw at call time. The helper still must not reject.
+    mocks.httpsCallable.mockImplementation(() => {
+      throw new Error('not initialized');
+    });
+
+    await expect(warmup(fakeFunctions, 'fnA')).resolves.toBeUndefined();
+  });
+
+  it('resolves when the returned callable throws synchronously', async () => {
+    mocks.httpsCallable.mockReturnValue(() => {
+      throw new Error('sync throw');
+    });
+
+    await expect(warmup(fakeFunctions, 'fnA')).resolves.toBeUndefined();
+  });
+
+  it('resolves when called with no function names', async () => {
+    await expect(warmup(fakeFunctions)).resolves.toBeUndefined();
+    expect(mocks.httpsCallable).not.toHaveBeenCalled();
+  });
+
+  it('fires one call per function name in parallel', async () => {
+    const calls: string[] = [];
+    mocks.httpsCallable.mockImplementation((_fns: unknown, name: string) => {
+      calls.push(name);
+      return () => Promise.resolve({ data: { warm: true } });
+    });
+
+    await warmup(fakeFunctions, 'a', 'b', 'c');
+
+    expect(calls).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns a Promise the caller can safely ignore', () => {
+    mocks.httpsCallable.mockReturnValue(() => Promise.reject(new Error('x')));
+
+    // Fire-and-forget — no await. If this threw, the widget mount effect
+    // would crash. The test passes if no exception escapes this block.
+    expect(() => {
+      warmup(fakeFunctions, 'fnA');
+    }).not.toThrow();
+  });
+});

--- a/apps/webflow-components/src/lib/warmup.ts
+++ b/apps/webflow-components/src/lib/warmup.ts
@@ -19,9 +19,17 @@ export function warmup(
   functions: Functions,
   ...functionNames: string[]
 ): Promise<void> {
+  // Wrapping each iteration in async/try-catch (not .catch()) catches BOTH
+  // sync throws from httpsCallable() / its returned callable AND async
+  // rejections. A bare .catch() would let a synchronous throw escape and
+  // break the widget mount effect that fired the warmup.
   return Promise.all(
-    functionNames.map((name) =>
-      httpsCallable(functions, name)({ __warmup: true }).catch(() => undefined)
-    )
+    functionNames.map(async (name) => {
+      try {
+        await httpsCallable(functions, name)({ __warmup: true });
+      } catch {
+        // best-effort
+      }
+    })
   ).then(() => undefined);
 }


### PR DESCRIPTION
## Summary

Locks in the warmup mechanism with two new test layers and fixes a real defect the tests caught.

**Integration coverage** (`apps/functions-integration-tests-utility/src/utility-functions.spec.ts` — 3 new tests):
- `healthCheck` (public) + `{ data: { __warmup: true } }` → 200 + `{ warm: true }`
- `checkAdminStatus` (normally 401 without an idToken) + warmup body → 200 + `{ warm: true }`, proving auth bypass over the wire
- Truthy-but-not-`=== true` `__warmup` value falls through to the real handler

**Unit coverage** (`apps/webflow-components/src/lib/warmup.spec.ts` — 7 new tests):
- `warmup()` resolves when one callable rejects, when all reject, when `httpsCallable()` throws synchronously, when the returned callable throws synchronously, and when called with no names
- Fires one call per name
- Caller can safely ignore the returned Promise

**Defect caught + fixed** (`apps/webflow-components/src/lib/warmup.ts`):

The original implementation:

```ts
httpsCallable(functions, name)({ __warmup: true }).catch(() => undefined)
```

`.catch()` only handles async rejections. If `httpsCallable()` itself or the returned callable threw synchronously (e.g. Firebase SDK init mid-flight), the error escaped the `.catch()` and would have crashed `RegistrationWidget`'s mount effect. Switched to `async (name) => { try { await ... } catch {} }` so both sync and async failures are swallowed. Concern flagged in #453 review — fix lives here so the test that exposes the bug ships with the fix.

## Test plan

- [x] `nx run firebase-maple-functions-utility-tests:test` against emulator (locally): all 7 tests pass, including the 3 new ones
- [x] `nx run webflow-components:test` warmup.spec.ts: 7/7 pass
- [x] Typecheck both projects: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)