### PR TITLE
fix(ci): webflow affected detection — grep -qx, not jq on plain text

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -105,12 +105,16 @@ jobs:
           # --- webflow-components (code components library) ---
           # Nx's project graph follows imports, so changes in e.g.
           # libs/react/registrations transitively mark webflow-components
-          # as affected. `nx show projects` outputs a JSON array, so we
-          # parse with jq rather than substring-grepping.
+          # as affected. `nx show projects --affected` prints one project
+          # per line (NOT a JSON array — an earlier comment here had this
+          # wrong, which silently skipped the publish on every merge that
+          # only touched webflow-components). Use grep -qx for a full-line
+          # match so substrings like "webflow-components-storybook" can't
+          # false-positive.
           WEBFLOW_AFFECTED=false
           if [ "$DEPLOY_ALL" == "true" ]; then
             WEBFLOW_AFFECTED=true
-          elif echo "$ALL_AFFECTED" | jq -e 'any(. == "webflow-components")' > /dev/null 2>&1; then
+          elif echo "$ALL_AFFECTED" | grep -qx 'webflow-components'; then
             WEBFLOW_AFFECTED=true
           fi
           if [ "$WEBFLOW_AFFECTED" == "true" ]; then


### PR DESCRIPTION
## Summary

`prepare_and_build` in `firebase-functions-merge.yml` was using `jq -e 'any(. == "webflow-components")'` against `$ALL_AFFECTED`, but `nx show projects --affected` outputs plain newline-separated names — **not** a JSON array. `jq` bailed with a parse error every run, exit 5 got swallowed by `2>&1 > /dev/null`, `WEBFLOW_AFFECTED` stayed `false`, and `publish_webflow_components` silently skipped every merge that touched only `webflow-components`.

Visible in #453's merge run ([27098822144](https://github.com/Maple-and-Spruce/maple-and-spruce/actions/runs/27098822144)): the affected list correctly contained `webflow-components` (logged at 16:54:16), but `publish_webflow_components` evaluated its `if:` to false and skipped.

Swap to `grep -qx 'webflow-components'` (line-exact — substring matches like `webflow-components-storybook` can't false-positive). The functions detection right below already uses plain `grep` on the same `$ALL_AFFECTED`, so this aligns the two branches.

## Reproduction (the broken check)

```bash
$ printf 'webflow-components\nregistration-test-harness\nfirebase-maple-functions-get-required-agreements-for-class\nfunctions\n' \
    | jq -e 'any(. == "webflow-components")'
jq: parse error: Invalid numeric literal at line 2, column 0
$ echo $?
5
```

## Test plan

- [x] New check matches when present: `printf 'webflow-components\n…' | grep -qx 'webflow-components'` → exit 0
- [x] No false-positive on substring: `printf 'webflow-components-storybook\n' | grep -qx 'webflow-components'` → exit 1
- [ ] After merge: next PR touching only `webflow-components` triggers `publish_webflow_components` instead of skipping

## Backfill for #453

PR #453's widget changes (the warmup call on mount) aren't on the live Webflow widget yet because of this bug. Publishing manually from main is the simplest backfill — see PR description comment for the command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)