### PR TITLE
feat(rooms): Spruce Room visibility — room field, lesson-derived events, getRoomSchedule, dashboard widget (#468)

### DIFF
--- a/apps/functions-integration-tests-lesson/src/lesson-functions.spec.ts
+++ b/apps/functions-integration-tests-lesson/src/lesson-functions.spec.ts
@@ -19,11 +19,22 @@ import type {
   CreateLessonSeriesResponse,
   GetLessonsRequest,
   GetLessonsResponse,
+  GetRoomScheduleRequest,
+  GetRoomScheduleResponse,
   UpdateLessonRequest,
   UpdateLessonResponse,
   DeleteLessonRequest,
   DeleteLessonResponse,
 } from '@maple/ts/firebase/api-types';
+
+/**
+ * Wait for the onLessonWrite trigger to process. Firestore triggers in the
+ * emulator are async — there's a brief delay between the write and the
+ * trigger completing its work.
+ */
+function waitForTrigger(ms = 4000): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 const TEACHER_ID = 'instructor-test-teacher';
 const SUBSTITUTE_ID = 'instructor-test-sub';
@@ -401,6 +412,122 @@ describe('Lesson Functions', () => {
           new Date('2026-06-20T23:59:59Z').getTime()
         );
       }
+    });
+  });
+
+  describe('Room schedule derivation (onLessonWrite + getRoomSchedule)', () => {
+    const SCHEDULED_AT = new Date('2026-07-01T15:00:00Z');
+    const DAY_START = '2026-07-01T00:00:00.000Z';
+    const DAY_END = '2026-07-02T00:00:00.000Z';
+    let roomLessonId: string;
+
+    async function getSpruceWindows() {
+      const result = await callFunction<
+        GetRoomScheduleRequest,
+        GetRoomScheduleResponse
+      >({
+        functionName: 'getRoomSchedule',
+        data: { room: 'spruce', start: DAY_START, end: DAY_END },
+        idToken: adminUser.idToken,
+      });
+      expect(result.status).toBe(200);
+      return result.data!.windows;
+    }
+
+    it('derives a private Spruce Room busy window when a lesson is scheduled', async () => {
+      const created = await callFunction<
+        CreateLessonRequest,
+        CreateLessonResponse
+      >({
+        functionName: 'createLesson',
+        data: {
+          studentId,
+          teacherId: TEACHER_ID,
+          scheduledAt: SCHEDULED_AT,
+          durationMinutes: 30,
+          status: 'scheduled',
+        },
+        idToken: adminUser.idToken,
+      });
+      expect(created.status).toBe(200);
+      roomLessonId = created.data!.lesson.id;
+
+      await waitForTrigger();
+
+      const windows = await getSpruceWindows();
+      const window = windows.find(
+        (w) => w.sourceRef === `lessons/${roomLessonId}`
+      );
+      expect(window).toBeDefined();
+      expect(window!.type).toBe('lesson');
+      expect(new Date(window!.start).toISOString()).toBe(
+        SCHEDULED_AT.toISOString()
+      );
+      expect(new Date(window!.end).toISOString()).toBe(
+        new Date(SCHEDULED_AT.getTime() + 30 * 60 * 1000).toISOString()
+      );
+      // Sanitized: the room schedule must not expose the student
+      expect(window!.title).toBe('Music Lesson');
+    });
+
+    it('rejects getRoomSchedule for non-admins and unknown rooms', async () => {
+      const nonAdmin = await callFunction<GetRoomScheduleRequest>({
+        functionName: 'getRoomSchedule',
+        data: { room: 'spruce', start: DAY_START, end: DAY_END },
+        idToken: nonAdminUser.idToken,
+      });
+      expect([403, 500]).toContain(nonAdmin.status);
+
+      const badRoom = await callFunction<Partial<GetRoomScheduleRequest>>({
+        functionName: 'getRoomSchedule',
+        data: { room: 'attic' as never, start: DAY_START, end: DAY_END },
+        idToken: adminUser.idToken,
+      });
+      expect(badRoom.status).not.toBe(200);
+    });
+
+    it('moves the busy window when the lesson is rescheduled', async () => {
+      const newTime = new Date('2026-07-01T18:00:00Z');
+      const updated = await callFunction<
+        UpdateLessonRequest,
+        UpdateLessonResponse
+      >({
+        functionName: 'updateLesson',
+        data: { id: roomLessonId, scheduledAt: newTime },
+        idToken: adminUser.idToken,
+      });
+      expect(updated.status).toBe(200);
+
+      await waitForTrigger();
+
+      const windows = await getSpruceWindows();
+      const matching = windows.filter(
+        (w) => w.sourceRef === `lessons/${roomLessonId}`
+      );
+      // Still exactly one window (stable deterministic ID), at the new time
+      expect(matching.length).toBe(1);
+      expect(new Date(matching[0].start).toISOString()).toBe(
+        newTime.toISOString()
+      );
+    });
+
+    it('frees the room when the lesson is cancelled', async () => {
+      const cancelled = await callFunction<
+        UpdateLessonRequest,
+        UpdateLessonResponse
+      >({
+        functionName: 'updateLesson',
+        data: { id: roomLessonId, status: 'cancelled' },
+        idToken: adminUser.idToken,
+      });
+      expect(cancelled.status).toBe(200);
+
+      await waitForTrigger();
+
+      const windows = await getSpruceWindows();
+      expect(
+        windows.find((w) => w.sourceRef === `lessons/${roomLessonId}`)
+      ).toBeUndefined();
     });
   });
 });

--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -135,6 +135,10 @@ export { deleteCalendarEvent } from '@maple/firebase/maple-functions/delete-cale
 
 // Calendar triggers (Firestore)
 export { onClassWrite } from '@maple/firebase/maple-functions/on-class-write';
+export { onLessonWrite } from '@maple/firebase/maple-functions/on-lesson-write';
+
+// Room availability
+export { getRoomSchedule } from '@maple/firebase/maple-functions/get-room-schedule';
 
 // Calendar embed config
 export { getCalendarEmbedConfig } from '@maple/firebase/maple-functions/get-calendar-embed-config';

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -58,6 +58,8 @@
     "../../libs/firebase/maple-functions/update-calendar-event/**/*.ts",
     "../../libs/firebase/maple-functions/delete-calendar-event/**/*.ts",
     "../../libs/firebase/maple-functions/on-class-write/**/*.ts",
+    "../../libs/firebase/maple-functions/on-lesson-write/**/*.ts",
+    "../../libs/firebase/maple-functions/get-room-schedule/**/*.ts",
     "../../libs/firebase/maple-functions/get-calendar-embed-config/**/*.ts",
     "../../libs/firebase/maple-functions/update-calendar-embed-config/**/*.ts",
     "../../libs/firebase/maple-functions/add-calendar-embed-source/**/*.ts",

--- a/apps/maple-spruce/src/app/(admin)/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/page.tsx
@@ -33,6 +33,7 @@ import StorefrontIcon from '@mui/icons-material/Storefront';
 import SyncProblemIcon from '@mui/icons-material/SyncProblem';
 import { formatClassPrice } from '@maple/ts/domain';
 import { useSyncConflictSummary } from '@maple/react/data';
+import { RoomStatusCard } from '@maple/react/events';
 import { useClasses, useRegistrations, useProducts } from '../../hooks';
 
 const quickLinks = [
@@ -163,6 +164,11 @@ export default function DashboardPage() {
       </Typography>
 
       <Grid container spacing={3}>
+        {/* Spruce Room status */}
+        <Grid size={12}>
+          <RoomStatusCard room="spruce" />
+        </Grid>
+
         {/* Upcoming Classes */}
         <Grid size={{ xs: 12, md: 6 }}>
           <Typography variant="h6" gutterBottom>

--- a/docs/reference/deployed-functions.md
+++ b/docs/reference/deployed-functions.md
@@ -56,6 +56,10 @@ Core CRUD operations, auth, triggers, and admin functions. No heavy third-party 
 
 ### Calendar Triggers
 - `onClassWrite` — Firestore trigger: auto-generates CalendarEvents from published classes
+- `onLessonWrite` — Firestore trigger: auto-generates a private (`public: false`) Spruce Room CalendarEvent per scheduled lesson; removes it on cancel/delete
+
+### Room Availability (#467)
+- `getRoomSchedule` — admin-only: busy windows for a room over a time range (powers the dashboard "Spruce Room" widget and booking conflict checks)
 
 ### Calendar Embed Config
 - `getCalendarEmbedConfig`, `updateCalendarEmbedConfig`, `addCalendarEmbedSource`, `removeCalendarEmbedSource`

--- a/docs/reference/implementation-status.md
+++ b/docs/reference/implementation-status.md
@@ -286,6 +286,20 @@ Uses Square Invoices API rather than a custom Webflow payment page — Square se
 | Firebase Hosting rewrites | **Complete** | `/calendar/*.ics` routes to feed functions |
 | Public calendar display | **Complete** | Open Web Calendar (self-hosted on Vercel), embedded in Webflow via iframe. See ADR-025. |
 
+## Spruce Room Availability — Epic #467 (In Progress)
+
+The Spruce Room is multi-tenant (music lessons, Music Together, ad hoc uses). Room occupancy is tracked via `CalendarEvent.room`; the portal is the source of truth. See #467 for product decisions and architecture.
+
+| Feature | Status | Location |
+|---------|--------|----------|
+| `Room` domain type + `getRoomStatus` logic | **Complete** (PR 1, #468) | `libs/ts/domain/src/lib/room.ts` |
+| `room` field on CalendarEvent + Class | **Complete** (PR 1, #468) | flows through `onClassWrite` |
+| `onLessonWrite` trigger (lessons → private room events) | **Complete** (PR 1, #468) | `libs/firebase/maple-functions/on-lesson-write/` |
+| `getRoomSchedule` Cloud Function | **Complete** (PR 1, #468) | `libs/firebase/maple-functions/get-room-schedule/` |
+| Dashboard "Spruce Room right now" widget | **Complete** (PR 1, #468) | `libs/react/events/src/lib/RoomStatusCard.tsx` |
+| Ad hoc room booking form | Planned (PR 2, #469) | — |
+| Day strip + conflict warnings in scheduling flows | Planned (PR 2, #469) | — |
+
 ## Admin User Management — Complete
 
 Admin `/users` page lists every Firebase Auth user with admin status. Admins can grant or revoke the admin role on others. Self-protection: an admin cannot revoke their own admin role.

--- a/docs/sessions/SESSION.md
+++ b/docs/sessions/SESSION.md
@@ -6,8 +6,20 @@
 
 ## Current Status
 
-**Date**: 2026-05-09
-**Status**: Phase 4 complete; Phase 5 in progress. Custom timesheet retired before usage in favor of Square Shifts + Square Payroll (now in trial).
+**Date**: 2026-06-11
+**Status**: Phase 4 complete; Phase 5 in progress. Spruce Room availability epic started (#467).
+
+### Spruce Room availability — PR 1 shipped (2026-06-11)
+
+The Spruce Room is going multi-tenant (music lessons, Music Together, ad hoc uses); David/Katie/Nathan need to know if it's free. Epic #467 holds the product decisions and architecture; the portal is the source of truth for room occupancy.
+
+PR 1 (#468 / PR #470): `room` field on CalendarEvent/Class, `onLessonWrite` trigger deriving private room-blocking events from scheduled lessons (closing the gap where lessons were invisible to the calendar aggregation), `getRoomSchedule` admin callable + composite index, and the dashboard "Spruce Room right now" widget.
+
+**Next steps**:
+- PR 2 (#469): ad hoc "Book the Spruce Room" form, day strip + warn-and-confirm conflict warnings in ScheduleLessonDialog / class form / event form
+- Ops: onboard Nathan (he signs up at `/login`, grant admin from `/users`) — decided full admin is fine
+
+### Timekeeping retired — replaced by Square (2026-05-09)
 
 ### Timekeeping retired — replaced by Square (2026-05-09)
 

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1329,6 +1329,20 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "calendarEvents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "room",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "startDateTime",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/libs/firebase/database/src/lib/calendar-event.repository.ts
+++ b/libs/firebase/database/src/lib/calendar-event.repository.ts
@@ -9,6 +9,7 @@ import type {
   CalendarEvent,
   CalendarEventType,
   CreateCalendarEventInput,
+  Room,
   UpdateCalendarEventInput,
 } from '@maple/ts/domain';
 
@@ -35,6 +36,7 @@ function docToCalendarEvent(
     location: data.location,
     type: data.type,
     public: data.public,
+    room: data.room ?? null,
     sourceRef: data.sourceRef ?? null,
     createdBy: data.createdBy,
     createdAt: toDate(data.createdAt),
@@ -97,6 +99,36 @@ export const CalendarEventRepository = {
    */
   async findPublicByType(type: CalendarEventType): Promise<CalendarEvent[]> {
     return this.findAll({ type, publicOnly: true });
+  },
+
+  /**
+   * Find all events occupying a room that overlap the given time range.
+   *
+   * Firestore only allows a range filter on one field, so the query bounds
+   * `startDateTime` and the `endDateTime > rangeStart` overlap condition is
+   * applied in memory. A 24-hour lookback before `rangeStart` catches events
+   * that started before the range but spill into it — no room event is
+   * expected to span longer than a day.
+   */
+  async findByRoomInRange(
+    room: Room,
+    rangeStart: Date,
+    rangeEnd: Date
+  ): Promise<CalendarEvent[]> {
+    const lookback = new Date(rangeStart.getTime() - 24 * 60 * 60 * 1000);
+
+    const snapshot = await db
+      .collection(COLLECTION)
+      .where('room', '==', room)
+      .where('startDateTime', '>=', lookback)
+      .where('startDateTime', '<', rangeEnd)
+      .orderBy('startDateTime', 'asc')
+      .get();
+
+    return snapshot.docs
+      .map((doc) => docToCalendarEvent(doc))
+      .filter((e): e is CalendarEvent => e !== undefined)
+      .filter((e) => e.endDateTime.getTime() > rangeStart.getTime());
   },
 
   /**

--- a/libs/firebase/maple-functions/get-room-schedule/project.json
+++ b/libs/firebase/maple-functions/get-room-schedule/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-get-room-schedule",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/get-room-schedule/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/get-room-schedule/src/index.ts
+++ b/libs/firebase/maple-functions/get-room-schedule/src/index.ts
@@ -1,0 +1,1 @@
+export { getRoomSchedule } from './lib/get-room-schedule';

--- a/libs/firebase/maple-functions/get-room-schedule/src/lib/get-room-schedule.spec.ts
+++ b/libs/firebase/maple-functions/get-room-schedule/src/lib/get-room-schedule.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CalendarEvent } from '@maple/ts/domain';
+
+/**
+ * Tests for getRoomSchedule Cloud Function
+ *
+ * Verifies input validation and the mapping from room-scoped CalendarEvents
+ * to serialized busy windows.
+ */
+
+const mocks = vi.hoisted(() => {
+  return {
+    findByRoomInRange: vi.fn(),
+  };
+});
+
+vi.mock('@maple/firebase/database', () => ({
+  CalendarEventRepository: {
+    findByRoomInRange: mocks.findByRoomInRange,
+  },
+}));
+
+// Unwrap createAdminFunction so we can invoke the handler directly
+vi.mock('@maple/firebase/functions', () => ({
+  createAdminFunction: (handler: (data: unknown) => unknown) => handler,
+  throwInvalidArgument: (message: string): never => {
+    throw new Error(message);
+  },
+}));
+
+import { getRoomSchedule } from './get-room-schedule';
+
+const handler = getRoomSchedule as unknown as (
+  data: unknown
+) => Promise<{ windows: unknown[] }>;
+
+function makeEvent(overrides?: Partial<CalendarEvent>): CalendarEvent {
+  return {
+    id: 'lesson-abc',
+    title: 'Music Lesson',
+    description: '',
+    startDateTime: new Date('2026-06-11T20:30:00Z'),
+    endDateTime: new Date('2026-06-11T21:00:00Z'),
+    recurrenceRule: null,
+    location: '688 Beulah Road, Morgantown, WV 26508',
+    type: 'lesson',
+    public: false,
+    room: 'spruce',
+    sourceRef: 'lessons/abc',
+    createdBy: 'system',
+    createdAt: new Date('2025-01-01'),
+    updatedAt: new Date('2025-01-01'),
+    ...overrides,
+  };
+}
+
+describe('getRoomSchedule', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findByRoomInRange.mockResolvedValue([]);
+  });
+
+  it('rejects an unknown room', async () => {
+    await expect(
+      handler({
+        room: 'attic',
+        start: '2026-06-11T00:00:00Z',
+        end: '2026-06-12T00:00:00Z',
+      })
+    ).rejects.toThrow();
+    expect(mocks.findByRoomInRange).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing or invalid date range', async () => {
+    await expect(
+      handler({ room: 'spruce', start: 'not-a-date', end: '2026-06-12' })
+    ).rejects.toThrow();
+    await expect(handler({ room: 'spruce' })).rejects.toThrow();
+  });
+
+  it('rejects an inverted range', async () => {
+    await expect(
+      handler({
+        room: 'spruce',
+        start: '2026-06-12T00:00:00Z',
+        end: '2026-06-11T00:00:00Z',
+      })
+    ).rejects.toThrow();
+  });
+
+  it('queries the repository with parsed dates and maps events to windows', async () => {
+    mocks.findByRoomInRange.mockResolvedValue([makeEvent()]);
+
+    const result = await handler({
+      room: 'spruce',
+      start: '2026-06-11T00:00:00.000Z',
+      end: '2026-06-12T00:00:00.000Z',
+    });
+
+    expect(mocks.findByRoomInRange).toHaveBeenCalledWith(
+      'spruce',
+      new Date('2026-06-11T00:00:00.000Z'),
+      new Date('2026-06-12T00:00:00.000Z')
+    );
+    expect(result.windows).toEqual([
+      {
+        eventId: 'lesson-abc',
+        title: 'Music Lesson',
+        type: 'lesson',
+        sourceRef: 'lessons/abc',
+        start: '2026-06-11T20:30:00.000Z',
+        end: '2026-06-11T21:00:00.000Z',
+      },
+    ]);
+  });
+
+  it('returns an empty list when the room has no events in range', async () => {
+    const result = await handler({
+      room: 'spruce',
+      start: '2026-06-11T00:00:00Z',
+      end: '2026-06-12T00:00:00Z',
+    });
+    expect(result.windows).toEqual([]);
+  });
+});

--- a/libs/firebase/maple-functions/get-room-schedule/src/lib/get-room-schedule.ts
+++ b/libs/firebase/maple-functions/get-room-schedule/src/lib/get-room-schedule.ts
@@ -1,0 +1,56 @@
+/**
+ * Get Room Schedule Cloud Function
+ *
+ * Returns the busy windows for a room over a time range — every calendar
+ * event (lesson-derived, class-derived, or ad hoc) that claims the room and
+ * overlaps the range. Powers the "Spruce right now" dashboard widget,
+ * scheduling-dialog day strips, and booking conflict warnings.
+ *
+ * Admin-only: lesson-derived windows exist for private events, so this must
+ * not be publicly callable.
+ */
+import {
+  createAdminFunction,
+  throwInvalidArgument,
+} from '@maple/firebase/functions';
+import { CalendarEventRepository } from '@maple/firebase/database';
+import { ROOMS } from '@maple/ts/domain';
+import type {
+  GetRoomScheduleRequest,
+  GetRoomScheduleResponse,
+} from '@maple/ts/firebase/api-types';
+
+export const getRoomSchedule = createAdminFunction<
+  GetRoomScheduleRequest,
+  GetRoomScheduleResponse
+>(async (data) => {
+  if (!data.room || !ROOMS.includes(data.room)) {
+    throwInvalidArgument('A valid room is required');
+  }
+
+  const start = data.start ? new Date(data.start) : undefined;
+  const end = data.end ? new Date(data.end) : undefined;
+  if (!start || isNaN(start.getTime()) || !end || isNaN(end.getTime())) {
+    throwInvalidArgument('start and end must be valid ISO date strings');
+  }
+  if (end.getTime() <= start.getTime()) {
+    throwInvalidArgument('end must be after start');
+  }
+
+  const events = await CalendarEventRepository.findByRoomInRange(
+    data.room,
+    start,
+    end
+  );
+
+  return {
+    windows: events.map((e) => ({
+      eventId: e.id,
+      title: e.title,
+      type: e.type,
+      sourceRef: e.sourceRef,
+      start: e.startDateTime.toISOString(),
+      end: e.endDateTime.toISOString(),
+    })),
+  };
+});

--- a/libs/firebase/maple-functions/get-room-schedule/tsconfig.json
+++ b/libs/firebase/maple-functions/get-room-schedule/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/get-room-schedule/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/get-room-schedule/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/on-class-write/src/lib/on-class-write.ts
+++ b/libs/firebase/maple-functions/on-class-write/src/lib/on-class-write.ts
@@ -173,6 +173,7 @@ export const onClassWrite = onDocumentWritten(
             location: afterClass.location || DEFAULT_EVENT_LOCATION,
             type: 'class',
             public: true,
+            room: afterClass.room ?? null,
             sourceRef,
             createdBy: 'system',
           });

--- a/libs/firebase/maple-functions/on-lesson-write/project.json
+++ b/libs/firebase/maple-functions/on-lesson-write/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-on-lesson-write",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/on-lesson-write/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/on-lesson-write/src/index.ts
+++ b/libs/firebase/maple-functions/on-lesson-write/src/index.ts
@@ -1,0 +1,1 @@
+export { onLessonWrite } from './lib/on-lesson-write';

--- a/libs/firebase/maple-functions/on-lesson-write/src/lib/on-lesson-write.spec.ts
+++ b/libs/firebase/maple-functions/on-lesson-write/src/lib/on-lesson-write.spec.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Tests for onLessonWrite Firestore trigger
+ *
+ * Verifies that lesson create/update/cancel/delete correctly reconciles the
+ * single derived CalendarEvent at the deterministic ID `lesson-{lessonId}`,
+ * and that derived events never leak student details to public feeds.
+ */
+
+const mocks = vi.hoisted(() => {
+  return {
+    upsertWithId: vi.fn(),
+    delete: vi.fn(),
+  };
+});
+
+vi.mock('@maple/firebase/database', () => ({
+  CalendarEventRepository: {
+    upsertWithId: mocks.upsertWithId,
+    delete: mocks.delete,
+  },
+}));
+
+vi.mock('firebase-functions/v2/firestore', () => ({
+  onDocumentWritten: vi.fn((_config, handler) => handler),
+}));
+
+import { onLessonWrite } from './on-lesson-write';
+
+const handler = onLessonWrite as unknown as (event: unknown) => Promise<void>;
+
+function makeSnapshot(
+  exists: boolean,
+  data?: Record<string, unknown>,
+  id = 'lesson-abc'
+) {
+  return {
+    exists,
+    id,
+    data: () => (exists ? data : undefined),
+  };
+}
+
+const scheduledAt = new Date('2030-06-15T20:30:00Z');
+
+function ts(date: Date) {
+  return { toDate: () => date };
+}
+
+const scheduledLessonData = {
+  studentId: 'student-1',
+  scheduledAt: ts(scheduledAt),
+  durationMinutes: 30,
+  teacherId: 'teacher-1',
+  status: 'scheduled',
+  createdAt: ts(new Date('2025-01-01')),
+  updatedAt: ts(new Date('2025-01-01')),
+};
+
+describe('onLessonWrite', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.upsertWithId.mockResolvedValue(undefined);
+    mocks.delete.mockResolvedValue(undefined);
+  });
+
+  it('upserts a CalendarEvent when a lesson is scheduled', async () => {
+    await handler({
+      params: { lessonId: 'abc' },
+      data: {
+        before: makeSnapshot(false),
+        after: makeSnapshot(true, scheduledLessonData),
+      },
+    });
+
+    expect(mocks.upsertWithId).toHaveBeenCalledOnce();
+    const [id, input] = mocks.upsertWithId.mock.calls[0];
+    expect(id).toBe('lesson-abc');
+    expect(input.type).toBe('lesson');
+    expect(input.room).toBe('spruce');
+    expect(input.sourceRef).toBe('lessons/abc');
+    expect(input.startDateTime).toEqual(scheduledAt);
+    expect(input.endDateTime).toEqual(
+      new Date(scheduledAt.getTime() + 30 * 60 * 1000)
+    );
+  });
+
+  it('keeps derived events off public feeds and free of student details', async () => {
+    await handler({
+      params: { lessonId: 'abc' },
+      data: {
+        before: makeSnapshot(false),
+        after: makeSnapshot(true, scheduledLessonData),
+      },
+    });
+
+    const [, input] = mocks.upsertWithId.mock.calls[0];
+    expect(input.public).toBe(false);
+    expect(input.title).toBe('Music Lesson');
+    expect(JSON.stringify(input)).not.toContain('student-1');
+  });
+
+  it('re-upserts at the same ID when a lesson is rescheduled', async () => {
+    const newTime = new Date('2030-06-16T21:00:00Z');
+    await handler({
+      params: { lessonId: 'abc' },
+      data: {
+        before: makeSnapshot(true, scheduledLessonData),
+        after: makeSnapshot(true, {
+          ...scheduledLessonData,
+          scheduledAt: ts(newTime),
+        }),
+      },
+    });
+
+    expect(mocks.upsertWithId).toHaveBeenCalledOnce();
+    const [id, input] = mocks.upsertWithId.mock.calls[0];
+    expect(id).toBe('lesson-abc');
+    expect(input.startDateTime).toEqual(newTime);
+    expect(mocks.delete).not.toHaveBeenCalled();
+  });
+
+  it('keeps the event when a lesson is marked rendered (it was taught)', async () => {
+    await handler({
+      params: { lessonId: 'abc' },
+      data: {
+        before: makeSnapshot(true, scheduledLessonData),
+        after: makeSnapshot(true, {
+          ...scheduledLessonData,
+          status: 'rendered',
+        }),
+      },
+    });
+
+    expect(mocks.upsertWithId).toHaveBeenCalledOnce();
+    expect(mocks.delete).not.toHaveBeenCalled();
+  });
+
+  it('deletes the event when a lesson is cancelled', async () => {
+    await handler({
+      params: { lessonId: 'abc' },
+      data: {
+        before: makeSnapshot(true, scheduledLessonData),
+        after: makeSnapshot(true, {
+          ...scheduledLessonData,
+          status: 'cancelled',
+        }),
+      },
+    });
+
+    expect(mocks.upsertWithId).not.toHaveBeenCalled();
+    expect(mocks.delete).toHaveBeenCalledWith('lesson-abc');
+  });
+
+  it('deletes the event when a lesson doc is deleted', async () => {
+    await handler({
+      params: { lessonId: 'abc' },
+      data: {
+        before: makeSnapshot(true, scheduledLessonData),
+        after: makeSnapshot(false),
+      },
+    });
+
+    expect(mocks.upsertWithId).not.toHaveBeenCalled();
+    expect(mocks.delete).toHaveBeenCalledWith('lesson-abc');
+  });
+
+  it('handles scheduledAt as ISO string (emulator REST API format)', async () => {
+    const iso = '2030-08-15T14:00:00.000Z';
+    await handler({
+      params: { lessonId: 'abc' },
+      data: {
+        before: makeSnapshot(false),
+        after: makeSnapshot(true, {
+          ...scheduledLessonData,
+          scheduledAt: iso,
+        }),
+      },
+    });
+
+    expect(mocks.upsertWithId).toHaveBeenCalledOnce();
+    const [, input] = mocks.upsertWithId.mock.calls[0];
+    expect(input.startDateTime).toEqual(new Date(iso));
+  });
+});

--- a/libs/firebase/maple-functions/on-lesson-write/src/lib/on-lesson-write.ts
+++ b/libs/firebase/maple-functions/on-lesson-write/src/lib/on-lesson-write.ts
@@ -1,0 +1,127 @@
+/**
+ * onLessonWrite Firestore Trigger
+ *
+ * Keeps the CalendarEvent collection in sync with the lessons collection so
+ * scheduled music lessons block the Spruce Room's availability.
+ *
+ * - Scheduled or rendered lesson: upserts one CalendarEvent at the stable ID
+ *   `lesson-{lessonId}` ('rendered' means the lesson was actually taught, so
+ *   it stays on the room schedule as history).
+ * - Cancelled or deleted lesson: removes the CalendarEvent.
+ *
+ * Derived events are `public: false` with a generic title — student names
+ * must never reach the public ICS feeds. The room schedule only needs to
+ * know the slot is taken.
+ *
+ * No feedback-loop guard is needed: this trigger watches `lessons` and only
+ * writes to `calendarEvents`, which has no trigger of its own.
+ */
+import {
+  onDocumentWritten,
+  type Change,
+  type DocumentSnapshot,
+} from 'firebase-functions/v2/firestore';
+import { CalendarEventRepository } from '@maple/firebase/database';
+import type { Lesson } from '@maple/ts/domain';
+import { DEFAULT_EVENT_LOCATION } from '@maple/ts/domain';
+
+function toDateLike(value: unknown): Date | undefined {
+  if (!value) return undefined;
+  if (value instanceof Date) return value;
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    'toDate' in value &&
+    typeof (value as { toDate: unknown }).toDate === 'function'
+  ) {
+    return (value as { toDate: () => Date }).toDate();
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    const d = new Date(value);
+    return isNaN(d.getTime()) ? undefined : d;
+  }
+  return undefined;
+}
+
+/**
+ * Extract lesson data from a Firestore snapshot.
+ */
+function extractLesson(snapshot: DocumentSnapshot | undefined): Lesson | null {
+  if (!snapshot || !snapshot.exists) {
+    return null;
+  }
+
+  const data = snapshot.data();
+  if (!data) return null;
+
+  const scheduledAt = toDateLike(data['scheduledAt']);
+  if (!scheduledAt) return null;
+
+  return {
+    id: snapshot.id,
+    ...data,
+    scheduledAt,
+    createdAt: toDateLike(data['createdAt']) ?? new Date(),
+    updatedAt: toDateLike(data['updatedAt']) ?? new Date(),
+  } as Lesson;
+}
+
+/**
+ * Deterministic doc ID for a lesson's calendar event. One event per lesson —
+ * recurring series are already modeled as N independent lesson docs.
+ */
+function lessonEventId(lessonId: string): string {
+  return `lesson-${lessonId}`;
+}
+
+export const onLessonWrite = onDocumentWritten(
+  {
+    document: 'lessons/{lessonId}',
+    region: 'us-east4',
+  },
+  async (event) => {
+    const change: Change<DocumentSnapshot> = event.data!;
+    const afterLesson = extractLesson(change.after);
+    const lessonId = event.params.lessonId;
+    const eventDocId = lessonEventId(lessonId);
+
+    try {
+      // Lesson deleted, cancelled, or unreadable — remove its event.
+      // Firestore deletes are no-ops when the doc doesn't exist.
+      if (!afterLesson || afterLesson.status === 'cancelled') {
+        await CalendarEventRepository.delete(eventDocId);
+        console.log('Removed CalendarEvent for lesson:', {
+          lessonId,
+          reason: afterLesson ? 'cancelled' : 'deleted',
+        });
+        return;
+      }
+
+      // Scheduled or rendered — the slot is (or was) genuinely occupied.
+      await CalendarEventRepository.upsertWithId(eventDocId, {
+        title: 'Music Lesson',
+        description: '',
+        startDateTime: afterLesson.scheduledAt,
+        endDateTime: new Date(
+          afterLesson.scheduledAt.getTime() +
+            afterLesson.durationMinutes * 60 * 1000
+        ),
+        recurrenceRule: null,
+        location: DEFAULT_EVENT_LOCATION,
+        type: 'lesson',
+        public: false,
+        room: 'spruce',
+        sourceRef: `lessons/${lessonId}`,
+        createdBy: 'system',
+      });
+
+      console.log('Upserted CalendarEvent for lesson:', {
+        lessonId,
+        startDateTime: afterLesson.scheduledAt.toISOString(),
+        status: afterLesson.status,
+      });
+    } catch (error) {
+      console.error('Error in onLessonWrite:', error);
+    }
+  }
+);

--- a/libs/firebase/maple-functions/on-lesson-write/tsconfig.json
+++ b/libs/firebase/maple-functions/on-lesson-write/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/on-lesson-write/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/on-lesson-write/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/react/data/src/index.ts
+++ b/libs/react/data/src/index.ts
@@ -24,6 +24,7 @@ export {
   type UseCalendarEventsFilters,
 } from './lib/useCalendarEvents';
 export { useCalendarEmbedConfig } from './lib/useCalendarEmbedConfig';
+export { useRoomSchedule } from './lib/useRoomSchedule';
 
 // Phase 5: Etsy Integration
 export { useEtsyConnection } from './lib/useEtsyConnection';

--- a/libs/react/data/src/lib/useRoomSchedule.ts
+++ b/libs/react/data/src/lib/useRoomSchedule.ts
@@ -1,0 +1,78 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { httpsCallable } from 'firebase/functions';
+import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
+import type { RequestState, Room, RoomBusyWindow } from '@maple/ts/domain';
+import type {
+  GetRoomScheduleRequest,
+  GetRoomScheduleResponse,
+} from '@maple/ts/firebase/api-types';
+
+/**
+ * Hook for fetching a room's busy windows for the rest of today.
+ *
+ * Powers point-in-time status displays (the dashboard "right now" widget).
+ * Windows are re-hydrated to Date objects and sorted by start time.
+ */
+export function useRoomSchedule(room: Room) {
+  const [roomScheduleState, setRoomScheduleState] = useState<
+    RequestState<RoomBusyWindow[]>
+  >({
+    status: 'idle',
+  });
+
+  const fetchRoomSchedule = useCallback(async () => {
+    setRoomScheduleState({ status: 'loading' });
+
+    try {
+      const functions = getMapleFunctions();
+      const getRoomSchedule = httpsCallable<
+        GetRoomScheduleRequest,
+        GetRoomScheduleResponse
+      >(functions, 'getRoomSchedule');
+
+      const now = new Date();
+      const endOfDay = new Date(now);
+      endOfDay.setHours(23, 59, 59, 999);
+
+      const result = await getRoomSchedule({
+        room,
+        start: now.toISOString(),
+        end: endOfDay.toISOString(),
+      });
+
+      const windows: RoomBusyWindow[] = result.data.windows
+        .map((w) => ({
+          eventId: w.eventId,
+          title: w.title,
+          type: w.type,
+          sourceRef: w.sourceRef,
+          start: new Date(w.start),
+          end: new Date(w.end),
+        }))
+        .sort((a, b) => a.start.getTime() - b.start.getTime());
+
+      setRoomScheduleState({ status: 'success', data: windows });
+    } catch (error) {
+      console.error('Failed to fetch room schedule:', error);
+      setRoomScheduleState({
+        status: 'error',
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to fetch room schedule',
+      });
+    }
+  }, [room]);
+
+  // Fetch on mount and when the room changes
+  useEffect(() => {
+    fetchRoomSchedule();
+  }, [fetchRoomSchedule]);
+
+  return {
+    roomScheduleState,
+    fetchRoomSchedule,
+  };
+}

--- a/libs/react/events/src/index.ts
+++ b/libs/react/events/src/index.ts
@@ -1,4 +1,5 @@
 export { CalendarEventList } from './lib/CalendarEventList';
+export { RoomStatusCard } from './lib/RoomStatusCard';
 export { CalendarEventForm } from './lib/CalendarEventForm';
 export {
   CalendarEventFilterToolbar,

--- a/libs/react/events/src/lib/RoomStatusCard.tsx
+++ b/libs/react/events/src/lib/RoomStatusCard.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { Alert, Box, Card, CardContent, Chip, Skeleton, Typography } from '@mui/material';
+import MeetingRoomIcon from '@mui/icons-material/MeetingRoom';
+import {
+  getRoomLabel,
+  getRoomStatus,
+  type Room,
+  type RoomBusyWindow,
+  type RoomStatus,
+} from '@maple/ts/domain';
+import { useRoomSchedule } from '@maple/react/data';
+
+/** Format time as "4:30 PM" */
+function formatTime(date: Date): string {
+  return date.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function windowLabel(w: RoomBusyWindow): string {
+  return `${w.title} (${formatTime(w.start)}–${formatTime(w.end)})`;
+}
+
+/**
+ * Point-in-time occupancy widget for a room: "Free until 4:30 PM" /
+ * "In use until 5:15 PM", with what's happening now and what's up next.
+ * Answers the standing-in-the-building question without opening a calendar.
+ */
+export function RoomStatusCard({ room }: { room: Room }) {
+  const { roomScheduleState } = useRoomSchedule(room);
+
+  const status =
+    roomScheduleState.status === 'success'
+      ? getRoomStatus(roomScheduleState.data, new Date())
+      : null;
+
+  return (
+    <Card variant="outlined">
+      <CardContent>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+          <MeetingRoomIcon fontSize="small" color="primary" />
+          <Typography variant="h6" component="h2">
+            {getRoomLabel(room)}
+          </Typography>
+          {status && (
+            <Chip
+              label={status.kind === 'in-use' ? 'In use' : 'Free'}
+              size="small"
+              color={status.kind === 'in-use' ? 'warning' : 'success'}
+            />
+          )}
+        </Box>
+
+        {roomScheduleState.status === 'loading' ||
+        roomScheduleState.status === 'idle' ? (
+          <Skeleton variant="text" width="70%" />
+        ) : roomScheduleState.status === 'error' ? (
+          <Alert severity="error">{roomScheduleState.error}</Alert>
+        ) : status ? (
+          <RoomStatusLines status={status} />
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function RoomStatusLines({ status }: { status: RoomStatus }) {
+  if (status.kind === 'free') {
+    return (
+      <>
+        <Typography variant="body1">
+          {status.until
+            ? `Free until ${formatTime(status.until)}`
+            : 'Free for the rest of the day'}
+        </Typography>
+        {status.next && (
+          <Typography variant="body2" color="text.secondary">
+            Next: {windowLabel(status.next)}
+          </Typography>
+        )}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Typography variant="body1">
+        In use until {formatTime(status.freeAt)}
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        Now: {windowLabel(status.current)}
+        {status.next ? ` · Next: ${windowLabel(status.next)}` : ''}
+      </Typography>
+    </>
+  );
+}

--- a/libs/ts/domain/src/index.ts
+++ b/libs/ts/domain/src/index.ts
@@ -34,6 +34,7 @@ export * from './lib/teacher-payout';
 // Phase 4.5: Calendar
 export * from './lib/calendar-event';
 export * from './lib/calendar-embed-config';
+export * from './lib/room';
 
 // Agreements & Waivers
 export * from './lib/agreement-template';

--- a/libs/ts/domain/src/lib/calendar-event.ts
+++ b/libs/ts/domain/src/lib/calendar-event.ts
@@ -3,8 +3,9 @@
  *
  * Represents events displayed on the public calendar and managed via the admin UI.
  * Events can be manually created (jams, store hours, ad-hoc events) or
- * auto-generated from other entities (classes, future music lessons).
+ * auto-generated from other entities (classes, music lessons).
  */
+import type { Room } from './room';
 
 /**
  * Type of calendar event, used for filtering and color-coding on the public calendar.
@@ -48,6 +49,12 @@ export interface CalendarEvent {
   type: CalendarEventType;
   /** Controls inclusion in public ICS feeds. Default true. */
   public: boolean;
+  /**
+   * Which bookable room this event occupies, if any. Drives room
+   * availability displays and conflict checks. Null/absent for events that
+   * don't claim a room (e.g. store hours, off-site classes).
+   */
+  room?: Room | null;
   /** Optional reference to originating doc, e.g. "classes/abc123". Null for ad-hoc events. */
   sourceRef: string | null;
   /** Firebase Auth UID of creator */

--- a/libs/ts/domain/src/lib/class.ts
+++ b/libs/ts/domain/src/lib/class.ts
@@ -11,6 +11,7 @@
  * Future payments will use Square (consistent with existing POS integration).
  */
 import type { GalleryImage } from './gallery-image';
+import type { Room } from './room';
 
 /**
  * Skill level recommendation for a class
@@ -84,6 +85,11 @@ export interface Class {
   status: ClassStatus;
   /** Location (defaults to store address if not specified) */
   location?: string;
+  /**
+   * Which bookable room sessions occupy, if any. Flows through to the
+   * derived CalendarEvents so the class blocks the room's availability.
+   */
+  room?: Room | null;
   /** Materials included in the price */
   materialsIncluded?: string;
   /** What students should bring */

--- a/libs/ts/domain/src/lib/room.spec.ts
+++ b/libs/ts/domain/src/lib/room.spec.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { getRoomStatus, getRoomLabel, type RoomBusyWindow } from './room';
+
+function win(
+  startIso: string,
+  endIso: string,
+  overrides?: Partial<RoomBusyWindow>
+): RoomBusyWindow {
+  return {
+    eventId: `evt-${startIso}`,
+    title: 'Music Lesson',
+    type: 'lesson',
+    sourceRef: null,
+    start: new Date(startIso),
+    end: new Date(endIso),
+    ...overrides,
+  };
+}
+
+describe('getRoomLabel', () => {
+  it('labels the spruce room', () => {
+    expect(getRoomLabel('spruce')).toBe('Spruce Room');
+  });
+});
+
+describe('getRoomStatus', () => {
+  const now = new Date('2026-06-11T15:00:00Z');
+
+  it('reports free with no windows at all', () => {
+    const status = getRoomStatus([], now);
+    expect(status).toEqual({ kind: 'free', until: null, next: null });
+  });
+
+  it('reports free with the next upcoming window', () => {
+    const next = win('2026-06-11T16:30:00Z', '2026-06-11T18:00:00Z', {
+      title: 'Music Together',
+    });
+    const status = getRoomStatus([next], now);
+    expect(status.kind).toBe('free');
+    if (status.kind === 'free') {
+      expect(status.until).toEqual(new Date('2026-06-11T16:30:00Z'));
+      expect(status.next?.title).toBe('Music Together');
+    }
+  });
+
+  it('ignores windows already in the past when free', () => {
+    const past = win('2026-06-11T10:00:00Z', '2026-06-11T11:00:00Z');
+    const status = getRoomStatus([past], now);
+    expect(status).toEqual({ kind: 'free', until: null, next: null });
+  });
+
+  it('reports in-use during a window', () => {
+    const current = win('2026-06-11T14:30:00Z', '2026-06-11T15:30:00Z');
+    const status = getRoomStatus([current], now);
+    expect(status.kind).toBe('in-use');
+    if (status.kind === 'in-use') {
+      expect(status.current.eventId).toBe(current.eventId);
+      expect(status.freeAt).toEqual(new Date('2026-06-11T15:30:00Z'));
+      expect(status.next).toBeNull();
+    }
+  });
+
+  it('treats a window ending exactly now as over', () => {
+    const ending = win('2026-06-11T14:00:00Z', '2026-06-11T15:00:00Z');
+    const status = getRoomStatus([ending], now);
+    expect(status.kind).toBe('free');
+  });
+
+  it('treats a window starting exactly now as current', () => {
+    const starting = win('2026-06-11T15:00:00Z', '2026-06-11T16:00:00Z');
+    const status = getRoomStatus([starting], now);
+    expect(status.kind).toBe('in-use');
+  });
+
+  it('coalesces back-to-back windows into one occupied run', () => {
+    const a = win('2026-06-11T14:30:00Z', '2026-06-11T15:30:00Z');
+    const b = win('2026-06-11T15:30:00Z', '2026-06-11T16:00:00Z');
+    const c = win('2026-06-11T16:00:00Z', '2026-06-11T16:45:00Z');
+    const status = getRoomStatus([c, a, b], now); // unsorted on purpose
+    expect(status.kind).toBe('in-use');
+    if (status.kind === 'in-use') {
+      expect(status.current.eventId).toBe(a.eventId);
+      expect(status.freeAt).toEqual(new Date('2026-06-11T16:45:00Z'));
+    }
+  });
+
+  it('coalesces overlapping windows', () => {
+    const a = win('2026-06-11T14:00:00Z', '2026-06-11T15:30:00Z');
+    const b = win('2026-06-11T15:00:00Z', '2026-06-11T17:00:00Z');
+    const status = getRoomStatus([a, b], now);
+    expect(status.kind).toBe('in-use');
+    if (status.kind === 'in-use') {
+      expect(status.freeAt).toEqual(new Date('2026-06-11T17:00:00Z'));
+    }
+  });
+
+  it('reports the next window after a coalesced run, not within it', () => {
+    const a = win('2026-06-11T14:30:00Z', '2026-06-11T15:30:00Z');
+    const b = win('2026-06-11T15:30:00Z', '2026-06-11T16:00:00Z');
+    const later = win('2026-06-11T18:00:00Z', '2026-06-11T19:00:00Z', {
+      title: 'Band Practice',
+    });
+    const status = getRoomStatus([a, b, later], now);
+    expect(status.kind).toBe('in-use');
+    if (status.kind === 'in-use') {
+      expect(status.freeAt).toEqual(new Date('2026-06-11T16:00:00Z'));
+      expect(status.next?.title).toBe('Band Practice');
+    }
+  });
+});

--- a/libs/ts/domain/src/lib/room.ts
+++ b/libs/ts/domain/src/lib/room.ts
@@ -1,0 +1,91 @@
+/**
+ * Room domain types
+ *
+ * Rooms are bookable spaces at the shop whose occupancy is tracked through
+ * CalendarEvents (`CalendarEvent.room`). Modeled as a string union rather
+ * than a managed entity — there is one contested room today (Spruce) and
+ * adding another is a one-line change.
+ */
+import type { CalendarEventType } from './calendar-event';
+
+export type Room = 'spruce';
+
+/**
+ * All valid rooms for validation
+ */
+export const ROOMS: Room[] = ['spruce'];
+
+/**
+ * Human-readable label for a room
+ */
+export function getRoomLabel(room: Room): string {
+  const labels: Record<Room, string> = {
+    spruce: 'Spruce Room',
+  };
+  return labels[room];
+}
+
+/**
+ * A contiguous block of time during which a room is occupied by one
+ * calendar event. Returned by the getRoomSchedule API and consumed by
+ * status displays, day strips, and conflict checks.
+ */
+export interface RoomBusyWindow {
+  /** ID of the CalendarEvent backing this window */
+  eventId: string;
+  title: string;
+  type: CalendarEventType;
+  /** Originating doc (e.g. "lessons/abc123"), null for ad-hoc events */
+  sourceRef: string | null;
+  start: Date;
+  end: Date;
+}
+
+/**
+ * Point-in-time occupancy status for a room.
+ *
+ * - `free`: the room is open right now. `until` is the start of the next
+ *   busy window (null when nothing else is scheduled in the queried range).
+ * - `in-use`: the room is occupied. `freeAt` is when the room actually
+ *   opens up — back-to-back and overlapping windows are coalesced, so a
+ *   4:00–4:30 lesson followed by a 4:30–5:00 lesson reports `freeAt` 5:00.
+ */
+export type RoomStatus =
+  | { kind: 'free'; until: Date | null; next: RoomBusyWindow | null }
+  | { kind: 'in-use'; current: RoomBusyWindow; freeAt: Date; next: RoomBusyWindow | null };
+
+/**
+ * Compute a room's occupancy status at a moment in time from its busy
+ * windows. Windows may be unsorted and may overlap.
+ */
+export function getRoomStatus(
+  windows: RoomBusyWindow[],
+  now: Date
+): RoomStatus {
+  const sorted = [...windows].sort(
+    (a, b) => a.start.getTime() - b.start.getTime()
+  );
+
+  const current = sorted.find(
+    (w) => w.start.getTime() <= now.getTime() && now.getTime() < w.end.getTime()
+  );
+
+  if (!current) {
+    const next = sorted.find((w) => w.start.getTime() > now.getTime()) ?? null;
+    return { kind: 'free', until: next?.start ?? null, next };
+  }
+
+  // Coalesce the contiguous run of windows: while the next window starts at
+  // or before the current run ends, the room never actually frees up.
+  let freeAt = current.end;
+  for (const w of sorted) {
+    if (w.start.getTime() <= freeAt.getTime() && w.end.getTime() > freeAt.getTime()) {
+      freeAt = w.end;
+    }
+  }
+
+  const next =
+    sorted.find((w) => w.start.getTime() > freeAt.getTime()) ?? null;
+
+  return { kind: 'in-use', current, freeAt, next };
+}

--- a/libs/ts/firebase/api-types/src/lib/calendar-event.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/calendar-event.types.ts
@@ -8,6 +8,7 @@ import type {
   CalendarEvent,
   CalendarEventType,
   CreateCalendarEventInput,
+  Room,
   UpdateCalendarEventInput,
 } from '@maple/ts/domain';
 
@@ -56,6 +57,37 @@ export interface UpdateCalendarEventRequest extends UpdateCalendarEventInput {}
 
 export interface UpdateCalendarEventResponse {
   calendarEvent: CalendarEvent;
+}
+
+// ============================================================================
+// Get Room Schedule
+// ============================================================================
+
+export interface GetRoomScheduleRequest {
+  room: Room;
+  /** ISO date string — start of the range (inclusive) */
+  start: string;
+  /** ISO date string — end of the range (exclusive) */
+  end: string;
+}
+
+/**
+ * Serialized busy window. Mirrors `RoomBusyWindow` from @maple/ts/domain
+ * with ISO-string dates for the wire; clients re-hydrate with `new Date()`.
+ */
+export interface RoomScheduleWindow {
+  eventId: string;
+  title: string;
+  type: CalendarEventType;
+  sourceRef: string | null;
+  /** ISO date string */
+  start: string;
+  /** ISO date string */
+  end: string;
+}
+
+export interface GetRoomScheduleResponse {
+  windows: RoomScheduleWindow[];
 }
 
 // ============================================================================

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -231,6 +231,9 @@ export type {
   UpdateCalendarEventResponse,
   DeleteCalendarEventRequest,
   DeleteCalendarEventResponse,
+  GetRoomScheduleRequest,
+  GetRoomScheduleResponse,
+  RoomScheduleWindow,
 } from './calendar-event.types';
 
 // Phase 3c: Registration types

--- a/libs/ts/validation/src/lib/calendar-event.validation.ts
+++ b/libs/ts/validation/src/lib/calendar-event.validation.ts
@@ -6,7 +6,7 @@
  */
 import { staticSuite, test, enforce, only } from 'vest';
 import type { CreateCalendarEventInput } from '@maple/ts/domain';
-import { CALENDAR_EVENT_TYPES } from '@maple/ts/domain';
+import { CALENDAR_EVENT_TYPES, ROOMS } from '@maple/ts/domain';
 
 /**
  * Validate calendar event form data
@@ -77,6 +77,13 @@ export const calendarEventValidation = staticSuite(
     test('recurrenceRule', 'Recurrence rule must not be empty if provided', () => {
       if (data.recurrenceRule !== undefined && data.recurrenceRule !== null) {
         enforce(data.recurrenceRule).isNotBlank();
+      }
+    });
+
+    // Room validation (optional, but must be a known room when set)
+    test('room', 'Room must be valid', () => {
+      if (data.room !== undefined && data.room !== null) {
+        enforce(data.room).inside(ROOMS);
       }
     });
 

--- a/libs/ts/validation/src/lib/class.validation.ts
+++ b/libs/ts/validation/src/lib/class.validation.ts
@@ -5,7 +5,7 @@
  * @see https://vestjs.dev/
  */
 import { staticSuite, test, enforce, only } from 'vest';
-import { GALLERY_IMAGE_MAX, type CreateClassInput } from '@maple/ts/domain';
+import { GALLERY_IMAGE_MAX, ROOMS, type CreateClassInput } from '@maple/ts/domain';
 
 /**
  * Validate class form data
@@ -195,6 +195,13 @@ export const classValidation = staticSuite(
     test('instructorId', 'Instructor is required for published classes', () => {
       if (data.status === 'published') {
         enforce(data.instructorId).isNotBlank();
+      }
+    });
+
+    // Room validation (optional, but must be a known room when set)
+    test('room', 'Room must be valid', () => {
+      if (data.room !== undefined && data.room !== null) {
+        enforce(data.room).inside(ROOMS);
       }
     });
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -314,6 +314,12 @@
       "@maple/firebase/maple-functions/on-class-write": [
         "libs/firebase/maple-functions/on-class-write/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/on-lesson-write": [
+        "libs/firebase/maple-functions/on-lesson-write/src/index.ts"
+      ],
+      "@maple/firebase/maple-functions/get-room-schedule": [
+        "libs/firebase/maple-functions/get-room-schedule/src/index.ts"
+      ],
       "@maple/react/instructors": ["libs/react/instructors/src/index.ts"],
       "@maple/react/students": ["libs/react/students/src/index.ts"],
       "@maple/react/lessons": ["libs/react/lessons/src/index.ts"],


### PR DESCRIPTION
## Summary

PR 1 of 2 for the Spruce Room availability epic (#467) — makes room occupancy **visible**. Scheduled music lessons (the room's heaviest user) were previously invisible to the calendar aggregation; they now derive private calendar events that block the room, and the dashboard answers "is the Spruce room free right now?" at a glance.

## Changes

- **`Room` domain type** (`libs/ts/domain/src/lib/room.ts`): `'spruce'` string union + `RoomBusyWindow` + pure `getRoomStatus()` logic (coalesces back-to-back/overlapping windows so "in use until" reports when the room *actually* frees up)
- **`room` field** on `CalendarEvent` and `Class`, flowing through `onClassWrite`; Vest validation on both suites
- **`onLessonWrite` Firestore trigger**: every scheduled/rendered lesson upserts a calendar event at the stable ID `lesson-{lessonId}`; cancelled/deleted lessons remove it. Derived events are `public: false` with the generic title "Music Lesson" — student names never reach public ICS feeds
- **`getRoomSchedule` admin callable**: busy windows for a room over a time range; new `calendarEvents` composite index (`room + startDateTime`) declared in `firestore.indexes.json` (analyzer passes)
- **Dashboard widget** (`RoomStatusCard` + `useRoomSchedule`): "Free until 4:30 PM — Next: Music Together (4:30–6:00 PM)" / "In use until 5:15 PM"
- Docs: `deployed-functions.md`, `implementation-status.md`

## Testing

- [x] 39 unit tests pass (room status logic, onLessonWrite, getRoomSchedule, onClassWrite regression)
- [x] Lesson integration suite passes locally against emulators (21 tests, including 4 new: derivation, reschedule moves the window, cancel frees the room, auth/room guards)
- [x] `nx build functions` + maple-spruce typecheck clean
- [x] `validate-function-tsconfigs.sh` and Firestore index analyzer pass

Note: `nx lint maple-spruce` reports 8 pre-existing circular-dependency errors (story files in react-classes/instructors/payouts/lessons importing app Storybook fixtures) — present on main, unrelated to this change.

Part of #467. Closes #468.

🤖 Generated with [Claude Code](https://claude.com/claude-code)