### PR TITLE
ci: auto-deploy admin web app to dev Vercel project on merge

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -6,10 +6,11 @@ name: Deploy on merge
 #     ├── prepare_and_build  (compute affected, build artifacts)
 #     ├── deploy_functions_dev   (deploy affected functions → maple-and-spruce-dev)
 #     ├── deploy_harness_dev     (build + deploy harness → maple-spruce-registration-test)
+#     ├── deploy_vercel_dev      (build + deploy admin app → dev Vercel project / business-dev)
 #     ├── e2e_dev                (Playwright → deployed dev URL)
 #     │     │
 #     │     └── approve_prod  ← MANUAL APPROVAL via `production` Environment
-#     │            │
+#     │            │                (gated on e2e_dev AND deploy_vercel_dev)
 #     │            ├── deploy_functions_prod        (only if approve_prod passed)
 #     │            ├── publish_webflow_components   (only if approve_prod passed)
 #     │            └── deploy_vercel_prod           (only if approve_prod passed)
@@ -446,6 +447,57 @@ jobs:
             --force \
             --token "$(gcloud auth print-access-token)"
 
+  deploy_vercel_dev:
+    # Auto-deploy the admin web app to the DEV Vercel project on every
+    # merge, so business-dev.* always mirrors main — the known-good dev
+    # environment we exercise before promoting to prod. Mirrors
+    # deploy_vercel_prod but targets the dev project (VERCEL_PROJECT_ID_DEV)
+    # and is NOT gated on approval: dev must lead prod, not follow it.
+    #
+    # vercel.json disables Vercel's own git auto-deploy on main for every
+    # project linked to this repo (git.deploymentEnabled.main = false), so
+    # without this job the dev project's production domain never updates —
+    # it was silently frozen at the last pre-disable commit. Runs
+    # unconditionally (no affected gate) so web-only changes — which don't
+    # flip the functions `has_changes` flag — still reach dev.
+    needs: prepare_and_build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      # Same flow as deploy_vercel_prod, pointed at the dev project. The
+      # dev project's *production* domain is business-dev.*, so `--prod`
+      # here promotes to dev — not to the prod project. The dev project's
+      # Production env already carries NEXT_PUBLIC_FIREBASE_ENV=dev + the
+      # Square sandbox IDs, so `vercel build` bakes the dev config. ORG_ID
+      # and TOKEN are shared with prod (same Vercel team); only the project
+      # id differs.
+      - name: Pull Vercel environment (dev production)
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_DEV }}
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build for Vercel (dev)
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_DEV }}
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy to dev Vercel (business-dev)
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_DEV }}
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+
   e2e_dev:
     # The gate: run the registration E2E suite against the deployed dev
     # backend + deployed harness. Any failure here blocks the prod deploy.
@@ -526,8 +578,12 @@ jobs:
     #
     # A single gate covers all three prod jobs (functions, webflow,
     # vercel) — one approval click unlocks the whole prod side.
-    needs: e2e_dev
-    if: needs.e2e_dev.result == 'success'
+    #
+    # Also gated on deploy_vercel_dev: we never promote to prod unless the
+    # dev admin app actually deployed, so "known-good dev" includes the web
+    # app, not just functions + harness.
+    needs: [e2e_dev, deploy_vercel_dev]
+    if: needs.e2e_dev.result == 'success' && needs.deploy_vercel_dev.result == 'success'
     runs-on: ubuntu-latest
     environment: production
     steps:

--- a/docs/architecture/ci-cd.md
+++ b/docs/architecture/ci-cd.md
@@ -37,6 +37,7 @@ merge to main
   ├── prepare_and_build  (build affected codebases, upload artifacts)
   ├── deploy_functions_dev   → maple-and-spruce-dev
   ├── deploy_harness_dev     → maple-spruce-registration-test.web.app
+  ├── deploy_vercel_dev      → admin app on dev Vercel project (business-dev.*)
   └── e2e_dev (registration Playwright suite vs deployed dev)
        └── approve_prod  ← MANUAL APPROVAL via `production` Environment
             ├── deploy_functions_prod        → maple-and-spruce
@@ -47,8 +48,10 @@ merge to main
 ```
 
 **Two gates**:
-1. **`e2e_dev`** must pass — the suite hits deployed dev callables + dev Firestore. Failures here mean prod stays on the previous deploy.
+1. **`e2e_dev`** must pass — the suite hits deployed dev callables + dev Firestore. Failures here mean prod stays on the previous deploy. `approve_prod` is *also* gated on `deploy_vercel_dev` succeeding, so a broken dev admin-app deploy blocks prod promotion too.
 2. **`approve_prod`** requires a human to click "Review pending deployments" in the GitHub UI. Uses the `production` Environment (Settings → Environments) which has required reviewers configured. One approval unlocks all three prod jobs.
+
+**Why `deploy_vercel_dev` runs every merge and isn't approval-gated**: dev must *lead* prod — it's the known-good environment we check before promoting. `vercel.json` sets `git.deploymentEnabled.main = false`, which disables Vercel's native git auto-deploy for **every** project linked to this repo (prod *and* dev), so without this job the dev project's production domain (`business-dev.*`) silently freezes at the last pre-disable commit. It runs unconditionally (no affected gate) because web-only changes don't flip the functions `has_changes` flag.
 
 **Why Firestore indexes don't gate**: index additions are forward-compatible (queries work without them, just slower or with a "missing index" error). Index builds take minutes server-side after the deploy submits the spec, so gating E2E on index readiness would add a lot of wall-clock without catching anything new. The PR-time analyzer (`tools/check-firestore-indexes.ts`) enforces declaration; that's the load-bearing check.
 
@@ -73,13 +76,14 @@ Optional but recommended: move `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_
 
 ### Required secrets
 
-The Vercel job needs three secrets (set once in repo settings → Secrets and variables → Actions):
+The Vercel jobs need these secrets (set once in repo settings → Secrets and variables → Actions):
 
 - `VERCEL_TOKEN` — generated at <https://vercel.com/account/tokens>
 - `VERCEL_ORG_ID` — from `.vercel/project.json` after `vercel link`
-- `VERCEL_PROJECT_ID` — same
+- `VERCEL_PROJECT_ID` — prod project (`maple-and-spruce-maple-spruce`), used by `deploy_vercel_prod`
+- `VERCEL_PROJECT_ID_DEV` — dev project (`maple-and-spruce-dev`), used by `deploy_vercel_dev`. Same Vercel team, so `VERCEL_ORG_ID` and `VERCEL_TOKEN` are reused — only the project id differs.
 
-Without these, the `deploy_vercel_prod` job fails and prod Vercel stays on the previous deploy. (Firebase prod deploy is unaffected.)
+Without `VERCEL_PROJECT_ID`, `deploy_vercel_prod` fails and prod Vercel stays on the previous deploy. Without `VERCEL_PROJECT_ID_DEV`, `deploy_vercel_dev` fails and `business-dev` stays stale (which now also blocks prod promotion, since `approve_prod` depends on it). Firebase deploys are unaffected either way.
 
 ### Required Firebase Hosting site
 


### PR DESCRIPTION
## Why

The dev admin app at `business-dev.*` has been **frozen since ~May 18** — its last deploy was `f29795b` (#427), the commit right before **#430** added `git.deploymentEnabled.main = false` to `vercel.json`. That one line disables Vercel's native git auto-deploy for **every** project linked to the repo, including the dev project. Nothing has refreshed `business-dev` since, so reviewing merged changes in dev (e.g. the Spruce Room work) was impossible — the deployed dev UI predated all of it.

CI deploys functions + Firestore indexes + the registration harness to dev on every merge, but never the **admin web app**. This closes that gap.

## What

- **New `deploy_vercel_dev` job** — mirrors `deploy_vercel_prod` but targets the dev Vercel project. Runs early (after `prepare_and_build`), on every merge, **not** approval-gated (dev must lead prod). `--prod` here promotes to the dev project's production domain = `business-dev.*`. Reuses `VERCEL_ORG_ID` + `VERCEL_TOKEN` (same Vercel team); only the project id differs.
  - Runs unconditionally (no affected gate) because web-only changes don't flip the functions `has_changes` flag.
- **`approve_prod` now also gates on `deploy_vercel_dev`** — a broken dev web deploy blocks prod promotion, so "known-good dev" includes the admin app, not just functions + harness.
- Updated the pipeline diagram comment + `docs/architecture/ci-cd.md`.

## ⚠️ Required before this works: add one secret

This job is inert until the repo has a new Actions secret:

- **`VERCEL_PROJECT_ID_DEV`** = `prj_zn9dsOb31Yqp3kisQEQplh2xRG4N` (the `maple-and-spruce-dev` Vercel project id)

The dev project's Production env already has `NEXT_PUBLIC_FIREBASE_ENV=dev` + the Square sandbox IDs, so the build bakes the right config — no env work needed.

## Verification

- `firebase-functions-merge.yml` parses as valid YAML; job graph: `… deploy_harness_dev, deploy_vercel_dev, e2e_dev, approve_prod …`.
- Once merged (with the secret set), this very merge will trigger the first dev deploy and bring `business-dev` current — including the Spruce Room dashboard card, unblocking the dev review.

## Follow-ups (not in this PR)

- No E2E coverage hits the admin app yet (`e2e_dev` exercises the registration harness). Adding an admin-app Playwright suite against `business-dev` would make the "regression test before prod" loop fully real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)