### PR TITLE
ci: deploy Firestore composite indexes to dev, not just prod

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -15,7 +15,8 @@ name: Deploy on merge
 #     │            ├── publish_webflow_components   (only if approve_prod passed)
 #     │            └── deploy_vercel_prod           (only if approve_prod passed)
 #     │
-#     └── deploy_firestore_indexes_prod  (independent — index changes don't block on E2E
+#     ├── deploy_firestore_indexes_dev   (independent — declared indexes → maple-and-spruce-dev)
+#     └── deploy_firestore_indexes (prod) (independent — index changes don't block on E2E
 #                                          because they take minutes to build and are
 #                                          additive; analyzer enforces declaration at PR)
 #
@@ -686,6 +687,76 @@ jobs:
       - name: Skip empty function group
         if: matrix.functions == ''
         run: echo "Skipping deployment for empty function group"
+
+  deploy_firestore_indexes_dev:
+    # Same as deploy_firestore_indexes but for the DEV project. Without
+    # this, composite indexes only ever reach prod — dev queries that need
+    # one fail at runtime with "requires an index", and the emulator never
+    # catches it (it doesn't enforce composite indexes). That stayed hidden
+    # while the dev web app was frozen; once it went live and called
+    # getRoomSchedule, the missing dev index surfaced immediately. Dev must
+    # mirror prod for pre-prod verification to mean anything.
+    #
+    # Independent of the dev→E2E→prod chain (index builds are async and
+    # forward-compatible). Runs early so dev has its indexes building as
+    # soon as possible.
+    runs-on: ubuntu-latest
+    if: github.repository == 'Maple-and-Spruce/maple-and-spruce'
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check if firestore.indexes.json changed
+        id: changed
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Manual run — deploying"
+            echo "changed=true" >> $GITHUB_OUTPUT
+          elif git diff --name-only HEAD~1 HEAD | grep -q '^firestore.indexes.json$'; then
+            echo "firestore.indexes.json changed in this push — deploying"
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "firestore.indexes.json unchanged — skipping"
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Authenticate to Google Cloud (Dev)
+        if: steps.changed.outputs.changed == 'true'
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/1062803455357/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
+          service_account: 'github-deployer@maple-and-spruce-dev.iam.gserviceaccount.com'
+          create_credentials_file: true
+
+      - name: Setup gcloud CLI
+        if: steps.changed.outputs.changed == 'true'
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Deploy Firestore indexes (dev)
+        if: steps.changed.outputs.changed == 'true'
+        timeout-minutes: 10
+        # No `--force` — same orphan-safety stance as prod (see the prod
+        # job below). On dev an orphan is lower-stakes, but failing loud
+        # keeps dev's declared index set honest and matching prod's.
+        run: |
+          set -eo pipefail
+          OUTPUT=$(mktemp)
+          trap 'rm -f "$OUTPUT"' EXIT
+
+          npx -y firebase-tools@latest deploy --only firestore:indexes \
+            --project maple-and-spruce-dev \
+            --token "$(gcloud auth print-access-token)" \
+            < /dev/null 2>&1 | tee "$OUTPUT"
+
+          if grep -q "indexes are defined in your project but are not present" "$OUTPUT"; then
+            echo ""
+            echo "::error title=Firestore index orphans (dev)::Dev has composite indexes that aren't declared in firestore.indexes.json. The new indexes from this merge were applied, but the orphans were NOT deleted. Resolve before the next merge: either add the listed orphans to firestore.indexes.json, or delete them with 'pnpm exec firebase firestore:indexes:delete --project maple-and-spruce-dev'."
+            exit 1
+          fi
 
   deploy_firestore_indexes:
     # Independent of the dev→E2E→prod chain. Index additions take minutes

--- a/docs/architecture/ci-cd.md
+++ b/docs/architecture/ci-cd.md
@@ -44,7 +44,8 @@ merge to main
             ├── publish_webflow_components   → Webflow library share
             └── deploy_vercel_prod           → maple-spruce on Vercel
 
-  + deploy_firestore_indexes  (independent — runs in parallel with everything)
+  + deploy_firestore_indexes_dev   (independent → maple-and-spruce-dev)
+  + deploy_firestore_indexes        (independent → maple-and-spruce, prod)
 ```
 
 **Two gates**:
@@ -54,6 +55,8 @@ merge to main
 **Why `deploy_vercel_dev` runs every merge and isn't approval-gated**: dev must *lead* prod — it's the known-good environment we check before promoting. `vercel.json` sets `git.deploymentEnabled.main = false`, which disables Vercel's native git auto-deploy for **every** project linked to this repo (prod *and* dev), so without this job the dev project's production domain (`business-dev.*`) silently freezes at the last pre-disable commit. It runs unconditionally (no affected gate) because web-only changes don't flip the functions `has_changes` flag.
 
 **Why Firestore indexes don't gate**: index additions are forward-compatible (queries work without them, just slower or with a "missing index" error). Index builds take minutes server-side after the deploy submits the spec, so gating E2E on index readiness would add a lot of wall-clock without catching anything new. The PR-time analyzer (`tools/check-firestore-indexes.ts`) enforces declaration; that's the load-bearing check.
+
+**Indexes deploy to dev *and* prod**: there are two index-deploy jobs — `deploy_firestore_indexes_dev` (→ `maple-and-spruce-dev`) and `deploy_firestore_indexes` (→ prod). Both fire only when `firestore.indexes.json` changed in the merge (or on manual `workflow_dispatch`). Dev needs its own because the emulator doesn't enforce composite indexes, so a query missing a dev index passes every test and only fails against the live dev project. To backfill all declared indexes into a freshly-recreated dev project, run the workflow via `workflow_dispatch` (deploys regardless of file diff).
 
 **Concurrency**: `concurrency.group: deploy-on-merge`, `cancel-in-progress: false`. Two back-to-back merges otherwise race on the shared dev project (B's dev deploy overwrites A's mid-E2E). Cancel-in-progress stays off so we never abort a deploy halfway.
 


### PR DESCRIPTION
## Why

Surfaced while verifying the Spruce Room feature on the freshly-deployed dev admin app (after #484): the dashboard's `getRoomSchedule` call failed against `maple-and-spruce-dev` with **"The query requires an index"**.

Root cause: `deploy_firestore_indexes` authenticates as the **prod** service account and deploys `--project maple-and-spruce` only. **Composite indexes never reach the dev project.** Two things kept this hidden:
- The dev web app was frozen, so it never ran the queries.
- The **Firestore emulator doesn't enforce composite indexes** (per our own `firebase-functions` rule doc), so integration tests pass green without them.

So "known-good dev" wasn't — dev could pass every check and still 500 on a query that needs an index.

## What

- **New `deploy_firestore_indexes_dev` job** — mirrors the prod index job but uses the dev WIF provider + `github-deployer@maple-and-spruce-dev` service account and deploys `--project maple-and-spruce-dev`.
- Same change-gate (only when `firestore.indexes.json` changed in the merge, or manual `workflow_dispatch`) and same no-`--force` orphan-safety check (with dev-specific wording).
- Updated the pipeline diagram + `ci-cd.md`.

## Scope note (read before expecting magic)

This job fires only when `firestore.indexes.json` **changes** in a merge — so merging *this* PR (which doesn't touch that file) won't backfill dev. Two ways to get current:
- **The one index needed now** (`room + startDateTime`): create it directly from the Firebase console link in the error card on `business-dev` — it's already declared in `firestore.indexes.json`, so no orphan risk.
- **Backfill everything** into dev: after merge, run this workflow via **`workflow_dispatch`** (the job deploys regardless of file diff on manual runs).

From then on, any PR that adds an index deploys it to dev and prod together.

## Verification
- Workflow parses as valid YAML; index jobs: `deploy_firestore_indexes_dev`, `deploy_firestore_indexes`.
- Dev job reuses the exact dev WIF provider / service account already used by `deploy_functions_dev` and `e2e_dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)