### PR TITLE
feat(rooms): "Book the Spruce Room" quick form (#469)

### DIFF
--- a/apps/maple-spruce/src/app/(admin)/book-room/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/book-room/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { Alert, Box, Snackbar, Typography } from '@mui/material';
+import type { CreateCalendarEventInput } from '@maple/ts/domain';
+import { BookSpruceRoomForm } from '@maple/react/events';
+import { useCalendarEvents } from '../../../hooks';
+
+export default function BookRoomPage() {
+  const { createCalendarEvent } = useCalendarEvents();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const handleSubmit = useCallback(
+    async (data: CreateCalendarEventInput) => {
+      setIsSubmitting(true);
+      try {
+        await createCalendarEvent(data);
+        setSuccessMessage(`Booked the Spruce Room: ${data.title}`);
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [createCalendarEvent]
+  );
+
+  return (
+    <Box sx={{ maxWidth: 560 }}>
+      <Typography variant="h4" component="h1" sx={{ mb: 1 }}>
+        Book the Spruce Room
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        Reserve the room for Music Together, a private rental, or any one-off
+        use. Booked time blocks the Spruce Room across the portal.
+      </Typography>
+
+      <BookSpruceRoomForm onSubmit={handleSubmit} isSubmitting={isSubmitting} />
+
+      <Snackbar
+        open={!!successMessage}
+        autoHideDuration={4000}
+        onClose={() => setSuccessMessage(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity="success" onClose={() => setSuccessMessage(null)}>
+          {successMessage}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+}

--- a/apps/maple-spruce/src/app/(admin)/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/page.tsx
@@ -166,7 +166,7 @@ export default function DashboardPage() {
       <Grid container spacing={3}>
         {/* Spruce Room status */}
         <Grid size={12}>
-          <RoomStatusCard room="spruce" />
+          <RoomStatusCard room="spruce" bookHref="/book-room" />
         </Grid>
 
         {/* Upcoming Classes */}

--- a/apps/maple-spruce/src/components/layout/AppShellWrapper.tsx
+++ b/apps/maple-spruce/src/components/layout/AppShellWrapper.tsx
@@ -12,6 +12,7 @@ import MusicNoteIcon from '@mui/icons-material/MusicNote';
 import PaymentsIcon from '@mui/icons-material/Payments';
 import EventIcon from '@mui/icons-material/Event';
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
+import MeetingRoomIcon from '@mui/icons-material/MeetingRoom';
 import TuneIcon from '@mui/icons-material/Tune';
 import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
 import SettingsIcon from '@mui/icons-material/Settings';
@@ -134,6 +135,11 @@ export function AppShellWrapper({
             label: 'Events',
             href: '/events',
             icon: <CalendarMonthIcon />,
+          },
+          {
+            label: 'Book the Spruce Room',
+            href: '/book-room',
+            icon: <MeetingRoomIcon />,
           },
           {
             label: 'Embed Settings',

--- a/libs/react/events/src/index.ts
+++ b/libs/react/events/src/index.ts
@@ -1,6 +1,7 @@
 export { CalendarEventList } from './lib/CalendarEventList';
 export { RoomStatusCard } from './lib/RoomStatusCard';
 export { CalendarEventForm } from './lib/CalendarEventForm';
+export { BookSpruceRoomForm } from './lib/BookSpruceRoomForm';
 export {
   CalendarEventFilterToolbar,
   type CalendarEventFilterValues,

--- a/libs/react/events/src/lib/BookSpruceRoomForm.tsx
+++ b/libs/react/events/src/lib/BookSpruceRoomForm.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { useCallback } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Checkbox,
+  FormControlLabel,
+  Stack,
+  Switch,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { TimePicker } from '@mui/x-date-pickers/TimePicker';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFnsV3';
+import type { CreateCalendarEventInput, Room } from '@maple/ts/domain';
+import { getRoomLabel } from '@maple/ts/domain';
+import { calendarEventValidation } from '@maple/ts/validation';
+import { useSignal, useComputed, batch, useSignals } from '@maple/react/signals';
+
+const ROOM: Room = 'spruce';
+
+/** Combine the Y/M/D of `date` with the H/M of `time` into one Date. */
+function combineDateTime(date: Date, time: Date): Date {
+  const combined = new Date(date);
+  combined.setHours(time.getHours(), time.getMinutes(), 0, 0);
+  return combined;
+}
+
+interface BookSpruceRoomFormProps {
+  onSubmit: (input: CreateCalendarEventInput) => Promise<void>;
+  isSubmitting?: boolean;
+}
+
+/**
+ * Quick form for reserving the Spruce Room for ad-hoc use (Music Together,
+ * a private rental, a one-off event). Creates a CalendarEvent with
+ * `room: 'spruce'` and `public: false` by default — so it blocks the room
+ * across the portal without showing up on the public site calendar (it can
+ * be flipped public, e.g. for Music Together).
+ *
+ * Conflict warnings against existing bookings are deliberately out of scope
+ * here — they ship with the day-strip work and cover all scheduling flows.
+ */
+export function BookSpruceRoomForm({
+  onSubmit,
+  isSubmitting = false,
+}: BookSpruceRoomFormProps) {
+  useSignals();
+
+  // Defaults: next top of the hour today, a one-hour block.
+  const now = new Date();
+  const defaultStart = new Date(now);
+  defaultStart.setHours(now.getHours() + 1, 0, 0, 0);
+  const defaultEnd = new Date(defaultStart);
+  defaultEnd.setHours(defaultStart.getHours() + 1);
+
+  const title = useSignal('');
+  const date = useSignal<Date>(defaultStart);
+  const startTime = useSignal<Date>(defaultStart);
+  const endTime = useSignal<Date>(defaultEnd);
+  const repeatWeekly = useSignal(false);
+  const isPublic = useSignal(false);
+
+  const showValidationErrors = useSignal(false);
+  const submitError = useSignal<string | null>(null);
+
+  const startDateTime = useComputed(() =>
+    combineDateTime(date.value, startTime.value)
+  );
+  const endDateTime = useComputed(() =>
+    combineDateTime(date.value, endTime.value)
+  );
+
+  const buildInput = useCallback(
+    (): CreateCalendarEventInput => ({
+      title: title.value.trim(),
+      description: '',
+      startDateTime: startDateTime.value,
+      endDateTime: endDateTime.value,
+      recurrenceRule: repeatWeekly.value ? 'FREQ=WEEKLY' : null,
+      location: getRoomLabel(ROOM),
+      type: 'event',
+      public: isPublic.value,
+      room: ROOM,
+      sourceRef: null,
+      createdBy: '',
+    }),
+    // signal .value reads are tracked by the computed/handlers that call this
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
+  const validation = useComputed(() => calendarEventValidation(buildInput()));
+
+  const errors = useComputed<Record<string, string[]>>(() =>
+    showValidationErrors.value ? validation.value.getErrors() : {}
+  );
+  const isValid = useComputed(() => validation.value.isValid());
+  const getFieldError = (field: string): string | null =>
+    errors.value[field]?.[0] ?? null;
+
+  const handleSubmit = useCallback(async () => {
+    showValidationErrors.value = true;
+    if (!isValid.value) return;
+
+    submitError.value = null;
+    try {
+      await onSubmit(buildInput());
+      // Reset the obvious fields on success; keep date/times so a user can
+      // book several adjacent slots quickly.
+      batch(() => {
+        title.value = '';
+        repeatWeekly.value = false;
+        isPublic.value = false;
+        showValidationErrors.value = false;
+      });
+    } catch (error) {
+      submitError.value =
+        error instanceof Error ? error.message : 'Failed to book the room';
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onSubmit]);
+
+  return (
+    <Card variant="outlined">
+      <CardContent>
+        <LocalizationProvider dateAdapter={AdapterDateFns}>
+          <Stack spacing={2}>
+            {submitError.value && (
+              <Alert severity="error">{submitError.value}</Alert>
+            )}
+
+            <TextField
+              label="What's the booking?"
+              placeholder="e.g. Music Together, private rental"
+              value={title.value}
+              onChange={(e) => (title.value = e.target.value)}
+              error={!!getFieldError('title')}
+              helperText={getFieldError('title')}
+              required
+              fullWidth
+            />
+
+            <DatePicker
+              label="Date"
+              value={date.value}
+              onChange={(newValue) => {
+                if (newValue) date.value = newValue;
+              }}
+              slotProps={{ textField: { fullWidth: true } }}
+            />
+
+            <Box sx={{ display: 'flex', gap: 2 }}>
+              <TimePicker
+                label="Start time"
+                value={startTime.value}
+                onChange={(newValue) => {
+                  if (newValue) startTime.value = newValue;
+                }}
+                slotProps={{
+                  textField: {
+                    fullWidth: true,
+                    error: !!getFieldError('startDateTime'),
+                    helperText: getFieldError('startDateTime'),
+                  },
+                }}
+              />
+              <TimePicker
+                label="End time"
+                value={endTime.value}
+                onChange={(newValue) => {
+                  if (newValue) endTime.value = newValue;
+                }}
+                slotProps={{
+                  textField: {
+                    fullWidth: true,
+                    error: !!getFieldError('endDateTime'),
+                    helperText: getFieldError('endDateTime'),
+                  },
+                }}
+              />
+            </Box>
+
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={repeatWeekly.value}
+                  onChange={(e) => (repeatWeekly.value = e.target.checked)}
+                />
+              }
+              label="Repeat weekly"
+            />
+
+            <Box>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={isPublic.value}
+                    onChange={(e) => (isPublic.value = e.target.checked)}
+                  />
+                }
+                label="Show on the public calendar"
+              />
+              <Typography variant="caption" color="text.secondary" display="block">
+                Off by default — the booking still blocks the room internally.
+                Turn on for things the public should see (e.g. Music Together).
+              </Typography>
+            </Box>
+
+            <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <Button
+                variant="contained"
+                onClick={handleSubmit}
+                disabled={isSubmitting}
+              >
+                {isSubmitting ? 'Booking…' : 'Book the room'}
+              </Button>
+            </Box>
+          </Stack>
+        </LocalizationProvider>
+      </CardContent>
+    </Card>
+  );
+}

--- a/libs/react/events/src/lib/RoomStatusCard.tsx
+++ b/libs/react/events/src/lib/RoomStatusCard.tsx
@@ -1,6 +1,16 @@
 'use client';
 
-import { Alert, Box, Card, CardContent, Chip, Skeleton, Typography } from '@mui/material';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Chip,
+  Skeleton,
+  Typography,
+} from '@mui/material';
 import MeetingRoomIcon from '@mui/icons-material/MeetingRoom';
 import {
   getRoomLabel,
@@ -28,7 +38,14 @@ function windowLabel(w: RoomBusyWindow): string {
  * "In use until 5:15 PM", with what's happening now and what's up next.
  * Answers the standing-in-the-building question without opening a calendar.
  */
-export function RoomStatusCard({ room }: { room: Room }) {
+export function RoomStatusCard({
+  room,
+  bookHref,
+}: {
+  room: Room;
+  /** When set, renders a "Book the room" action linking here. */
+  bookHref?: string;
+}) {
   const { roomScheduleState } = useRoomSchedule(room);
 
   const status =
@@ -62,6 +79,13 @@ export function RoomStatusCard({ room }: { room: Room }) {
           <RoomStatusLines status={status} />
         ) : null}
       </CardContent>
+      {bookHref && (
+        <CardActions>
+          <Button size="small" href={bookHref}>
+            Book the room
+          </Button>
+        </CardActions>
+      )}
     </Card>
   );
 }


### PR DESCRIPTION
Part of the Spruce Room epic (#467). First slice of **PR 2 (#469)** — makes the room *managed* by giving Music Together, ad-hoc uses, and rentals a real way into the room.

## Why
Until now the only UI-driven way to occupy the Spruce Room was scheduling a **music lesson** (which auto-defaults to `room: 'spruce'`). Classes, Music Together, and one-off bookings had **no path** — you'd have to set `room: 'spruce'` on a Firestore doc by hand.

## What
- **New `/book-room` page + nav entry** (under *Calendar*), backed by a new **`BookSpruceRoomForm`** lib component.
- Quick form: title, date, start/end time, **optional weekly repeat** (`FREQ=WEEKLY`), and a **"show on public calendar"** toggle (off by default).
- Creates a `CalendarEvent` with `room: 'spruce'`, `public: false` by default — so it blocks the room across the portal without leaking to the public site calendar (flip public for things like Music Together).
- **"Book the room"** action added to the dashboard `RoomStatusCard`.

This is purely the missing UI: the `room` field, validation, and `createCalendarEvent` plumbing all shipped in PR 1 (#470), so the form just sends `room: 'spruce'` through the existing callable.

## Out of scope (next slice of #469)
- Room pickers on the **class** and **event** forms.
- The **day strip** + inline **conflict warnings** (warn-and-confirm) across the lesson / class / event scheduling flows.

## Verification
- `nx typecheck maple-spruce` ✅ (transitively typechecks the new lib component + `RoomStatusCard` prop, since the app imports both).
- `nx lint react-events` ✅ — 0 errors; the new file produced no warnings (the 4 warnings are pre-existing in `CalendarEventForm`/`RoomStatusLines`).
- Manual dev walkthrough to follow after merge — dev now auto-deploys (#484), so the form will be live on `business-dev` shortly after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)