### PR TITLE
feat(rooms): conflict warnings + day strip in lesson scheduling (#469)

### DIFF
--- a/libs/react/data/src/index.ts
+++ b/libs/react/data/src/index.ts
@@ -25,6 +25,7 @@ export {
 } from './lib/useCalendarEvents';
 export { useCalendarEmbedConfig } from './lib/useCalendarEmbedConfig';
 export { useRoomSchedule } from './lib/useRoomSchedule';
+export { useRoomScheduleForDate } from './lib/useRoomScheduleForDate';
 
 // Phase 5: Etsy Integration
 export { useEtsyConnection } from './lib/useEtsyConnection';

--- a/libs/react/data/src/lib/useRoomScheduleForDate.ts
+++ b/libs/react/data/src/lib/useRoomScheduleForDate.ts
@@ -1,0 +1,90 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { httpsCallable } from 'firebase/functions';
+import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
+import type { RequestState, Room, RoomBusyWindow } from '@maple/ts/domain';
+import type {
+  GetRoomScheduleRequest,
+  GetRoomScheduleResponse,
+} from '@maple/ts/firebase/api-types';
+
+/**
+ * Fetch a room's busy windows for the whole calendar day containing `date`.
+ *
+ * Powers the day strip and conflict warnings in scheduling dialogs once a
+ * date is picked. Unlike `useRoomSchedule` (which is hard-scoped to "now →
+ * end of today" for the dashboard widget), this queries an arbitrary day.
+ *
+ * When `date` is null the hook stays idle and issues no request — so a form
+ * can mount it before a date is chosen.
+ */
+export function useRoomScheduleForDate(room: Room, date: Date | null) {
+  const [roomScheduleState, setRoomScheduleState] = useState<
+    RequestState<RoomBusyWindow[]>
+  >({ status: 'idle' });
+
+  // Bucket on the calendar day so we don't refetch as the user nudges the
+  // minute/second of the picked time.
+  const dayKey = date
+    ? `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`
+    : null;
+
+  const fetchRoomSchedule = useCallback(async () => {
+    if (!date) {
+      setRoomScheduleState({ status: 'idle' });
+      return;
+    }
+
+    setRoomScheduleState({ status: 'loading' });
+
+    try {
+      const functions = getMapleFunctions();
+      const getRoomSchedule = httpsCallable<
+        GetRoomScheduleRequest,
+        GetRoomScheduleResponse
+      >(functions, 'getRoomSchedule');
+
+      const start = new Date(date);
+      start.setHours(0, 0, 0, 0);
+      const end = new Date(date);
+      end.setHours(23, 59, 59, 999);
+
+      const result = await getRoomSchedule({
+        room,
+        start: start.toISOString(),
+        end: end.toISOString(),
+      });
+
+      const windows: RoomBusyWindow[] = result.data.windows
+        .map((w) => ({
+          eventId: w.eventId,
+          title: w.title,
+          type: w.type,
+          sourceRef: w.sourceRef,
+          start: new Date(w.start),
+          end: new Date(w.end),
+        }))
+        .sort((a, b) => a.start.getTime() - b.start.getTime());
+
+      setRoomScheduleState({ status: 'success', data: windows });
+    } catch (error) {
+      console.error('Failed to fetch room schedule:', error);
+      setRoomScheduleState({
+        status: 'error',
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to fetch room schedule',
+      });
+    }
+    // dayKey stands in for `date`; room is primitive
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [room, dayKey]);
+
+  useEffect(() => {
+    fetchRoomSchedule();
+  }, [fetchRoomSchedule]);
+
+  return { roomScheduleState, refetch: fetchRoomSchedule };
+}

--- a/libs/react/events/src/index.ts
+++ b/libs/react/events/src/index.ts
@@ -2,6 +2,7 @@ export { CalendarEventList } from './lib/CalendarEventList';
 export { RoomStatusCard } from './lib/RoomStatusCard';
 export { CalendarEventForm } from './lib/CalendarEventForm';
 export { BookSpruceRoomForm } from './lib/BookSpruceRoomForm';
+export { RoomAvailability } from './lib/RoomAvailability';
 export {
   CalendarEventFilterToolbar,
   type CalendarEventFilterValues,

--- a/libs/react/events/src/lib/RoomAvailability.tsx
+++ b/libs/react/events/src/lib/RoomAvailability.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { Alert, Box, Skeleton, Typography } from '@mui/material';
+import {
+  getDayStrip,
+  getRoomConflicts,
+  getRoomLabel,
+  type Room,
+  type RoomBusyWindow,
+  type RoomDaySegment,
+} from '@maple/ts/domain';
+import { useRoomScheduleForDate } from '@maple/react/data';
+
+/** Format a time as "4:30 PM". */
+function formatTime(date: Date): string {
+  return date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+}
+
+/** Distinct booking titles in a busy band, e.g. "Music Together, Music Lesson". */
+function busyTitles(windows: RoomBusyWindow[]): string {
+  return [...new Set(windows.map((w) => w.title))].join(', ');
+}
+
+function conflictSummary(conflicts: RoomBusyWindow[]): string {
+  return conflicts
+    .map((c) => `${formatTime(c.start)}–${formatTime(c.end)} (${c.title})`)
+    .join(', ');
+}
+
+function segmentLabel(seg: RoomDaySegment): string {
+  if (seg.kind === 'open') {
+    return `Open ${formatTime(seg.start)}–${formatTime(seg.end)}`;
+  }
+  return `${busyTitles(seg.windows)} ${formatTime(seg.start)}–${formatTime(seg.end)}`;
+}
+
+/**
+ * Compute display bounds for the day strip: a default 9–6 window for the
+ * picked day, widened to cover any booking or the proposed slot that falls
+ * outside it — so nothing is ever clipped out of view.
+ */
+function dayBounds(
+  refDate: Date,
+  proposed: { start: Date; end: Date },
+  windows: RoomBusyWindow[]
+): { dayStart: Date; dayEnd: Date } {
+  const dayStart = new Date(refDate);
+  dayStart.setHours(9, 0, 0, 0);
+  const dayEnd = new Date(refDate);
+  dayEnd.setHours(18, 0, 0, 0);
+
+  const times = [
+    proposed.start,
+    proposed.end,
+    ...windows.flatMap((w) => [w.start, w.end]),
+  ];
+  for (const t of times) {
+    if (t.getTime() < dayStart.getTime()) dayStart.setTime(t.getTime());
+    if (t.getTime() > dayEnd.getTime()) dayEnd.setTime(t.getTime());
+  }
+  return { dayStart, dayEnd };
+}
+
+interface RoomAvailabilityProps {
+  room: Room;
+  /** Proposed slot start (also picks the day to display). */
+  start: Date;
+  /** Proposed slot end. */
+  end: Date;
+  /** Skip this event when checking conflicts (edit flows — don't self-flag). */
+  ignoreEventId?: string;
+}
+
+/**
+ * Inline availability for a room on the day of a proposed slot: a
+ * warn-and-confirm conflict notice (never blocks submission — legitimate
+ * overlaps like setup time exist) plus a day strip of open/busy bands.
+ *
+ * Drop into any scheduling dialog once a date/time is picked.
+ */
+export function RoomAvailability({
+  room,
+  start,
+  end,
+  ignoreEventId,
+}: RoomAvailabilityProps) {
+  const { roomScheduleState } = useRoomScheduleForDate(room, start);
+
+  if (
+    roomScheduleState.status === 'idle' ||
+    roomScheduleState.status === 'loading'
+  ) {
+    return <Skeleton variant="text" width="80%" />;
+  }
+
+  if (roomScheduleState.status === 'error') {
+    return (
+      <Typography variant="caption" color="text.secondary">
+        Couldn&apos;t check {getRoomLabel(room)} availability.
+      </Typography>
+    );
+  }
+
+  const windows = roomScheduleState.data;
+  const conflicts = getRoomConflicts({ start, end }, windows, { ignoreEventId });
+  const { dayStart, dayEnd } = dayBounds(start, { start, end }, windows);
+  const strip = getDayStrip(windows, dayStart, dayEnd);
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+      {conflicts.length > 0 && (
+        <Alert severity="warning" sx={{ py: 0.5 }}>
+          {getRoomLabel(room)} is already booked {conflictSummary(conflicts)}.
+          You can still save — overlaps are sometimes intentional.
+        </Alert>
+      )}
+
+      <Typography variant="caption" color="text.secondary">
+        {windows.length === 0 ? (
+          <>No other {getRoomLabel(room)} bookings that day.</>
+        ) : (
+          <>
+            {getRoomLabel(room)}:{' '}
+            {strip.map((seg, i) => (
+              <span key={`${seg.kind}-${seg.start.getTime()}`}>
+                {i > 0 ? ' · ' : ''}
+                {segmentLabel(seg)}
+              </span>
+            ))}
+          </>
+        )}
+      </Typography>
+    </Box>
+  );
+}

--- a/libs/react/lessons/src/lib/ScheduleLessonDialog.tsx
+++ b/libs/react/lessons/src/lib/ScheduleLessonDialog.tsx
@@ -52,6 +52,7 @@ import {
   useSignal,
   useSignals,
 } from '@maple/react/signals';
+import { RoomAvailability } from '@maple/react/events';
 import {
   generateWeeklyDates,
   type SeriesCadence,
@@ -294,21 +295,35 @@ export function ScheduleLessonDialog({
 
           <LocalizationProvider dateAdapter={AdapterDateFns}>
             {mode.value === 'single' ? (
-              <DateTimePicker
-                label="Date & time"
-                value={scheduledAt.value}
-                onChange={(v) => {
-                  if (v) scheduledAt.value = v;
-                }}
-                slotProps={{
-                  textField: {
-                    fullWidth: true,
-                    required: true,
-                    error: !!errorFor('scheduledAt'),
-                    helperText: errorFor('scheduledAt') ?? undefined,
-                  },
-                }}
-              />
+              <>
+                <DateTimePicker
+                  label="Date & time"
+                  value={scheduledAt.value}
+                  onChange={(v) => {
+                    if (v) scheduledAt.value = v;
+                  }}
+                  slotProps={{
+                    textField: {
+                      fullWidth: true,
+                      required: true,
+                      error: !!errorFor('scheduledAt'),
+                      helperText: errorFor('scheduledAt') ?? undefined,
+                    },
+                  }}
+                />
+                {/* Lessons occupy the Spruce Room — surface that day's
+                    availability and warn (non-blocking) on overlaps. */}
+                <RoomAvailability
+                  room="spruce"
+                  start={scheduledAt.value}
+                  end={
+                    new Date(
+                      scheduledAt.value.getTime() +
+                        durationMinutes.value * 60_000
+                    )
+                  }
+                />
+              </>
             ) : (
               <>
                 <DateTimePicker

--- a/libs/ts/domain/src/lib/room.spec.ts
+++ b/libs/ts/domain/src/lib/room.spec.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { getRoomStatus, getRoomLabel, type RoomBusyWindow } from './room';
+import {
+  getRoomStatus,
+  getRoomLabel,
+  getRoomConflicts,
+  getDayStrip,
+  type RoomBusyWindow,
+} from './room';
 
 function win(
   startIso: string,
@@ -106,5 +112,120 @@ describe('getRoomStatus', () => {
       expect(status.freeAt).toEqual(new Date('2026-06-11T16:00:00Z'));
       expect(status.next?.title).toBe('Band Practice');
     }
+  });
+});
+
+describe('getRoomConflicts', () => {
+  const booked = win('2026-06-11T16:30:00Z', '2026-06-11T18:00:00Z', {
+    eventId: 'evt-mt',
+    title: 'Music Together',
+  });
+
+  it('returns no conflicts when the room is empty', () => {
+    expect(
+      getRoomConflicts(
+        { start: new Date('2026-06-11T16:30:00Z'), end: new Date('2026-06-11T17:00:00Z') },
+        []
+      )
+    ).toEqual([]);
+  });
+
+  it('flags a proposed slot that overlaps a booking', () => {
+    const conflicts = getRoomConflicts(
+      { start: new Date('2026-06-11T17:00:00Z'), end: new Date('2026-06-11T17:30:00Z') },
+      [booked]
+    );
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].title).toBe('Music Together');
+  });
+
+  it('does not flag a back-to-back slot ending exactly when a booking starts', () => {
+    const conflicts = getRoomConflicts(
+      { start: new Date('2026-06-11T16:00:00Z'), end: new Date('2026-06-11T16:30:00Z') },
+      [booked]
+    );
+    expect(conflicts).toEqual([]);
+  });
+
+  it('does not flag a back-to-back slot starting exactly when a booking ends', () => {
+    const conflicts = getRoomConflicts(
+      { start: new Date('2026-06-11T18:00:00Z'), end: new Date('2026-06-11T18:30:00Z') },
+      [booked]
+    );
+    expect(conflicts).toEqual([]);
+  });
+
+  it('flags a proposed slot fully containing a booking', () => {
+    const conflicts = getRoomConflicts(
+      { start: new Date('2026-06-11T16:00:00Z'), end: new Date('2026-06-11T19:00:00Z') },
+      [booked]
+    );
+    expect(conflicts).toHaveLength(1);
+  });
+
+  it('ignores the event named in ignoreEventId (edit flow)', () => {
+    const conflicts = getRoomConflicts(
+      { start: new Date('2026-06-11T17:00:00Z'), end: new Date('2026-06-11T17:30:00Z') },
+      [booked],
+      { ignoreEventId: 'evt-mt' }
+    );
+    expect(conflicts).toEqual([]);
+  });
+
+  it('returns multiple overlapping bookings', () => {
+    const second = win('2026-06-11T17:00:00Z', '2026-06-11T17:45:00Z', {
+      eventId: 'evt-lesson',
+      title: 'Music Lesson',
+    });
+    const conflicts = getRoomConflicts(
+      { start: new Date('2026-06-11T16:45:00Z'), end: new Date('2026-06-11T17:15:00Z') },
+      [booked, second]
+    );
+    expect(conflicts.map((c) => c.eventId).sort()).toEqual([
+      'evt-lesson',
+      'evt-mt',
+    ]);
+  });
+});
+
+describe('getDayStrip', () => {
+  const dayStart = new Date('2026-06-11T13:00:00Z'); // 9:00 local-ish
+  const dayEnd = new Date('2026-06-11T23:00:00Z');
+
+  it('is one open band when nothing is booked', () => {
+    const strip = getDayStrip([], dayStart, dayEnd);
+    expect(strip).toEqual([{ kind: 'open', start: dayStart, end: dayEnd }]);
+  });
+
+  it('produces open · busy · open around a single booking', () => {
+    const mt = win('2026-06-11T20:30:00Z', '2026-06-11T22:00:00Z', {
+      title: 'Music Together',
+    });
+    const strip = getDayStrip([mt], dayStart, dayEnd);
+    expect(strip.map((s) => s.kind)).toEqual(['open', 'busy', 'open']);
+    expect(strip[1].start).toEqual(new Date('2026-06-11T20:30:00Z'));
+    expect(strip[1].end).toEqual(new Date('2026-06-11T22:00:00Z'));
+  });
+
+  it('merges back-to-back bookings into one busy band carrying both', () => {
+    const a = win('2026-06-11T20:00:00Z', '2026-06-11T20:30:00Z', {
+      eventId: 'a',
+    });
+    const b = win('2026-06-11T20:30:00Z', '2026-06-11T21:00:00Z', {
+      eventId: 'b',
+    });
+    const strip = getDayStrip([a, b], dayStart, dayEnd);
+    expect(strip.map((s) => s.kind)).toEqual(['open', 'busy', 'open']);
+    const busy = strip[1];
+    expect(busy.kind === 'busy' && busy.windows).toHaveLength(2);
+    expect(busy.end).toEqual(new Date('2026-06-11T21:00:00Z'));
+  });
+
+  it('clips a booking that overruns the day bounds', () => {
+    const overrun = win('2026-06-11T12:00:00Z', '2026-06-12T02:00:00Z');
+    const strip = getDayStrip([overrun], dayStart, dayEnd);
+    expect(strip).toEqual([
+      { kind: 'busy', start: dayStart, end: dayEnd, windows: [overrun] },
+    ]);
   });
 });

--- a/libs/ts/domain/src/lib/room.ts
+++ b/libs/ts/domain/src/lib/room.ts
@@ -89,3 +89,112 @@ export function getRoomStatus(
 
   return { kind: 'in-use', current, freeAt, next };
 }
+
+/** A proposed time range to check against a room's existing bookings. */
+export interface TimeRange {
+  start: Date;
+  end: Date;
+}
+
+/**
+ * Return the busy windows that overlap a proposed time range — i.e. the
+ * room is already taken during part of it. Powers the warn-and-confirm
+ * conflict notices in the scheduling flows.
+ *
+ * Overlap is half-open: a proposed slot that starts exactly when a window
+ * ends (or ends exactly when one starts) does NOT conflict — back-to-back
+ * bookings share a boundary but not a moment. A zero-length proposed range
+ * never conflicts.
+ *
+ * `ignoreEventId` skips a specific event — used by edit flows so a booking
+ * doesn't flag a conflict against its own existing window.
+ */
+export function getRoomConflicts(
+  proposed: TimeRange,
+  windows: RoomBusyWindow[],
+  options?: { ignoreEventId?: string }
+): RoomBusyWindow[] {
+  const startMs = proposed.start.getTime();
+  const endMs = proposed.end.getTime();
+  return windows.filter(
+    (w) =>
+      w.eventId !== options?.ignoreEventId &&
+      startMs < w.end.getTime() &&
+      w.start.getTime() < endMs
+  );
+}
+
+/**
+ * One band in a room's day view: either `open` (available) or `busy`
+ * (occupied by one or more coalesced bookings). Segments are contiguous,
+ * non-overlapping, and together cover exactly [dayStart, dayEnd].
+ */
+export type RoomDaySegment =
+  | { kind: 'open'; start: Date; end: Date }
+  | { kind: 'busy'; start: Date; end: Date; windows: RoomBusyWindow[] };
+
+/**
+ * Build the day strip for a room: the open/busy bands across a day, e.g.
+ * "Open 9:00–4:30 · Music Together 4:30–6:00 · Open after 6:00". Windows
+ * are clipped to [dayStart, dayEnd]; overlapping and back-to-back windows
+ * are merged into a single busy band that carries all its source windows.
+ */
+export function getDayStrip(
+  windows: RoomBusyWindow[],
+  dayStart: Date,
+  dayEnd: Date
+): RoomDaySegment[] {
+  const dayStartMs = dayStart.getTime();
+  const dayEndMs = dayEnd.getTime();
+
+  // Clip to the day and drop anything fully outside it.
+  const clipped = windows
+    .map((w) => ({
+      window: w,
+      start: Math.max(w.start.getTime(), dayStartMs),
+      end: Math.min(w.end.getTime(), dayEndMs),
+    }))
+    .filter((c) => c.start < c.end)
+    .sort((a, b) => a.start - b.start);
+
+  // Merge overlapping/adjacent clipped windows into busy runs.
+  const runs: { start: number; end: number; windows: RoomBusyWindow[] }[] = [];
+  for (const c of clipped) {
+    const last = runs[runs.length - 1];
+    if (last && c.start <= last.end) {
+      last.end = Math.max(last.end, c.end);
+      last.windows.push(c.window);
+    } else {
+      runs.push({ start: c.start, end: c.end, windows: [c.window] });
+    }
+  }
+
+  // Walk the day, filling gaps with open segments.
+  const segments: RoomDaySegment[] = [];
+  let cursor = dayStartMs;
+  for (const run of runs) {
+    if (run.start > cursor) {
+      segments.push({
+        kind: 'open',
+        start: new Date(cursor),
+        end: new Date(run.start),
+      });
+    }
+    segments.push({
+      kind: 'busy',
+      start: new Date(run.start),
+      end: new Date(run.end),
+      windows: run.windows,
+    });
+    cursor = run.end;
+  }
+  if (cursor < dayEndMs) {
+    segments.push({
+      kind: 'open',
+      start: new Date(cursor),
+      end: new Date(dayEndMs),
+    });
+  }
+
+  return segments;
+}


### PR DESCRIPTION
Second slice of the Spruce Room epic's PR 2 (#469) — makes the room *aware*: when you pick a time, you see what else is in the room and get a non-blocking conflict nudge. Starts with **music lessons** (the room's heaviest user); class/event forms come next.

Builds on the booking form (#487) and the visibility work (#470).

## What

**Domain — pure, fully tested (`libs/ts/domain/room.ts`):**
- `getRoomConflicts(proposed, windows, { ignoreEventId })` — busy windows overlapping a proposed slot. Half-open overlap, so **back-to-back bookings don't conflict** (shared boundary, not a shared moment); a zero-length slot never conflicts; `ignoreEventId` lets edit flows skip an event's own window.
- `getDayStrip(windows, dayStart, dayEnd)` — the open/busy bands for a day; clips to the day and coalesces overlapping/adjacent windows into one busy band carrying its sources.
- **+11 unit tests** (21 total in `room.spec.ts`): overlap edges, both back-to-back boundaries, containment, multi-window, day-bound clipping, coalescing.

**Data:** `useRoomScheduleForDate(room, date)` — busy windows for an arbitrary calendar day (the dashboard's `useRoomSchedule` is hard-scoped to "today"); idle when `date` is null so a form can mount it pre-selection.

**UI:** `RoomAvailability` — a drop-in inline component: a warn-and-confirm conflict `Alert` (*"Spruce Room is already booked 4:30–6:00 PM (Music Together). You can still save — overlaps are sometimes intentional."*) plus the day strip. Wired into `ScheduleLessonDialog`'s single-lesson mode; lessons default to `room:'spruce'` so it always shows. **Never blocks submission** — legitimate overlaps (setup time) exist, per the epic.

## Out of scope (next slice)
- Room pickers + `RoomAvailability` on the **class** and **event** forms.
- Series-mode conflict display in the lesson dialog (single mode only here).

## Verification
- `nx typecheck maple-spruce` ✅ (transitively typechecks the new lib code, hook, and the lesson-dialog wiring).
- `nx test domain` ✅ — 21 room tests pass.
- `eslint ScheduleLessonDialog.tsx` ✅ — 0 errors on my changes. (The `react-lessons:lint` task crashes on `LessonList.stories.tsx`'s app-fixture import — the **pre-existing** Storybook boundary issue documented in #470, unrelated to this PR.)
- Manual dev walkthrough to follow after merge (dev auto-deploys via #484).

🤖 Generated with [Claude Code](https://claude.com/claude-code)