### PR TITLE
perf(portal): dedupe concurrent dashboard reads + stop admin-gate remount (#490)

### DIFF
--- a/libs/react/auth/src/lib/AdminGuard.tsx
+++ b/libs/react/auth/src/lib/AdminGuard.tsx
@@ -40,33 +40,6 @@ export function AdminGuardView({
   adminState,
   onSignOut,
 }: AdminGuardViewProps) {
-  // While checking admin status, keep children mounted (but hidden) so their
-  // data hooks fire in parallel with the admin check instead of waiting for it
-  // to resolve. The overlay hides any admin content until access is confirmed;
-  // the admin-only Cloud Functions reject non-admins server-side, so kicking
-  // off these fetches before the check completes is safe.
-  if (isCheckingAdmin) {
-    return (
-      <Box sx={{ position: 'relative', minHeight: '100vh' }}>
-        <Box sx={{ visibility: 'hidden' }} aria-hidden>
-          {children}
-        </Box>
-        <Box
-          sx={{
-            position: 'absolute',
-            inset: 0,
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            bgcolor: 'background.default',
-          }}
-        >
-          <CircularProgress color="primary" />
-        </Box>
-      </Box>
-    );
-  }
-
   // If check failed with error, show a generic message
   if (adminState.status === 'error') {
     return (
@@ -105,8 +78,9 @@ export function AdminGuardView({
     );
   }
 
-  // Not an admin - show friendly message
-  if (!isAdmin) {
+  // Resolved and not an admin — show the friendly onboarding message.
+  // (While still checking, fall through to render children hidden below.)
+  if (!isCheckingAdmin && !isAdmin) {
     return (
       <Box
         sx={{
@@ -147,8 +121,37 @@ export function AdminGuardView({
     );
   }
 
-  // User is admin, render children
-  return <>{children}</>;
+  // Admin confirmed, or still checking: render children in a STABLE wrapper
+  // so that resolving admin status doesn't remount them — a remount refires
+  // every data hook (the dashboard was fetching each query a second time the
+  // instant the check resolved). While still checking, hide the children
+  // behind a spinner overlay; their data hooks fetch in parallel with the
+  // admin check (admin-only functions reject non-admins server-side, so the
+  // early fetch is safe).
+  return (
+    <Box sx={{ position: 'relative', minHeight: '100vh' }}>
+      <Box
+        sx={{ visibility: isCheckingAdmin ? 'hidden' : 'visible' }}
+        aria-hidden={isCheckingAdmin || undefined}
+      >
+        {children}
+      </Box>
+      {isCheckingAdmin && (
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            bgcolor: 'background.default',
+          }}
+        >
+          <CircularProgress color="primary" />
+        </Box>
+      )}
+    </Box>
+  );
 }
 
 /**

--- a/libs/react/data/src/index.ts
+++ b/libs/react/data/src/index.ts
@@ -1,3 +1,4 @@
+export { callDeduped } from './lib/call-deduped';
 export { useProducts } from './lib/useProducts';
 export { useArtists } from './lib/useArtists';
 export { useCategories } from './lib/useCategories';

--- a/libs/react/data/src/lib/call-deduped.ts
+++ b/libs/react/data/src/lib/call-deduped.ts
@@ -1,0 +1,53 @@
+import {
+  httpsCallable,
+  type HttpsCallableResult,
+} from 'firebase/functions';
+import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
+
+/**
+ * In-flight requests keyed by dedupe key. An entry exists only while its
+ * request is pending — it's removed as soon as the call settles.
+ */
+const inFlight = new Map<string, Promise<HttpsCallableResult<unknown>>>();
+
+/**
+ * Invoke a callable Cloud Function, sharing a single in-flight request across
+ * concurrent identical callers.
+ *
+ * The portal mounts the same read hooks from multiple components (e.g. the
+ * sync-conflict summary lives in both the app shell and the dashboard) and
+ * remounts them during the auth -> admin transition, which previously fired
+ * each query 2-3x on first load. Collapsing concurrent identical calls onto
+ * one promise removes that burst without any cross-render caching: the entry
+ * clears the moment the request settles, so this never serves stale data — it
+ * only merges calls that overlap in time.
+ *
+ * Use this for idempotent reads only. Mutations call `httpsCallable` directly.
+ *
+ * @param name       callable function name (e.g. 'getClasses')
+ * @param data       request payload
+ * @param dedupeKey  override the key when the payload carries volatile fields
+ *                   that shouldn't affect identity (e.g. a request timestamp).
+ *                   Defaults to the function name + serialized payload.
+ */
+export function callDeduped<Req, Res>(
+  name: string,
+  data: Req,
+  dedupeKey = `${name}:${JSON.stringify(data ?? {})}`
+): Promise<HttpsCallableResult<Res>> {
+  const existing = inFlight.get(dedupeKey);
+  if (existing) {
+    return existing as Promise<HttpsCallableResult<Res>>;
+  }
+
+  const functions = getMapleFunctions();
+  const promise = httpsCallable<Req, Res>(
+    functions,
+    name
+  )(data).finally(() => {
+    inFlight.delete(dedupeKey);
+  });
+
+  inFlight.set(dedupeKey, promise as Promise<HttpsCallableResult<unknown>>);
+  return promise;
+}

--- a/libs/react/data/src/lib/useClasses.ts
+++ b/libs/react/data/src/lib/useClasses.ts
@@ -3,6 +3,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import { httpsCallable } from 'firebase/functions';
 import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
+import { callDeduped } from './call-deduped';
 import type {
   Class,
   CreateClassInput,
@@ -47,18 +48,15 @@ export function useClasses(filters?: UseClassesFilters) {
     setClassesState({ status: 'loading' });
 
     try {
-      const functions = getMapleFunctions();
-      const getClasses = httpsCallable<GetClassesRequest, GetClassesResponse>(
-        functions,
-        'getClasses'
+      const result = await callDeduped<GetClassesRequest, GetClassesResponse>(
+        'getClasses',
+        {
+          status: filters?.status,
+          categoryId: filters?.categoryId,
+          instructorId: filters?.instructorId,
+          upcoming: filters?.upcoming,
+        }
       );
-
-      const result = await getClasses({
-        status: filters?.status,
-        categoryId: filters?.categoryId,
-        instructorId: filters?.instructorId,
-        upcoming: filters?.upcoming,
-      });
       setClassesState({
         status: 'success',
         data: result.data.classes,

--- a/libs/react/data/src/lib/useProducts.ts
+++ b/libs/react/data/src/lib/useProducts.ts
@@ -3,6 +3,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import { httpsCallable } from 'firebase/functions';
 import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
+import { callDeduped } from './call-deduped';
 import type {
   Product,
   CreateProductInput,
@@ -34,13 +35,10 @@ export function useProducts() {
     setProductsState({ status: 'loading' });
 
     try {
-      const functions = getMapleFunctions();
-      const getProducts = httpsCallable<
+      const result = await callDeduped<
         GetProductsRequest,
         GetProductsResponse
-      >(functions, 'getProducts');
-
-      const result = await getProducts({});
+      >('getProducts', {});
       setProductsState({
         status: 'success',
         data: result.data.products,

--- a/libs/react/data/src/lib/useRegistrations.ts
+++ b/libs/react/data/src/lib/useRegistrations.ts
@@ -3,6 +3,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import { httpsCallable } from 'firebase/functions';
 import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
+import { callDeduped } from './call-deduped';
 import type {
   Registration,
   UpdateRegistrationInput,
@@ -43,13 +44,10 @@ export function useRegistrations(filters?: UseRegistrationsFilters) {
     setRegistrationsState({ status: 'loading' });
 
     try {
-      const functions = getMapleFunctions();
-      const getRegistrations = httpsCallable<
+      const result = await callDeduped<
         GetRegistrationsRequest,
         GetRegistrationsResponse
-      >(functions, 'getRegistrations');
-
-      const result = await getRegistrations({
+      >('getRegistrations', {
         classId: filters?.classId,
         status: filters?.status,
         customerEmail: filters?.customerEmail,

--- a/libs/react/data/src/lib/useRoomSchedule.ts
+++ b/libs/react/data/src/lib/useRoomSchedule.ts
@@ -1,8 +1,7 @@
 'use client';
 
 import { useState, useCallback, useEffect } from 'react';
-import { httpsCallable } from 'firebase/functions';
-import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
+import { callDeduped } from './call-deduped';
 import type { RequestState, Room, RoomBusyWindow } from '@maple/ts/domain';
 import type {
   GetRoomScheduleRequest,
@@ -26,21 +25,25 @@ export function useRoomSchedule(room: Room) {
     setRoomScheduleState({ status: 'loading' });
 
     try {
-      const functions = getMapleFunctions();
-      const getRoomSchedule = httpsCallable<
-        GetRoomScheduleRequest,
-        GetRoomScheduleResponse
-      >(functions, 'getRoomSchedule');
-
       const now = new Date();
       const endOfDay = new Date(now);
       endOfDay.setHours(23, 59, 59, 999);
 
-      const result = await getRoomSchedule({
-        room,
-        start: now.toISOString(),
-        end: endOfDay.toISOString(),
-      });
+      // Dedupe by room only — `start`/`end` are derived from the current
+      // instant, so they differ by milliseconds between remounts and would
+      // otherwise defeat the in-flight dedupe.
+      const result = await callDeduped<
+        GetRoomScheduleRequest,
+        GetRoomScheduleResponse
+      >(
+        'getRoomSchedule',
+        {
+          room,
+          start: now.toISOString(),
+          end: endOfDay.toISOString(),
+        },
+        `getRoomSchedule:${room}`
+      );
 
       const windows: RoomBusyWindow[] = result.data.windows
         .map((w) => ({

--- a/libs/react/data/src/lib/useSyncConflictSummary.ts
+++ b/libs/react/data/src/lib/useSyncConflictSummary.ts
@@ -1,8 +1,7 @@
 'use client';
 
 import { useState, useCallback, useEffect } from 'react';
-import { httpsCallable } from 'firebase/functions';
-import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
+import { callDeduped } from './call-deduped';
 import type { SyncConflictSummary, RequestState } from '@maple/ts/domain';
 import type {
   GetSyncConflictSummaryRequest,
@@ -31,13 +30,10 @@ export function useSyncConflictSummary() {
     setSummaryState({ status: 'loading' });
 
     try {
-      const functions = getMapleFunctions();
-      const getSyncConflictSummary = httpsCallable<
+      const result = await callDeduped<
         GetSyncConflictSummaryRequest,
         GetSyncConflictSummaryResponse
-      >(functions, 'getSyncConflictSummary');
-
-      const result = await getSyncConflictSummary({});
+      >('getSyncConflictSummary', {});
       setSummaryState({
         status: 'success',
         data: result.data.summary,


### PR DESCRIPTION
## Summary

Follow-up to #491. The post-deploy HAR confirmed the warmup/de-serialize win (**23s → 9s**), but surfaced a new inefficiency: the dashboard fires **each read query 2–3×** on first load (~18 calls that should be 6), across three overlapping waves at ~4448ms / ~4486ms / ~6115ms.

Two root causes:

1. **AdminGuard remount (a regression from #491).** While checking, the guard rendered children inside a hidden wrapper; once admin resolved it switched to a bare `<>{children}</>` — a *different tree position*, so React **remounted the whole dashboard** and refired every data hook (~1.6s after the first wave).
2. **Shared hooks across components.** The same reads mount from multiple places (e.g. `useSyncConflictSummary` lives in both `AppShellWrapper` and the dashboard `page.tsx`), and remount during the auth→admin transition, so identical queries overlap in flight.

## Changes

- **Stable AdminGuard wrapper** — children now render in the same wrapper element across the checking→admin transition (toggling `visibility` + a spinner overlay instead of swapping the element tree), so resolving admin status no longer remounts the dashboard.
- **`callDeduped()`** — idempotent reads share a single in-flight request keyed by `name + payload` (or an explicit key for hooks with volatile args, like `getRoomSchedule`'s per-call timestamps). The map entry clears the instant the call settles, so it only merges calls that *overlap in time* — no stale-cache semantics. Routed `useClasses` / `useRegistrations` / `useProducts` / `useSyncConflictSummary` / `useRoomSchedule` reads through it; mutations still call `httpsCallable` directly.

Since the three first-load waves all overlap in time, in-flight dedup collapses them to one each: **~18 → 6 calls**.

## Testing
- [x] `nx typecheck maple-spruce` passes
- [x] `nx build maple-spruce` (production) passes
- [x] AdminGuard interaction tests: 14/14 pass (guard restructure covered)
- [x] eslint clean on changed files
- [ ] Real proof point: post-deploy HAR should show one wave of 6 reads instead of three

## Notes
- `@maple/react/data` has no test runner configured (zero existing specs), so `callDeduped` isn't unit-tested here; behavior is covered by typecheck/build + the HAR follow-up. Happy to wire a test target if preferred.
- Doesn't touch the remaining ~2s initial-JS-load portion (needs a separate Lighthouse capture on the authed page).

Relates to #490