### PR TITLE
perf(portal): drop unused Firestore client SDK from the bundle (#490)

### DIFF
--- a/libs/ts/firebase/firebase-config/src/index.ts
+++ b/libs/ts/firebase/firebase-config/src/index.ts
@@ -1,7 +1,6 @@
 export { mapleFirebaseConfig } from './lib/maple-firebase-config';
 export { getMapleApp } from './lib/maple-app';
 export { getMapleAuth } from './lib/maple-auth';
-export { getMapleFirestore } from './lib/maple-firestore';
 export { getMapleFunctions } from './lib/maple-functions';
 export {
   getMapleRemoteConfig,

--- a/libs/ts/firebase/firebase-config/src/lib/maple-firestore.ts
+++ b/libs/ts/firebase/firebase-config/src/lib/maple-firestore.ts
@@ -1,9 +1,0 @@
-import { getFirestore } from 'firebase/firestore';
-import { getMapleApp } from './maple-app';
-
-let _mapleFirestore: ReturnType<typeof getFirestore> | undefined;
-
-export const getMapleFirestore = () => {
-  _mapleFirestore ??= getFirestore(getMapleApp());
-  return _mapleFirestore;
-};


### PR DESCRIPTION
## Summary

While investigating the ~2s pre-auth load that the post-#491 HAR surfaced, I found the **Firestore client SDK is bundled and parsed on every load but never used.** The admin portal talks to the backend exclusively via Cloud Functions (`httpsCallable`) + Firebase Auth. `getMapleFirestore` / `firebase/firestore` have **zero callers** anywhere in `apps/` or `libs/` — the only references are the definition and its barrel re-export.

(Server-side Firestore via `firebase-admin` in Cloud Functions is a separate SDK and is unaffected.)

## Change
Delete the dead `getMapleFirestore` helper and remove its export from `@maple/ts/firebase/firebase-config`. This drops the `firebase/firestore` entrypoint — the largest part of the Firebase SDK — from the client bundle.

## Measured impact
`nx build maple-spruce --skip-nx-cache`, gzip of all `static/**.js`:

| | Total JS (gzip) | Firestore chunks |
|---|---|---|
| before | 1340.1 KB | 1 |
| after | **1283.2 KB** | **0** |

**−56.9 KB gzip (~4.2%)** off every load, and the Firestore code is gone entirely — so it's also ~57KB+ less to **parse/eval** during the pre-auth window, not just download.

## Testing
- [x] `nx typecheck maple-spruce` passes
- [x] `nx affected -t typecheck` — no other consumer affected (zero callers confirmed by grep across `apps/` + `libs/`)
- [x] Firestore confirmed absent from rebuilt bundle (`grep firestore.googleapis static/chunks` → 0)

Relates to #490