### PR TITLE
fix(ci): unblock prod deploys skipped by approve_prod's always() (#490)

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -630,7 +630,13 @@ jobs:
 
   deploy_functions_prod:
     needs: [prepare_and_build, approve_prod]
+    # `!cancelled()` is required because approve_prod uses `always()` in its
+    # own `if` (to survive a skipped e2e_dev on web-app-only merges). A job
+    # that depends on an `always()` job is implicitly skipped unless it also
+    # uses a status-check function in its `if` — without this, the prod
+    # deploy was silently skipped even after approve_prod succeeded.
     if: >-
+      !cancelled() &&
       needs.approve_prod.result == 'success' &&
       needs.prepare_and_build.outputs.has_changes == 'true' &&
       needs.prepare_and_build.outputs.matrix != '' &&
@@ -878,7 +884,10 @@ jobs:
     # Gate the webflow-components publish on the manual approval (which
     # itself depends on E2E passing). The published bundle becomes the
     # live widget, so it's treated as a prod-side action.
+    # `!cancelled()` is required because approve_prod uses `always()` — see
+    # deploy_functions_prod for why a status-check function is needed here.
     if: >-
+      !cancelled() &&
       needs.approve_prod.result == 'success' &&
       needs.prepare_and_build.outputs.webflow_components_affected == 'true'
     runs-on: ubuntu-latest
@@ -917,7 +926,11 @@ jobs:
     # PR previews still auto-deploy from Vercel because the disable only
     # covers `main`.
     needs: approve_prod
-    if: needs.approve_prod.result == 'success'
+    # `!cancelled()` is required because approve_prod uses `always()` — a job
+    # depending on an `always()` job is implicitly skipped unless it also uses
+    # a status-check function. Without this, deploy_vercel_prod was skipped on
+    # #493 despite approve_prod succeeding, so the portal never reached prod.
+    if: ${{ !cancelled() && needs.approve_prod.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

**Regression from #492 — currently blocking all production deploys.**

#492 added `always()` to `approve_prod` so it survives a skipped `e2e_dev` on web-app-only merges. But this is a well-known GitHub Actions footgun: **a job that depends on an `always()` job is implicitly skipped unless it also uses a status-check function** (`always()`, `!cancelled()`, `success()`, …) in its own `if`.

As a result, all three prod-side jobs were silently skipped *even when `approve_prod` succeeded*:
- `deploy_functions_prod`
- `publish_webflow_components`
- `deploy_vercel_prod`

This surfaced on #493: the deploy was approved, `approve_prod` ✅ and `e2e_dev` ✅, but `deploy_vercel_prod` **skipped** — so the portal never reached prod. It also means function prod deploys would skip on the next backend merge.

## Fix
Prepend `!cancelled() &&` to each of the three prod jobs' `if`. The status-check function removes the implicit skip; the existing `needs.approve_prod.result == 'success'` clause preserves the gate (runs only when approval succeeded, never on cancel).

`deploy_vercel_prod`'s single-line `if` is wrapped in `${{ }}` because a leading `!` in YAML flow context is a tag indicator — the block-scalar (`>-`) conditions take it literally and don't need wrapping.

## Verification
- [x] YAML validates
- [ ] Real proof: next merge that reaches `approve_prod` should run `deploy_vercel_prod` (not skip it)

## Note on shipping #493/#494
`deploy_vercel_prod` checks out the triggering commit, so once this merges, the **next web-app-affecting merge** (e.g. #494) will deploy main HEAD — carrying #493 + #494 + this fix — to prod after approval.

Fixes the gap left by #492. Relates to #490