### PR TITLE
fix(ci): authenticate firebase deploys via ADC, not deprecated --token (#490)

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -373,11 +373,14 @@ jobs:
         run: |
           set -o pipefail
           for attempt in 1 2 3; do
+            # Auth via ADC: google-github-actions/auth (create_credentials_file:
+            # true) exports GOOGLE_APPLICATION_CREDENTIALS, which firebase-tools
+            # uses. Passing a gcloud access token via `--token` is deprecated and
+            # firebase-tools@15 now rejects it ("credentials are no longer valid").
             if pnpm exec firebase deploy \
               --only ${{ matrix.functions }} \
               --project maple-and-spruce-dev \
-              --force \
-              --token "$(gcloud auth print-access-token)"; then
+              --force; then
               exit 0
             fi
             if [ $attempt -lt 3 ]; then
@@ -460,7 +463,6 @@ jobs:
           npx -y firebase-tools@latest hosting:sites:create \
             maple-spruce-registration-test \
             --project maple-and-spruce-dev \
-            --token "$(gcloud auth print-access-token)" \
             < /dev/null || true
 
       - name: Deploy harness to dev Hosting
@@ -468,8 +470,7 @@ jobs:
           pnpm exec firebase deploy \
             --only hosting:registration-test \
             --project maple-and-spruce-dev \
-            --force \
-            --token "$(gcloud auth print-access-token)"
+            --force
 
   deploy_vercel_dev:
     # Auto-deploy the admin web app to the DEV Vercel project on every
@@ -712,11 +713,11 @@ jobs:
         run: |
           set -o pipefail
           for attempt in 1 2 3; do
+            # Auth via ADC (GOOGLE_APPLICATION_CREDENTIALS) — see deploy_functions_dev.
             if pnpm exec firebase deploy \
               --only ${{ matrix.functions }} \
               --project maple-and-spruce \
-              --force \
-              --token "$(gcloud auth print-access-token)"; then
+              --force; then
               exit 0
             fi
             if [ $attempt -lt 3 ]; then
@@ -792,7 +793,6 @@ jobs:
 
           npx -y firebase-tools@latest deploy --only firestore:indexes \
             --project maple-and-spruce-dev \
-            --token "$(gcloud auth print-access-token)" \
             < /dev/null 2>&1 | tee "$OUTPUT"
 
           if grep -q "indexes are defined in your project but are not present" "$OUTPUT"; then
@@ -870,7 +870,6 @@ jobs:
 
           npx -y firebase-tools@latest deploy --only firestore:indexes \
             --project maple-and-spruce \
-            --token "$(gcloud auth print-access-token)" \
             < /dev/null 2>&1 | tee "$OUTPUT"
 
           if grep -q "indexes are defined in your project but are not present" "$OUTPUT"; then


### PR DESCRIPTION
## Summary

**All Firebase prod deploys are currently broken** — surfaced while shipping the portal perf PRs. `deploy_harness_dev` fails with:

> Authentication Error: Your credentials are no longer valid... Authenticating with `--token` is deprecated.

`firebase-tools@15` now rejects a gcloud **access** token passed via `--token` (that flag expects a `firebase login:ci` **refresh** token). Because the registration harness deploy fails, the gate cascades — `e2e_dev` skips → `approve_prod` skips → no prod deploy. This blocks **functions and the portal both**, not just our changes. The last successful Firebase prod deploy was **2026-06-21**; it broke sometime before **2026-06-25** when the deprecation was enforced.

(Vercel deploys are unaffected — different auth — so #493/#494 are already live on dev.)

## Fix
Every deploy job already runs `google-github-actions/auth@v2` with `create_credentials_file: true`, which exports `GOOGLE_APPLICATION_CREDENTIALS`. `firebase-tools` authenticates via those Application Default Credentials when `--token` is absent. So this drops `--token "$(gcloud auth print-access-token)"` from **all 6** commands:
- `deploy_functions_dev` / `deploy_functions_prod` (`firebase deploy`)
- `deploy_harness_dev` (`hosting:sites:create` + `firebase deploy`)
- `deploy_firestore_indexes_dev` / `deploy_firestore_indexes` (`deploy --only firestore:indexes`)

No secrets needed — WIF identity (`github-deployer@…`) already has deploy permissions (it's the same identity the access token came from).

## Testing
- [x] YAML validates
- [x] 0 remaining `--token`/`FIREBASE_TOKEN` references
- [ ] Real proof: after merge, a `deploy_all` run should show `deploy_harness_dev` + `deploy_functions_*` succeeding via ADC

## Next
Once merged, I'll trigger a `deploy_all` run — it exercises the harness + function deploys (validating ADC) and, after approval, `deploy_vercel_prod` ships the portal (#493 + #494) through the now-working gate.

Relates to #490