### PR TITLE
fix(ci): authenticate functions deploys with a service-account key (#490)

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -320,10 +320,14 @@ jobs:
 
       - name: Authenticate to Google Cloud (Dev)
         id: auth
+        # `firebase deploy --only functions` routes through the Firebase Admin
+        # SDK, which does NOT support keyless WIF (external_account) creds
+        # (firebase-admin-node#2168) — it needs a service-account key. So the
+        # functions jobs alone authenticate with a key; every other deploy
+        # (hosting, firestore, vercel) stays keyless WIF.
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: 'projects/1062803455357/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
-          service_account: 'github-deployer@maple-and-spruce-dev.iam.gserviceaccount.com'
+          credentials_json: ${{ secrets.FIREBASE_DEPLOY_KEY_DEV }}
           create_credentials_file: true
 
       - name: Setup gcloud CLI
@@ -661,10 +665,11 @@ jobs:
 
       - name: Authenticate to Google Cloud (Prod)
         id: auth
+        # Service-account key — see deploy_functions_dev (functions deploy
+        # can't use keyless WIF). Other prod deploys stay keyless WIF.
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: 'projects/138840458966/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
-          service_account: 'github-deployer@maple-and-spruce.iam.gserviceaccount.com'
+          credentials_json: ${{ secrets.FIREBASE_DEPLOY_KEY_PROD }}
           create_credentials_file: true
 
       - name: Setup gcloud CLI


### PR DESCRIPTION
## Summary

The end of a long diagnosis: `firebase deploy --only functions` cannot authenticate with keyless Workload Identity Federation, on **any** firebase-tools version (confirmed on 15.15 and 15.22). The reason is documented:

- `firebase deploy --only functions` routes through the **Firebase Admin SDK**, whose Node credential layer **doesn't implement `external_account` (WIF)** — only `service_account` (key) and `authorized_user` (refresh token). [firebase-admin-node#2168](https://github.com/firebase/firebase-admin-node/issues/2168).
- Official confirmation in [`google-github-actions/auth`](https://github.com/google-github-actions/auth): *"not supported by Firebase Admin SDK. Use Service Account Key JSON authentication instead."*
- That's why **hosting** and **firestore:indexes** deploy fine keyless (they use `google-auth-library`, which *does* handle WIF) while **functions** always failed `"Failed to authenticate."`

## Change
Switch **only the two functions deploy jobs** to authenticate with a service-account key via `google-github-actions/auth`'s `credentials_json`. Everything else — hosting/harness, firestore:indexes, Vercel — **stays keyless WIF**. Reuses the existing `github-deployer@` SAs (no new identity/roles).

## Required secrets (see comment below for exact commands)
| Secret | Service account |
|---|---|
| `FIREBASE_DEPLOY_KEY_DEV` | `github-deployer@maple-and-spruce-dev` |
| `FIREBASE_DEPLOY_KEY_PROD` | `github-deployer@maple-and-spruce` |

## Testing
- [x] YAML validates; diff is limited to the 2 functions auth steps
- [ ] After secrets are added + merge: a `deploy_all` run should show `deploy_functions_dev/prod` authenticating and deploying

Relates to #490