### PR TITLE
fix(ci): tolerate 'already the live version' on harness deploy (#490)

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -478,11 +478,25 @@ jobs:
 
       - name: Deploy harness to dev Hosting
         run: |
-          pnpm exec firebase deploy \
+          set -o pipefail
+          OUT=$(mktemp); trap 'rm -f "$OUT"' EXIT
+          if pnpm exec firebase deploy \
             --only hosting:registration-test \
             --project maple-and-spruce-dev \
             --force \
-            --token "${{ steps.auth.outputs.access_token }}"
+            --token "${{ steps.auth.outputs.access_token }}" 2>&1 | tee "$OUT"; then
+            exit 0
+          fi
+          # Idempotent: this job redeploys the harness on every run, so when the
+          # content is byte-identical to what's live (e.g. back-to-back deploys
+          # with no harness change) Firebase rejects the release with "is the
+          # current active version". The harness is already at the desired
+          # state, so treat that specific case as success.
+          if grep -q "is the current active version" "$OUT"; then
+            echo "::notice::Harness already at the live version — treating as success."
+            exit 0
+          fi
+          exit 1
 
   deploy_vercel_dev:
     # Auto-deploy the admin web app to the DEV Vercel project on every


### PR DESCRIPTION
## Summary

Final blocker in the deploy pipeline. After the keyless-auth fixes (#499, #500), a `deploy_all` run had **everything pass** — functions (all shards), firestore (dev + prod), vercel-dev — **except `deploy_harness_dev`**, which failed with:

> `400 ... supplied version ... is the current active version`

This is **not** an auth failure — the harness authenticated, uploaded, and finalized the version. It's an **idempotency quirk**: the job redeploys the harness every run, and when the content is byte-identical to what's already live (back-to-back deploys with no harness change), Firebase refuses to re-release the already-active version.

## Fix
Capture the deploy output; if it fails *only* with `"is the current active version"`, treat it as success (the harness is already at the desired state). Any other error still fails the job. This unblocks `e2e_dev` → `approve_prod` when the harness hasn't changed.

## Next
Merge → `deploy_all` from main → harness passes → `e2e_dev` → `approve_prod` pauses for approval → ships functions to prod + the portal (#493/#494).

Relates to #490