### PR TITLE
fix(ci): pin e2e_dev to Node 22.22.3 (node-fetch keep-alive regression) (#490)

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -587,7 +587,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          # Pinned to 22.22.3: Node 22.23.0 (security release backporting the
+          # http.Agent "response queue poisoning" fix) exposes a node-fetch@2
+          # keep-alive regression — false "Premature close" on the concurrent
+          # Google auth requests the Admin SDK makes seeding dev Firestore
+          # (nodejs/node#63989). 22.22.3 is the last version verified to pass
+          # (deploy_all on 22.22.3 succeeded; 22.23.0 fails). Revert to '22'
+          # once Node ships the node-fetch keep-alive fix.
+          node-version: '22.22.3'
           cache: 'pnpm'
 
       - name: Restore node_modules cache


### PR DESCRIPTION
## Root cause (found, with proof)

The `e2e_dev` "Premature close" failures are a **Node.js regression**, not our code, deps, or STS. Comparing the e2e job's Node version across runs:

| Run | Node | e2e_dev |
|---|---|---|
| 2026-06-25 03:26 | **22.22.3** | ✅ |
| 2026-06-26 02:59 | **22.23.0** | ❌ |

The GitHub runner's Node auto-updated **22.22.3 → 22.23.0** in between. Node 22.23.0 backports the `http.Agent` "response queue poisoning" security fix, which exposes a latent **node-fetch@2** keep-alive bug — false `ERR_STREAM_PREMATURE_CLOSE` on concurrent requests to `*.googleapis.com` ([nodejs/node#63989](https://github.com/nodejs/node/issues/63989)).

**Why only e2e:** `globalSetup` seeds dev Firestore via **firebase-admin**, whose auth runs through `gaxios → node-fetch` with a keep-alive agent and fires **3 concurrent** writes (`Promise.all`) — exactly the pattern the regression breaks. The deploy jobs authenticate via the `google-github-actions/auth` action + bearer `--token` (no in-process node-fetch), so they're unaffected (they ran fine on 22.23.0).

## Fix
Pin **only** `e2e_dev` to Node **22.22.3** — the last version verified to pass (per the table). Node team's recommended workaround for this regression is "pin Node." Revert to `'22'` once Node ships the node-fetch keep-alive fix ([PR #64004](https://github.com/nodejs/node/issues/63989)).

## Testing
- [x] YAML validates; only e2e_dev pinned (7 other jobs unchanged on '22')
- [ ] Next `deploy_all`: e2e_dev passes on 22.22.3 → approve_prod

Relates to #490