### PR TITLE
feat(rooms): upcoming Spruce Room schedule agenda

### DIFF
--- a/apps/maple-spruce/src/app/(admin)/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/page.tsx
@@ -166,7 +166,11 @@ export default function DashboardPage() {
       <Grid container spacing={3}>
         {/* Spruce Room status */}
         <Grid size={12}>
-          <RoomStatusCard room="spruce" bookHref="/book-room" />
+          <RoomStatusCard
+            room="spruce"
+            bookHref="/book-room"
+            scheduleHref="/room-schedule"
+          />
         </Grid>
 
         {/* Upcoming Classes */}

--- a/apps/maple-spruce/src/app/(admin)/room-schedule/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/room-schedule/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { Box, Typography } from '@mui/material';
+import { RoomScheduleAgenda } from '@maple/react/rooms';
+
+export default function RoomSchedulePage() {
+  return (
+    <Box sx={{ maxWidth: 720 }}>
+      <Typography variant="h4" component="h1" sx={{ mb: 1 }}>
+        Spruce Room Schedule
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        Every upcoming use of the Spruce Room — lessons, classes, and ad hoc
+        bookings — so you can see when it&apos;s free to plan your own. Pick a
+        time range below.
+      </Typography>
+
+      <RoomScheduleAgenda room="spruce" bookHref="/book-room" />
+    </Box>
+  );
+}

--- a/apps/maple-spruce/src/components/layout/AppShellWrapper.tsx
+++ b/apps/maple-spruce/src/components/layout/AppShellWrapper.tsx
@@ -13,6 +13,7 @@ import PaymentsIcon from '@mui/icons-material/Payments';
 import EventIcon from '@mui/icons-material/Event';
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import MeetingRoomIcon from '@mui/icons-material/MeetingRoom';
+import EventNoteIcon from '@mui/icons-material/EventNote';
 import TuneIcon from '@mui/icons-material/Tune';
 import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
 import SettingsIcon from '@mui/icons-material/Settings';
@@ -135,6 +136,11 @@ export function AppShellWrapper({
             label: 'Events',
             href: '/events',
             icon: <CalendarMonthIcon />,
+          },
+          {
+            label: 'Spruce Room Schedule',
+            href: '/room-schedule',
+            icon: <EventNoteIcon />,
           },
           {
             label: 'Book the Spruce Room',

--- a/docs/sessions/SESSION.md
+++ b/docs/sessions/SESSION.md
@@ -6,8 +6,17 @@
 
 ## Current Status
 
-**Date**: 2026-06-11
-**Status**: Phase 4 complete; Phase 5 in progress. Spruce Room availability epic started (#467).
+**Date**: 2026-06-26
+**Status**: Phase 4 complete; Phase 5 in progress. Spruce Room availability epic (#467) — PRs 1 & 2 shipped; adding the upcoming-schedule agenda (#504).
+
+### Spruce Room upcoming-schedule agenda (#504, 2026-06-26)
+
+The epic deferred a "check the calendar" view ("Add later only if missed"). It was missed — the portal could say if the room was free *right now* and warn on conflicts inline, but there was no way to see all upcoming usage to plan around. Added a read-only **agenda view** at `/room-schedule` (Calendar nav group + a "View schedule" link on the dashboard room widget): bookings over the next 2/4/8 weeks grouped by day, with consecutive free days collapsed into an "Open" range.
+
+Pure additive UI on top of the existing `getRoomSchedule` callable — **no backend or Firestore index changes**:
+- `groupRoomScheduleByDay` domain helper (`libs/ts/domain/room.ts`) + unit tests
+- `useRoomScheduleRange(room, start, end)` hook (`libs/react/rooms`) — generalizes `useRoomScheduleForDate` to an arbitrary span
+- `RoomScheduleAgenda` / `RoomScheduleAgendaList` components (`libs/react/rooms`) + tests
 
 ### Spruce Room availability — PR 1 shipped (2026-06-11)
 

--- a/libs/react/events/src/lib/RoomStatusCard.tsx
+++ b/libs/react/events/src/lib/RoomStatusCard.tsx
@@ -41,10 +41,13 @@ function windowLabel(w: RoomBusyWindow): string {
 export function RoomStatusCard({
   room,
   bookHref,
+  scheduleHref,
 }: {
   room: Room;
   /** When set, renders a "Book the room" action linking here. */
   bookHref?: string;
+  /** When set, renders a "View schedule" action linking here. */
+  scheduleHref?: string;
 }) {
   const { roomScheduleState } = useRoomSchedule(room);
 
@@ -79,11 +82,18 @@ export function RoomStatusCard({
           <RoomStatusLines status={status} />
         ) : null}
       </CardContent>
-      {bookHref && (
+      {(bookHref || scheduleHref) && (
         <CardActions>
-          <Button size="small" href={bookHref}>
-            Book the room
-          </Button>
+          {scheduleHref && (
+            <Button size="small" href={scheduleHref}>
+              View schedule
+            </Button>
+          )}
+          {bookHref && (
+            <Button size="small" href={bookHref}>
+              Book the room
+            </Button>
+          )}
         </CardActions>
       )}
     </Card>

--- a/libs/react/rooms/src/index.ts
+++ b/libs/react/rooms/src/index.ts
@@ -1,2 +1,8 @@
 export { RoomAvailability } from './lib/RoomAvailability';
 export { useRoomScheduleForDate } from './lib/useRoomScheduleForDate';
+export { useRoomScheduleRange } from './lib/useRoomScheduleRange';
+export {
+  RoomScheduleAgenda,
+  RoomScheduleAgendaList,
+  type RoomScheduleAgendaProps,
+} from './lib/RoomScheduleAgenda';

--- a/libs/react/rooms/src/lib/RoomScheduleAgenda.spec.tsx
+++ b/libs/react/rooms/src/lib/RoomScheduleAgenda.spec.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup, within } from '@testing-library/react';
+import type { RoomBusyWindow, RoomScheduleDay } from '@maple/ts/domain';
+import { RoomScheduleAgendaList } from './RoomScheduleAgenda';
+
+afterEach(cleanup);
+
+function win(
+  start: Date,
+  end: Date,
+  overrides: Partial<RoomBusyWindow> = {}
+): RoomBusyWindow {
+  return {
+    eventId: `evt-${start.getTime()}`,
+    title: 'Music Together',
+    type: 'event',
+    sourceRef: null,
+    start,
+    end,
+    ...overrides,
+  };
+}
+
+function day(date: Date, windows: RoomBusyWindow[] = []): RoomScheduleDay {
+  return { date, windows };
+}
+
+const now = new Date(2026, 5, 26, 9, 0); // Fri Jun 26
+
+describe('RoomScheduleAgendaList', () => {
+  it('renders a booking row with time range, title, and type chip', () => {
+    const days = [
+      day(new Date(2026, 5, 26), [
+        win(new Date(2026, 5, 26, 16, 30), new Date(2026, 5, 26, 18, 0), {
+          title: 'Music Together',
+          type: 'event',
+        }),
+      ]),
+    ];
+    render(<RoomScheduleAgendaList days={days} now={now} />);
+
+    expect(screen.getByText('Music Together')).toBeTruthy();
+    expect(screen.getByText('Booking')).toBeTruthy(); // event → "Booking"
+    expect(screen.getByText(/4:30/)).toBeTruthy();
+  });
+
+  it('prefixes the current day with "Today"', () => {
+    const days = [
+      day(new Date(2026, 5, 26), [
+        win(new Date(2026, 5, 26, 16, 0), new Date(2026, 5, 26, 17, 0)),
+      ]),
+    ];
+    render(<RoomScheduleAgendaList days={days} now={now} />);
+    expect(screen.getByText(/^Today ·/)).toBeTruthy();
+  });
+
+  it('collapses consecutive open days into one open range row', () => {
+    const days = [
+      day(new Date(2026, 5, 26), [
+        win(new Date(2026, 5, 26, 16, 0), new Date(2026, 5, 26, 17, 0)),
+      ]),
+      day(new Date(2026, 5, 27)),
+      day(new Date(2026, 5, 28)),
+      day(new Date(2026, 5, 29)),
+    ];
+    render(<RoomScheduleAgendaList days={days} now={now} />);
+
+    // The three open days collapse into a single "Open all day" row.
+    const openRows = screen.getAllByText(/Open all day/);
+    expect(openRows).toHaveLength(1);
+    // Rendered as a range Jun 27 – Jun 29.
+    expect(screen.getByText(/Jun 27 – Jun 29/)).toBeTruthy();
+  });
+
+  it('labels lesson and class windows distinctly', () => {
+    const days = [
+      day(new Date(2026, 5, 26), [
+        win(new Date(2026, 5, 26, 10, 0), new Date(2026, 5, 26, 11, 0), {
+          eventId: 'lesson-1',
+          type: 'lesson',
+          title: 'Music Lesson',
+        }),
+        win(new Date(2026, 5, 26, 14, 0), new Date(2026, 5, 26, 15, 0), {
+          eventId: 'class-1',
+          type: 'class',
+          title: 'Watercolor 101',
+        }),
+      ]),
+    ];
+    render(<RoomScheduleAgendaList days={days} now={now} />);
+    const region = screen.getByText('Music Lesson').closest('div');
+    expect(within(region as HTMLElement).getByText('Lesson')).toBeTruthy();
+    expect(screen.getByText('Class')).toBeTruthy();
+  });
+});

--- a/libs/react/rooms/src/lib/RoomScheduleAgenda.stories.tsx
+++ b/libs/react/rooms/src/lib/RoomScheduleAgenda.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Box } from '@mui/material';
+import type { CalendarEventType, RoomBusyWindow, RoomScheduleDay } from '@maple/ts/domain';
+import { RoomScheduleAgendaList } from './RoomScheduleAgenda';
+
+// Fixed reference day so the Today/Tomorrow prefixes and dates render
+// deterministically: Thursday, June 26 2026.
+const NOW = new Date(2026, 5, 26, 9, 0);
+
+function win(
+  d: Date,
+  sh: number,
+  sm: number,
+  eh: number,
+  em: number,
+  title: string,
+  type: CalendarEventType
+): RoomBusyWindow {
+  return {
+    eventId: `${title}-${d.getDate()}-${sh}`,
+    title,
+    type,
+    sourceRef: type === 'lesson' ? 'lessons/x' : null,
+    start: new Date(d.getFullYear(), d.getMonth(), d.getDate(), sh, sm),
+    end: new Date(d.getFullYear(), d.getMonth(), d.getDate(), eh, em),
+  };
+}
+
+function dayAt(offset: number): Date {
+  return new Date(2026, 5, 26 + offset);
+}
+
+function day(offset: number, windows: RoomBusyWindow[] = []): RoomScheduleDay {
+  return { date: dayAt(offset), windows };
+}
+
+// A realistic stretch: a busy today, a free Friday, a class+lesson Saturday,
+// a run of open days that collapses, then a midweek booking.
+const DAYS: RoomScheduleDay[] = [
+  day(0, [
+    win(dayAt(0), 16, 30, 18, 0, 'Music Together', 'event'),
+    win(dayAt(0), 18, 30, 19, 15, 'Music Lesson', 'lesson'),
+  ]),
+  day(1),
+  day(2, [
+    win(dayAt(2), 10, 0, 11, 0, 'Watercolor 101', 'class'),
+    win(dayAt(2), 14, 0, 14, 45, 'Music Lesson', 'lesson'),
+  ]),
+  day(3),
+  day(4),
+  day(5),
+  day(6, [win(dayAt(6), 16, 30, 18, 0, 'Music Together', 'event')]),
+];
+
+const meta = {
+  component: RoomScheduleAgendaList,
+  title: 'Rooms/RoomScheduleAgenda',
+  parameters: { layout: 'centered' },
+} satisfies Meta<typeof RoomScheduleAgendaList>;
+
+export default meta;
+type Story = StoryObj<typeof RoomScheduleAgendaList>;
+
+/** A populated week+ of Spruce Room usage, with a collapsed open-day range. */
+export const Default: Story = {
+  args: { days: DAYS, now: NOW },
+  render: (args) => (
+    <Box sx={{ width: 480, maxWidth: '100%' }}>
+      <RoomScheduleAgendaList {...args} />
+    </Box>
+  ),
+};
+
+/** A single busy day. */
+export const OneDay: Story = {
+  args: {
+    days: [
+      day(0, [
+        win(dayAt(0), 9, 0, 10, 0, 'Music Lesson', 'lesson'),
+        win(dayAt(0), 16, 30, 18, 0, 'Music Together', 'event'),
+      ]),
+    ],
+    now: NOW,
+  },
+  render: (args) => (
+    <Box sx={{ width: 480, maxWidth: '100%' }}>
+      <RoomScheduleAgendaList {...args} />
+    </Box>
+  ),
+};

--- a/libs/react/rooms/src/lib/RoomScheduleAgenda.tsx
+++ b/libs/react/rooms/src/lib/RoomScheduleAgenda.tsx
@@ -1,0 +1,274 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Divider,
+  Skeleton,
+  Stack,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from '@mui/material';
+import EventBusyIcon from '@mui/icons-material/EventBusy';
+import MeetingRoomIcon from '@mui/icons-material/MeetingRoom';
+import {
+  getRoomLabel,
+  groupRoomScheduleByDay,
+  type CalendarEventType,
+  type Room,
+  type RoomBusyWindow,
+  type RoomScheduleDay,
+} from '@maple/ts/domain';
+import { useRoomScheduleRange } from './useRoomScheduleRange';
+
+const HORIZON_OPTIONS = [2, 4, 8] as const;
+const DEFAULT_HORIZON_WEEKS = 4;
+const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
+
+/** Chip label + MUI color for each calendar event type. */
+const TYPE_CHIP: Record<
+  CalendarEventType,
+  { label: string; color: 'default' | 'primary' | 'secondary' | 'info' | 'success' }
+> = {
+  lesson: { label: 'Lesson', color: 'info' },
+  class: { label: 'Class', color: 'primary' },
+  event: { label: 'Booking', color: 'secondary' },
+  jam: { label: 'Jam', color: 'success' },
+  hours: { label: 'Hours', color: 'default' },
+};
+
+/** Format a time as "4:30 PM". */
+function formatTime(date: Date): string {
+  return date.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+/** "Thu, Jun 26" */
+function formatDay(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+/** "Jun 26" — no weekday, for collapsed open-day ranges. */
+function formatDayShort(date: Date): string {
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+function isSameLocalDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+/** Day heading with a relative prefix for today/tomorrow. */
+function dayHeading(date: Date, now: Date): string {
+  const tomorrow = new Date(now);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  if (isSameLocalDay(date, now)) return `Today · ${formatDay(date)}`;
+  if (isSameLocalDay(date, tomorrow)) return `Tomorrow · ${formatDay(date)}`;
+  return formatDay(date);
+}
+
+function BookingRow({ window }: { window: RoomBusyWindow }) {
+  const chip = TYPE_CHIP[window.type];
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'baseline',
+        gap: 1.5,
+        py: 0.5,
+      }}
+    >
+      <Typography
+        variant="body2"
+        sx={{ minWidth: 132, color: 'text.secondary', flexShrink: 0 }}
+      >
+        {formatTime(window.start)}–{formatTime(window.end)}
+      </Typography>
+      <Typography variant="body2" sx={{ flexGrow: 1 }}>
+        {window.title}
+      </Typography>
+      <Chip label={chip.label} color={chip.color} size="small" variant="outlined" />
+    </Box>
+  );
+}
+
+/**
+ * The grouped day list. Presentational — takes the already-bucketed days and
+ * the reference "now" (for the Today/Tomorrow prefixes). Consecutive days
+ * with no bookings collapse into a single "Open" range so a mostly-free
+ * horizon doesn't become a wall of "Open all day" rows.
+ */
+export function RoomScheduleAgendaList({
+  days,
+  now,
+}: {
+  days: RoomScheduleDay[];
+  now: Date;
+}) {
+  const rows: React.ReactNode[] = [];
+  let openRunStart: Date | null = null;
+  let openRunEnd: Date | null = null;
+
+  const flushOpenRun = () => {
+    if (!openRunStart || !openRunEnd) return;
+    const single = isSameLocalDay(openRunStart, openRunEnd);
+    const label = single
+      ? dayHeading(openRunStart, now)
+      : `${formatDayShort(openRunStart)} – ${formatDayShort(openRunEnd)}`;
+    rows.push(
+      <Box
+        key={`open-${openRunStart.getTime()}`}
+        sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.75 }}
+      >
+        <Typography variant="subtitle2" sx={{ color: 'text.secondary' }}>
+          {label}
+        </Typography>
+        <Typography variant="body2" sx={{ color: 'text.disabled' }}>
+          · Open all day
+        </Typography>
+      </Box>
+    );
+    openRunStart = null;
+    openRunEnd = null;
+  };
+
+  for (const day of days) {
+    if (day.windows.length === 0) {
+      if (!openRunStart) openRunStart = day.date;
+      openRunEnd = day.date;
+      continue;
+    }
+    flushOpenRun();
+    rows.push(
+      <Box key={`day-${day.date.getTime()}`} sx={{ py: 0.75 }}>
+        <Typography variant="subtitle2" gutterBottom>
+          {dayHeading(day.date, now)}
+        </Typography>
+        <Stack divider={<Divider flexItem />} sx={{ pl: 0.5 }}>
+          {day.windows.map((w) => (
+            <BookingRow key={w.eventId} window={w} />
+          ))}
+        </Stack>
+      </Box>
+    );
+  }
+  flushOpenRun();
+
+  return <Stack divider={<Divider flexItem />}>{rows}</Stack>;
+}
+
+export interface RoomScheduleAgendaProps {
+  room: Room;
+  /** When set, renders a "Book the room" action linking here. */
+  bookHref?: string;
+}
+
+/**
+ * Upcoming-usage agenda for a room: every booking over the next few weeks,
+ * grouped by day, so anyone can see when the room is free to plan a use.
+ * Read-only — booking happens through the linked form. Powered by the same
+ * `getRoomSchedule` callable as the dashboard widget and conflict warnings.
+ */
+export function RoomScheduleAgenda({ room, bookHref }: RoomScheduleAgendaProps) {
+  const [horizonWeeks, setHorizonWeeks] = useState<number>(DEFAULT_HORIZON_WEEKS);
+
+  // Pin "now" to the mounted horizon so the query window is stable across
+  // renders; the hook itself buckets refetches on the calendar day.
+  const { start, end } = useMemo(() => {
+    const startDate = new Date();
+    const endDate = new Date(startDate.getTime() + horizonWeeks * MS_PER_WEEK);
+    return { start: startDate, end: endDate };
+  }, [horizonWeeks]);
+
+  const { roomScheduleState } = useRoomScheduleRange(room, start, end);
+
+  const days = useMemo(() => {
+    if (roomScheduleState.status !== 'success') return [];
+    return groupRoomScheduleByDay(roomScheduleState.data, start, end);
+  }, [roomScheduleState, start, end]);
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 1.5,
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          mb: 2,
+        }}
+      >
+        <ToggleButtonGroup
+          size="small"
+          exclusive
+          value={horizonWeeks}
+          onChange={(_, value) => value && setHorizonWeeks(value)}
+          aria-label="schedule horizon"
+        >
+          {HORIZON_OPTIONS.map((weeks) => (
+            <ToggleButton key={weeks} value={weeks} aria-label={`${weeks} weeks`}>
+              {weeks}w
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+
+        {bookHref && (
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<MeetingRoomIcon />}
+            href={bookHref}
+          >
+            Book the room
+          </Button>
+        )}
+      </Box>
+
+      {roomScheduleState.status === 'loading' ||
+      roomScheduleState.status === 'idle' ? (
+        <Stack spacing={1}>
+          <Skeleton variant="rounded" height={56} />
+          <Skeleton variant="rounded" height={56} />
+          <Skeleton variant="rounded" height={56} />
+        </Stack>
+      ) : roomScheduleState.status === 'error' ? (
+        <Alert severity="error">
+          Couldn&apos;t load the {getRoomLabel(room)} schedule:{' '}
+          {roomScheduleState.error}
+        </Alert>
+      ) : days.every((d) => d.windows.length === 0) ? (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            color: 'text.secondary',
+            py: 3,
+          }}
+        >
+          <EventBusyIcon fontSize="small" />
+          <Typography variant="body2">
+            No {getRoomLabel(room)} bookings in the next {horizonWeeks} weeks —
+            it&apos;s open the whole time.
+          </Typography>
+        </Box>
+      ) : (
+        <RoomScheduleAgendaList days={days} now={start} />
+      )}
+    </Box>
+  );
+}

--- a/libs/react/rooms/src/lib/useRoomScheduleRange.spec.ts
+++ b/libs/react/rooms/src/lib/useRoomScheduleRange.spec.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+const callable = vi.fn();
+vi.mock('firebase/functions', () => ({
+  httpsCallable: () => callable,
+}));
+vi.mock('@maple/ts/firebase/firebase-config', () => ({
+  getMapleFunctions: () => ({}),
+}));
+
+import { useRoomScheduleRange } from './useRoomScheduleRange';
+
+afterEach(() => vi.clearAllMocks());
+beforeEach(() => vi.clearAllMocks());
+
+const start = new Date(2026, 5, 26, 0, 0);
+const end = new Date(2026, 6, 24, 0, 0);
+
+describe('useRoomScheduleRange', () => {
+  it('fetches the range and re-hydrates windows to Dates, sorted by start', async () => {
+    callable.mockResolvedValue({
+      data: {
+        windows: [
+          {
+            eventId: 'b',
+            title: 'Later',
+            type: 'event',
+            sourceRef: null,
+            start: '2026-06-28T20:00:00.000Z',
+            end: '2026-06-28T21:00:00.000Z',
+          },
+          {
+            eventId: 'a',
+            title: 'Earlier',
+            type: 'lesson',
+            sourceRef: 'lessons/x',
+            start: '2026-06-26T20:00:00.000Z',
+            end: '2026-06-26T21:00:00.000Z',
+          },
+        ],
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useRoomScheduleRange('spruce', start, end)
+    );
+
+    await waitFor(() =>
+      expect(result.current.roomScheduleState.status).toBe('success')
+    );
+
+    const state = result.current.roomScheduleState;
+    if (state.status !== 'success') throw new Error('expected success');
+    expect(state.data.map((w) => w.eventId)).toEqual(['a', 'b']);
+    expect(state.data[0].start).toBeInstanceOf(Date);
+    expect(callable).toHaveBeenCalledWith({
+      room: 'spruce',
+      start: start.toISOString(),
+      end: end.toISOString(),
+    });
+  });
+
+  it('surfaces an error state when the call rejects', async () => {
+    callable.mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() =>
+      useRoomScheduleRange('spruce', start, end)
+    );
+
+    await waitFor(() =>
+      expect(result.current.roomScheduleState.status).toBe('error')
+    );
+    const state = result.current.roomScheduleState;
+    if (state.status !== 'error') throw new Error('expected error');
+    expect(state.error).toBe('boom');
+  });
+});

--- a/libs/react/rooms/src/lib/useRoomScheduleRange.ts
+++ b/libs/react/rooms/src/lib/useRoomScheduleRange.ts
@@ -1,0 +1,80 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { httpsCallable } from 'firebase/functions';
+import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
+import type { RequestState, Room, RoomBusyWindow } from '@maple/ts/domain';
+import type {
+  GetRoomScheduleRequest,
+  GetRoomScheduleResponse,
+} from '@maple/ts/firebase/api-types';
+
+/**
+ * Fetch a room's busy windows across an arbitrary date range.
+ *
+ * Powers the upcoming-schedule agenda (now → several weeks out). Unlike
+ * `useRoomScheduleForDate` (one calendar day) and `useRoomSchedule` (rest of
+ * today), this queries any span. Windows are re-hydrated to Date objects and
+ * sorted by start time.
+ *
+ * Refetch is bucketed on the calendar day of `start` and `end` so a `start`
+ * derived from `new Date()` doesn't re-trigger on every render as the clock
+ * ticks — change the horizon (the `end` day) to fetch a wider range.
+ */
+export function useRoomScheduleRange(room: Room, start: Date, end: Date) {
+  const [roomScheduleState, setRoomScheduleState] = useState<
+    RequestState<RoomBusyWindow[]>
+  >({ status: 'idle' });
+
+  const dayKey = (d: Date) => `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+  const startKey = dayKey(start);
+  const endKey = dayKey(end);
+
+  const fetchRoomSchedule = useCallback(async () => {
+    setRoomScheduleState({ status: 'loading' });
+
+    try {
+      const functions = getMapleFunctions();
+      const getRoomSchedule = httpsCallable<
+        GetRoomScheduleRequest,
+        GetRoomScheduleResponse
+      >(functions, 'getRoomSchedule');
+
+      const result = await getRoomSchedule({
+        room,
+        start: start.toISOString(),
+        end: end.toISOString(),
+      });
+
+      const windows: RoomBusyWindow[] = result.data.windows
+        .map((w) => ({
+          eventId: w.eventId,
+          title: w.title,
+          type: w.type,
+          sourceRef: w.sourceRef,
+          start: new Date(w.start),
+          end: new Date(w.end),
+        }))
+        .sort((a, b) => a.start.getTime() - b.start.getTime());
+
+      setRoomScheduleState({ status: 'success', data: windows });
+    } catch (error) {
+      console.error('Failed to fetch room schedule:', error);
+      setRoomScheduleState({
+        status: 'error',
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to fetch room schedule',
+      });
+    }
+    // startKey/endKey stand in for the Date objects; room is primitive.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [room, startKey, endKey]);
+
+  useEffect(() => {
+    fetchRoomSchedule();
+  }, [fetchRoomSchedule]);
+
+  return { roomScheduleState, refetch: fetchRoomSchedule };
+}

--- a/libs/ts/domain/src/lib/room.spec.ts
+++ b/libs/ts/domain/src/lib/room.spec.ts
@@ -4,6 +4,7 @@ import {
   getRoomLabel,
   getRoomConflicts,
   getDayStrip,
+  groupRoomScheduleByDay,
   type RoomBusyWindow,
 } from './room';
 
@@ -203,6 +204,100 @@ describe('getRoomConflicts', () => {
       'evt-lesson',
       'evt-mt',
     ]);
+  });
+});
+
+describe('groupRoomScheduleByDay', () => {
+  // Local-time helper so day bucketing is deterministic across runner TZ.
+  function localWin(
+    y: number,
+    mo: number,
+    d: number,
+    sh: number,
+    eh: number,
+    overrides?: Partial<RoomBusyWindow>
+  ): RoomBusyWindow {
+    return {
+      eventId: `evt-${y}-${mo}-${d}-${sh}`,
+      title: 'Music Together',
+      type: 'event',
+      sourceRef: null,
+      start: new Date(y, mo, d, sh, 0, 0, 0),
+      end: new Date(y, mo, d, eh, 0, 0, 0),
+      ...overrides,
+    };
+  }
+
+  it('returns one entry per calendar day across the range, inclusive', () => {
+    const days = groupRoomScheduleByDay(
+      [],
+      new Date(2026, 5, 26, 10, 0),
+      new Date(2026, 5, 28, 14, 0)
+    );
+    expect(days).toHaveLength(3);
+    expect(days.map((d) => d.date.getDate())).toEqual([26, 27, 28]);
+    // Each day starts at local midnight.
+    expect(days[0].date.getHours()).toBe(0);
+  });
+
+  it('leaves days with no bookings empty (open all day)', () => {
+    const days = groupRoomScheduleByDay(
+      [localWin(2026, 5, 26, 16, 17)],
+      new Date(2026, 5, 26, 0, 0),
+      new Date(2026, 5, 27, 0, 0)
+    );
+    expect(days[0].windows).toHaveLength(1);
+    expect(days[1].windows).toHaveLength(0);
+  });
+
+  it('assigns each window to its day and sorts within a day by start', () => {
+    const days = groupRoomScheduleByDay(
+      [
+        localWin(2026, 5, 26, 18, 19, { title: 'Late' }),
+        localWin(2026, 5, 26, 16, 17, { title: 'Early' }),
+        localWin(2026, 5, 27, 10, 11, { title: 'NextDay' }),
+      ],
+      new Date(2026, 5, 26, 0, 0),
+      new Date(2026, 5, 27, 0, 0)
+    );
+    expect(days[0].windows.map((w) => w.title)).toEqual(['Early', 'Late']);
+    expect(days[1].windows.map((w) => w.title)).toEqual(['NextDay']);
+  });
+
+  it('lists a window that spans midnight under both days', () => {
+    const spanning: RoomBusyWindow = {
+      eventId: 'overnight',
+      title: 'Overnight',
+      type: 'event',
+      sourceRef: null,
+      start: new Date(2026, 5, 26, 23, 0),
+      end: new Date(2026, 5, 27, 1, 0),
+    };
+    const days = groupRoomScheduleByDay(
+      [spanning],
+      new Date(2026, 5, 26, 0, 0),
+      new Date(2026, 5, 27, 0, 0)
+    );
+    expect(days[0].windows).toHaveLength(1);
+    expect(days[1].windows).toHaveLength(1);
+  });
+
+  it('excludes a window that ends exactly at the next midnight from that next day', () => {
+    const upToMidnight: RoomBusyWindow = {
+      eventId: 'till-midnight',
+      title: 'Closes out the day',
+      type: 'event',
+      sourceRef: null,
+      start: new Date(2026, 5, 26, 22, 0),
+      end: new Date(2026, 5, 27, 0, 0),
+    };
+    const days = groupRoomScheduleByDay(
+      [upToMidnight],
+      new Date(2026, 5, 26, 0, 0),
+      new Date(2026, 5, 27, 0, 0)
+    );
+    expect(days[0].windows).toHaveLength(1);
+    expect(days[1].windows).toHaveLength(0);
   });
 });
 

--- a/libs/ts/domain/src/lib/room.ts
+++ b/libs/ts/domain/src/lib/room.ts
@@ -203,3 +203,60 @@ export function getDayStrip(
 
   return segments;
 }
+
+/**
+ * One calendar day in a room's upcoming-schedule agenda: the day (local
+ * midnight) and the busy windows that touch it, sorted by start. Days with
+ * no bookings are still included with an empty `windows` array so the
+ * agenda can render them as "Open all day".
+ */
+export interface RoomScheduleDay {
+  /** Local midnight of the day. */
+  date: Date;
+  windows: RoomBusyWindow[];
+}
+
+/**
+ * Bucket a room's busy windows into one entry per local calendar day across
+ * [rangeStart, rangeEnd] — the upcoming-schedule agenda. Every day in the
+ * range gets an entry; an empty `windows` array means the room is open all
+ * day. A window is listed under each calendar day it overlaps, so a booking
+ * that spans midnight appears on both days. Windows within a day are sorted
+ * by start time.
+ *
+ * Days are enumerated in local time from the start of `rangeStart`'s day
+ * through the start of `rangeEnd`'s day, inclusive.
+ */
+export function groupRoomScheduleByDay(
+  windows: RoomBusyWindow[],
+  rangeStart: Date,
+  rangeEnd: Date
+): RoomScheduleDay[] {
+  const days: RoomScheduleDay[] = [];
+
+  const cursor = new Date(rangeStart);
+  cursor.setHours(0, 0, 0, 0);
+  const lastDay = new Date(rangeEnd);
+  lastDay.setHours(0, 0, 0, 0);
+
+  while (cursor.getTime() <= lastDay.getTime()) {
+    const dayStart = new Date(cursor);
+    const dayEnd = new Date(cursor);
+    dayEnd.setHours(23, 59, 59, 999);
+
+    const dayWindows = windows
+      .filter(
+        (w) =>
+          // Half-open overlap with the day: a window that ends exactly at
+          // midnight belongs to the previous day, not this one.
+          w.start.getTime() <= dayEnd.getTime() &&
+          w.end.getTime() > dayStart.getTime()
+      )
+      .sort((a, b) => a.start.getTime() - b.start.getTime());
+
+    days.push({ date: new Date(dayStart), windows: dayWindows });
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  return days;
+}


### PR DESCRIPTION
Closes #504. Part of #467 (Epic: Spruce Room availability & booking).

## Why

The portal could tell you if the Spruce Room was free *right now* (dashboard widget) and warned about conflicts inline when scheduling — but there was **no way to see all upcoming usage** so David/Katie/Nathan could plan when to use the room. The epic deliberately deferred the "check the calendar" view ("Add later only if missed"). It's been missed, so this adds it.

## What

A read-only **agenda view** at `/room-schedule` (under the **Calendar** nav group, plus a "View schedule" link on the dashboard room widget): every upcoming Spruce Room booking — lessons, classes, ad hoc bookings — grouped by day so you can see the gaps.

- **Horizon selector**: next 2 / 4 / 8 weeks.
- **Per booking**: time range, title, and a type chip (Lesson / Class / Booking / Jam / Hours).
- **Free days**: consecutive open days collapse into one "Open" range so a mostly-empty horizon isn't a wall of "Open all day" rows.
- **Today / Tomorrow** prefixes on day headings; a "Book the room" CTA into the existing booking form.

## Scope / risk

Pure **additive UI** on the existing `getRoomSchedule` admin callable (same data powering the widget and conflict warnings). **No backend changes, no new Cloud Function, no new Firestore index** — it just queries a wider date range than the existing per-day hook.

## Changes

- `groupRoomScheduleByDay(windows, rangeStart, rangeEnd)` domain helper (`libs/ts/domain/room.ts`) — one bucket per local calendar day; multi-day windows listed under each day they touch; empty days kept for "Open all day". Unit-tested (range inclusivity, open days, sort, midnight-spanning, half-open boundary).
- `useRoomScheduleRange(room, start, end)` hook (`libs/react/rooms`) — generalizes `useRoomScheduleForDate` to an arbitrary span; refetch bucketed on the start/end calendar day. Tested (success + error).
- `RoomScheduleAgenda` (connected) + `RoomScheduleAgendaList` (presentational) components (`libs/react/rooms`). Presentational list is unit-tested (rows, Today prefix, open-day collapsing, type chips).
- `/room-schedule` page + nav item; `scheduleHref` action on `RoomStatusCard`.

## Testing

- `vitest run libs/react/rooms libs/ts/domain/src/lib/room.spec.ts` → 5 files, 42 tests pass
- `nx typecheck maple-spruce` → pass
- `nx lint` (react-rooms, react-events, domain) + eslint on app files → 0 errors (only pre-existing style warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)