### PR TITLE
feat(craft-club): Phase 2 — Square plan, signup widget, subscribe flow (#506)

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -45,3 +45,8 @@ META_PIXEL_ID=1625932185289127
 GA4_BASE_URL=https://www.google-analytics.com
 META_CAPI_BASE_URL=https://graph.facebook.com
 META_CAPI_API_VERSION=v20.0
+
+# Craft Club subscription plan variation ID (Square Catalog).
+# Placeholder until `npx tsx tools/create-craft-club-plan.ts` is run against sandbox;
+# paste the printed variation ID here. The mock Square server ignores the value in tests.
+CRAFT_CLUB_PLAN_VARIATION_ID=SANDBOX_PLACEHOLDER_RUN_create-craft-club-plan

--- a/.env.prod
+++ b/.env.prod
@@ -39,3 +39,7 @@ META_PIXEL_ID=1625932185289127
 GA4_BASE_URL=https://www.google-analytics.com
 META_CAPI_BASE_URL=https://graph.facebook.com
 META_CAPI_API_VERSION=v20.0
+
+# Craft Club subscription plan variation ID (Square Catalog).
+# Fill at go-live: run `npx tsx tools/create-craft-club-plan.ts --prod` and paste the printed variation ID.
+CRAFT_CLUB_PLAN_VARIATION_ID=PROD_PLACEHOLDER_RUN_create-craft-club-plan

--- a/apps/functions-integration-tests-square/src/create-craft-club-subscription.spec.ts
+++ b/apps/functions-integration-tests-square/src/create-craft-club-subscription.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * Integration tests for createCraftClubSubscription Cloud Function.
+ *
+ * Runs in the Firebase emulator against real Firestore; Square customer/card/
+ * subscription calls are intercepted by the mock server via SQUARE_BASE_URL.
+ * Exercises the approved-only gate and the customer → card → subscription →
+ * member-state-mirror flow.
+ */
+import {
+  clearAuthEmulator,
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  callFunction,
+} from '@maple/firebase/integration-test-utils';
+import type {
+  CreateCraftClubSubscriptionRequest,
+  CreateCraftClubSubscriptionResponse,
+} from '@maple/ts/firebase/api-types';
+
+const APPROVED_EMAIL = 'approved-member@test.com';
+const ACTIVE_EMAIL = 'active-member@test.com';
+
+function memberDoc(overrides: Record<string, unknown>) {
+  return {
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('createCraftClubSubscription', () => {
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+
+    await setFirestoreDoc(
+      'craftClubMembers',
+      'approved-1',
+      memberDoc({ email: APPROVED_EMAIL, status: 'approved' })
+    );
+    await setFirestoreDoc(
+      'craftClubMembers',
+      'active-1',
+      memberDoc({
+        email: ACTIVE_EMAIL,
+        status: 'active',
+        squareSubscriptionId: 'existing-sub',
+      })
+    );
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  it('subscribes an approved member and mirrors Square state', async () => {
+    const result = await callFunction<
+      CreateCraftClubSubscriptionRequest,
+      CreateCraftClubSubscriptionResponse
+    >({
+      functionName: 'createCraftClubSubscription',
+      data: {
+        email: APPROVED_EMAIL,
+        name: 'Approved Member',
+        paymentNonce: 'cnon:card-nonce-ok',
+      },
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data?.member.status).toBe('active');
+    expect(result.data?.member.squareSubscriptionId).toBeDefined();
+    expect(result.data?.member.squareCustomerId).toBeDefined();
+    expect(result.data?.member.squareCardId).toBeDefined();
+    expect(result.data?.cardLast4).toBe('1111');
+  });
+
+  it('rejects an email that is not on the approved list', async () => {
+    const result = await callFunction<
+      CreateCraftClubSubscriptionRequest,
+      CreateCraftClubSubscriptionResponse
+    >({
+      functionName: 'createCraftClubSubscription',
+      data: {
+        email: 'stranger@test.com',
+        name: 'Stranger',
+        paymentNonce: 'cnon:card-nonce-ok',
+      },
+    });
+
+    expect(result.status).not.toBe(200);
+  });
+
+  it('rejects a member who is already active', async () => {
+    const result = await callFunction<
+      CreateCraftClubSubscriptionRequest,
+      CreateCraftClubSubscriptionResponse
+    >({
+      functionName: 'createCraftClubSubscription',
+      data: {
+        email: ACTIVE_EMAIL,
+        name: 'Active Member',
+        paymentNonce: 'cnon:card-nonce-ok',
+      },
+    });
+
+    expect(result.status).not.toBe(200);
+  });
+
+  it('rejects invalid input', async () => {
+    const result = await callFunction<
+      CreateCraftClubSubscriptionRequest,
+      CreateCraftClubSubscriptionResponse
+    >({
+      functionName: 'createCraftClubSubscription',
+      data: {
+        email: 'not-an-email',
+        name: 'X',
+        paymentNonce: 'cnon:card-nonce-ok',
+      },
+    });
+
+    expect(result.status).not.toBe(200);
+  });
+});

--- a/apps/functions-square/src/index.ts
+++ b/apps/functions-square/src/index.ts
@@ -41,3 +41,6 @@ export { importEtsyListings } from '@maple/firebase/maple-functions/import-etsy-
 
 // Cross-channel inventory sync (Square)
 export { syncInventoryToSquare } from '@maple/firebase/maple-functions/sync-inventory-to-square';
+
+// Craft Club subscription signup (public; Square customer + card + subscription)
+export { createCraftClubSubscription } from '@maple/firebase/maple-functions/create-craft-club-subscription';

--- a/apps/functions-square/tsconfig.app.json
+++ b/apps/functions-square/tsconfig.app.json
@@ -18,6 +18,7 @@
     "../../libs/firebase/maple-functions/sync-invoice-to-square/**/*.ts",
     "../../libs/firebase/maple-functions/import-etsy-listings/**/*.ts",
     "../../libs/firebase/maple-functions/sync-inventory-to-square/**/*.ts",
+    "../../libs/firebase/maple-functions/create-craft-club-subscription/**/*.ts",
     "../../libs/firebase/database/src/**/*.ts",
     "../../libs/firebase/functions/src/**/*.ts",
     "../../libs/firebase/square/src/**/*.ts",

--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -209,7 +209,10 @@ export { revokeAdminRole } from '@maple/firebase/maple-functions/revoke-admin-ro
 export { tallyLeadWebhook } from '@maple/firebase/maple-functions/tally-lead-webhook';
 
 // Craft Club — admin approval & management (no Square dep; subscribe/lifecycle
-// functions live in the maple-square codebase and arrive in later phases)
+// functions live in the maple-square codebase)
 export { getCraftClubMembers } from '@maple/firebase/maple-functions/get-craft-club-members';
 export { approveCraftClubMember } from '@maple/firebase/maple-functions/approve-craft-club-member';
 export { updateCraftClubMember } from '@maple/firebase/maple-functions/update-craft-club-member';
+// Craft Club — public signup-gate endpoints (no Square dep)
+export { checkCraftClubEligibility } from '@maple/firebase/maple-functions/check-craft-club-eligibility';
+export { requestCraftClubAccess } from '@maple/firebase/maple-functions/request-craft-club-access';

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -117,6 +117,8 @@
     "../../libs/firebase/maple-functions/get-craft-club-members/**/*.ts",
     "../../libs/firebase/maple-functions/approve-craft-club-member/**/*.ts",
     "../../libs/firebase/maple-functions/update-craft-club-member/**/*.ts",
+    "../../libs/firebase/maple-functions/check-craft-club-eligibility/**/*.ts",
+    "../../libs/firebase/maple-functions/request-craft-club-access/**/*.ts",
     "../../libs/firebase/database/src/**/*.ts",
     "../../libs/firebase/functions/src/**/*.ts",
     "../../libs/ts/domain/src/**/*.ts",

--- a/apps/webflow-components/src/CraftClubSignupWidget.spec.tsx
+++ b/apps/webflow-components/src/CraftClubSignupWidget.spec.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useEffect } from 'react';
+
+// Canned eligibility response for the next checkCraftClubEligibility call.
+let nextEligibility: { status: string; alreadyMember: boolean } = {
+  status: 'unknown',
+  alreadyMember: false,
+};
+// Records the last payload sent to each callable, by name.
+const calls: Record<string, unknown> = {};
+
+vi.mock('./firebase-init', () => ({
+  getWidgetFunctions: () => ({ __mock: true }),
+}));
+
+vi.mock('./lib/warmup', () => ({ warmup: vi.fn() }));
+
+vi.mock('firebase/functions', () => ({
+  httpsCallable:
+    (_fns: unknown, name: string) => (payload: unknown) => {
+      calls[name] = payload;
+      if (name === 'checkCraftClubEligibility') {
+        return Promise.resolve({ data: nextEligibility });
+      }
+      if (name === 'createCraftClubSubscription') {
+        return Promise.resolve({
+          data: { member: { id: 'm1' }, cardLast4: '1111' },
+        });
+      }
+      if (name === 'requestCraftClubAccess') {
+        return Promise.resolve({ data: { status: 'requested' } });
+      }
+      return Promise.resolve({ data: {} });
+    },
+}));
+
+// Stub the Square card form: immediately ready, with a fake tokenizer, and
+// render the submit button passed via afterCardContent.
+vi.mock('@maple/react/registrations', () => ({
+  SquareCardForm: ({
+    onReady,
+    onTokenizeRef,
+    afterCardContent,
+  }: {
+    onReady?: () => void;
+    onTokenizeRef: (fn: () => Promise<string>) => void;
+    afterCardContent?: React.ReactNode;
+  }) => {
+    useEffect(() => {
+      onTokenizeRef(async () => 'cnon:test-nonce');
+      onReady?.();
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return <div data-testid="mock-card-form">{afterCardContent}</div>;
+  },
+}));
+
+import { CraftClubSignupWidget } from './CraftClubSignupWidget';
+
+function renderWidget() {
+  return render(
+    <CraftClubSignupWidget
+      squareAppId="sandbox-app"
+      squareLocationId="LOC1"
+      env="dev"
+      manageUrl="https://example.com/manage"
+    />
+  );
+}
+
+async function enterEmailAndContinue(email: string) {
+  const user = userEvent.setup();
+  await user.type(screen.getByLabelText(/Email/i), email);
+  await user.click(screen.getByRole('button', { name: /Continue/i }));
+  return user;
+}
+
+describe('CraftClubSignupWidget', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(calls)) delete calls[k];
+  });
+  afterEach(() => cleanup());
+
+  it('shows the request-access form for an unknown email and submits it', async () => {
+    nextEligibility = { status: 'unknown', alreadyMember: false };
+    const user = await renderAndContinue('nobody@example.com');
+
+    expect(
+      await screen.findByText(/isn't on the approved list/i)
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: /Request access/i })
+    );
+
+    expect(
+      await screen.findByText(/pending approval/i)
+    ).toBeInTheDocument();
+    expect(calls['requestCraftClubAccess']).toMatchObject({
+      email: 'nobody@example.com',
+    });
+  });
+
+  it('lets an approved member subscribe', async () => {
+    nextEligibility = { status: 'approved', alreadyMember: false };
+    const user = await renderAndContinue('approved@example.com');
+
+    // Name is required before the subscribe button enables.
+    await user.type(screen.getByLabelText(/Full name/i), 'Ada Lovelace');
+
+    const subscribeBtn = await screen.findByRole('button', {
+      name: /Subscribe/i,
+    });
+    await waitFor(() => expect(subscribeBtn).toBeEnabled());
+    await user.click(subscribeBtn);
+
+    expect(await screen.findByText(/You're in!/i)).toBeInTheDocument();
+    expect(calls['createCraftClubSubscription']).toMatchObject({
+      email: 'approved@example.com',
+      name: 'Ada Lovelace',
+      paymentNonce: 'cnon:test-nonce',
+    });
+  });
+
+  it('points an existing member to the manage page', async () => {
+    nextEligibility = { status: 'active', alreadyMember: true };
+    await renderAndContinue('member@example.com');
+
+    expect(
+      await screen.findByText(/already have an active Craft Club/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /Manage your membership/i })
+    ).toHaveAttribute('href', 'https://example.com/manage');
+  });
+});
+
+async function renderAndContinue(email: string) {
+  renderWidget();
+  return enterEmailAndContinue(email);
+}

--- a/apps/webflow-components/src/CraftClubSignupWidget.tsx
+++ b/apps/webflow-components/src/CraftClubSignupWidget.tsx
@@ -1,0 +1,320 @@
+/**
+ * Craft Club Signup Widget — self-contained membership signup component.
+ *
+ * Designed for embedding in Webflow via Code Components. Drives the
+ * approved-only signup flow:
+ *   enter email → checkCraftClubEligibility →
+ *     • approved  → collect name + card → createCraftClubSubscription
+ *     • active    → "you're already a member" + manage link
+ *     • requested → "your request is pending approval"
+ *     • unknown   → request-access form → requestCraftClubAccess
+ *
+ * No Next.js dependencies — Firebase is initialized explicitly from the `env`
+ * prop (see firebase-init.ts).
+ */
+import { useState, useMemo, useRef, useCallback } from 'react';
+import {
+  Box,
+  Typography,
+  CircularProgress,
+  Alert,
+  Button,
+  TextField,
+  Stack,
+  Link,
+  ThemeProvider,
+} from '@mui/material';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import { httpsCallable } from 'firebase/functions';
+import { theme } from '@maple/react/theme';
+import { SquareCardForm } from '@maple/react/registrations';
+import { CRAFT_CLUB_MONTHLY_PRICE_CENTS } from '@maple/ts/domain';
+import type {
+  CheckCraftClubEligibilityRequest,
+  CheckCraftClubEligibilityResponse,
+  CreateCraftClubSubscriptionRequest,
+  CreateCraftClubSubscriptionResponse,
+  RequestCraftClubAccessRequest,
+  RequestCraftClubAccessResponse,
+} from '@maple/ts/firebase/api-types';
+import { getWidgetFunctions } from './firebase-init';
+import { warmup } from './lib/warmup';
+
+type Step =
+  | 'enterEmail'
+  | 'approved' // collect name + card
+  | 'active' // already a member
+  | 'requested' // pending approval (pre-existing or just submitted)
+  | 'unknown' // offer request-access form
+  | 'success'; // subscribed
+
+export interface CraftClubSignupWidgetProps {
+  /** Square application ID (sandbox or production). */
+  squareAppId: string;
+  /** Square location ID. */
+  squareLocationId: string;
+  /** 'dev' | 'prod' | 'emulator' — selects Firebase project + Square SDK. */
+  env: string;
+  /** URL of the public "manage my membership" page (for existing members). */
+  manageUrl: string;
+}
+
+const MONTHLY_PRICE = (CRAFT_CLUB_MONTHLY_PRICE_CENTS / 100).toFixed(2);
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function CraftClubSignupWidget({
+  squareAppId,
+  squareLocationId,
+  env,
+  manageUrl,
+}: CraftClubSignupWidgetProps) {
+  const functions = useMemo(() => getWidgetFunctions(env), [env]);
+
+  const [step, setStep] = useState<Step>('enterEmail');
+  const [email, setEmail] = useState('');
+  const [name, setName] = useState('');
+  const [phone, setPhone] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [cardReady, setCardReady] = useState(false);
+  const tokenizeRef = useRef<(() => Promise<string>) | null>(null);
+
+  const emailValid = EMAIL_RE.test(email.trim());
+
+  const handleCheckEmail = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      setError(null);
+      setBusy(true);
+      try {
+        const call = httpsCallable<
+          CheckCraftClubEligibilityRequest,
+          CheckCraftClubEligibilityResponse
+        >(functions, 'checkCraftClubEligibility');
+        const res = await call({ email: email.trim() });
+        // Warm the subscribe function — the user is about to need it.
+        if (res.data.status === 'approved') {
+          warmup(functions, 'createCraftClubSubscription');
+        }
+        setStep(res.data.status);
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : 'Something went wrong.'
+        );
+      } finally {
+        setBusy(false);
+      }
+    },
+    [functions, email]
+  );
+
+  const handlePay = useCallback(async () => {
+    if (!tokenizeRef.current) return;
+    setError(null);
+    setBusy(true);
+    try {
+      const nonce = await tokenizeRef.current();
+      const call = httpsCallable<
+        CreateCraftClubSubscriptionRequest,
+        CreateCraftClubSubscriptionResponse
+      >(functions, 'createCraftClubSubscription');
+      await call({
+        email: email.trim(),
+        name: name.trim(),
+        phone: phone.trim() || undefined,
+        paymentNonce: nonce,
+      });
+      setStep('success');
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'We could not start your membership. Please try again.'
+      );
+    } finally {
+      setBusy(false);
+    }
+  }, [functions, email, name, phone]);
+
+  const handleRequestAccess = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      setError(null);
+      setBusy(true);
+      try {
+        const call = httpsCallable<
+          RequestCraftClubAccessRequest,
+          RequestCraftClubAccessResponse
+        >(functions, 'requestCraftClubAccess');
+        await call({
+          email: email.trim(),
+          name: name.trim() || undefined,
+          phone: phone.trim() || undefined,
+        });
+        setStep('requested');
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : 'Something went wrong.'
+        );
+      } finally {
+        setBusy(false);
+      }
+    },
+    [functions, email, name, phone]
+  );
+
+  return (
+    <ThemeProvider theme={theme}>
+      <Box sx={{ maxWidth: 480, mx: 'auto' }}>
+        <Typography variant="h5" component="h2" gutterBottom>
+          Join the Craft Club
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+          ${MONTHLY_PRICE}/month for studio access during Craft Club hours.
+          Materials are billed separately at checkout. Cancel anytime.
+        </Typography>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        {/* Step 1 — enter email */}
+        {step === 'enterEmail' && (
+          <Box component="form" onSubmit={handleCheckEmail}>
+            <Stack spacing={2}>
+              <TextField
+                label="Email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                fullWidth
+                autoFocus
+              />
+              <Button
+                type="submit"
+                variant="contained"
+                disabled={busy || !emailValid}
+              >
+                {busy ? 'Checking…' : 'Continue'}
+              </Button>
+            </Stack>
+          </Box>
+        )}
+
+        {/* Step 2a — approved: collect name + card, then pay */}
+        {step === 'approved' && (
+          <Stack spacing={2}>
+            <Alert severity="success">
+              You&apos;re approved! Set up your ${MONTHLY_PRICE}/month
+              membership below.
+            </Alert>
+            <TextField
+              label="Full name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              fullWidth
+            />
+            <TextField
+              label="Phone (optional)"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              fullWidth
+            />
+            <SquareCardForm
+              applicationId={squareAppId}
+              locationId={squareLocationId}
+              env={env}
+              totalCents={CRAFT_CLUB_MONTHLY_PRICE_CENTS}
+              onReady={() => setCardReady(true)}
+              onTokenizeRef={(fn) => {
+                tokenizeRef.current = fn;
+              }}
+              afterCardContent={
+                <Button
+                  variant="contained"
+                  fullWidth
+                  disabled={busy || !cardReady || !name.trim()}
+                  onClick={handlePay}
+                >
+                  {busy
+                    ? 'Starting membership…'
+                    : `Subscribe — $${MONTHLY_PRICE}/month`}
+                </Button>
+              }
+            />
+          </Stack>
+        )}
+
+        {/* Step 2b — already an active member */}
+        {step === 'active' && (
+          <Alert severity="info">
+            You already have an active Craft Club membership.{' '}
+            <Link href={manageUrl}>Manage your membership</Link>.
+          </Alert>
+        )}
+
+        {/* Step 2c — request already pending */}
+        {step === 'requested' && (
+          <Alert severity="info">
+            Thanks! Your request is pending approval — we&apos;ll email you
+            when you&apos;re approved to join.
+          </Alert>
+        )}
+
+        {/* Step 2d — unknown email: offer to request access */}
+        {step === 'unknown' && (
+          <Box component="form" onSubmit={handleRequestAccess}>
+            <Stack spacing={2}>
+              <Alert severity="info">
+                This email isn&apos;t on the approved list yet. Request access
+                and we&apos;ll be in touch.
+              </Alert>
+              <TextField
+                label="Full name (optional)"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                fullWidth
+              />
+              <TextField
+                label="Phone (optional)"
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+                fullWidth
+              />
+              <Button type="submit" variant="contained" disabled={busy}>
+                {busy ? 'Submitting…' : 'Request access'}
+              </Button>
+            </Stack>
+          </Box>
+        )}
+
+        {/* Step 3 — subscribed */}
+        {step === 'success' && (
+          <Stack spacing={1} alignItems="center" sx={{ py: 2 }}>
+            <CheckCircleOutlineIcon color="success" sx={{ fontSize: 48 }} />
+            <Typography variant="h6">You&apos;re in!</Typography>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              align="center"
+            >
+              Your ${MONTHLY_PRICE}/month Craft Club membership is active.
+              You can manage or cancel it anytime at{' '}
+              <Link href={manageUrl}>your membership page</Link>.
+            </Typography>
+          </Stack>
+        )}
+
+        {busy && step === 'enterEmail' && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
+            <CircularProgress size={20} />
+          </Box>
+        )}
+      </Box>
+    </ThemeProvider>
+  );
+}

--- a/apps/webflow-components/src/craft-club-signup.webflow.tsx
+++ b/apps/webflow-components/src/craft-club-signup.webflow.tsx
@@ -1,0 +1,37 @@
+/**
+ * Webflow Code Component: Craft Club Signup
+ *
+ * Wraps the CraftClubSignupWidget for use in the Webflow Designer.
+ * Place this on a private/linked page (or behind a QR code); the approval gate
+ * is enforced server-side regardless of where the component is embedded.
+ */
+import { declareComponent } from '@webflow/react';
+import { props } from '@webflow/data-types';
+import { emotionShadowDomDecorator } from '@webflow/emotion-utils';
+import { CraftClubSignupWidget } from './CraftClubSignupWidget';
+
+export default declareComponent(CraftClubSignupWidget, {
+  name: 'Craft Club Signup',
+  description:
+    'Approved-only Craft Club membership signup with Square recurring payment. Enter email → eligibility → subscribe ($30/mo) or request access.',
+  decorators: [emotionShadowDomDecorator],
+  props: {
+    squareAppId: props.Text({
+      name: 'Square App ID',
+      defaultValue: '',
+    }),
+    squareLocationId: props.Text({
+      name: 'Square Location ID',
+      defaultValue: '',
+    }),
+    env: props.Variant({
+      name: 'Environment',
+      options: ['dev', 'prod'],
+      defaultValue: 'prod',
+    }),
+    manageUrl: props.Text({
+      name: 'Manage Membership URL',
+      defaultValue: 'https://mapleandsprucewv.com/craft-club/manage',
+    }),
+  },
+});

--- a/docs/reference/deployed-functions.md
+++ b/docs/reference/deployed-functions.md
@@ -102,7 +102,9 @@ Core CRUD operations, auth, triggers, and admin functions. No heavy third-party 
 - `getCraftClubMembers` _(admin)_ — lists members, optional status filter
 - `approveCraftClubMember` _(admin)_ — pre-approves an email (upsert by email; promotes a `requested` record to `approved`)
 - `updateCraftClubMember` _(admin)_ — edits a member's notes/contact/status (e.g. revoke approval)
-- _Public signup + subscribe, magic-link self-service, and subscription lifecycle webhooks land in later phases (maple-square codebase)._
+- `checkCraftClubEligibility` _(public)_ — signup-gate lookup: `approved` / `active` / `requested` / `unknown`
+- `requestCraftClubAccess` _(public)_ — captures a non-approved email as a pending request (idempotent by email)
+- _Subscribe (Square) lives in the `maple-square` codebase; magic-link self-service + subscription webhooks land in later phases._
 
 ---
 
@@ -139,6 +141,9 @@ Square SDK integration for payments, catalog management, and sync conflict resol
 
 ### Cross-Channel Inventory Sync
 - `syncInventoryToSquare` — pushes current Firestore product quantities to Square via physical count adjustments
+
+### Craft Club subscription (Square)
+- `createCraftClubSubscription` _(public)_ — re-checks the approval gate server-side, then upserts the Square customer, stores the card on file from the Web Payments nonce, enrolls it in the $30/mo subscription plan, and mirrors the result onto the member record
 
 ---
 

--- a/docs/reference/implementation-status.md
+++ b/docs/reference/implementation-status.md
@@ -447,8 +447,8 @@ magic-link self-service management. Delivered in phases.
 
 | Phase | Scope | Status |
 |-------|-------|--------|
-| 1 | Data model + repository + Vest validation + admin approve/list UI (`/craft-club`) + `getCraftClubMembers` / `approveCraftClubMember` / `updateCraftClubMember` | **In Progress** |
-| 2 | Square $30/mo plan + signup Webflow widget + `checkCraftClubEligibility` / `createCraftClubSubscription` / `requestCraftClubAccess` | Not Started |
+| 1 | Data model + repository + Vest validation + admin approve/list UI (`/craft-club`) + `getCraftClubMembers` / `approveCraftClubMember` / `updateCraftClubMember` | **Complete (PR #507)** |
+| 2 | Square $30/mo plan (`tools/create-craft-club-plan.ts`) + cards/subscriptions/customers services + signup Webflow widget + `checkCraftClubEligibility` / `createCraftClubSubscription` / `requestCraftClubAccess` (unit + interaction + integration tests) | **In Progress** |
 | 3 | Magic-link self-service: request link → session → cancel / change payment method | Not Started |
 | 4 | Square subscription webhooks + admin pause/resume/cancel + welcome/cancel emails | Not Started |
 

--- a/function-codebases.json
+++ b/function-codebases.json
@@ -36,7 +36,8 @@
     "firebase-maple-functions-update-etsy-listing": "maple-sync",
     "firebase-maple-functions-poll-etsy-orders": "maple-sync",
     "firebase-maple-functions-sync-inventory-to-etsy": "maple-sync",
-    "firebase-maple-functions-sync-inventory-to-square": "maple-square"
+    "firebase-maple-functions-sync-inventory-to-square": "maple-square",
+    "firebase-maple-functions-create-craft-club-subscription": "maple-square"
   },
   "defaultCodebase": "maple-core"
 }

--- a/libs/firebase/maple-functions/check-craft-club-eligibility/project.json
+++ b/libs/firebase/maple-functions/check-craft-club-eligibility/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-check-craft-club-eligibility",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/check-craft-club-eligibility/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/check-craft-club-eligibility/src/index.ts
+++ b/libs/firebase/maple-functions/check-craft-club-eligibility/src/index.ts
@@ -1,0 +1,1 @@
+export { checkCraftClubEligibility } from './lib/check-craft-club-eligibility';

--- a/libs/firebase/maple-functions/check-craft-club-eligibility/src/lib/check-craft-club-eligibility.spec.ts
+++ b/libs/firebase/maple-functions/check-craft-club-eligibility/src/lib/check-craft-club-eligibility.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findByEmail: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/functions', () => ({
+  createPublicFunction: <TReq, TRes>(
+    handler: (data: TReq) => Promise<TRes>
+  ) => handler,
+  throwInvalidArgument: (msg: string) => {
+    throw new Error(msg);
+  },
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  CraftClubMemberRepository: { findByEmail: mocks.findByEmail },
+}));
+
+import { checkCraftClubEligibility } from './check-craft-club-eligibility';
+
+type Handler = (data: unknown) => Promise<{ status: string; alreadyMember: boolean }>;
+const handler = checkCraftClubEligibility as unknown as Handler;
+
+describe('checkCraftClubEligibility', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns unknown for an email not on file', async () => {
+    mocks.findByEmail.mockResolvedValue(undefined);
+    const r = await handler({ email: 'nobody@example.com' });
+    expect(r).toEqual({ status: 'unknown', alreadyMember: false });
+  });
+
+  it('returns approved for an approved member', async () => {
+    mocks.findByEmail.mockResolvedValue({ status: 'approved' });
+    expect(await handler({ email: 'a@b.com' })).toEqual({
+      status: 'approved',
+      alreadyMember: false,
+    });
+  });
+
+  it('treats a cancelled member as re-subscribable (approved)', async () => {
+    mocks.findByEmail.mockResolvedValue({ status: 'cancelled' });
+    expect((await handler({ email: 'a@b.com' })).status).toBe('approved');
+  });
+
+  it('flags an active member as alreadyMember', async () => {
+    mocks.findByEmail.mockResolvedValue({ status: 'active' });
+    expect(await handler({ email: 'a@b.com' })).toEqual({
+      status: 'active',
+      alreadyMember: true,
+    });
+  });
+
+  it('reports requested members as requested', async () => {
+    mocks.findByEmail.mockResolvedValue({ status: 'requested' });
+    expect((await handler({ email: 'a@b.com' })).status).toBe('requested');
+  });
+
+  it('rejects a missing email', async () => {
+    await expect(handler({})).rejects.toThrow(/Email is required/);
+  });
+});

--- a/libs/firebase/maple-functions/check-craft-club-eligibility/src/lib/check-craft-club-eligibility.ts
+++ b/libs/firebase/maple-functions/check-craft-club-eligibility/src/lib/check-craft-club-eligibility.ts
@@ -1,0 +1,49 @@
+/**
+ * Check Craft Club Eligibility Cloud Function (public)
+ *
+ * Signup-gate lookup for the Webflow widget: given an email, returns a coarse
+ * status so the widget can branch to the payment form (approved), a "you're
+ * already a member → manage" link (active), or a request-access form (unknown).
+ *
+ * Deployed to us-east4 via CI/CD pipeline.
+ */
+import {
+  createPublicFunction,
+  throwInvalidArgument,
+} from '@maple/firebase/functions';
+import { CraftClubMemberRepository } from '@maple/firebase/database';
+import { isCraftClubMemberActive } from '@maple/ts/domain';
+import type {
+  CheckCraftClubEligibilityRequest,
+  CheckCraftClubEligibilityResponse,
+  CraftClubEligibilityStatus,
+} from '@maple/ts/firebase/api-types';
+
+export const checkCraftClubEligibility = createPublicFunction<
+  CheckCraftClubEligibilityRequest,
+  CheckCraftClubEligibilityResponse
+>(async (data) => {
+  if (!data.email) throwInvalidArgument('Email is required');
+
+  const member = await CraftClubMemberRepository.findByEmail(data.email);
+  if (!member) {
+    return { status: 'unknown', alreadyMember: false };
+  }
+
+  const alreadyMember = isCraftClubMemberActive(member);
+
+  let status: CraftClubEligibilityStatus;
+  if (alreadyMember) {
+    status = 'active';
+  } else if (member.status === 'requested') {
+    status = 'requested';
+  } else if (member.status === 'approved' || member.status === 'cancelled') {
+    // Cancelled members were approved before and may re-subscribe.
+    status = 'approved';
+  } else {
+    // paused — admin-managed; not self-serviceable from the widget.
+    status = 'unknown';
+  }
+
+  return { status, alreadyMember };
+});

--- a/libs/firebase/maple-functions/check-craft-club-eligibility/tsconfig.json
+++ b/libs/firebase/maple-functions/check-craft-club-eligibility/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/check-craft-club-eligibility/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/check-craft-club-eligibility/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/create-craft-club-subscription/project.json
+++ b/libs/firebase/maple-functions/create-craft-club-subscription/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-create-craft-club-subscription",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/create-craft-club-subscription/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/create-craft-club-subscription/src/index.ts
+++ b/libs/firebase/maple-functions/create-craft-club-subscription/src/index.ts
@@ -1,0 +1,1 @@
+export { createCraftClubSubscription } from './lib/create-craft-club-subscription';

--- a/libs/firebase/maple-functions/create-craft-club-subscription/src/lib/create-craft-club-subscription.spec.ts
+++ b/libs/firebase/maple-functions/create-craft-club-subscription/src/lib/create-craft-club-subscription.spec.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  capturedHandler: null as
+    | ((d: unknown, c: unknown, s: unknown, st: unknown) => Promise<unknown>)
+    | null,
+  findByEmail: vi.fn(),
+  update: vi.fn(),
+  upsertByEmail: vi.fn(),
+  createCardOnFile: vi.fn(),
+  subscriptionCreate: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/functions', () => {
+  class HttpsError extends Error {
+    constructor(public code: string, message: string) {
+      super(message);
+    }
+  }
+  const endpoint = {
+    usingSecrets: vi.fn(() => endpoint),
+    usingStrings: vi.fn(() => endpoint),
+    handle: vi.fn((h: typeof mocks.capturedHandler) => {
+      mocks.capturedHandler = h;
+      return 'mock-function';
+    }),
+  };
+  return {
+    Functions: { endpoint },
+    throwInvalidArgument: (m: string) => {
+      throw new HttpsError('invalid-argument', m);
+    },
+    throwValidationError: (e: Record<string, string[]>) => {
+      throw new HttpsError('invalid-argument', `validation: ${Object.keys(e).join(',')}`);
+    },
+    throwFailedPrecondition: (m: string) => {
+      throw new HttpsError('failed-precondition', m);
+    },
+  };
+});
+
+vi.mock('@maple/firebase/square', () => ({
+  SQUARE_SECRET_NAMES: ['SQUARE_ACCESS_TOKEN'],
+  SQUARE_STRING_NAMES: ['SQUARE_ENV', 'SQUARE_LOCATION_ID', 'SALES_TAX_RATE'],
+  Square: class {
+    locationId = 'LOC1';
+    customersService = { upsertByEmail: mocks.upsertByEmail };
+    cardsService = { createCardOnFile: mocks.createCardOnFile };
+    subscriptionsService = { create: mocks.subscriptionCreate };
+  },
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  CraftClubMemberRepository: {
+    findByEmail: mocks.findByEmail,
+    update: mocks.update,
+  },
+}));
+
+import './create-craft-club-subscription';
+
+const STRINGS = {
+  CRAFT_CLUB_PLAN_VARIATION_ID: 'PLAN_VAR_1',
+  SQUARE_ENV: 'LOCAL',
+  SQUARE_LOCATION_ID: 'LOC1',
+  SALES_TAX_RATE: '6.0',
+};
+const SECRETS = { SQUARE_ACCESS_TOKEN: 'tok' };
+
+function run(data: unknown, strings: unknown = STRINGS) {
+  return mocks.capturedHandler!(data, {}, SECRETS, strings);
+}
+
+const validPayload = {
+  email: 'member@example.com',
+  name: 'Member Person',
+  paymentNonce: 'cnon:card-nonce-abcdef',
+};
+
+describe('createCraftClubSubscription', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('subscribes an approved member end to end', async () => {
+    mocks.findByEmail.mockResolvedValue({
+      id: 'm1',
+      email: 'member@example.com',
+      status: 'approved',
+    });
+    mocks.upsertByEmail.mockResolvedValue('cust-1');
+    mocks.createCardOnFile.mockResolvedValue({ cardId: 'card-1', last4: '1111' });
+    mocks.subscriptionCreate.mockResolvedValue({
+      subscriptionId: 'sub-1',
+      status: 'ACTIVE',
+      chargedThroughDate: '2026-07-26',
+    });
+    mocks.update.mockImplementation(async (input) => ({ id: 'm1', ...input }));
+
+    const result = (await run(validPayload)) as {
+      member: { status: string };
+      cardLast4?: string;
+    };
+
+    expect(mocks.upsertByEmail).toHaveBeenCalled();
+    expect(mocks.createCardOnFile).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceId: 'cnon:card-nonce-abcdef', customerId: 'cust-1' })
+    );
+    expect(mocks.subscriptionCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        planVariationId: 'PLAN_VAR_1',
+        customerId: 'cust-1',
+        cardId: 'card-1',
+      })
+    );
+    expect(mocks.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'm1',
+        status: 'active',
+        squareSubscriptionId: 'sub-1',
+        squareCardId: 'card-1',
+      })
+    );
+    expect(result.member.status).toBe('active');
+    expect(result.cardLast4).toBe('1111');
+  });
+
+  it('reuses an existing Square customer id when present', async () => {
+    mocks.findByEmail.mockResolvedValue({
+      id: 'm1',
+      email: 'member@example.com',
+      status: 'cancelled',
+      squareCustomerId: 'existing-cust',
+    });
+    mocks.createCardOnFile.mockResolvedValue({ cardId: 'card-2' });
+    mocks.subscriptionCreate.mockResolvedValue({ subscriptionId: 'sub-2' });
+    mocks.update.mockImplementation(async (i) => i);
+
+    await run(validPayload);
+
+    expect(mocks.upsertByEmail).not.toHaveBeenCalled();
+    expect(mocks.createCardOnFile).toHaveBeenCalledWith(
+      expect.objectContaining({ customerId: 'existing-cust' })
+    );
+  });
+
+  it('rejects an email that is not on the approved list (no Square calls)', async () => {
+    mocks.findByEmail.mockResolvedValue(undefined);
+    await expect(run(validPayload)).rejects.toThrow(/not approved/);
+    expect(mocks.createCardOnFile).not.toHaveBeenCalled();
+  });
+
+  it('rejects a member who is already active', async () => {
+    mocks.findByEmail.mockResolvedValue({ id: 'm1', status: 'active' });
+    await expect(run(validPayload)).rejects.toThrow(/already have an active/);
+    expect(mocks.subscriptionCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid input before any Square call', async () => {
+    await expect(
+      run({ email: 'bad', name: 'X', paymentNonce: 'n' })
+    ).rejects.toThrow(/validation/);
+    expect(mocks.findByEmail).not.toHaveBeenCalled();
+  });
+
+  it('fails clearly when the plan is not configured', async () => {
+    mocks.findByEmail.mockResolvedValue({ id: 'm1', status: 'approved' });
+    await expect(
+      run(validPayload, { ...STRINGS, CRAFT_CLUB_PLAN_VARIATION_ID: '' })
+    ).rejects.toThrow(/plan is not configured/);
+  });
+});

--- a/libs/firebase/maple-functions/create-craft-club-subscription/src/lib/create-craft-club-subscription.ts
+++ b/libs/firebase/maple-functions/create-craft-club-subscription/src/lib/create-craft-club-subscription.ts
@@ -1,0 +1,121 @@
+/**
+ * Create Craft Club Subscription Cloud Function (public, Square)
+ *
+ * The signup widget's payment step. Validates the payload, re-checks the
+ * approval gate server-side (never trusts the client), then in Square:
+ * upserts the customer → stores the card on file → enrolls the card in the
+ * $30/mo subscription plan. Finally mirrors the resulting state onto the
+ * member record.
+ *
+ * Validation runs BEFORE any Square write so invalid data never reaches the
+ * payment API and fails halfway through.
+ *
+ * Deployed to us-east4 via CI/CD pipeline.
+ */
+import {
+  Functions,
+  throwInvalidArgument,
+  throwValidationError,
+  throwFailedPrecondition,
+} from '@maple/firebase/functions';
+import { Square, SQUARE_SECRET_NAMES, SQUARE_STRING_NAMES } from '@maple/firebase/square';
+import { CraftClubMemberRepository } from '@maple/firebase/database';
+import {
+  isCraftClubMemberActive,
+  canSubscribeToCraftClub,
+} from '@maple/ts/domain';
+import { craftClubMemberValidation } from '@maple/ts/validation';
+import type {
+  CreateCraftClubSubscriptionRequest,
+  CreateCraftClubSubscriptionResponse,
+} from '@maple/ts/firebase/api-types';
+
+export const createCraftClubSubscription = Functions.endpoint
+  .usingSecrets(...SQUARE_SECRET_NAMES)
+  .usingStrings(...SQUARE_STRING_NAMES, 'CRAFT_CLUB_PLAN_VARIATION_ID')
+  .handle<
+    CreateCraftClubSubscriptionRequest,
+    CreateCraftClubSubscriptionResponse
+  >(async (data, _context, secrets, strings) => {
+    // 1. Validate input before touching Square.
+    const result = craftClubMemberValidation({
+      email: data.email,
+      name: data.name,
+      phone: data.phone,
+    });
+    if (result.hasErrors()) {
+      throwValidationError(result.getErrors());
+    }
+    if (!data.paymentNonce) {
+      throwInvalidArgument('Payment information is required');
+    }
+
+    // 2. Server-side approval gate — never trust the client's eligibility check.
+    const member = await CraftClubMemberRepository.findByEmail(data.email);
+    if (!member) {
+      throwFailedPrecondition(
+        'This email is not approved for the Craft Club.'
+      );
+    }
+    if (isCraftClubMemberActive(member)) {
+      throwFailedPrecondition(
+        'You already have an active Craft Club membership.'
+      );
+    }
+    if (!canSubscribeToCraftClub(member)) {
+      throwFailedPrecondition(
+        'This email is not approved for the Craft Club.'
+      );
+    }
+
+    const planVariationId = strings.CRAFT_CLUB_PLAN_VARIATION_ID;
+    if (!planVariationId) {
+      throw new Error(
+        'Craft Club plan is not configured (CRAFT_CLUB_PLAN_VARIATION_ID).'
+      );
+    }
+
+    const square = new Square(secrets, strings);
+
+    // 3. Square: customer → card on file → subscription.
+    const customerId =
+      member.squareCustomerId ??
+      (await square.customersService.upsertByEmail({
+        email: data.email,
+        name: data.name,
+        phone: data.phone,
+      }));
+
+    const card = await square.cardsService.createCardOnFile({
+      sourceId: data.paymentNonce,
+      customerId,
+      cardholderName: data.name,
+      // Nonce is unique per tokenization, so this is unique per attempt.
+      idempotencyKey: `cccard-${member.id}-${data.paymentNonce.slice(-8)}`,
+    });
+
+    const subscription = await square.subscriptionsService.create({
+      planVariationId,
+      customerId,
+      cardId: card.cardId,
+      locationId: square.locationId,
+      // Keyed on the card so a re-subscribe (new card) is not de-duped to an
+      // old cancelled subscription.
+      idempotencyKey: `ccsub-${card.cardId}`,
+    });
+
+    // 4. Mirror Square state onto the member record.
+    const updated = await CraftClubMemberRepository.update({
+      id: member.id,
+      status: 'active',
+      squareCustomerId: customerId,
+      squareCardId: card.cardId,
+      squareSubscriptionId: subscription.subscriptionId,
+      subscribedAt: new Date(),
+      currentPeriodEndsAt: subscription.chargedThroughDate
+        ? new Date(subscription.chargedThroughDate)
+        : undefined,
+    });
+
+    return { member: updated, cardLast4: card.last4 };
+  });

--- a/libs/firebase/maple-functions/create-craft-club-subscription/tsconfig.json
+++ b/libs/firebase/maple-functions/create-craft-club-subscription/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/create-craft-club-subscription/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/create-craft-club-subscription/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/request-craft-club-access/project.json
+++ b/libs/firebase/maple-functions/request-craft-club-access/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-request-craft-club-access",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/request-craft-club-access/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/request-craft-club-access/src/index.ts
+++ b/libs/firebase/maple-functions/request-craft-club-access/src/index.ts
@@ -1,0 +1,1 @@
+export { requestCraftClubAccess } from './lib/request-craft-club-access';

--- a/libs/firebase/maple-functions/request-craft-club-access/src/lib/request-craft-club-access.spec.ts
+++ b/libs/firebase/maple-functions/request-craft-club-access/src/lib/request-craft-club-access.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findByEmail: vi.fn(),
+  create: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/functions', () => ({
+  createPublicFunction: <TReq, TRes>(
+    handler: (data: TReq) => Promise<TRes>
+  ) => handler,
+  throwValidationError: (errors: Record<string, string[]>) => {
+    throw new Error(`validation: ${Object.keys(errors).join(',')}`);
+  },
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  CraftClubMemberRepository: {
+    findByEmail: mocks.findByEmail,
+    create: mocks.create,
+  },
+}));
+
+import { requestCraftClubAccess } from './request-craft-club-access';
+
+type Handler = (data: unknown) => Promise<{ status: string }>;
+const handler = requestCraftClubAccess as unknown as Handler;
+
+describe('requestCraftClubAccess', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('creates a requested record for a new email', async () => {
+    mocks.findByEmail.mockResolvedValue(undefined);
+    mocks.create.mockResolvedValue({ id: 'x' });
+
+    const r = await handler({ email: 'new@example.com', name: 'New' });
+
+    expect(r).toEqual({ status: 'requested' });
+    expect(mocks.create).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'new@example.com', status: 'requested' })
+    );
+  });
+
+  it('does not duplicate; reports approved for an approved email', async () => {
+    mocks.findByEmail.mockResolvedValue({ status: 'approved' });
+    const r = await handler({ email: 'a@b.com' });
+    expect(r).toEqual({ status: 'approved' });
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+
+  it('reports active for a current member', async () => {
+    mocks.findByEmail.mockResolvedValue({ status: 'active' });
+    expect((await handler({ email: 'a@b.com' })).status).toBe('active');
+  });
+
+  it('rejects an invalid email before writing', async () => {
+    await expect(handler({ email: 'bad' })).rejects.toThrow(/validation: email/);
+    expect(mocks.findByEmail).not.toHaveBeenCalled();
+  });
+});

--- a/libs/firebase/maple-functions/request-craft-club-access/src/lib/request-craft-club-access.ts
+++ b/libs/firebase/maple-functions/request-craft-club-access/src/lib/request-craft-club-access.ts
@@ -1,0 +1,55 @@
+/**
+ * Request Craft Club Access Cloud Function (public)
+ *
+ * Captures a non-approved email as a pending access request (status
+ * `requested`) so an admin can approve it later — we don't lose interested
+ * people. Idempotent by email: re-requesting never duplicates a record, and an
+ * already-approved/active email is reported back as such.
+ *
+ * Deployed to us-east4 via CI/CD pipeline.
+ */
+import {
+  createPublicFunction,
+  throwValidationError,
+} from '@maple/firebase/functions';
+import { CraftClubMemberRepository } from '@maple/firebase/database';
+import {
+  isCraftClubMemberActive,
+  canSubscribeToCraftClub,
+} from '@maple/ts/domain';
+import { craftClubMemberValidation } from '@maple/ts/validation';
+import type {
+  RequestCraftClubAccessRequest,
+  RequestCraftClubAccessResponse,
+} from '@maple/ts/firebase/api-types';
+
+export const requestCraftClubAccess = createPublicFunction<
+  RequestCraftClubAccessRequest,
+  RequestCraftClubAccessResponse
+>(async (data) => {
+  const result = craftClubMemberValidation({
+    email: data.email,
+    name: data.name,
+    phone: data.phone,
+  });
+  if (result.hasErrors()) {
+    throwValidationError(result.getErrors());
+  }
+
+  const existing = await CraftClubMemberRepository.findByEmail(data.email);
+  if (existing) {
+    if (isCraftClubMemberActive(existing)) return { status: 'active' };
+    if (canSubscribeToCraftClub(existing)) return { status: 'approved' };
+    // requested or paused — leave as-is.
+    return { status: 'requested' };
+  }
+
+  await CraftClubMemberRepository.create({
+    email: data.email,
+    name: data.name,
+    phone: data.phone,
+    status: 'requested',
+  });
+
+  return { status: 'requested' };
+});

--- a/libs/firebase/maple-functions/request-craft-club-access/tsconfig.json
+++ b/libs/firebase/maple-functions/request-craft-club-access/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/request-craft-club-access/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/request-craft-club-access/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/square-test-mock-server/src/lib/routes/square.ts
+++ b/libs/firebase/square-test-mock-server/src/lib/routes/square.ts
@@ -20,9 +20,14 @@ let refundCounter = 0;
 let catalogCounter = 0;
 let imageCounter = 0;
 let inventoryChangeCounter = 0;
+let customerCounter = 0;
+let cardCounter = 0;
+let subscriptionCounter = 0;
 
 /** In-memory store of created payments for get/refund lookups */
 const payments = new Map<string, Record<string, unknown>>();
+/** Craft Club: subscriptions are stored so cancel can look them up. */
+const subscriptions = new Map<string, Record<string, unknown>>();
 
 export function registerSquareRoutes(server: SquareMockServer): void {
   // Create order (required before payment in registration flow)
@@ -309,6 +314,84 @@ export function registerSquareRoutes(server: SquareMockServer): void {
       body: { counts },
     };
   });
+
+  registerCraftClubRoutes(server);
+}
+
+/**
+ * Craft Club routes: Square customers, cards on file, and subscriptions.
+ * Split out to keep `registerSquareRoutes` readable.
+ */
+function registerCraftClubRoutes(server: SquareMockServer): void {
+  // Search customers by email (upsert lookup). Default: none found → caller
+  // proceeds to create. Returns an empty list so each test starts clean.
+  server.post('/v2/customers/search', () => {
+    return { status: 200, body: { customers: [] } };
+  });
+
+  // Create customer
+  server.post('/v2/customers', (req) => {
+    const body = req.body as Record<string, unknown>;
+    customerCounter++;
+    const id = `mock-customer-${customerCounter}`;
+    const customer = {
+      id,
+      given_name: body['given_name'],
+      family_name: body['family_name'],
+      email_address: body['email_address'],
+      phone_number: body['phone_number'],
+      created_at: new Date().toISOString(),
+    };
+    return { status: 200, body: { customer } };
+  });
+
+  // Create card on file (from a Web Payments SDK nonce)
+  server.post('/v2/cards', (req) => {
+    const body = req.body as Record<string, unknown>;
+    cardCounter++;
+    const id = `ccof:mock-card-${cardCounter}`;
+    const cardInput = (body['card'] as Record<string, unknown>) ?? {};
+    const card = {
+      id,
+      card_brand: 'VISA',
+      last_4: '1111',
+      customer_id: cardInput['customer_id'],
+      cardholder_name: cardInput['cardholder_name'],
+      enabled: true,
+    };
+    return { status: 200, body: { card } };
+  });
+
+  // Create subscription
+  server.post('/v2/subscriptions', (req) => {
+    const body = req.body as Record<string, unknown>;
+    subscriptionCounter++;
+    const id = `mock-subscription-${subscriptionCounter}`;
+    const subscription = {
+      id,
+      location_id: body['location_id'],
+      plan_variation_id: body['plan_variation_id'],
+      customer_id: body['customer_id'],
+      card_id: body['card_id'],
+      status: 'ACTIVE',
+      charged_through_date: '2026-07-26',
+      created_at: new Date().toISOString(),
+    };
+    subscriptions.set(id, subscription);
+    return { status: 200, body: { subscription } };
+  });
+
+  // Cancel subscription (used by self-service management in a later phase)
+  server.post('/v2/subscriptions/:subscriptionId/cancel', (req) => {
+    const existing = subscriptions.get(req.params['subscriptionId']);
+    const subscription = {
+      ...(existing ?? { id: req.params['subscriptionId'] }),
+      status: 'CANCELED',
+      canceled_date: '2026-08-26',
+    };
+    subscriptions.set(req.params['subscriptionId'], subscription);
+    return { status: 200, body: { subscription } };
+  });
 }
 
 /**
@@ -321,5 +404,9 @@ export function resetSquareState(): void {
   catalogCounter = 0;
   imageCounter = 0;
   inventoryChangeCounter = 0;
+  customerCounter = 0;
+  cardCounter = 0;
+  subscriptionCounter = 0;
   payments.clear();
+  subscriptions.clear();
 }

--- a/libs/firebase/square/src/index.ts
+++ b/libs/firebase/square/src/index.ts
@@ -58,3 +58,24 @@ export {
   type InvoiceCustomerInput,
   type InvoiceLineItemInput,
 } from './lib/invoices.service';
+
+// Cards service (cards on file for subscription billing)
+export {
+  CardsService,
+  type CreateCardOnFileInput,
+  type CreateCardOnFileResult,
+} from './lib/cards.service';
+
+// Subscriptions service (recurring Craft Club billing)
+export {
+  SubscriptionsService,
+  type CreateSubscriptionInput,
+  type CreateSubscriptionResult,
+  type CancelSubscriptionResult,
+} from './lib/subscriptions.service';
+
+// Customers service (email-first upsert)
+export {
+  CustomersService,
+  type UpsertCustomerInput,
+} from './lib/customers.service';

--- a/libs/firebase/square/src/lib/cards.service.ts
+++ b/libs/firebase/square/src/lib/cards.service.ts
@@ -1,0 +1,72 @@
+/**
+ * Square Cards API service
+ *
+ * Stores a card on file for a customer from a Web Payments SDK nonce. The
+ * resulting `cardId` is what recurring subscriptions charge against (a nonce
+ * is single-use, so subscriptions cannot use it directly).
+ *
+ * @see https://developer.squareup.com/docs/cards-api/overview
+ */
+import { SquareClient, Square } from 'square';
+
+export interface CreateCardOnFileInput {
+  /** Single-use nonce from the Web Payments SDK `card.tokenize()`. */
+  sourceId: string;
+  /** Square customer the card is filed under. */
+  customerId: string;
+  /** Cardholder name for display (optional). */
+  cardholderName?: string;
+  /** Idempotency key — repeated calls with the same key are de-duped. */
+  idempotencyKey: string;
+}
+
+export interface CreateCardOnFileResult {
+  cardId: string;
+  last4?: string;
+  cardBrand?: string;
+}
+
+export class CardsService {
+  constructor(private readonly client: SquareClient) {}
+
+  /**
+   * Convert a single-use payment nonce into a durable card on file under the
+   * given customer, returning the `cardId` for subscription billing.
+   */
+  async createCardOnFile(
+    input: CreateCardOnFileInput
+  ): Promise<CreateCardOnFileResult> {
+    const response = await this.client.cards.create({
+      idempotencyKey: input.idempotencyKey,
+      sourceId: input.sourceId,
+      card: {
+        customerId: input.customerId,
+        cardholderName: input.cardholderName,
+      },
+    });
+
+    throwIfErrors(response.errors, 'create card');
+
+    const card = response.card;
+    if (!card?.id) {
+      throw new Error('Square card create returned no id');
+    }
+
+    return {
+      cardId: card.id,
+      last4: card.last4,
+      cardBrand: card.cardBrand as string | undefined,
+    };
+  }
+}
+
+function throwIfErrors(
+  errors: Square.Error_[] | undefined,
+  operation: string
+): void {
+  if (!errors || errors.length === 0) return;
+  const msg = errors
+    .map((e) => e.detail || e.code || 'Unknown error')
+    .join('; ');
+  throw new Error(`Square ${operation} error: ${msg}`);
+}

--- a/libs/firebase/square/src/lib/customers.service.spec.ts
+++ b/libs/firebase/square/src/lib/customers.service.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { SquareClient } from 'square';
+import { CustomersService } from './customers.service';
+
+function makeClient(search: unknown, create: unknown): SquareClient {
+  return {
+    customers: {
+      search: vi.fn().mockResolvedValue(search),
+      create: vi.fn().mockResolvedValue(create),
+    },
+  } as unknown as SquareClient;
+}
+
+describe('CustomersService.upsertByEmail', () => {
+  it('returns an existing customer id without creating', async () => {
+    const client = makeClient({ customers: [{ id: 'existing' }] }, {});
+    const id = await new CustomersService(client).upsertByEmail({
+      email: 'a@b.com',
+    });
+    expect(id).toBe('existing');
+    expect(client.customers.create).not.toHaveBeenCalled();
+  });
+
+  it('creates a customer when none is found', async () => {
+    const client = makeClient(
+      { customers: [] },
+      { customer: { id: 'new-id' } }
+    );
+    const id = await new CustomersService(client).upsertByEmail({
+      email: 'a@b.com',
+      name: 'Ada Lovelace',
+    });
+    expect(id).toBe('new-id');
+    expect(client.customers.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAddress: 'a@b.com',
+        givenName: 'Ada',
+        familyName: 'Lovelace',
+      })
+    );
+  });
+
+  it('throws on a Square error', async () => {
+    const client = makeClient(
+      { customers: [] },
+      { errors: [{ code: 'BAD_REQUEST', detail: 'nope' }] }
+    );
+    await expect(
+      new CustomersService(client).upsertByEmail({ email: 'a@b.com' })
+    ).rejects.toThrow(/create customer/);
+  });
+});

--- a/libs/firebase/square/src/lib/customers.service.ts
+++ b/libs/firebase/square/src/lib/customers.service.ts
@@ -1,0 +1,64 @@
+/**
+ * Square Customers API service
+ *
+ * Email-first customer upsert. Square customers are not strictly deduplicated,
+ * so we look up by exact email before creating to avoid duplicate profiles when
+ * the same person subscribes, is invoiced, or registers.
+ *
+ * @see https://developer.squareup.com/docs/customers-api/what-it-does
+ */
+import { SquareClient, Square } from 'square';
+
+export interface UpsertCustomerInput {
+  email: string;
+  name?: string;
+  phone?: string;
+}
+
+export class CustomersService {
+  constructor(private readonly client: SquareClient) {}
+
+  /** Find a Square customer by exact email, or create one. Returns the ID. */
+  async upsertByEmail(input: UpsertCustomerInput): Promise<string> {
+    const searchResponse = await this.client.customers.search({
+      query: {
+        filter: { emailAddress: { exact: input.email } },
+      },
+    });
+
+    const existingId = searchResponse.customers?.[0]?.id;
+    if (existingId) {
+      return existingId;
+    }
+
+    const [givenName, ...familyNameParts] = (input.name ?? '').split(' ');
+    const familyName = familyNameParts.join(' ') || undefined;
+
+    const createResponse = await this.client.customers.create({
+      idempotencyKey: `craftclub-customer-${input.email}`,
+      givenName: givenName || input.email,
+      familyName,
+      emailAddress: input.email,
+      phoneNumber: input.phone,
+    });
+
+    throwIfErrors(createResponse.errors, 'create customer');
+
+    const newId = createResponse.customer?.id;
+    if (!newId) {
+      throw new Error('Square customer create returned no id');
+    }
+    return newId;
+  }
+}
+
+function throwIfErrors(
+  errors: Square.Error_[] | undefined,
+  operation: string
+): void {
+  if (!errors || errors.length === 0) return;
+  const msg = errors
+    .map((e) => e.detail || e.code || 'Unknown error')
+    .join('; ');
+  throw new Error(`Square ${operation} error: ${msg}`);
+}

--- a/libs/firebase/square/src/lib/square.utility.ts
+++ b/libs/firebase/square/src/lib/square.utility.ts
@@ -16,6 +16,9 @@ import { InventoryService } from './inventory.service';
 import { OrdersService } from './orders.service';
 import { PaymentsService } from './payments.service';
 import { InvoicesService } from './invoices.service';
+import { CardsService } from './cards.service';
+import { SubscriptionsService } from './subscriptions.service';
+import { CustomersService } from './customers.service';
 
 /**
  * Secret names for Firebase Functions secrets
@@ -83,6 +86,9 @@ export class Square {
   private readonly _ordersService: OrdersService;
   private readonly _paymentsService: PaymentsService;
   private readonly _invoicesService: InvoicesService;
+  private readonly _cardsService: CardsService;
+  private readonly _subscriptionsService: SubscriptionsService;
+  private readonly _customersService: CustomersService;
   public readonly locationId: string;
   public readonly taxRatePercent: number;
 
@@ -128,6 +134,9 @@ export class Square {
     this._ordersService = new OrdersService(this.client);
     this._paymentsService = new PaymentsService(this.client);
     this._invoicesService = new InvoicesService(this.client);
+    this._cardsService = new CardsService(this.client);
+    this._subscriptionsService = new SubscriptionsService(this.client);
+    this._customersService = new CustomersService(this.client);
   }
 
   /**
@@ -177,6 +186,27 @@ export class Square {
    */
   get invoicesService(): InvoicesService {
     return this._invoicesService;
+  }
+
+  /**
+   * Get the cards service for storing cards on file (subscription billing)
+   */
+  get cardsService(): CardsService {
+    return this._cardsService;
+  }
+
+  /**
+   * Get the subscriptions service for recurring Craft Club billing
+   */
+  get subscriptionsService(): SubscriptionsService {
+    return this._subscriptionsService;
+  }
+
+  /**
+   * Get the customers service for email-first customer upsert
+   */
+  get customersService(): CustomersService {
+    return this._customersService;
   }
 
   /**

--- a/libs/firebase/square/src/lib/subscriptions.service.spec.ts
+++ b/libs/firebase/square/src/lib/subscriptions.service.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { SquareClient } from 'square';
+import { SubscriptionsService } from './subscriptions.service';
+
+function clientWith(method: string, value: unknown): SquareClient {
+  return {
+    subscriptions: { [method]: vi.fn().mockResolvedValue(value) },
+  } as unknown as SquareClient;
+}
+
+const createInput = {
+  planVariationId: 'plan',
+  customerId: 'cust',
+  cardId: 'card',
+  locationId: 'loc',
+  idempotencyKey: 'key',
+};
+
+describe('SubscriptionsService', () => {
+  it('create returns id, status, and chargedThroughDate', async () => {
+    const client = clientWith('create', {
+      subscription: {
+        id: 'sub-1',
+        status: 'ACTIVE',
+        chargedThroughDate: '2026-07-26',
+      },
+    });
+    const result = await new SubscriptionsService(client).create(createInput);
+    expect(result).toEqual({
+      subscriptionId: 'sub-1',
+      status: 'ACTIVE',
+      chargedThroughDate: '2026-07-26',
+    });
+  });
+
+  it('create throws on a Square error', async () => {
+    const client = clientWith('create', {
+      errors: [{ code: 'X', detail: 'bad plan' }],
+    });
+    await expect(
+      new SubscriptionsService(client).create(createInput)
+    ).rejects.toThrow(/create subscription/);
+  });
+
+  it('create throws when no id is returned', async () => {
+    const client = clientWith('create', { subscription: {} });
+    await expect(
+      new SubscriptionsService(client).create(createInput)
+    ).rejects.toThrow(/returned no id/);
+  });
+
+  it('cancel returns status and canceledDate', async () => {
+    const client = clientWith('cancel', {
+      subscription: { status: 'CANCELED', canceledDate: '2026-08-01' },
+    });
+    expect(await new SubscriptionsService(client).cancel('sub-1')).toEqual({
+      status: 'CANCELED',
+      canceledDate: '2026-08-01',
+    });
+  });
+});

--- a/libs/firebase/square/src/lib/subscriptions.service.ts
+++ b/libs/firebase/square/src/lib/subscriptions.service.ts
@@ -1,0 +1,112 @@
+/**
+ * Square Subscriptions API service
+ *
+ * Recurring billing for the Craft Club membership. Square owns the billing
+ * cycle, retries, and dunning; we react to subscription/invoice webhooks to
+ * mirror state. A subscription charges a card on file (see {@link CardsService})
+ * against a Catalog subscription plan variation.
+ *
+ * @see https://developer.squareup.com/docs/subscriptions-api/overview
+ */
+import { SquareClient, Square } from 'square';
+
+export interface CreateSubscriptionInput {
+  /** Catalog subscription plan variation to enroll in (the $30/mo plan). */
+  planVariationId: string;
+  /** Square customer to bill. */
+  customerId: string;
+  /** Card on file to charge. */
+  cardId: string;
+  /** Location the subscription belongs to. */
+  locationId: string;
+  /** Idempotency key — repeated calls with the same key are de-duped. */
+  idempotencyKey: string;
+}
+
+export interface CreateSubscriptionResult {
+  subscriptionId: string;
+  status?: string;
+  /** `YYYY-MM-DD` end of the current paid period, when Square provides it. */
+  chargedThroughDate?: string;
+}
+
+export interface CancelSubscriptionResult {
+  status?: string;
+  /** `YYYY-MM-DD` date the subscription is scheduled to stop billing. */
+  canceledDate?: string;
+}
+
+export class SubscriptionsService {
+  constructor(private readonly client: SquareClient) {}
+
+  /** Enroll a customer's card on file in a subscription plan variation. */
+  async create(
+    input: CreateSubscriptionInput
+  ): Promise<CreateSubscriptionResult> {
+    const response = await this.client.subscriptions.create({
+      idempotencyKey: input.idempotencyKey,
+      locationId: input.locationId,
+      planVariationId: input.planVariationId,
+      customerId: input.customerId,
+      cardId: input.cardId,
+    });
+
+    throwIfErrors(response.errors, 'create subscription');
+
+    const subscription = response.subscription;
+    if (!subscription?.id) {
+      throw new Error('Square subscription create returned no id');
+    }
+
+    return {
+      subscriptionId: subscription.id,
+      status: subscription.status,
+      chargedThroughDate: subscription.chargedThroughDate,
+    };
+  }
+
+  /**
+   * Cancel at the end of the current billing period (Square stops billing on
+   * the period boundary rather than immediately).
+   */
+  async cancel(subscriptionId: string): Promise<CancelSubscriptionResult> {
+    const response = await this.client.subscriptions.cancel({
+      subscriptionId,
+    });
+
+    throwIfErrors(response.errors, 'cancel subscription');
+
+    return {
+      status: response.subscription?.status,
+      canceledDate: response.subscription?.canceledDate ?? undefined,
+    };
+  }
+
+  /** Swap the card a subscription charges (used by self-service payment change). */
+  async updateCard(subscriptionId: string, cardId: string): Promise<void> {
+    const response = await this.client.subscriptions.update({
+      subscriptionId,
+      subscription: { cardId },
+    });
+
+    throwIfErrors(response.errors, 'update subscription');
+  }
+
+  /** Fetch the current state of a subscription. */
+  async get(subscriptionId: string): Promise<Square.Subscription | undefined> {
+    const response = await this.client.subscriptions.get({ subscriptionId });
+    throwIfErrors(response.errors, 'get subscription');
+    return response.subscription;
+  }
+}
+
+function throwIfErrors(
+  errors: Square.Error_[] | undefined,
+  operation: string
+): void {
+  if (!errors || errors.length === 0) return;
+  const msg = errors
+    .map((e) => e.detail || e.code || 'Unknown error')
+    .join('; ');
+  throw new Error(`Square ${operation} error: ${msg}`);
+}

--- a/libs/ts/firebase/api-types/src/lib/craft-club.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/craft-club.types.ts
@@ -67,3 +67,63 @@ export interface UpdateCraftClubMemberRequest {
 export interface UpdateCraftClubMemberResponse {
   member: CraftClubMember;
 }
+
+// ============================================================================
+// Check Eligibility (Public — signup widget gate)
+// ============================================================================
+
+/**
+ * Coarse eligibility status for an email at the signup gate:
+ * - `approved` — pre-approved, may subscribe now
+ * - `active` — already has a live subscription (send to manage)
+ * - `requested` — has asked for access, awaiting admin approval
+ * - `unknown` — not on file
+ */
+export type CraftClubEligibilityStatus =
+  | 'approved'
+  | 'active'
+  | 'requested'
+  | 'unknown';
+
+export interface CheckCraftClubEligibilityRequest {
+  email: string;
+}
+
+export interface CheckCraftClubEligibilityResponse {
+  status: CraftClubEligibilityStatus;
+  /** True when there is already an active/past-due subscription for this email. */
+  alreadyMember: boolean;
+}
+
+// ============================================================================
+// Create Subscription (Public — signup widget, with payment)
+// ============================================================================
+
+export interface CreateCraftClubSubscriptionRequest {
+  email: string;
+  name: string;
+  phone?: string;
+  /** Nonce from the Square Web Payments SDK card tokenization. */
+  paymentNonce: string;
+}
+
+export interface CreateCraftClubSubscriptionResponse {
+  member: CraftClubMember;
+  /** Last 4 digits of the card on file, for display. */
+  cardLast4?: string;
+}
+
+// ============================================================================
+// Request Access (Public — non-approved email capture)
+// ============================================================================
+
+export interface RequestCraftClubAccessRequest {
+  email: string;
+  name?: string;
+  phone?: string;
+}
+
+export interface RequestCraftClubAccessResponse {
+  /** Resulting status so the widget can confirm what happened. */
+  status: 'requested' | 'approved' | 'active';
+}

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -390,4 +390,11 @@ export type {
   ApproveCraftClubMemberResponse,
   UpdateCraftClubMemberRequest,
   UpdateCraftClubMemberResponse,
+  CraftClubEligibilityStatus,
+  CheckCraftClubEligibilityRequest,
+  CheckCraftClubEligibilityResponse,
+  CreateCraftClubSubscriptionRequest,
+  CreateCraftClubSubscriptionResponse,
+  RequestCraftClubAccessRequest,
+  RequestCraftClubAccessResponse,
 } from './craft-club.types';

--- a/tools/create-craft-club-plan.ts
+++ b/tools/create-craft-club-plan.ts
@@ -1,0 +1,128 @@
+/**
+ * One-time setup: create the Craft Club Catalog subscription plan in Square.
+ *
+ * The Craft Club is a flat $30.00/month membership billed through the Square
+ * Subscriptions API. A subscription enrolls a customer's card on file in a
+ * Catalog SUBSCRIPTION_PLAN_VARIATION; this script creates that plan + monthly
+ * variation and prints the variation ID.
+ *
+ * Run it once per environment, then paste the printed variation ID into the
+ * matching `.env` as `CRAFT_CLUB_PLAN_VARIATION_ID`:
+ *   - sandbox → .env.dev
+ *   - production → .env.prod
+ *
+ * Credentials:
+ *   - Square: SQUARE_ACCESS_TOKEN env var (sandbox token for dev, production
+ *     token for --prod). From Square Developer Dashboard → Applications.
+ *
+ * Usage:
+ *   export SQUARE_ACCESS_TOKEN=EAAA...                      # sandbox or prod
+ *   npx tsx tools/create-craft-club-plan.ts                 # sandbox
+ *   npx tsx tools/create-craft-club-plan.ts --prod          # production
+ */
+
+import { randomUUID } from 'node:crypto';
+import { SquareClient, SquareEnvironment } from 'square';
+
+/** Flat monthly Craft Club price, in cents ($30.00). Mirrors CRAFT_CLUB_MONTHLY_PRICE_CENTS. */
+const MONTHLY_PRICE_CENTS = 3000;
+
+const isProd = process.argv.includes('--prod');
+
+const accessToken = process.env['SQUARE_ACCESS_TOKEN'];
+if (!accessToken) {
+  console.error(
+    'SQUARE_ACCESS_TOKEN env var is required. Grab one from the Square Developer Dashboard.'
+  );
+  process.exit(1);
+}
+
+const client = new SquareClient({
+  token: accessToken,
+  environment: isProd
+    ? SquareEnvironment.Production
+    : SquareEnvironment.Sandbox,
+});
+
+const PLAN_TEMP_ID = '#craft-club-plan';
+const VARIATION_TEMP_ID = '#craft-club-monthly';
+
+async function main(): Promise<void> {
+  console.log(
+    `Creating Craft Club subscription plan ($${(
+      MONTHLY_PRICE_CENTS / 100
+    ).toFixed(2)}/month) in ${isProd ? 'PRODUCTION' : 'SANDBOX'}…`
+  );
+
+  const response = await client.catalog.object.upsert({
+    idempotencyKey: randomUUID(),
+    object: {
+      type: 'SUBSCRIPTION_PLAN',
+      id: PLAN_TEMP_ID,
+      subscriptionPlanData: {
+        name: 'Craft Club Membership',
+        subscriptionPlanVariations: [
+          {
+            type: 'SUBSCRIPTION_PLAN_VARIATION',
+            id: VARIATION_TEMP_ID,
+            subscriptionPlanVariationData: {
+              name: 'Monthly',
+              phases: [
+                {
+                  cadence: 'MONTHLY',
+                  pricing: {
+                    type: 'STATIC',
+                    priceMoney: {
+                      amount: BigInt(MONTHLY_PRICE_CENTS),
+                      currency: 'USD',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  });
+
+  if (response.errors && response.errors.length > 0) {
+    console.error('Square returned errors:');
+    for (const e of response.errors) {
+      console.error(`  ${e.category}/${e.code}: ${e.detail}`);
+    }
+    process.exit(1);
+  }
+
+  // The variation's real ID comes back via idMappings (temp → real).
+  const variationMapping = response.idMappings?.find(
+    (m) => m.clientObjectId === VARIATION_TEMP_ID
+  );
+  const planMapping = response.idMappings?.find(
+    (m) => m.clientObjectId === PLAN_TEMP_ID
+  );
+
+  const variationId = variationMapping?.objectId;
+  if (!variationId) {
+    console.error(
+      'Could not resolve the subscription plan variation ID from the response.'
+    );
+    console.error(JSON.stringify(response.idMappings, null, 2));
+    process.exit(1);
+  }
+
+  console.log('');
+  console.log('✓ Craft Club subscription plan created.');
+  console.log(`  Plan ID:      ${planMapping?.objectId ?? '(unknown)'}`);
+  console.log(`  Variation ID: ${variationId}`);
+  console.log('');
+  console.log('Next: paste this line into the matching .env file');
+  console.log(`(${isProd ? '.env.prod' : '.env.dev'}):`);
+  console.log('');
+  console.log(`  CRAFT_CLUB_PLAN_VARIATION_ID=${variationId}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,6 +17,15 @@
     "paths": {
       "@maple/firebase/database": ["libs/firebase/database/src/index.ts"],
       "@maple/firebase/functions": ["libs/firebase/functions/src/index.ts"],
+      "@maple/firebase/maple-functions/check-craft-club-eligibility": [
+        "libs/firebase/maple-functions/check-craft-club-eligibility/src/index.ts"
+      ],
+      "@maple/firebase/maple-functions/create-craft-club-subscription": [
+        "libs/firebase/maple-functions/create-craft-club-subscription/src/index.ts"
+      ],
+      "@maple/firebase/maple-functions/request-craft-club-access": [
+        "libs/firebase/maple-functions/request-craft-club-access/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/get-craft-club-members": [
         "libs/firebase/maple-functions/get-craft-club-members/src/index.ts"
       ],


### PR DESCRIPTION
## Summary

Phase 2 of the **Craft Club** membership (epic #506). Adds the customer-facing signup and recurring billing. **Stacked on #507** (Phase 1) — base will auto-retarget to `main` once #507 merges.

Members enter their email on a private/QR Webflow page → if pre-approved, they attach a card and start a flat **$30/month** Square subscription. Non-approved emails are captured as access requests. Materials remain separate at the POS.

## Changes
- **Square services** (`libs/firebase/square`): `CardsService` (card on file from a Web Payments nonce), `SubscriptionsService` (create/cancel/update/get), `CustomersService` (email-first upsert). Wired into the `Square` class + barrel.
- **Plan setup**: `tools/create-craft-club-plan.ts` creates the $30/mo Catalog subscription plan and prints the variation ID. `CRAFT_CLUB_PLAN_VARIATION_ID` is declared per-function (like `ALLOWED_ORIGINS`) and added to `.env.dev`/`.env.prod` (placeholder until the script is run).
- **Public functions**: `checkCraftClubEligibility` + `requestCraftClubAccess` (maple-core); `createCraftClubSubscription` (maple-square) — re-checks the approval gate server-side, validates before any Square write, then customer → card → subscription → mirrors state onto the member.
- **Webflow signup widget**: `CraftClubSignupWidget` + `craft-club-signup.webflow.tsx`. email → eligibility → branches to payment (reusing the shared `SquareCardForm`) / request-access / already-member-manage.

## Testing
This is the phase where integration + interaction tests start to earn their cost (Phase 1 was pure CRUD).
- [x] **Unit**: functions (eligibility/subscribe/request) + services (customers/subscriptions) — `vi.mock`
- [x] **Interaction**: signup-widget branching via Testing Library (unknown→request, approved→subscribe, active→manage)
- [x] **Integration**: Square mock-server routes (customers/cards/subscriptions) + emulator suite for the subscribe flow — `./tools/run-integration-tests.sh square` → **37/37 pass** (incl. 4 new)
- [x] `tsc` clean (maple-core, maple-square, webflow-components); `validate-function-tsconfigs.sh` + firestore-index analyzer pass; eslint 0 errors

## Follow-ups (later phases)
- Phase 3: magic-link self-service (cancel / change card) + one E2E happy path
- Phase 4: subscription webhooks + admin pause/resume/cancel + emails
- Before go-live: run `tools/create-craft-club-plan.ts` for sandbox + prod and fill `CRAFT_CLUB_PLAN_VARIATION_ID`

Part of #506