### PR TITLE
fix(rooms): keep Spruce Room default booking within one day

### DIFF
--- a/libs/react/events/src/lib/BookSpruceRoomForm.spec.tsx
+++ b/libs/react/events/src/lib/BookSpruceRoomForm.spec.tsx
@@ -32,6 +32,30 @@ describe('BookSpruceRoomForm', () => {
     expect(input.location).toBe('Spruce Room');
   });
 
+  it('submits with valid defaults late at night (block must not cross midnight)', async () => {
+    // Regression: before the 22:00 cap, the default 1-hour block starting at
+    // 23:00 wrapped the end time to 00:00, which combineDateTime folded back to
+    // the *same* day → end before start → "end after start" validation blocked
+    // submit. Fake only Date so waitFor's real timers still fire.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date(2026, 5, 15, 22, 30, 0));
+    try {
+      const { onSubmit } = setup();
+      fireEvent.change(screen.getByLabelText(/what's the booking/i), {
+        target: { value: 'Late rental' },
+      });
+      fireEvent.click(bookButton());
+
+      await vi.waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+      const input = onSubmit.mock.calls[0][0] as CreateCalendarEventInput;
+      expect(input.endDateTime.getTime()).toBeGreaterThan(
+        input.startDateTime.getTime()
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not submit when the title is blank', async () => {
     const { onSubmit } = setup();
     fireEvent.click(bookButton());

--- a/libs/react/events/src/lib/BookSpruceRoomForm.tsx
+++ b/libs/react/events/src/lib/BookSpruceRoomForm.tsx
@@ -53,10 +53,16 @@ export function BookSpruceRoomForm({
 }: BookSpruceRoomFormProps) {
   useSignals();
 
-  // Defaults: next top of the hour today, a one-hour block.
+  // Defaults: next top of the hour today, a one-hour block. The form models a
+  // single calendar date (`combineDateTime` folds both times onto `date`'s
+  // Y/M/D), so the default block must not cross midnight — otherwise the end
+  // time wraps to 00:00 and lands *before* the start, failing "end after
+  // start" validation. Cap the start at 22:00 so the 1-hour block ends by
+  // 23:00 the same day, regardless of what time it currently is.
   const now = new Date();
   const defaultStart = new Date(now);
-  defaultStart.setHours(now.getHours() + 1, 0, 0, 0);
+  const defaultStartHour = Math.min(now.getHours() + 1, 22);
+  defaultStart.setHours(defaultStartHour, 0, 0, 0);
   const defaultEnd = new Date(defaultStart);
   defaultEnd.setHours(defaultStart.getHours() + 1);
 


### PR DESCRIPTION
## Summary

The `BookSpruceRoomForm` unit tests fail in CI whenever the job runs in the **22:00–23:59 UTC** window (e.g. they failed on #509 at 22:05 UTC, blocking it). This is a **real product bug**, not just a flaky test.

## Root cause
The form defaults to "next top of the hour, one-hour block":
```js
defaultStart.setHours(now.getHours() + 1, 0, 0, 0);  // 22:05 → 23:00 today
defaultEnd.setHours(defaultStart.getHours() + 1);     // 23+1 = 24 → 00:00 NEXT day
```
But the form models a **single calendar date** — `combineDateTime` rebuilds the end from that one date's Y/M/D + the end time's H/M, so a `00:00` end folds back to **00:00 *today***, i.e. *before* the 23:00 start → fails "end after start" validation → submit is silently blocked. Any user booking the room after 10pm hits this.

## Fix
Cap the default start hour at **22:00** so the one-hour block always ends by 23:00 the same day, at any time of day. One line, plus a regression test that fakes the clock to 22:30 (faking only `Date` so `waitFor` still works) and asserts the form submits with `end > start`.

## Testing
- [x] New test **fails without the fix** (reproduces the CI failure), passes with it — verified locally
- [x] All 6 `BookSpruceRoomForm` tests green; eslint clean

Unblocks #509 (Craft Club Phase 2) once merged.