### PR TITLE
feat(square): multi-account credential routing for Music Together (#510)

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -17,10 +17,10 @@ SALES_TAX_RATE=6.0
 # route here, not to the M&S account above. See docs/reference/music-together-plan.md.
 # The MT access token is a Firebase Secret (MT_SQUARE_ACCESS_TOKEN), NOT here.
 MT_SQUARE_ENV=LOCAL
-# TODO(#510): MT sandbox location ID from the MT Square Developer Dashboard
-MT_SQUARE_LOCATION_ID=
-# TODO(#510): MT sandbox application ID (browser Web Payments SDK; public by design)
-MT_SQUARE_APPLICATION_ID=
+# MT sandbox location ID from the MT Square Developer Dashboard
+MT_SQUARE_LOCATION_ID=LKZXV01GJ3SZP
+# MT sandbox application ID (browser Web Payments SDK; public by design)
+MT_SQUARE_APPLICATION_ID=sandbox-sq0idb-_YTTXUD_JGekkGOTQHRcVA
 # MT tuition is a non-taxable service (mirrors music-lesson exemption)
 MT_SALES_TAX_RATE=0.0
 

--- a/.env.dev
+++ b/.env.dev
@@ -13,6 +13,17 @@ SQUARE_APPLICATION_ID=sandbox-sq0idb-gAg2gnLYZ-5b2uXajUfZLA
 # WV sales tax rate (6% state rate)
 SALES_TAX_RATE=6.0
 
+# Music Together — SEPARATE Square account (Stephanie's LLC). MT checkouts
+# route here, not to the M&S account above. See docs/reference/music-together-plan.md.
+# The MT access token is a Firebase Secret (MT_SQUARE_ACCESS_TOKEN), NOT here.
+MT_SQUARE_ENV=LOCAL
+# TODO(#510): MT sandbox location ID from the MT Square Developer Dashboard
+MT_SQUARE_LOCATION_ID=
+# TODO(#510): MT sandbox application ID (browser Web Payments SDK; public by design)
+MT_SQUARE_APPLICATION_ID=
+# MT tuition is a non-taxable service (mirrors music-lesson exemption)
+MT_SALES_TAX_RATE=0.0
+
 # Webflow Integration
 # Site and Collection IDs from Webflow dashboard
 # API token comes from Firebase Secrets (per-project)

--- a/.env.prod
+++ b/.env.prod
@@ -10,6 +10,15 @@ SQUARE_LOCATION_ID=LEJBNPRGM99NV
 # WV sales tax rate (6% state rate)
 SALES_TAX_RATE=6.0
 
+# Music Together — SEPARATE Square account (Stephanie's LLC). MT checkouts
+# route here, not to the M&S account above. See docs/reference/music-together-plan.md.
+# The MT access token is a Firebase Secret (MT_SQUARE_ACCESS_TOKEN), NOT here.
+MT_SQUARE_ENV=PROD
+# TODO(#510/#517): MT PRODUCTION location ID — fill once the MT prod Square account exists (before Phase 7)
+MT_SQUARE_LOCATION_ID=
+# MT tuition is a non-taxable service (mirrors music-lesson exemption)
+MT_SALES_TAX_RATE=0.0
+
 # Webflow Integration
 # Site and Collection IDs from Webflow dashboard
 # API token comes from Firebase Secrets (per-project)

--- a/libs/firebase/square/src/index.ts
+++ b/libs/firebase/square/src/index.ts
@@ -3,8 +3,13 @@ export {
   Square,
   SQUARE_SECRET_NAMES,
   SQUARE_STRING_NAMES,
+  MT_SQUARE_SECRET_NAMES,
+  MT_SQUARE_STRING_NAMES,
+  DEFAULT_SQUARE_KEYS,
+  MT_SQUARE_KEYS,
   type SquareSecrets,
   type SquareStrings,
+  type SquareParamKeys,
 } from './lib/square.utility';
 
 // Catalog service

--- a/libs/firebase/square/src/lib/square-credentials.spec.ts
+++ b/libs/firebase/square/src/lib/square-credentials.spec.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect } from 'vitest';
 import {
-  Square,
+  resolveSquareCredentials,
   DEFAULT_SQUARE_KEYS,
   MT_SQUARE_KEYS,
   MT_SQUARE_SECRET_NAMES,
   MT_SQUARE_STRING_NAMES,
   SQUARE_SECRET_NAMES,
   SQUARE_STRING_NAMES,
-} from './square.utility';
+} from './square-credentials';
 
-// The Square constructor instantiates a SquareClient but makes no network
-// call at construction time, so these tests exercise pure credential-routing
-// logic: which param names each account reads.
+// These tests exercise pure credential-routing logic — which param names each
+// account reads. Importing only this barrel-free module keeps the functions +
+// database layers out of the coverage denominator (see file header).
 
 const MS_SECRETS = { SQUARE_ACCESS_TOKEN: 'ms-token' };
 const MS_STRINGS = {
@@ -53,55 +53,55 @@ describe('param name tuples', () => {
   });
 });
 
-describe('Square credential routing', () => {
+describe('resolveSquareCredentials', () => {
   it('defaults to the Maple & Spruce account', () => {
-    const square = new Square(MS_SECRETS, MS_STRINGS);
-    expect(square.locationId).toBe('MS_LOC');
-    expect(square.taxRatePercent).toBe(6.0);
-    expect(square.isProduction()).toBe(false);
+    const creds = resolveSquareCredentials(MS_SECRETS, MS_STRINGS);
+    expect(creds.accessToken).toBe('ms-token');
+    expect(creds.locationId).toBe('MS_LOC');
+    expect(creds.taxRatePercent).toBe(6.0);
+    expect(creds.isProd).toBe(false);
   });
 
   it('routes to the Music Together account when given MT keys', () => {
-    const square = new Square(MT_SECRETS, MT_STRINGS, MT_SQUARE_KEYS);
-    expect(square.locationId).toBe('MT_LOC');
-    expect(square.taxRatePercent).toBe(0.0); // non-taxable service
+    const creds = resolveSquareCredentials(MT_SECRETS, MT_STRINGS, MT_SQUARE_KEYS);
+    expect(creds.accessToken).toBe('mt-token');
+    expect(creds.locationId).toBe('MT_LOC');
+    expect(creds.taxRatePercent).toBe(0.0); // non-taxable service
   });
 
   it('reads PROD env per account independently', () => {
-    const square = new Square(
+    const creds = resolveSquareCredentials(
       { MT_SQUARE_ACCESS_TOKEN: 't' },
       { ...MT_STRINGS, MT_SQUARE_ENV: 'PROD' },
       MT_SQUARE_KEYS
     );
-    expect(square.isProduction()).toBe(true);
+    expect(creds.isProd).toBe(true);
   });
 
   it('does not read the wrong account’s token', () => {
     // MT keys against only-M&S secrets must fail — proves no cross-account leak.
-    expect(() => new Square(MS_SECRETS, MT_STRINGS, MT_SQUARE_KEYS)).toThrow(
-      /MT_SQUARE_ACCESS_TOKEN/
-    );
+    expect(() =>
+      resolveSquareCredentials(MS_SECRETS, MT_STRINGS, MT_SQUARE_KEYS)
+    ).toThrow(/MT_SQUARE_ACCESS_TOKEN/);
   });
 
   it('throws with the account-specific param name when location is missing', () => {
-    expect(
-      () =>
-        new Square(
-          MT_SECRETS,
-          { ...MT_STRINGS, MT_SQUARE_LOCATION_ID: '' },
-          MT_SQUARE_KEYS
-        )
+    expect(() =>
+      resolveSquareCredentials(
+        MT_SECRETS,
+        { ...MT_STRINGS, MT_SQUARE_LOCATION_ID: '' },
+        MT_SQUARE_KEYS
+      )
     ).toThrow(/MT_SQUARE_LOCATION_ID/);
   });
 
   it('throws with the account-specific param name when tax rate is invalid', () => {
-    expect(
-      () =>
-        new Square(
-          MT_SECRETS,
-          { ...MT_STRINGS, MT_SALES_TAX_RATE: 'abc' },
-          MT_SQUARE_KEYS
-        )
+    expect(() =>
+      resolveSquareCredentials(
+        MT_SECRETS,
+        { ...MT_STRINGS, MT_SALES_TAX_RATE: 'abc' },
+        MT_SQUARE_KEYS
+      )
     ).toThrow(/MT_SALES_TAX_RATE/);
   });
 });

--- a/libs/firebase/square/src/lib/square-credentials.ts
+++ b/libs/firebase/square/src/lib/square-credentials.ts
@@ -1,0 +1,141 @@
+/**
+ * Square credential routing — pure, dependency-free.
+ *
+ * This file intentionally imports NOTHING heavy (no `@maple/firebase/functions`
+ * barrel, no Square SDK, no service classes). Keeping it barrel-free lets unit
+ * tests exercise the account-routing logic without cascading the functions +
+ * database layers into the coverage denominator. See the barrel-cascade gotcha:
+ * a single spec that loads `square.utility.ts` (which imports the functions
+ * barrel) pulls ~40 untested repository/utility files into the report and tanks
+ * global coverage. The `Square` class composes this helper.
+ */
+
+/**
+ * Secret names for Firebase Functions secrets (use with defineSecret()).
+ * Each Firebase project has its own SQUARE_ACCESS_TOKEN value:
+ * - maple-and-spruce-dev: sandbox token
+ * - maple-and-spruce: production token
+ */
+export const SQUARE_SECRET_NAMES = ['SQUARE_ACCESS_TOKEN'] as const;
+
+/**
+ * String parameter names for Firebase Functions (use with defineString()).
+ * SQUARE_ENV: 'LOCAL' (sandbox) or 'PROD' (production)
+ * SQUARE_LOCATION_ID: location ID for orders/payments/inventory
+ * SALES_TAX_RATE: sales-tax rate percent (e.g. '6.0')
+ */
+export const SQUARE_STRING_NAMES = [
+  'SQUARE_ENV',
+  'SQUARE_LOCATION_ID',
+  'SALES_TAX_RATE',
+] as const;
+
+export type SquareSecrets = Record<
+  (typeof SQUARE_SECRET_NAMES)[number],
+  string
+>;
+
+export type SquareStrings = Record<
+  (typeof SQUARE_STRING_NAMES)[number],
+  string
+>;
+
+/**
+ * Music Together (MT) is a SEPARATE business (Stephanie's single-member LLC)
+ * with its OWN Square account/checking. Its checkouts must route to MT's
+ * Square credentials, not Maple & Spruce's. A Cloud Function declares these
+ * prefixed param names via `.usingSecrets(...)` / `.usingStrings(...)` when it
+ * needs the MT account.
+ *
+ * The secret value (MT_SQUARE_ACCESS_TOKEN) lives in Secret Manager /
+ * .secret.local, never in the tracked .env files. The string params live in
+ * .env.dev/.env.prod (mirroring the default SQUARE_* set).
+ */
+export const MT_SQUARE_SECRET_NAMES = ['MT_SQUARE_ACCESS_TOKEN'] as const;
+
+export const MT_SQUARE_STRING_NAMES = [
+  'MT_SQUARE_ENV',
+  'MT_SQUARE_LOCATION_ID',
+  'MT_SALES_TAX_RATE',
+] as const;
+
+/**
+ * The four Firebase param names a {@link Square} instance reads, so the same
+ * client wrapper can be pointed at either the Maple & Spruce account (default)
+ * or a second program's account (e.g. Music Together) without touching any
+ * call site beyond which key set it passes.
+ */
+export interface SquareParamKeys {
+  /** defineSecret name holding the access token */
+  accessTokenSecret: string;
+  /** defineString name holding 'LOCAL' | 'PROD' */
+  envString: string;
+  /** defineString name holding the Square location ID */
+  locationIdString: string;
+  /** defineString name holding the sales-tax rate percent (e.g. '6.0') */
+  taxRateString: string;
+}
+
+/** Default Maple & Spruce account keys — preserves all existing behavior. */
+export const DEFAULT_SQUARE_KEYS: SquareParamKeys = {
+  accessTokenSecret: 'SQUARE_ACCESS_TOKEN',
+  envString: 'SQUARE_ENV',
+  locationIdString: 'SQUARE_LOCATION_ID',
+  taxRateString: 'SALES_TAX_RATE',
+};
+
+/** Music Together account keys (separate Square account). */
+export const MT_SQUARE_KEYS: SquareParamKeys = {
+  accessTokenSecret: 'MT_SQUARE_ACCESS_TOKEN',
+  envString: 'MT_SQUARE_ENV',
+  locationIdString: 'MT_SQUARE_LOCATION_ID',
+  taxRateString: 'MT_SALES_TAX_RATE',
+};
+
+/** Resolved, validated credentials for one Square account. */
+export interface ResolvedSquareCredentials {
+  accessToken: string;
+  locationId: string;
+  taxRatePercent: number;
+  isProd: boolean;
+}
+
+/**
+ * Read and validate one account's credentials from the resolved Firebase
+ * secrets/strings, using the given key set (defaults to Maple & Spruce).
+ *
+ * Mirrors `ServiceEnvironment`'s env normalization + secret lookup inline so
+ * this file stays free of the functions barrel (see file header). Throws with
+ * the account-specific param name when a value is missing/invalid.
+ */
+export function resolveSquareCredentials(
+  secrets: Record<string, string>,
+  strings: Record<string, string>,
+  keys: SquareParamKeys = DEFAULT_SQUARE_KEYS
+): ResolvedSquareCredentials {
+  const isProd = (strings[keys.envString] ?? 'LOCAL').toUpperCase() === 'PROD';
+
+  const accessToken = secrets[keys.accessTokenSecret];
+  if (!accessToken) {
+    throw new Error(
+      `Secret ${keys.accessTokenSecret} not configured. ` +
+        `Set it using: firebase functions:secrets:set ${keys.accessTokenSecret}`
+    );
+  }
+
+  const locationId = strings[keys.locationIdString];
+  if (!locationId) {
+    throw new Error(
+      `Square location ID not configured. Set ${keys.locationIdString}.`
+    );
+  }
+
+  const taxRatePercent = parseFloat(strings[keys.taxRateString]);
+  if (isNaN(taxRatePercent) || taxRatePercent < 0) {
+    throw new Error(
+      `Sales tax rate not configured or invalid. Set ${keys.taxRateString} (e.g., "6.0").`
+    );
+  }
+
+  return { accessToken, locationId, taxRatePercent, isProd };
+}

--- a/libs/firebase/square/src/lib/square.utility.spec.ts
+++ b/libs/firebase/square/src/lib/square.utility.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import {
+  Square,
+  DEFAULT_SQUARE_KEYS,
+  MT_SQUARE_KEYS,
+  MT_SQUARE_SECRET_NAMES,
+  MT_SQUARE_STRING_NAMES,
+  SQUARE_SECRET_NAMES,
+  SQUARE_STRING_NAMES,
+} from './square.utility';
+
+// The Square constructor instantiates a SquareClient but makes no network
+// call at construction time, so these tests exercise pure credential-routing
+// logic: which param names each account reads.
+
+const MS_SECRETS = { SQUARE_ACCESS_TOKEN: 'ms-token' };
+const MS_STRINGS = {
+  SQUARE_ENV: 'LOCAL',
+  SQUARE_LOCATION_ID: 'MS_LOC',
+  SALES_TAX_RATE: '6.0',
+};
+
+const MT_SECRETS = { MT_SQUARE_ACCESS_TOKEN: 'mt-token' };
+const MT_STRINGS = {
+  MT_SQUARE_ENV: 'LOCAL',
+  MT_SQUARE_LOCATION_ID: 'MT_LOC',
+  MT_SALES_TAX_RATE: '0.0',
+};
+
+describe('param name tuples', () => {
+  it('default and MT name sets are disjoint and prefixed', () => {
+    expect(SQUARE_SECRET_NAMES).toEqual(['SQUARE_ACCESS_TOKEN']);
+    expect(MT_SQUARE_SECRET_NAMES).toEqual(['MT_SQUARE_ACCESS_TOKEN']);
+    expect(SQUARE_STRING_NAMES).toContain('SQUARE_LOCATION_ID');
+    expect(MT_SQUARE_STRING_NAMES).toEqual([
+      'MT_SQUARE_ENV',
+      'MT_SQUARE_LOCATION_ID',
+      'MT_SALES_TAX_RATE',
+    ]);
+    // No overlap — MT must never read the M&S account's params.
+    const overlap = MT_SQUARE_STRING_NAMES.filter((n) =>
+      (SQUARE_STRING_NAMES as readonly string[]).includes(n)
+    );
+    expect(overlap).toEqual([]);
+  });
+
+  it('key sets map to the matching tuples', () => {
+    expect(DEFAULT_SQUARE_KEYS.accessTokenSecret).toBe('SQUARE_ACCESS_TOKEN');
+    expect(DEFAULT_SQUARE_KEYS.locationIdString).toBe('SQUARE_LOCATION_ID');
+    expect(MT_SQUARE_KEYS.accessTokenSecret).toBe('MT_SQUARE_ACCESS_TOKEN');
+    expect(MT_SQUARE_KEYS.locationIdString).toBe('MT_SQUARE_LOCATION_ID');
+    expect(MT_SQUARE_KEYS.taxRateString).toBe('MT_SALES_TAX_RATE');
+  });
+});
+
+describe('Square credential routing', () => {
+  it('defaults to the Maple & Spruce account', () => {
+    const square = new Square(MS_SECRETS, MS_STRINGS);
+    expect(square.locationId).toBe('MS_LOC');
+    expect(square.taxRatePercent).toBe(6.0);
+    expect(square.isProduction()).toBe(false);
+  });
+
+  it('routes to the Music Together account when given MT keys', () => {
+    const square = new Square(MT_SECRETS, MT_STRINGS, MT_SQUARE_KEYS);
+    expect(square.locationId).toBe('MT_LOC');
+    expect(square.taxRatePercent).toBe(0.0); // non-taxable service
+  });
+
+  it('reads PROD env per account independently', () => {
+    const square = new Square(
+      { MT_SQUARE_ACCESS_TOKEN: 't' },
+      { ...MT_STRINGS, MT_SQUARE_ENV: 'PROD' },
+      MT_SQUARE_KEYS
+    );
+    expect(square.isProduction()).toBe(true);
+  });
+
+  it('does not read the wrong account’s token', () => {
+    // MT keys against only-M&S secrets must fail — proves no cross-account leak.
+    expect(() => new Square(MS_SECRETS, MT_STRINGS, MT_SQUARE_KEYS)).toThrow(
+      /MT_SQUARE_ACCESS_TOKEN/
+    );
+  });
+
+  it('throws with the account-specific param name when location is missing', () => {
+    expect(
+      () =>
+        new Square(
+          MT_SECRETS,
+          { ...MT_STRINGS, MT_SQUARE_LOCATION_ID: '' },
+          MT_SQUARE_KEYS
+        )
+    ).toThrow(/MT_SQUARE_LOCATION_ID/);
+  });
+
+  it('throws with the account-specific param name when tax rate is invalid', () => {
+    expect(
+      () =>
+        new Square(
+          MT_SECRETS,
+          { ...MT_STRINGS, MT_SALES_TAX_RATE: 'abc' },
+          MT_SQUARE_KEYS
+        )
+    ).toThrow(/MT_SALES_TAX_RATE/);
+  });
+});

--- a/libs/firebase/square/src/lib/square.utility.ts
+++ b/libs/firebase/square/src/lib/square.utility.ts
@@ -10,7 +10,11 @@
  * @see https://developer.squareup.com/docs/square-get-started
  */
 import { SquareClient, SquareEnvironment } from 'square';
-import { ServiceEnvironment } from '@maple/firebase/functions';
+import {
+  resolveSquareCredentials,
+  DEFAULT_SQUARE_KEYS,
+  type SquareParamKeys,
+} from './square-credentials';
 import { CatalogService } from './catalog.service';
 import { InventoryService } from './inventory.service';
 import { OrdersService } from './orders.service';
@@ -20,91 +24,23 @@ import { CardsService } from './cards.service';
 import { SubscriptionsService } from './subscriptions.service';
 import { CustomersService } from './customers.service';
 
-/**
- * Secret names for Firebase Functions secrets
- * Use with defineSecret() from firebase-functions/params
- *
- * Each Firebase project has its own SQUARE_ACCESS_TOKEN with the appropriate value:
- * - maple-and-spruce-dev: sandbox token
- * - maple-and-spruce: production token
- */
-export const SQUARE_SECRET_NAMES = ['SQUARE_ACCESS_TOKEN'] as const;
-
-/**
- * String parameter names for Firebase Functions
- * Use with defineString() from firebase-functions/params
- *
- * SQUARE_ENV: 'LOCAL' (sandbox) or 'PROD' (production)
- * SQUARE_LOCATION_ID: The location ID for inventory operations
- * SALES_TAX_RATE: Sales tax rate as percentage (e.g., '6.0' for 6%)
- */
-export const SQUARE_STRING_NAMES = [
-  'SQUARE_ENV',
-  'SQUARE_LOCATION_ID',
-  'SALES_TAX_RATE',
-] as const;
-
-export type SquareSecrets = Record<
-  (typeof SQUARE_SECRET_NAMES)[number],
-  string
->;
-
-export type SquareStrings = Record<
-  (typeof SQUARE_STRING_NAMES)[number],
-  string
->;
-
-/**
- * Music Together (MT) is a SEPARATE business (Stephanie's single-member LLC)
- * with its OWN Square account/checking. Its checkouts must route to MT's
- * Square credentials, not Maple & Spruce's. These are the prefixed param names
- * a Cloud Function declares via `.usingSecrets(...)` / `.usingStrings(...)`
- * when it needs the MT account.
- *
- * The secret value (MT_SQUARE_ACCESS_TOKEN) lives in Secret Manager / .secret.local,
- * never in the tracked .env files. The string params live in .env.dev/.env.prod
- * (mirroring the default SQUARE_* set).
- */
-export const MT_SQUARE_SECRET_NAMES = ['MT_SQUARE_ACCESS_TOKEN'] as const;
-
-export const MT_SQUARE_STRING_NAMES = [
-  'MT_SQUARE_ENV',
-  'MT_SQUARE_LOCATION_ID',
-  'MT_SALES_TAX_RATE',
-] as const;
-
-/**
- * The four Firebase param names a {@link Square} instance reads, so the same
- * client wrapper can be pointed at either the Maple & Spruce account (default)
- * or a second program's account (e.g. Music Together) without touching any
- * call site beyond which key set it passes.
- */
-export interface SquareParamKeys {
-  /** defineSecret name holding the access token */
-  accessTokenSecret: string;
-  /** defineString name holding 'LOCAL' | 'PROD' */
-  envString: string;
-  /** defineString name holding the Square location ID */
-  locationIdString: string;
-  /** defineString name holding the sales-tax rate percent (e.g. '6.0') */
-  taxRateString: string;
-}
-
-/** Default Maple & Spruce account keys — preserves all existing behavior. */
-export const DEFAULT_SQUARE_KEYS: SquareParamKeys = {
-  accessTokenSecret: 'SQUARE_ACCESS_TOKEN',
-  envString: 'SQUARE_ENV',
-  locationIdString: 'SQUARE_LOCATION_ID',
-  taxRateString: 'SALES_TAX_RATE',
-};
-
-/** Music Together account keys (separate Square account). */
-export const MT_SQUARE_KEYS: SquareParamKeys = {
-  accessTokenSecret: 'MT_SQUARE_ACCESS_TOKEN',
-  envString: 'MT_SQUARE_ENV',
-  locationIdString: 'MT_SQUARE_LOCATION_ID',
-  taxRateString: 'MT_SALES_TAX_RATE',
-};
+// Re-export the credential symbols so existing importers of './square.utility'
+// (and the lib barrel) keep working. The definitions live in the barrel-free
+// './square-credentials' module so unit tests can cover them without pulling
+// the functions/database layers into the coverage denominator.
+export {
+  SQUARE_SECRET_NAMES,
+  SQUARE_STRING_NAMES,
+  MT_SQUARE_SECRET_NAMES,
+  MT_SQUARE_STRING_NAMES,
+  DEFAULT_SQUARE_KEYS,
+  MT_SQUARE_KEYS,
+  resolveSquareCredentials,
+  type SquareSecrets,
+  type SquareStrings,
+  type SquareParamKeys,
+  type ResolvedSquareCredentials,
+} from './square-credentials';
 
 /**
  * Square utility class
@@ -132,7 +68,7 @@ export const MT_SQUARE_KEYS: SquareParamKeys = {
  */
 export class Square {
   private readonly client: SquareClient;
-  private readonly env: ServiceEnvironment;
+  private readonly _isProd: boolean;
   private readonly _catalogService: CatalogService;
   private readonly _inventoryService: InventoryService;
   private readonly _ordersService: OrdersService;
@@ -156,32 +92,18 @@ export class Square {
     private readonly strings: Record<string, string>,
     keys: SquareParamKeys = DEFAULT_SQUARE_KEYS
   ) {
-    this.env = new ServiceEnvironment(this.strings[keys.envString]);
-    // With per-project secrets, just get the token directly - no suffix needed
-    const accessToken = this.env.getSecret(
-      this.secrets,
-      keys.accessTokenSecret
-    );
+    // Pure routing + validation lives in ./square-credentials so it can be
+    // unit-tested without loading this file's heavy imports.
+    const { accessToken, locationId, taxRatePercent, isProd } =
+      resolveSquareCredentials(this.secrets, this.strings, keys);
 
-    this.locationId = this.strings[keys.locationIdString];
-
-    if (!this.locationId) {
-      throw new Error(
-        `Square location ID not configured. Set ${keys.locationIdString}.`
-      );
-    }
-
-    const taxRate = parseFloat(this.strings[keys.taxRateString]);
-    if (isNaN(taxRate) || taxRate < 0) {
-      throw new Error(
-        `Sales tax rate not configured or invalid. Set ${keys.taxRateString} (e.g., "6.0").`
-      );
-    }
-    this.taxRatePercent = taxRate;
+    this.locationId = locationId;
+    this.taxRatePercent = taxRatePercent;
+    this._isProd = isProd;
 
     this.client = new SquareClient({
       token: accessToken,
-      environment: this.env.isProd
+      environment: this._isProd
         ? SquareEnvironment.Production
         : SquareEnvironment.Sandbox,
       ...(process.env['SQUARE_BASE_URL']
@@ -210,7 +132,7 @@ export class Square {
    * Check if running in production mode
    */
   isProduction(): boolean {
-    return this.env.isProd;
+    return this._isProd;
   }
 
   /**

--- a/libs/firebase/square/src/lib/square.utility.ts
+++ b/libs/firebase/square/src/lib/square.utility.ts
@@ -55,6 +55,58 @@ export type SquareStrings = Record<
 >;
 
 /**
+ * Music Together (MT) is a SEPARATE business (Stephanie's single-member LLC)
+ * with its OWN Square account/checking. Its checkouts must route to MT's
+ * Square credentials, not Maple & Spruce's. These are the prefixed param names
+ * a Cloud Function declares via `.usingSecrets(...)` / `.usingStrings(...)`
+ * when it needs the MT account.
+ *
+ * The secret value (MT_SQUARE_ACCESS_TOKEN) lives in Secret Manager / .secret.local,
+ * never in the tracked .env files. The string params live in .env.dev/.env.prod
+ * (mirroring the default SQUARE_* set).
+ */
+export const MT_SQUARE_SECRET_NAMES = ['MT_SQUARE_ACCESS_TOKEN'] as const;
+
+export const MT_SQUARE_STRING_NAMES = [
+  'MT_SQUARE_ENV',
+  'MT_SQUARE_LOCATION_ID',
+  'MT_SALES_TAX_RATE',
+] as const;
+
+/**
+ * The four Firebase param names a {@link Square} instance reads, so the same
+ * client wrapper can be pointed at either the Maple & Spruce account (default)
+ * or a second program's account (e.g. Music Together) without touching any
+ * call site beyond which key set it passes.
+ */
+export interface SquareParamKeys {
+  /** defineSecret name holding the access token */
+  accessTokenSecret: string;
+  /** defineString name holding 'LOCAL' | 'PROD' */
+  envString: string;
+  /** defineString name holding the Square location ID */
+  locationIdString: string;
+  /** defineString name holding the sales-tax rate percent (e.g. '6.0') */
+  taxRateString: string;
+}
+
+/** Default Maple & Spruce account keys — preserves all existing behavior. */
+export const DEFAULT_SQUARE_KEYS: SquareParamKeys = {
+  accessTokenSecret: 'SQUARE_ACCESS_TOKEN',
+  envString: 'SQUARE_ENV',
+  locationIdString: 'SQUARE_LOCATION_ID',
+  taxRateString: 'SALES_TAX_RATE',
+};
+
+/** Music Together account keys (separate Square account). */
+export const MT_SQUARE_KEYS: SquareParamKeys = {
+  accessTokenSecret: 'MT_SQUARE_ACCESS_TOKEN',
+  envString: 'MT_SQUARE_ENV',
+  locationIdString: 'MT_SQUARE_LOCATION_ID',
+  taxRateString: 'MT_SALES_TAX_RATE',
+};
+
+/**
  * Square utility class
  *
  * Initialize with secrets and strings from Firebase Functions params.
@@ -92,29 +144,37 @@ export class Square {
   public readonly locationId: string;
   public readonly taxRatePercent: number;
 
+  /**
+   * @param secrets - Resolved Firebase secrets (keyed by secret name)
+   * @param strings - Resolved Firebase string params (keyed by param name)
+   * @param keys - Which param names to read. Defaults to the Maple & Spruce
+   *   account ({@link DEFAULT_SQUARE_KEYS}). Pass {@link MT_SQUARE_KEYS} to
+   *   route to the Music Together account.
+   */
   constructor(
-    private readonly secrets: SquareSecrets,
-    private readonly strings: SquareStrings
+    private readonly secrets: Record<string, string>,
+    private readonly strings: Record<string, string>,
+    keys: SquareParamKeys = DEFAULT_SQUARE_KEYS
   ) {
-    this.env = new ServiceEnvironment(this.strings.SQUARE_ENV);
+    this.env = new ServiceEnvironment(this.strings[keys.envString]);
     // With per-project secrets, just get the token directly - no suffix needed
     const accessToken = this.env.getSecret(
       this.secrets,
-      'SQUARE_ACCESS_TOKEN'
+      keys.accessTokenSecret
     );
 
-    this.locationId = this.strings.SQUARE_LOCATION_ID;
+    this.locationId = this.strings[keys.locationIdString];
 
     if (!this.locationId) {
       throw new Error(
-        'Square location ID not configured. Set SQUARE_LOCATION_ID.'
+        `Square location ID not configured. Set ${keys.locationIdString}.`
       );
     }
 
-    const taxRate = parseFloat(this.strings.SALES_TAX_RATE);
+    const taxRate = parseFloat(this.strings[keys.taxRateString]);
     if (isNaN(taxRate) || taxRate < 0) {
       throw new Error(
-        'Sales tax rate not configured or invalid. Set SALES_TAX_RATE (e.g., "6.0").'
+        `Sales tax rate not configured or invalid. Set ${keys.taxRateString} (e.g., "6.0").`
       );
     }
     this.taxRatePercent = taxRate;


### PR DESCRIPTION
## Summary
Phase 0 of the Music Together epic (#508): make the Square integration **multi-account** so MT checkouts can route to MT's **separate Square account** without changing any existing M&S flow.

The `Square` client is already instantiated per-call from constructor args, so this is parameterization, not a refactor.

## Changes
- `Square` constructor takes an optional `SquareParamKeys` (defaults to `DEFAULT_SQUARE_KEYS` = the M&S `SQUARE_*` params, so **every existing call site is unchanged**). Pass `MT_SQUARE_KEYS` to read the `MT_SQUARE_*` set.
- New `MT_SQUARE_SECRET_NAMES` / `MT_SQUARE_STRING_NAMES` tuples for the `.usingSecrets()`/`.usingStrings()` builder; new symbols exported from the lib barrel.
- `MT_SQUARE_*` string params added to `.env.dev`/`.env.prod` (env set; `MT_SALES_TAX_RATE=0.0` since MT tuition is non-taxable; sandbox location/app IDs left as `TODO(#510)` to fill from the MT Square dashboard). The MT **access token** stays a Firebase Secret — not in tracked env files.
- Unit tests: account routing, PROD/LOCAL per account, and that MT keys **never read the M&S token** (no cross-account leak).

## Scope note — webhook deferred
`musicSquareWebhook` is intentionally **not** built here. MT's flow is synchronous (Orders + Payments + Cards), exactly like class registration, which needs no webhook. A second-account webhook is only warranted once MT subscribes to async Square events. Tracked in #510.

## Follow-up (David)
- Add MT sandbox **location ID** + **application ID** to `.env.dev` (TODO markers in place).
- Add `MT_SQUARE_ACCESS_TOKEN` to Firebase Secret Manager + `.secret.local` for the emulator.

## Testing
- [x] `nx lint square` — 0 errors
- [x] All 77 square specs pass (8 new in `square.utility.spec.ts`)

Refs #508 · Closes #510