### PR TITLE
feat(music-together): data layer — sections + registrations (#511)

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1357,6 +1357,98 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "musicTogetherRegistrations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "sectionId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "musicTogetherRegistrations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "sectionId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "email",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "musicTogetherSections",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "firstSessionAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "musicTogetherRegistrations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "sectionId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "musicTogetherRegistrations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "email",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "musicTogetherRegistrations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1449,6 +1449,70 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "musicTogetherScheduledCharges",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dueAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "musicTogetherScheduledCharges",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "registrationId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "sectionId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dueAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "musicTogetherScheduledCharges",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "registrationId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dueAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "musicTogetherScheduledCharges",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "sectionId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dueAt",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/libs/firebase/database/src/index.ts
+++ b/libs/firebase/database/src/index.ts
@@ -92,6 +92,16 @@ export {
   CRAFT_CLUB_SESSION_TTL_MS,
 } from './lib/craft-club-token.repository';
 
+// Music Together (separate-business early-childhood music program)
+export {
+  MusicTogetherSectionRepository,
+  type MusicTogetherSectionFilters,
+} from './lib/music-together-section.repository';
+export {
+  MusicTogetherRegistrationRepository,
+  type MusicTogetherRegistrationFilters,
+} from './lib/music-together-registration.repository';
+
 // Phase 5: Etsy
 export {
   FirestoreTokenStorage,

--- a/libs/firebase/database/src/index.ts
+++ b/libs/firebase/database/src/index.ts
@@ -101,6 +101,10 @@ export {
   MusicTogetherRegistrationRepository,
   type MusicTogetherRegistrationFilters,
 } from './lib/music-together-registration.repository';
+export {
+  MusicTogetherScheduledChargeRepository,
+  type MusicTogetherScheduledChargeFilters,
+} from './lib/music-together-scheduled-charge.repository';
 
 // Phase 5: Etsy
 export {

--- a/libs/firebase/database/src/lib/music-together-registration.repository.ts
+++ b/libs/firebase/database/src/lib/music-together-registration.repository.ts
@@ -9,7 +9,6 @@ import {
   MT_CAPACITY_STATUSES,
   type MusicTogetherRegistration,
   type MusicTogetherChild,
-  type MusicTogetherInstallment,
   type MusicTogetherPaymentPlan,
   type MusicTogetherRegistrationStatus,
   type CreateMusicTogetherRegistrationInput,
@@ -30,20 +29,6 @@ function parseChildren(raw: unknown): MusicTogetherChild[] {
     out.push({ name: e.name, dob: toDate(e.dob) });
   }
   return out;
-}
-
-function parseInstallment(raw: unknown): MusicTogetherInstallment | undefined {
-  if (!raw || typeof raw !== 'object') return undefined;
-  const r = raw as Record<string, unknown>;
-  return {
-    status: r.status as MusicTogetherInstallment['status'],
-    dueAt: toDate(r.dueAt),
-    amountCents: r.amountCents as number,
-    idempotencyKey: r.idempotencyKey as string,
-    squarePaymentId: r.squarePaymentId as string | undefined,
-    lastError: r.lastError as string | undefined,
-    resolvedAt: r.resolvedAt ? toDate(r.resolvedAt) : undefined,
-  };
 }
 
 function docToRegistration(
@@ -70,7 +55,7 @@ function docToRegistration(
     squarePaymentId: data.squarePaymentId,
     squareOrderId: data.squareOrderId,
     squareReceiptUrl: data.squareReceiptUrl,
-    installment2: parseInstallment(data.installment2),
+    scheduledChargeCount: data.scheduledChargeCount,
     status: data.status as MusicTogetherRegistrationStatus,
     notes: data.notes,
     confirmationSentAt: data.confirmationSentAt

--- a/libs/firebase/database/src/lib/music-together-registration.repository.ts
+++ b/libs/firebase/database/src/lib/music-together-registration.repository.ts
@@ -1,0 +1,185 @@
+/**
+ * Music Together Registration Repository
+ *
+ * Firestore operations for Music Together registrations (one document per
+ * enrolled family). All access goes through this repository (deny-all rules).
+ */
+import { getDb, toDate } from './utilities/database.config';
+import {
+  MT_CAPACITY_STATUSES,
+  type MusicTogetherRegistration,
+  type MusicTogetherChild,
+  type MusicTogetherInstallment,
+  type MusicTogetherPaymentPlan,
+  type MusicTogetherRegistrationStatus,
+  type CreateMusicTogetherRegistrationInput,
+  type UpdateMusicTogetherRegistrationInput,
+} from '@maple/ts/domain';
+
+const COLLECTION = 'musicTogetherRegistrations';
+
+function parseChildren(raw: unknown): MusicTogetherChild[] {
+  if (!Array.isArray(raw)) return [];
+  const out: MusicTogetherChild[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue;
+    const e = entry as { name?: unknown; dob?: unknown };
+    if (typeof e.name !== 'string' || e.dob === undefined || e.dob === null) {
+      continue;
+    }
+    out.push({ name: e.name, dob: toDate(e.dob) });
+  }
+  return out;
+}
+
+function parseInstallment(raw: unknown): MusicTogetherInstallment | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const r = raw as Record<string, unknown>;
+  return {
+    status: r.status as MusicTogetherInstallment['status'],
+    dueAt: toDate(r.dueAt),
+    amountCents: r.amountCents as number,
+    idempotencyKey: r.idempotencyKey as string,
+    squarePaymentId: r.squarePaymentId as string | undefined,
+    lastError: r.lastError as string | undefined,
+    resolvedAt: r.resolvedAt ? toDate(r.resolvedAt) : undefined,
+  };
+}
+
+function docToRegistration(
+  doc: FirebaseFirestore.DocumentSnapshot
+): MusicTogetherRegistration | undefined {
+  if (!doc.exists) return undefined;
+  const data = doc.data()!;
+  return {
+    id: doc.id,
+    sectionId: data.sectionId,
+    parentNames: Array.isArray(data.parentNames) ? data.parentNames : [],
+    children: parseChildren(data.children),
+    email: data.email,
+    phone: data.phone,
+    address: data.address,
+    paymentPlan: data.paymentPlan as MusicTogetherPaymentPlan,
+    policiesAcceptedAt: toDate(data.policiesAcceptedAt),
+    cardOnFileAuthAt: data.cardOnFileAuthAt
+      ? toDate(data.cardOnFileAuthAt)
+      : undefined,
+    pricePaidCents: data.pricePaidCents,
+    squareCustomerId: data.squareCustomerId,
+    squareCardId: data.squareCardId,
+    squarePaymentId: data.squarePaymentId,
+    squareOrderId: data.squareOrderId,
+    squareReceiptUrl: data.squareReceiptUrl,
+    installment2: parseInstallment(data.installment2),
+    status: data.status as MusicTogetherRegistrationStatus,
+    notes: data.notes,
+    confirmationSentAt: data.confirmationSentAt
+      ? toDate(data.confirmationSentAt)
+      : undefined,
+    createdAt: toDate(data.createdAt),
+    updatedAt: toDate(data.updatedAt),
+  };
+}
+
+export interface MusicTogetherRegistrationFilters {
+  sectionId?: string;
+  email?: string;
+  status?: MusicTogetherRegistrationStatus;
+}
+
+export const MusicTogetherRegistrationRepository = {
+  async findAll(
+    filters?: MusicTogetherRegistrationFilters
+  ): Promise<MusicTogetherRegistration[]> {
+    let query: FirebaseFirestore.Query = getDb().collection(COLLECTION);
+
+    if (filters?.sectionId) {
+      query = query.where('sectionId', '==', filters.sectionId);
+    }
+    if (filters?.email) {
+      query = query.where('email', '==', filters.email);
+    }
+    if (filters?.status) {
+      query = query.where('status', '==', filters.status);
+    }
+
+    query = query.orderBy('createdAt', 'desc');
+
+    const snapshot = await query.get();
+    return snapshot.docs
+      .map((doc) => docToRegistration(doc))
+      .filter((r): r is MusicTogetherRegistration => r !== undefined);
+  },
+
+  async findById(id: string): Promise<MusicTogetherRegistration | undefined> {
+    const doc = await getDb().collection(COLLECTION).doc(id).get();
+    return docToRegistration(doc);
+  },
+
+  async findBySectionId(
+    sectionId: string
+  ): Promise<MusicTogetherRegistration[]> {
+    return this.findAll({ sectionId });
+  },
+
+  /**
+   * Count families holding a spot in a section (each registration is one
+   * family). Defaults to pending + confirmed — the capacity-relevant states.
+   */
+  async countBySectionId(
+    sectionId: string,
+    statuses: readonly MusicTogetherRegistrationStatus[] = MT_CAPACITY_STATUSES
+  ): Promise<number> {
+    const snapshot = await getDb()
+      .collection(COLLECTION)
+      .where('sectionId', '==', sectionId)
+      .where('status', 'in', statuses as MusicTogetherRegistrationStatus[])
+      .get();
+    return snapshot.size;
+  },
+
+  async create(
+    input: CreateMusicTogetherRegistrationInput
+  ): Promise<MusicTogetherRegistration> {
+    const docRef = getDb().collection(COLLECTION).doc();
+    const now = new Date();
+    const data = { ...input, createdAt: now, updatedAt: now };
+    await docRef.set(data);
+    const created = await docRef.get();
+    const registration = docToRegistration(created);
+    if (!registration) {
+      throw new Error(`Registration ${docRef.id} not found after create`);
+    }
+    return registration;
+  },
+
+  async update(
+    input: UpdateMusicTogetherRegistrationInput
+  ): Promise<MusicTogetherRegistration> {
+    const { id, ...updates } = input;
+    const docRef = getDb().collection(COLLECTION).doc(id);
+    await docRef.update({ ...updates, updatedAt: new Date() });
+    const updated = await docRef.get();
+    const registration = docToRegistration(updated);
+    if (!registration) {
+      throw new Error(`Registration ${id} not found after update`);
+    }
+    return registration;
+  },
+
+  async delete(id: string): Promise<void> {
+    await getDb().collection(COLLECTION).doc(id).delete();
+  },
+
+  /** Collection reference (for transactions / the Week-5 charge query). */
+  getCollectionRef() {
+    return getDb().collection(COLLECTION);
+  },
+
+  /** Document reference (for transactions). */
+  getDocRef(id?: string) {
+    return id
+      ? getDb().collection(COLLECTION).doc(id)
+      : getDb().collection(COLLECTION).doc();
+  },
+};

--- a/libs/firebase/database/src/lib/music-together-scheduled-charge.repository.ts
+++ b/libs/firebase/database/src/lib/music-together-scheduled-charge.repository.ts
@@ -1,0 +1,146 @@
+/**
+ * Music Together Scheduled Charge Repository
+ *
+ * Firestore operations for materialized future installment charges. The
+ * auto-charge job (Phase 4) queries `findDue()`; cancellation flips a
+ * registration's charges via `findByRegistrationId()`.
+ */
+import { getDb, toDate } from './utilities/database.config';
+import {
+  mtChargeIdempotencyKey,
+  type MusicTogetherScheduledCharge,
+  type MusicTogetherChargeStatus,
+  type CreateMusicTogetherScheduledChargeInput,
+  type UpdateMusicTogetherScheduledChargeInput,
+} from '@maple/ts/domain';
+
+const COLLECTION = 'musicTogetherScheduledCharges';
+
+function docToCharge(
+  doc: FirebaseFirestore.DocumentSnapshot
+): MusicTogetherScheduledCharge | undefined {
+  if (!doc.exists) return undefined;
+  const data = doc.data()!;
+  return {
+    id: doc.id,
+    registrationId: data.registrationId,
+    sectionId: data.sectionId,
+    installmentNumber: data.installmentNumber,
+    amountCents: data.amountCents,
+    dueAt: toDate(data.dueAt),
+    status: data.status as MusicTogetherChargeStatus,
+    idempotencyKey: data.idempotencyKey,
+    squarePaymentId: data.squarePaymentId,
+    lastError: data.lastError,
+    resolvedAt: data.resolvedAt ? toDate(data.resolvedAt) : undefined,
+    createdAt: toDate(data.createdAt),
+    updatedAt: toDate(data.updatedAt),
+  };
+}
+
+export interface MusicTogetherScheduledChargeFilters {
+  registrationId?: string;
+  sectionId?: string;
+  status?: MusicTogetherChargeStatus;
+}
+
+export const MusicTogetherScheduledChargeRepository = {
+  async findAll(
+    filters?: MusicTogetherScheduledChargeFilters
+  ): Promise<MusicTogetherScheduledCharge[]> {
+    let query: FirebaseFirestore.Query = getDb().collection(COLLECTION);
+
+    if (filters?.registrationId) {
+      query = query.where('registrationId', '==', filters.registrationId);
+    }
+    if (filters?.sectionId) {
+      query = query.where('sectionId', '==', filters.sectionId);
+    }
+    if (filters?.status) {
+      query = query.where('status', '==', filters.status);
+    }
+
+    query = query.orderBy('dueAt', 'asc');
+
+    const snapshot = await query.get();
+    return snapshot.docs
+      .map((doc) => docToCharge(doc))
+      .filter((c): c is MusicTogetherScheduledCharge => c !== undefined);
+  },
+
+  async findById(
+    id: string
+  ): Promise<MusicTogetherScheduledCharge | undefined> {
+    const doc = await getDb().collection(COLLECTION).doc(id).get();
+    return docToCharge(doc);
+  },
+
+  /** All charges for a registration (used by the cancel flow). */
+  async findByRegistrationId(
+    registrationId: string
+  ): Promise<MusicTogetherScheduledCharge[]> {
+    return this.findAll({ registrationId });
+  },
+
+  /**
+   * Charges that are due to run: still `scheduled` with `dueAt <= asOf`.
+   * This is the auto-charge job's primary query.
+   */
+  async findDue(asOf: Date): Promise<MusicTogetherScheduledCharge[]> {
+    const snapshot = await getDb()
+      .collection(COLLECTION)
+      .where('status', '==', 'scheduled')
+      .where('dueAt', '<=', asOf)
+      .orderBy('dueAt', 'asc')
+      .get();
+    return snapshot.docs
+      .map((doc) => docToCharge(doc))
+      .filter((c): c is MusicTogetherScheduledCharge => c !== undefined);
+  },
+
+  async create(
+    input: CreateMusicTogetherScheduledChargeInput
+  ): Promise<MusicTogetherScheduledCharge> {
+    const docRef = getDb().collection(COLLECTION).doc();
+    const now = new Date();
+    // Idempotency key derives from the (stable) doc id — never time-based.
+    const data = {
+      ...input,
+      idempotencyKey: mtChargeIdempotencyKey(docRef.id),
+      createdAt: now,
+      updatedAt: now,
+    };
+    await docRef.set(data);
+    const created = await docRef.get();
+    const charge = docToCharge(created);
+    if (!charge) {
+      throw new Error(`Scheduled charge ${docRef.id} not found after create`);
+    }
+    return charge;
+  },
+
+  async update(
+    input: UpdateMusicTogetherScheduledChargeInput
+  ): Promise<MusicTogetherScheduledCharge> {
+    const { id, ...updates } = input;
+    const docRef = getDb().collection(COLLECTION).doc(id);
+    await docRef.update({ ...updates, updatedAt: new Date() });
+    const updated = await docRef.get();
+    const charge = docToCharge(updated);
+    if (!charge) {
+      throw new Error(`Scheduled charge ${id} not found after update`);
+    }
+    return charge;
+  },
+
+  async delete(id: string): Promise<void> {
+    await getDb().collection(COLLECTION).doc(id).delete();
+  },
+
+  /** Document reference (for transactional lease claims in the charge job). */
+  getDocRef(id?: string) {
+    return id
+      ? getDb().collection(COLLECTION).doc(id)
+      : getDb().collection(COLLECTION).doc();
+  },
+};

--- a/libs/firebase/database/src/lib/music-together-section.repository.ts
+++ b/libs/firebase/database/src/lib/music-together-section.repository.ts
@@ -9,6 +9,7 @@ import {
   mtSectionFirstSessionAt,
   type MusicTogetherSection,
   type MusicTogetherSession,
+  type MusicTogetherInstallmentPlanItem,
   type MusicTogetherSectionStatus,
   type CreateMusicTogetherSectionInput,
   type UpdateMusicTogetherSectionInput,
@@ -28,6 +29,22 @@ function parseSessions(raw: unknown): MusicTogetherSession[] {
   return out;
 }
 
+function parseInstallmentPlan(
+  raw: unknown
+): MusicTogetherInstallmentPlanItem[] | undefined {
+  if (!Array.isArray(raw) || raw.length === 0) return undefined;
+  const out: MusicTogetherInstallmentPlanItem[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue;
+    const e = entry as { amountCents?: unknown; dueAt?: unknown };
+    if (typeof e.amountCents !== 'number' || e.dueAt === undefined || e.dueAt === null) {
+      continue;
+    }
+    out.push({ amountCents: e.amountCents, dueAt: toDate(e.dueAt) });
+  }
+  return out.length > 0 ? out : undefined;
+}
+
 function docToSection(
   doc: FirebaseFirestore.DocumentSnapshot
 ): MusicTogetherSection | undefined {
@@ -40,9 +57,7 @@ function docToSection(
     sessions: parseSessions(data.sessions),
     capacityFamilies: data.capacityFamilies,
     priceFullCents: data.priceFullCents,
-    installmentCents: data.installmentCents,
-    installmentCount: data.installmentCount,
-    week5ChargeAt: toDate(data.week5ChargeAt),
+    installmentPlan: parseInstallmentPlan(data.installmentPlan),
     status: data.status as MusicTogetherSectionStatus,
     location: data.location,
     room: data.room,

--- a/libs/firebase/database/src/lib/music-together-section.repository.ts
+++ b/libs/firebase/database/src/lib/music-together-section.repository.ts
@@ -1,0 +1,143 @@
+/**
+ * Music Together Section Repository
+ *
+ * Firestore operations for Music Together sections (one term of the program).
+ * All database access goes through this repository (deny-all rules; Admin SDK).
+ */
+import { getDb, toDate } from './utilities/database.config';
+import {
+  mtSectionFirstSessionAt,
+  type MusicTogetherSection,
+  type MusicTogetherSession,
+  type MusicTogetherSectionStatus,
+  type CreateMusicTogetherSectionInput,
+  type UpdateMusicTogetherSectionInput,
+} from '@maple/ts/domain';
+
+const COLLECTION = 'musicTogetherSections';
+
+function parseSessions(raw: unknown): MusicTogetherSession[] {
+  if (!Array.isArray(raw)) return [];
+  const out: MusicTogetherSession[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue;
+    const e = entry as { dateTime?: unknown };
+    if (e.dateTime === undefined || e.dateTime === null) continue;
+    out.push({ dateTime: toDate(e.dateTime) });
+  }
+  return out;
+}
+
+function docToSection(
+  doc: FirebaseFirestore.DocumentSnapshot
+): MusicTogetherSection | undefined {
+  if (!doc.exists) return undefined;
+  const data = doc.data()!;
+  return {
+    id: doc.id,
+    name: data.name,
+    description: data.description,
+    sessions: parseSessions(data.sessions),
+    capacityFamilies: data.capacityFamilies,
+    priceFullCents: data.priceFullCents,
+    installmentCents: data.installmentCents,
+    installmentCount: data.installmentCount,
+    week5ChargeAt: toDate(data.week5ChargeAt),
+    status: data.status as MusicTogetherSectionStatus,
+    location: data.location,
+    room: data.room,
+    webflowItemId: data.webflowItemId,
+    createdAt: toDate(data.createdAt),
+    updatedAt: toDate(data.updatedAt),
+  };
+}
+
+/**
+ * Build the persisted payload, denormalizing `firstSessionAt` as an indexed
+ * sort key (mirrors class.repository — the field is write-only, not on the
+ * domain interface).
+ */
+function toPersisted(
+  input:
+    | CreateMusicTogetherSectionInput
+    | Omit<UpdateMusicTogetherSectionInput, 'id'>
+): Record<string, unknown> {
+  const data: Record<string, unknown> = { ...input };
+  if (input.sessions) {
+    data.firstSessionAt = mtSectionFirstSessionAt({ sessions: input.sessions });
+  }
+  return data;
+}
+
+export interface MusicTogetherSectionFilters {
+  status?: MusicTogetherSectionStatus;
+}
+
+export const MusicTogetherSectionRepository = {
+  async findAll(
+    filters?: MusicTogetherSectionFilters
+  ): Promise<MusicTogetherSection[]> {
+    let query: FirebaseFirestore.Query = getDb().collection(COLLECTION);
+
+    if (filters?.status) {
+      query = query.where('status', '==', filters.status);
+    }
+
+    query = query.orderBy('firstSessionAt', 'asc');
+
+    const snapshot = await query.get();
+    return snapshot.docs
+      .map((doc) => docToSection(doc))
+      .filter((s): s is MusicTogetherSection => s !== undefined);
+  },
+
+  async findById(id: string): Promise<MusicTogetherSection | undefined> {
+    const doc = await getDb().collection(COLLECTION).doc(id).get();
+    return docToSection(doc);
+  },
+
+  async create(
+    input: CreateMusicTogetherSectionInput
+  ): Promise<MusicTogetherSection> {
+    const docRef = getDb().collection(COLLECTION).doc();
+    const now = new Date();
+    const data = { ...toPersisted(input), createdAt: now, updatedAt: now };
+    await docRef.set(data);
+    const created = await docRef.get();
+    const section = docToSection(created);
+    if (!section) {
+      throw new Error(`Section ${docRef.id} not found after create`);
+    }
+    return section;
+  },
+
+  async update(
+    input: UpdateMusicTogetherSectionInput
+  ): Promise<MusicTogetherSection> {
+    const { id, ...updates } = input;
+    const docRef = getDb().collection(COLLECTION).doc(id);
+    await docRef.update({ ...toPersisted(updates), updatedAt: new Date() });
+    const updated = await docRef.get();
+    const section = docToSection(updated);
+    if (!section) {
+      throw new Error(`Section ${id} not found after update`);
+    }
+    return section;
+  },
+
+  async delete(id: string): Promise<void> {
+    await getDb().collection(COLLECTION).doc(id).delete();
+  },
+
+  /** Collection reference (for transactions). */
+  getCollectionRef() {
+    return getDb().collection(COLLECTION);
+  },
+
+  /** Document reference (for transactions). */
+  getDocRef(id?: string) {
+    return id
+      ? getDb().collection(COLLECTION).doc(id)
+      : getDb().collection(COLLECTION).doc();
+  },
+};

--- a/libs/ts/domain/src/index.ts
+++ b/libs/ts/domain/src/index.ts
@@ -44,6 +44,10 @@ export * from './lib/signed-agreement';
 // Craft Club (recurring studio-access membership)
 export * from './lib/craft-club-member';
 
+// Music Together (separate-business early-childhood music program)
+export * from './lib/music-together-section';
+export * from './lib/music-together-registration';
+
 // User & role administration
 export * from './lib/app-user';
 

--- a/libs/ts/domain/src/index.ts
+++ b/libs/ts/domain/src/index.ts
@@ -47,6 +47,7 @@ export * from './lib/craft-club-member';
 // Music Together (separate-business early-childhood music program)
 export * from './lib/music-together-section';
 export * from './lib/music-together-registration';
+export * from './lib/music-together-scheduled-charge';
 
 // User & role administration
 export * from './lib/app-user';

--- a/libs/ts/domain/src/lib/music-together-registration.spec.ts
+++ b/libs/ts/domain/src/lib/music-together-registration.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   isMtRegistrationConfirmed,
-  mtHasPendingInstallment,
+  mtRegistrationHasScheduledCharges,
   MT_CAPACITY_STATUSES,
 } from './music-together-registration';
 
@@ -19,33 +19,16 @@ describe('MT_CAPACITY_STATUSES', () => {
   });
 });
 
-describe('mtHasPendingInstallment', () => {
-  it('is true only when the second installment is still scheduled', () => {
+describe('mtRegistrationHasScheduledCharges', () => {
+  it('reflects the denormalized scheduled-charge count', () => {
+    expect(mtRegistrationHasScheduledCharges({ scheduledChargeCount: 1 })).toBe(
+      true
+    );
+    expect(mtRegistrationHasScheduledCharges({ scheduledChargeCount: 0 })).toBe(
+      false
+    );
     expect(
-      mtHasPendingInstallment({
-        installment2: {
-          status: 'scheduled',
-          dueAt: new Date(),
-          amountCents: 13200,
-          idempotencyKey: 'mt-installment2-abc',
-        },
-      })
-    ).toBe(true);
-  });
-
-  it('is false for terminal or absent installments', () => {
-    expect(mtHasPendingInstallment({ installment2: undefined })).toBe(false);
-    for (const status of ['charging', 'paid', 'failed', 'cancelled'] as const) {
-      expect(
-        mtHasPendingInstallment({
-          installment2: {
-            status,
-            dueAt: new Date(),
-            amountCents: 13200,
-            idempotencyKey: 'k',
-          },
-        })
-      ).toBe(false);
-    }
+      mtRegistrationHasScheduledCharges({ scheduledChargeCount: undefined })
+    ).toBe(false);
   });
 });

--- a/libs/ts/domain/src/lib/music-together-registration.spec.ts
+++ b/libs/ts/domain/src/lib/music-together-registration.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isMtRegistrationConfirmed,
+  mtHasPendingInstallment,
+  MT_CAPACITY_STATUSES,
+} from './music-together-registration';
+
+describe('isMtRegistrationConfirmed', () => {
+  it('is true only for confirmed', () => {
+    expect(isMtRegistrationConfirmed({ status: 'confirmed' })).toBe(true);
+    expect(isMtRegistrationConfirmed({ status: 'pending' })).toBe(false);
+    expect(isMtRegistrationConfirmed({ status: 'cancelled' })).toBe(false);
+  });
+});
+
+describe('MT_CAPACITY_STATUSES', () => {
+  it('counts pending and confirmed toward capacity', () => {
+    expect([...MT_CAPACITY_STATUSES]).toEqual(['pending', 'confirmed']);
+  });
+});
+
+describe('mtHasPendingInstallment', () => {
+  it('is true only when the second installment is still scheduled', () => {
+    expect(
+      mtHasPendingInstallment({
+        installment2: {
+          status: 'scheduled',
+          dueAt: new Date(),
+          amountCents: 13200,
+          idempotencyKey: 'mt-installment2-abc',
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('is false for terminal or absent installments', () => {
+    expect(mtHasPendingInstallment({ installment2: undefined })).toBe(false);
+    for (const status of ['charging', 'paid', 'failed', 'cancelled'] as const) {
+      expect(
+        mtHasPendingInstallment({
+          installment2: {
+            status,
+            dueAt: new Date(),
+            amountCents: 13200,
+            idempotencyKey: 'k',
+          },
+        })
+      ).toBe(false);
+    }
+  });
+});

--- a/libs/ts/domain/src/lib/music-together-registration.ts
+++ b/libs/ts/domain/src/lib/music-together-registration.ts
@@ -1,0 +1,153 @@
+/**
+ * Music Together registration domain types
+ *
+ * One document per family enrolled in a Music Together section. Unlike class
+ * `Registration` (email-keyed, single attendee row), MT registrations are
+ * family-shaped: one or more parents and one or more children with DOBs (the
+ * licensee report needs parent name, child name, child DOB per section).
+ *
+ * Payments route to MT's separate Square account. The installment plan vaults
+ * a card on file at registration and self-charges the second installment at
+ * `installment2.dueAt` (the section's week-5 anchor). Overcharge safety is
+ * enforced by the `installment2.status` lease + the stable `idempotencyKey`
+ * (see `docs/reference/music-together-plan.md`).
+ */
+
+/** How the family chose to pay. */
+export type MusicTogetherPaymentPlan =
+  | 'full' // One charge of priceFullCents
+  | 'installments'; // installmentCount charges; card on file for the rest
+
+/** Registration lifecycle status. */
+export type MusicTogetherRegistrationStatus =
+  | 'pending' // Reserved in a transaction; payment not yet confirmed
+  | 'confirmed' // Payment succeeded; family is enrolled
+  | 'cancelled' // Cancelled (may be partially refunded)
+  | 'refunded'; // Refund issued
+
+/**
+ * State of a scheduled installment charge. The progression
+ * `scheduled → charging → paid | failed` is driven by the Week-5 charge job;
+ * `cancelled` is set when the registration is cancelled so the job skips it.
+ * This status is one of the three overcharge-safety layers (the others being
+ * the stable Square idempotency key and the cancel guard).
+ */
+export type MusicTogetherInstallmentStatus =
+  | 'scheduled' // Due in the future; awaiting the charge job
+  | 'charging' // Lease held by an in-flight charge attempt
+  | 'paid' // Successfully charged
+  | 'failed' // Charge declined/errored — needs manual resolution
+  | 'cancelled'; // Registration cancelled; do not charge
+
+/** An enrolled child (for the licensee report). */
+export interface MusicTogetherChild {
+  name: string;
+  /** Date of birth. */
+  dob: Date;
+}
+
+/**
+ * A future auto-charge against the family's card on file. Present only on the
+ * installments plan.
+ */
+export interface MusicTogetherInstallment {
+  status: MusicTogetherInstallmentStatus;
+  /** When the charge becomes due — the section's week-5 anchor at creation. */
+  dueAt: Date;
+  amountCents: number;
+  /**
+   * Stable Square idempotency key (e.g. `mt-installment2-{registrationId}`).
+   * Never time-based — a retry with the same key returns the original payment
+   * instead of charging again.
+   */
+  idempotencyKey: string;
+  /** Square payment ID once charged. */
+  squarePaymentId?: string;
+  /** Failure detail surfaced to admins when `status === 'failed'`. */
+  lastError?: string;
+  /** When the charge reached a terminal state (paid/failed/cancelled). */
+  resolvedAt?: Date;
+}
+
+/**
+ * Music Together registration entity — one enrolled family.
+ */
+export interface MusicTogetherRegistration {
+  id: string;
+  sectionId: string;
+  /** Parent/guardian name(s). At least one. */
+  parentNames: string[];
+  /** Enrolled children with DOBs. At least one. */
+  children: MusicTogetherChild[];
+  email: string;
+  phone: string;
+  address: string;
+  paymentPlan: MusicTogetherPaymentPlan;
+  /** When the family accepted the program policies. */
+  policiesAcceptedAt: Date;
+  /**
+   * When the family authorized storing a card for the second charge. Set only
+   * on the installments plan.
+   */
+  cardOnFileAuthAt?: Date;
+  /** Amount charged at registration (full price, or installment 1). In cents. */
+  pricePaidCents: number;
+  /** Square customer ID (created/reused at registration). */
+  squareCustomerId?: string;
+  /** Square card-on-file ID used by the second installment. */
+  squareCardId?: string;
+  /** Square payment ID for the registration-time charge. */
+  squarePaymentId?: string;
+  /** Square order ID for the registration-time charge. */
+  squareOrderId?: string;
+  /** Square receipt URL for the registration-time charge. */
+  squareReceiptUrl?: string;
+  /** The scheduled second installment. Present only on the installments plan. */
+  installment2?: MusicTogetherInstallment;
+  status: MusicTogetherRegistrationStatus;
+  notes?: string;
+  confirmationSentAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Input for creating a registration. The server stamps `id`, `createdAt`,
+ * `updatedAt`, and `confirmationSentAt`.
+ */
+export type CreateMusicTogetherRegistrationInput = Omit<
+  MusicTogetherRegistration,
+  'id' | 'createdAt' | 'updatedAt' | 'confirmationSentAt'
+>;
+
+/**
+ * Input for updating a registration. `sectionId` is immutable.
+ */
+export type UpdateMusicTogetherRegistrationInput = Partial<
+  Omit<MusicTogetherRegistration, 'id' | 'createdAt' | 'updatedAt' | 'sectionId'>
+> & {
+  id: string;
+};
+
+/** Whether the family is enrolled (will attend). */
+export function isMtRegistrationConfirmed(
+  registration: Pick<MusicTogetherRegistration, 'status'>
+): boolean {
+  return registration.status === 'confirmed';
+}
+
+/** Statuses that count toward a section's family capacity. */
+export const MT_CAPACITY_STATUSES: readonly MusicTogetherRegistrationStatus[] = [
+  'pending',
+  'confirmed',
+];
+
+/**
+ * Whether a registration still has a live second installment that the charge
+ * job should consider (scheduled, not yet terminal).
+ */
+export function mtHasPendingInstallment(
+  registration: Pick<MusicTogetherRegistration, 'installment2'>
+): boolean {
+  return registration.installment2?.status === 'scheduled';
+}

--- a/libs/ts/domain/src/lib/music-together-registration.ts
+++ b/libs/ts/domain/src/lib/music-together-registration.ts
@@ -6,11 +6,11 @@
  * family-shaped: one or more parents and one or more children with DOBs (the
  * licensee report needs parent name, child name, child DOB per section).
  *
- * Payments route to MT's separate Square account. The installment plan vaults
- * a card on file at registration and self-charges the second installment at
- * `installment2.dueAt` (the section's week-5 anchor). Overcharge safety is
- * enforced by the `installment2.status` lease + the stable `idempotencyKey`
- * (see `docs/reference/music-together-plan.md`).
+ * Payments route to MT's separate Square account. On the installments plan the
+ * first installment is charged at registration and a card is vaulted; the
+ * remaining installments are materialized as `MusicTogetherScheduledCharge`
+ * documents that the auto-charge job processes on their due dates (see
+ * `docs/reference/music-together-plan.md`).
  */
 
 /** How the family chose to pay. */
@@ -25,48 +25,11 @@ export type MusicTogetherRegistrationStatus =
   | 'cancelled' // Cancelled (may be partially refunded)
   | 'refunded'; // Refund issued
 
-/**
- * State of a scheduled installment charge. The progression
- * `scheduled → charging → paid | failed` is driven by the Week-5 charge job;
- * `cancelled` is set when the registration is cancelled so the job skips it.
- * This status is one of the three overcharge-safety layers (the others being
- * the stable Square idempotency key and the cancel guard).
- */
-export type MusicTogetherInstallmentStatus =
-  | 'scheduled' // Due in the future; awaiting the charge job
-  | 'charging' // Lease held by an in-flight charge attempt
-  | 'paid' // Successfully charged
-  | 'failed' // Charge declined/errored — needs manual resolution
-  | 'cancelled'; // Registration cancelled; do not charge
-
 /** An enrolled child (for the licensee report). */
 export interface MusicTogetherChild {
   name: string;
   /** Date of birth. */
   dob: Date;
-}
-
-/**
- * A future auto-charge against the family's card on file. Present only on the
- * installments plan.
- */
-export interface MusicTogetherInstallment {
-  status: MusicTogetherInstallmentStatus;
-  /** When the charge becomes due — the section's week-5 anchor at creation. */
-  dueAt: Date;
-  amountCents: number;
-  /**
-   * Stable Square idempotency key (e.g. `mt-installment2-{registrationId}`).
-   * Never time-based — a retry with the same key returns the original payment
-   * instead of charging again.
-   */
-  idempotencyKey: string;
-  /** Square payment ID once charged. */
-  squarePaymentId?: string;
-  /** Failure detail surfaced to admins when `status === 'failed'`. */
-  lastError?: string;
-  /** When the charge reached a terminal state (paid/failed/cancelled). */
-  resolvedAt?: Date;
 }
 
 /**
@@ -102,8 +65,13 @@ export interface MusicTogetherRegistration {
   squareOrderId?: string;
   /** Square receipt URL for the registration-time charge. */
   squareReceiptUrl?: string;
-  /** The scheduled second installment. Present only on the installments plan. */
-  installment2?: MusicTogetherInstallment;
+  /**
+   * Number of scheduled card-on-file charges created for this registration
+   * (the installments after the first). 0 for pay-in-full. The charges
+   * themselves live in `musicTogetherScheduledCharges`, keyed by
+   * `registrationId`; this is a denormalized convenience count for admin views.
+   */
+  scheduledChargeCount?: number;
   status: MusicTogetherRegistrationStatus;
   notes?: string;
   confirmationSentAt?: Date;
@@ -142,12 +110,9 @@ export const MT_CAPACITY_STATUSES: readonly MusicTogetherRegistrationStatus[] = 
   'confirmed',
 ];
 
-/**
- * Whether a registration still has a live second installment that the charge
- * job should consider (scheduled, not yet terminal).
- */
-export function mtHasPendingInstallment(
-  registration: Pick<MusicTogetherRegistration, 'installment2'>
+/** Whether this registration has scheduled card-on-file charges outstanding. */
+export function mtRegistrationHasScheduledCharges(
+  registration: Pick<MusicTogetherRegistration, 'scheduledChargeCount'>
 ): boolean {
-  return registration.installment2?.status === 'scheduled';
+  return (registration.scheduledChargeCount ?? 0) > 0;
 }

--- a/libs/ts/domain/src/lib/music-together-scheduled-charge.spec.ts
+++ b/libs/ts/domain/src/lib/music-together-scheduled-charge.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mtChargeIdempotencyKey,
+  mtChargeIsPending,
+  MT_TERMINAL_CHARGE_STATUSES,
+  type MusicTogetherChargeStatus,
+} from './music-together-scheduled-charge';
+
+describe('mtChargeIdempotencyKey', () => {
+  it('derives a stable key from the charge id (never time-based)', () => {
+    expect(mtChargeIdempotencyKey('abc123')).toBe('mt-charge-abc123');
+    // Stability: same id always yields the same key.
+    expect(mtChargeIdempotencyKey('abc123')).toBe(
+      mtChargeIdempotencyKey('abc123')
+    );
+  });
+});
+
+describe('mtChargeIsPending', () => {
+  it('is true only for scheduled', () => {
+    expect(mtChargeIsPending({ status: 'scheduled' })).toBe(true);
+    for (const status of [
+      'charging',
+      'paid',
+      'failed',
+      'cancelled',
+    ] as MusicTogetherChargeStatus[]) {
+      expect(mtChargeIsPending({ status })).toBe(false);
+    }
+  });
+});
+
+describe('MT_TERMINAL_CHARGE_STATUSES', () => {
+  it('lists the statuses the charge job must skip', () => {
+    expect([...MT_TERMINAL_CHARGE_STATUSES]).toEqual([
+      'paid',
+      'failed',
+      'cancelled',
+    ]);
+  });
+});

--- a/libs/ts/domain/src/lib/music-together-scheduled-charge.ts
+++ b/libs/ts/domain/src/lib/music-together-scheduled-charge.ts
@@ -1,0 +1,94 @@
+/**
+ * Music Together scheduled charge domain types
+ *
+ * A scheduled charge is one future installment a family owes after the
+ * registration-time payment — materialized as its own document so the Week-5
+ * (and any later) auto-charge job can query "what's due now" directly:
+ * `where status == 'scheduled' and dueAt <= now`. This mirrors the codebase's
+ * "materialize the schedule as documents" convention (lessons `seriesId`).
+ *
+ * One registration on the installments plan produces N-1 of these (the first
+ * installment is charged at registration time, not scheduled).
+ *
+ * Overcharge safety is enforced by three layers: the `status` lease here
+ * (`scheduled → charging → paid | failed`), a stable `idempotencyKey`, and the
+ * cancel guard (cancelling a registration flips its charges to `cancelled`).
+ */
+
+/**
+ * Lifecycle of a scheduled charge.
+ * `scheduled → charging → paid | failed`; `cancelled` is terminal and set when
+ * the owning registration is cancelled so the charge job skips it.
+ */
+export type MusicTogetherChargeStatus =
+  | 'scheduled' // Due in the future; awaiting the charge job
+  | 'charging' // Lease held by an in-flight attempt (prevents overlap)
+  | 'paid' // Successfully charged
+  | 'failed' // Declined/errored — needs manual resolution
+  | 'cancelled'; // Registration cancelled; do not charge
+
+/** Statuses the charge job must skip (already terminal or in flight). */
+export const MT_TERMINAL_CHARGE_STATUSES: readonly MusicTogetherChargeStatus[] =
+  ['paid', 'failed', 'cancelled'];
+
+/**
+ * A future card-on-file charge for one installment of one registration.
+ */
+export interface MusicTogetherScheduledCharge {
+  id: string;
+  registrationId: string;
+  sectionId: string;
+  /** 1-based index of this installment within the registration's plan (2 = the second installment). */
+  installmentNumber: number;
+  amountCents: number;
+  /** When the charge becomes due. */
+  dueAt: Date;
+  status: MusicTogetherChargeStatus;
+  /**
+   * Stable Square idempotency key (e.g. `mt-charge-{id}`). Never time-based —
+   * a retry with the same key returns the original payment instead of charging
+   * again. The charge document id is itself stable, so derive the key from it.
+   */
+  idempotencyKey: string;
+  /** Square payment ID once charged. */
+  squarePaymentId?: string;
+  /** Failure detail surfaced to admins when `status === 'failed'`. */
+  lastError?: string;
+  /** When the charge reached a terminal state (paid/failed/cancelled). */
+  resolvedAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Input for creating a scheduled charge. The server stamps `id`, `createdAt`,
+ * `updatedAt`, and (since the key derives from the id) `idempotencyKey`.
+ */
+export type CreateMusicTogetherScheduledChargeInput = Omit<
+  MusicTogetherScheduledCharge,
+  'id' | 'idempotencyKey' | 'createdAt' | 'updatedAt'
+>;
+
+/**
+ * Input for updating a scheduled charge (status transitions, payment result).
+ */
+export type UpdateMusicTogetherScheduledChargeInput = Partial<
+  Omit<
+    MusicTogetherScheduledCharge,
+    'id' | 'registrationId' | 'sectionId' | 'idempotencyKey' | 'createdAt' | 'updatedAt'
+  >
+> & {
+  id: string;
+};
+
+/** Derive the stable idempotency key for a charge from its document id. */
+export function mtChargeIdempotencyKey(chargeId: string): string {
+  return `mt-charge-${chargeId}`;
+}
+
+/** Whether the charge is still awaiting its first/next attempt. */
+export function mtChargeIsPending(
+  charge: Pick<MusicTogetherScheduledCharge, 'status'>
+): boolean {
+  return charge.status === 'scheduled';
+}

--- a/libs/ts/domain/src/lib/music-together-section.spec.ts
+++ b/libs/ts/domain/src/lib/music-together-section.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mtSectionFirstSessionAt,
+  mtSpotsRemaining,
+  mtSectionHasAvailability,
+  MT_DEFAULT_CAPACITY_FAMILIES,
+  MT_PRICE_FULL_CENTS,
+  MT_INSTALLMENT_CENTS,
+  type MusicTogetherSection,
+} from './music-together-section';
+
+describe('Music Together pricing constants', () => {
+  it('matches the published prices ($252 full, $132 per installment)', () => {
+    expect(MT_PRICE_FULL_CENTS).toBe(25200);
+    expect(MT_INSTALLMENT_CENTS).toBe(13200);
+  });
+  it('paying in full is cheaper than two installments (a pay-in-full discount)', () => {
+    // Two installments total $264; paying in full is $252 — a $12 incentive.
+    expect(MT_INSTALLMENT_CENTS * 2).toBeGreaterThan(MT_PRICE_FULL_CENTS);
+    expect(MT_INSTALLMENT_CENTS * 2 - MT_PRICE_FULL_CENTS).toBe(1200);
+  });
+  it('default capacity is 8 families', () => {
+    expect(MT_DEFAULT_CAPACITY_FAMILIES).toBe(8);
+  });
+});
+
+describe('mtSectionFirstSessionAt', () => {
+  it('returns the earliest session start regardless of order', () => {
+    const earliest = new Date('2026-09-01T14:00:00Z');
+    const result = mtSectionFirstSessionAt({
+      sessions: [
+        { dateTime: new Date('2026-09-15T14:00:00Z') },
+        { dateTime: earliest },
+        { dateTime: new Date('2026-09-08T14:00:00Z') },
+      ],
+    });
+    expect(result).toEqual(earliest);
+  });
+
+  it('returns undefined when there are no sessions', () => {
+    expect(mtSectionFirstSessionAt({ sessions: [] })).toBeUndefined();
+  });
+});
+
+describe('mtSpotsRemaining', () => {
+  it('subtracts the family count from capacity', () => {
+    expect(mtSpotsRemaining({ capacityFamilies: 8 }, 3)).toBe(5);
+  });
+  it('never goes negative when over capacity', () => {
+    expect(mtSpotsRemaining({ capacityFamilies: 8 }, 9)).toBe(0);
+  });
+});
+
+describe('mtSectionHasAvailability', () => {
+  const open: Pick<MusicTogetherSection, 'capacityFamilies' | 'status'> = {
+    capacityFamilies: 8,
+    status: 'open',
+  };
+
+  it('is true when open and under capacity', () => {
+    expect(mtSectionHasAvailability(open, 7)).toBe(true);
+  });
+  it('is false at capacity', () => {
+    expect(mtSectionHasAvailability(open, 8)).toBe(false);
+  });
+  it('is false when not open even with room', () => {
+    expect(mtSectionHasAvailability({ ...open, status: 'draft' }, 0)).toBe(
+      false
+    );
+  });
+});

--- a/libs/ts/domain/src/lib/music-together-section.spec.ts
+++ b/libs/ts/domain/src/lib/music-together-section.spec.ts
@@ -3,24 +3,51 @@ import {
   mtSectionFirstSessionAt,
   mtSpotsRemaining,
   mtSectionHasAvailability,
+  mtSectionOffersInstallments,
+  mtInstallmentPlanTotalCents,
   MT_DEFAULT_CAPACITY_FAMILIES,
   MT_PRICE_FULL_CENTS,
-  MT_INSTALLMENT_CENTS,
+  MT_DEFAULT_INSTALLMENT_CENTS,
   type MusicTogetherSection,
 } from './music-together-section';
 
-describe('Music Together pricing constants', () => {
-  it('matches the published prices ($252 full, $132 per installment)', () => {
+describe('Music Together prefill defaults', () => {
+  it('provides sensible form prefills (configurable per semester)', () => {
     expect(MT_PRICE_FULL_CENTS).toBe(25200);
-    expect(MT_INSTALLMENT_CENTS).toBe(13200);
-  });
-  it('paying in full is cheaper than two installments (a pay-in-full discount)', () => {
-    // Two installments total $264; paying in full is $252 — a $12 incentive.
-    expect(MT_INSTALLMENT_CENTS * 2).toBeGreaterThan(MT_PRICE_FULL_CENTS);
-    expect(MT_INSTALLMENT_CENTS * 2 - MT_PRICE_FULL_CENTS).toBe(1200);
-  });
-  it('default capacity is 8 families', () => {
+    expect(MT_DEFAULT_INSTALLMENT_CENTS).toBe(13200);
     expect(MT_DEFAULT_CAPACITY_FAMILIES).toBe(8);
+  });
+});
+
+describe('installment plan helpers', () => {
+  const plan = [
+    { amountCents: 13200, dueAt: new Date('2026-09-01T14:00:00Z') },
+    { amountCents: 13200, dueAt: new Date('2026-09-29T14:00:00Z') },
+  ];
+
+  it('offers installments only when the plan has 2+ items', () => {
+    expect(mtSectionOffersInstallments({ installmentPlan: plan })).toBe(true);
+    expect(
+      mtSectionOffersInstallments({ installmentPlan: [plan[0]] })
+    ).toBe(false);
+    expect(mtSectionOffersInstallments({ installmentPlan: undefined })).toBe(
+      false
+    );
+  });
+
+  it('sums the plan total', () => {
+    expect(mtInstallmentPlanTotalCents(plan)).toBe(26400);
+    expect(mtInstallmentPlanTotalCents(undefined)).toBe(0);
+  });
+
+  it('supports an arbitrary N-installment plan', () => {
+    const three = [
+      { amountCents: 10500, dueAt: new Date('2026-09-01T14:00:00Z') },
+      { amountCents: 10500, dueAt: new Date('2026-09-22T14:00:00Z') },
+      { amountCents: 10500, dueAt: new Date('2026-10-13T14:00:00Z') },
+    ];
+    expect(mtSectionOffersInstallments({ installmentPlan: three })).toBe(true);
+    expect(mtInstallmentPlanTotalCents(three)).toBe(31500);
   });
 });
 

--- a/libs/ts/domain/src/lib/music-together-section.ts
+++ b/libs/ts/domain/src/lib/music-together-section.ts
@@ -1,0 +1,127 @@
+/**
+ * Music Together section domain types
+ *
+ * A Music Together (MT) section is one term of the early-childhood music
+ * program that families register for. MT is a SEPARATE business (Stephanie's
+ * single-member LLC) with its own Square account — see the per-program payment
+ * routing in `@maple/firebase/square` (MT_SQUARE_KEYS) and the program plan in
+ * `docs/reference/music-together-plan.md`.
+ *
+ * A section has a fixed family capacity (8) and offers two payment options:
+ * pay in full, or two equal installments where the second auto-charges at the
+ * start of week 5 (see `week5ChargeAt`).
+ */
+
+/** Default per-section family capacity. */
+export const MT_DEFAULT_CAPACITY_FAMILIES = 8;
+/** Pay-in-full tuition, in cents ($252.00). */
+export const MT_PRICE_FULL_CENTS = 25200;
+/**
+ * Each installment when paying in two parts, in cents ($132.00).
+ *
+ * Note: two installments total $264 — $12 MORE than paying in full ($252).
+ * This is intentional per the program spec (a small pay-in-full incentive),
+ * not a rounding error. If the prices are ever meant to net the same, revisit
+ * both constants together.
+ */
+export const MT_INSTALLMENT_CENTS = 13200;
+/** Number of installments on the installment plan. */
+export const MT_INSTALLMENT_COUNT = 2;
+
+/** One scheduled weekly meeting of a section. */
+export interface MusicTogetherSession {
+  dateTime: Date;
+}
+
+/** Section lifecycle status. */
+export type MusicTogetherSectionStatus =
+  | 'draft' // Not yet open for registration
+  | 'open' // Accepting registrations
+  | 'closed' // Registration closed (full, or term started)
+  | 'completed'; // Term finished
+
+/**
+ * Music Together section entity — one bookable term of the program.
+ */
+export interface MusicTogetherSection {
+  id: string;
+  /** Display name, e.g. "Spring 2026 — Tuesdays 10am". */
+  name: string;
+  description?: string;
+  /** Weekly meeting times for the term. */
+  sessions: MusicTogetherSession[];
+  /** Maximum number of families (not children). Defaults to 8. */
+  capacityFamilies: number;
+  /** Pay-in-full price in cents. */
+  priceFullCents: number;
+  /** Installment amount in cents (charged `installmentCount` times). */
+  installmentCents: number;
+  /** Number of installments on the two-payment plan. */
+  installmentCount: number;
+  /**
+   * When the second installment auto-charges (start of week 5). Set explicitly
+   * per section rather than derived, so the scheduled charge job has a single
+   * unambiguous anchor regardless of how sessions are scheduled.
+   */
+  week5ChargeAt: Date;
+  status: MusicTogetherSectionStatus;
+  location?: string;
+  room?: string;
+  /** Webflow CMS item ID, once synced to the public site. */
+  webflowItemId?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Input for creating a section. The server stamps `id`, `createdAt`,
+ * `updatedAt`.
+ */
+export type CreateMusicTogetherSectionInput = Omit<
+  MusicTogetherSection,
+  'id' | 'createdAt' | 'updatedAt'
+>;
+
+/**
+ * Input for updating a section.
+ */
+export type UpdateMusicTogetherSectionInput = Partial<
+  Omit<MusicTogetherSection, 'id' | 'createdAt' | 'updatedAt'>
+> & {
+  id: string;
+};
+
+/**
+ * The earliest session start, used as the indexed sort key for upcoming
+ * sections. Returns `undefined` when a section has no sessions yet.
+ */
+export function mtSectionFirstSessionAt(
+  section: Pick<MusicTogetherSection, 'sessions'>
+): Date | undefined {
+  if (!section.sessions || section.sessions.length === 0) {
+    return undefined;
+  }
+  return section.sessions.reduce(
+    (earliest, s) => (s.dateTime < earliest ? s.dateTime : earliest),
+    section.sessions[0].dateTime
+  );
+}
+
+/**
+ * Spots (families) remaining given the current confirmed/pending family count.
+ * Never negative.
+ */
+export function mtSpotsRemaining(
+  section: Pick<MusicTogetherSection, 'capacityFamilies'>,
+  familyCount: number
+): number {
+  return Math.max(0, section.capacityFamilies - familyCount);
+}
+
+/** Whether the section can still accept another family. */
+export function mtSectionHasAvailability(
+  section: Pick<MusicTogetherSection, 'capacityFamilies' | 'status'>,
+  familyCount: number
+): boolean {
+  return section.status === 'open' && familyCount < section.capacityFamilies;
+}

--- a/libs/ts/domain/src/lib/music-together-section.ts
+++ b/libs/ts/domain/src/lib/music-together-section.ts
@@ -12,25 +12,38 @@
  * start of week 5 (see `week5ChargeAt`).
  */
 
+/**
+ * Form-prefill defaults only — every amount is configurable per semester on
+ * the section document. Admins can override any of these when creating a
+ * section; nothing here is enforced as a fixed price.
+ */
 /** Default per-section family capacity. */
 export const MT_DEFAULT_CAPACITY_FAMILIES = 8;
-/** Pay-in-full tuition, in cents ($252.00). */
+/** Default pay-in-full tuition, in cents ($252.00). */
 export const MT_PRICE_FULL_CENTS = 25200;
-/**
- * Each installment when paying in two parts, in cents ($132.00).
- *
- * Note: two installments total $264 — $12 MORE than paying in full ($252).
- * This is intentional per the program spec (a small pay-in-full incentive),
- * not a rounding error. If the prices are ever meant to net the same, revisit
- * both constants together.
- */
-export const MT_INSTALLMENT_CENTS = 13200;
-/** Number of installments on the installment plan. */
-export const MT_INSTALLMENT_COUNT = 2;
+/** Default per-installment amount used to prefill the plan, in cents ($132.00). */
+export const MT_DEFAULT_INSTALLMENT_CENTS = 13200;
+/** Default number of installments used to prefill the plan. */
+export const MT_DEFAULT_INSTALLMENT_COUNT = 2;
 
 /** One scheduled weekly meeting of a section. */
 export interface MusicTogetherSession {
   dateTime: Date;
+}
+
+/**
+ * One installment in a section's configurable payment plan. The plan is an
+ * ordered list: the first item is charged at registration (via the Web
+ * Payments nonce); the rest become scheduled card-on-file charges (see
+ * `MusicTogetherScheduledCharge`). Amounts and dates are set per semester, so
+ * a section can offer 1, 2, or N installments totaling whatever the admin
+ * chooses (the total need not equal `priceFullCents` — paying in full may be
+ * a discount).
+ */
+export interface MusicTogetherInstallmentPlanItem {
+  amountCents: number;
+  /** When this installment is charged. The first item is effectively "now". */
+  dueAt: Date;
 }
 
 /** Section lifecycle status. */
@@ -54,16 +67,12 @@ export interface MusicTogetherSection {
   capacityFamilies: number;
   /** Pay-in-full price in cents. */
   priceFullCents: number;
-  /** Installment amount in cents (charged `installmentCount` times). */
-  installmentCents: number;
-  /** Number of installments on the two-payment plan. */
-  installmentCount: number;
   /**
-   * When the second installment auto-charges (start of week 5). Set explicitly
-   * per section rather than derived, so the scheduled charge job has a single
-   * unambiguous anchor regardless of how sessions are scheduled.
+   * Configurable installment plan offered for this semester. Ordered: the
+   * first item is charged at registration, later items become scheduled
+   * card-on-file charges on their `dueAt`. Absent or empty ⇒ pay-in-full only.
    */
-  week5ChargeAt: Date;
+  installmentPlan?: MusicTogetherInstallmentPlanItem[];
   status: MusicTogetherSectionStatus;
   location?: string;
   room?: string;
@@ -124,4 +133,21 @@ export function mtSectionHasAvailability(
   familyCount: number
 ): boolean {
   return section.status === 'open' && familyCount < section.capacityFamilies;
+}
+
+/**
+ * Whether this section offers an installment option (a plan with at least two
+ * charges — a single charge is just pay-in-full by card).
+ */
+export function mtSectionOffersInstallments(
+  section: Pick<MusicTogetherSection, 'installmentPlan'>
+): boolean {
+  return (section.installmentPlan?.length ?? 0) >= 2;
+}
+
+/** Total of all installments in a plan, in cents. */
+export function mtInstallmentPlanTotalCents(
+  plan: MusicTogetherInstallmentPlanItem[] | undefined
+): number {
+  return (plan ?? []).reduce((sum, item) => sum + item.amountCents, 0);
 }

--- a/libs/ts/validation/src/lib/index.ts
+++ b/libs/ts/validation/src/lib/index.ts
@@ -75,3 +75,15 @@ export {
   craftClubMemberValidation,
   type CraftClubMemberValidationInput,
 } from './craft-club-member.validation';
+
+// Music Together (separate-business early-childhood music program)
+export {
+  musicTogetherRegistrationValidation,
+  type MusicTogetherRegistrationValidationInput,
+  type MusicTogetherChildInput,
+} from './music-together-registration.validation';
+export {
+  musicTogetherSectionValidation,
+  type MusicTogetherSectionValidationInput,
+  type MusicTogetherSessionInput,
+} from './music-together-section.validation';

--- a/libs/ts/validation/src/lib/index.ts
+++ b/libs/ts/validation/src/lib/index.ts
@@ -86,4 +86,5 @@ export {
   musicTogetherSectionValidation,
   type MusicTogetherSectionValidationInput,
   type MusicTogetherSessionInput,
+  type MusicTogetherInstallmentInput,
 } from './music-together-section.validation';

--- a/libs/ts/validation/src/lib/music-together-registration.validation.spec.ts
+++ b/libs/ts/validation/src/lib/music-together-registration.validation.spec.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import {
+  musicTogetherRegistrationValidation,
+  type MusicTogetherRegistrationValidationInput,
+} from './music-together-registration.validation';
+
+const valid: MusicTogetherRegistrationValidationInput = {
+  sectionId: 'sec-1',
+  parentNames: ['Jamie Rivera'],
+  children: [{ name: 'Sky', dob: new Date('2023-04-01') }],
+  email: 'jamie@example.com',
+  phone: '304-555-1212',
+  address: '123 Spruce St, Morgantown, WV',
+  paymentPlan: 'full',
+  policiesAccepted: true,
+};
+
+describe('musicTogetherRegistrationValidation', () => {
+  it('passes a complete full-pay registration', () => {
+    expect(musicTogetherRegistrationValidation(valid).hasErrors()).toBe(false);
+  });
+
+  it('requires a section', () => {
+    const r = musicTogetherRegistrationValidation({ ...valid, sectionId: '' });
+    expect(r.hasErrors('sectionId')).toBe(true);
+  });
+
+  it('requires at least one parent name', () => {
+    const r = musicTogetherRegistrationValidation({
+      ...valid,
+      parentNames: ['  '],
+    });
+    expect(r.hasErrors('parentNames')).toBe(true);
+  });
+
+  it('requires at least one child', () => {
+    const r = musicTogetherRegistrationValidation({ ...valid, children: [] });
+    expect(r.hasErrors('children')).toBe(true);
+  });
+
+  it('requires each child to have a name and valid DOB', () => {
+    expect(
+      musicTogetherRegistrationValidation({
+        ...valid,
+        children: [{ name: '', dob: new Date('2023-04-01') }],
+      }).hasErrors('children')
+    ).toBe(true);
+    expect(
+      musicTogetherRegistrationValidation({
+        ...valid,
+        children: [{ name: 'Sky', dob: 'not-a-date' }],
+      }).hasErrors('children')
+    ).toBe(true);
+  });
+
+  it('rejects a future date of birth', () => {
+    const future = new Date(Date.now() + 86_400_000);
+    const r = musicTogetherRegistrationValidation({
+      ...valid,
+      children: [{ name: 'Sky', dob: future }],
+    });
+    expect(r.hasErrors('children')).toBe(true);
+  });
+
+  it('accepts an ISO-string DOB', () => {
+    const r = musicTogetherRegistrationValidation({
+      ...valid,
+      children: [{ name: 'Sky', dob: '2023-04-01' }],
+    });
+    expect(r.hasErrors('children')).toBe(false);
+  });
+
+  it('validates email and phone format', () => {
+    expect(
+      musicTogetherRegistrationValidation({
+        ...valid,
+        email: 'nope',
+      }).hasErrors('email')
+    ).toBe(true);
+    expect(
+      musicTogetherRegistrationValidation({
+        ...valid,
+        phone: 'abc',
+      }).hasErrors('phone')
+    ).toBe(true);
+  });
+
+  it('requires policies acceptance', () => {
+    const r = musicTogetherRegistrationValidation({
+      ...valid,
+      policiesAccepted: false,
+    });
+    expect(r.hasErrors('policiesAccepted')).toBe(true);
+  });
+
+  it('requires card-on-file auth only for installments', () => {
+    // installments without auth → error
+    expect(
+      musicTogetherRegistrationValidation({
+        ...valid,
+        paymentPlan: 'installments',
+        cardOnFileAuth: false,
+      }).hasErrors('cardOnFileAuth')
+    ).toBe(true);
+    // installments with auth → ok
+    expect(
+      musicTogetherRegistrationValidation({
+        ...valid,
+        paymentPlan: 'installments',
+        cardOnFileAuth: true,
+      }).hasErrors('cardOnFileAuth')
+    ).toBe(false);
+    // full pay doesn't require it
+    expect(
+      musicTogetherRegistrationValidation({
+        ...valid,
+        paymentPlan: 'full',
+        cardOnFileAuth: false,
+      }).hasErrors('cardOnFileAuth')
+    ).toBe(false);
+  });
+
+  it('supports partial single-field validation', () => {
+    // Only validating email: a blank section must not register an error.
+    const r = musicTogetherRegistrationValidation(
+      { email: 'jamie@example.com' },
+      'email'
+    );
+    expect(r.hasErrors('email')).toBe(false);
+    expect(r.hasErrors('sectionId')).toBe(false);
+  });
+});

--- a/libs/ts/validation/src/lib/music-together-registration.validation.ts
+++ b/libs/ts/validation/src/lib/music-together-registration.validation.ts
@@ -1,0 +1,146 @@
+/**
+ * Music Together registration validation suite
+ *
+ * Vest validation for the family enrollment form. Used on both the public
+ * Webflow checkout and the server (the rule in firebase-functions.md requires
+ * mutating functions to validate with the shared suite before any external
+ * write — invalid data must never reach the MT Square account).
+ *
+ * @see https://vestjs.dev/
+ */
+import { staticSuite, test, enforce, only } from 'vest';
+
+/** One child row from the form. `dob` may arrive as a Date or ISO string. */
+export interface MusicTogetherChildInput {
+  name?: string;
+  dob?: Date | string;
+}
+
+/**
+ * Input shape for Music Together registration validation.
+ */
+export interface MusicTogetherRegistrationValidationInput {
+  sectionId?: string;
+  parentNames?: string[];
+  children?: MusicTogetherChildInput[];
+  email?: string;
+  phone?: string;
+  address?: string;
+  paymentPlan?: 'full' | 'installments';
+  /** Policies-accepted checkbox. */
+  policiesAccepted?: boolean;
+  /** Card-on-file authorization checkbox (required for installments). */
+  cardOnFileAuth?: boolean;
+}
+
+/** Parse a Date|string DOB to a Date, or undefined if unparseable. */
+function parseDob(dob: Date | string | undefined): Date | undefined {
+  if (dob === undefined) return undefined;
+  const d = dob instanceof Date ? dob : new Date(dob);
+  return isNaN(d.getTime()) ? undefined : d;
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PHONE_RE = /^[+]?[\d\s()-]{7,20}$/;
+
+/**
+ * Validate Music Together registration form data.
+ *
+ * @param data - Partial registration data to validate
+ * @param field - Optional field(s) to validate (for partial/single-field runs)
+ */
+export const musicTogetherRegistrationValidation = staticSuite(
+  (
+    data: MusicTogetherRegistrationValidationInput,
+    field?: string | string[]
+  ) => {
+    only(field);
+
+    test('sectionId', 'Section is required', () => {
+      enforce(data.sectionId).isNotBlank();
+    });
+
+    // At least one non-blank parent/guardian name.
+    test('parentNames', 'At least one parent or guardian name is required', () => {
+      enforce(
+        (data.parentNames ?? []).filter((n) => n && n.trim().length > 0)
+      ).longerThanOrEquals(1);
+    });
+
+    test('parentNames', 'Each name must be less than 100 characters', () => {
+      for (const name of data.parentNames ?? []) {
+        if (name) enforce(name).shorterThan(100);
+      }
+    });
+
+    // At least one child, each with a name and a valid past date of birth.
+    test('children', 'At least one child is required', () => {
+      enforce(data.children ?? []).longerThanOrEquals(1);
+    });
+
+    test('children', 'Each child needs a name', () => {
+      for (const child of data.children ?? []) {
+        enforce(child.name).isNotBlank();
+      }
+    });
+
+    test('children', 'Each child needs a valid date of birth', () => {
+      for (const child of data.children ?? []) {
+        const dob = parseDob(child.dob);
+        enforce(dob).isNotNullish();
+      }
+    });
+
+    test('children', "A child's date of birth cannot be in the future", () => {
+      const now = Date.now();
+      for (const child of data.children ?? []) {
+        const dob = parseDob(child.dob);
+        if (dob) enforce(dob.getTime()).lessThanOrEquals(now);
+      }
+    });
+
+    test('email', 'Email is required', () => {
+      enforce(data.email).isNotBlank();
+    });
+
+    test('email', 'Email must be a valid email address', () => {
+      if (data.email) enforce(data.email).matches(EMAIL_RE);
+    });
+
+    test('phone', 'Phone number is required', () => {
+      enforce(data.phone).isNotBlank();
+    });
+
+    test('phone', 'Phone number must be valid', () => {
+      if (data.phone) enforce(data.phone).matches(PHONE_RE);
+    });
+
+    test('address', 'Address is required', () => {
+      enforce(data.address).isNotBlank();
+    });
+
+    test('address', 'Address must be less than 300 characters', () => {
+      if (data.address) enforce(data.address).shorterThanOrEquals(300);
+    });
+
+    test('paymentPlan', 'Choose a payment option', () => {
+      enforce(data.paymentPlan).inside(['full', 'installments']);
+    });
+
+    test('policiesAccepted', 'You must accept the program policies', () => {
+      enforce(data.policiesAccepted).equals(true);
+    });
+
+    // Card-on-file authorization is required only for the installment plan,
+    // where a second charge runs later with no parent present.
+    test(
+      'cardOnFileAuth',
+      'You must authorize the second installment charge',
+      () => {
+        if (data.paymentPlan === 'installments') {
+          enforce(data.cardOnFileAuth).equals(true);
+        }
+      }
+    );
+  }
+);

--- a/libs/ts/validation/src/lib/music-together-section.validation.spec.ts
+++ b/libs/ts/validation/src/lib/music-together-section.validation.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import {
+  musicTogetherSectionValidation,
+  type MusicTogetherSectionValidationInput,
+} from './music-together-section.validation';
+
+const valid: MusicTogetherSectionValidationInput = {
+  name: 'Spring 2026 — Tuesdays 10am',
+  sessions: [{ dateTime: new Date('2026-09-01T14:00:00Z') }],
+  capacityFamilies: 8,
+  priceFullCents: 25200,
+  installmentCents: 13200,
+  installmentCount: 2,
+  week5ChargeAt: new Date('2026-09-29T14:00:00Z'),
+  status: 'open',
+};
+
+describe('musicTogetherSectionValidation', () => {
+  it('passes a complete section', () => {
+    expect(musicTogetherSectionValidation(valid).hasErrors()).toBe(false);
+  });
+
+  it('requires a name', () => {
+    expect(
+      musicTogetherSectionValidation({ ...valid, name: '' }).hasErrors('name')
+    ).toBe(true);
+  });
+
+  it('requires at least one valid session', () => {
+    expect(
+      musicTogetherSectionValidation({ ...valid, sessions: [] }).hasErrors(
+        'sessions'
+      )
+    ).toBe(true);
+    expect(
+      musicTogetherSectionValidation({
+        ...valid,
+        sessions: [{ dateTime: 'bad' }],
+      }).hasErrors('sessions')
+    ).toBe(true);
+  });
+
+  it('requires a valid week-5 charge date', () => {
+    expect(
+      musicTogetherSectionValidation({
+        ...valid,
+        week5ChargeAt: undefined,
+      }).hasErrors('week5ChargeAt')
+    ).toBe(true);
+  });
+
+  it('rejects non-positive prices and bad capacity', () => {
+    expect(
+      musicTogetherSectionValidation({
+        ...valid,
+        priceFullCents: 0,
+      }).hasErrors('priceFullCents')
+    ).toBe(true);
+    expect(
+      musicTogetherSectionValidation({
+        ...valid,
+        capacityFamilies: 0,
+      }).hasErrors('capacityFamilies')
+    ).toBe(true);
+  });
+
+  it('rejects an invalid status', () => {
+    expect(
+      musicTogetherSectionValidation({
+        ...valid,
+        status: 'archived',
+      }).hasErrors('status')
+    ).toBe(true);
+  });
+});

--- a/libs/ts/validation/src/lib/music-together-section.validation.spec.ts
+++ b/libs/ts/validation/src/lib/music-together-section.validation.spec.ts
@@ -9,9 +9,10 @@ const valid: MusicTogetherSectionValidationInput = {
   sessions: [{ dateTime: new Date('2026-09-01T14:00:00Z') }],
   capacityFamilies: 8,
   priceFullCents: 25200,
-  installmentCents: 13200,
-  installmentCount: 2,
-  week5ChargeAt: new Date('2026-09-29T14:00:00Z'),
+  installmentPlan: [
+    { amountCents: 13200, dueAt: new Date('2026-09-01T14:00:00Z') },
+    { amountCents: 13200, dueAt: new Date('2026-09-29T14:00:00Z') },
+  ],
   status: 'open',
 };
 
@@ -40,13 +41,57 @@ describe('musicTogetherSectionValidation', () => {
     ).toBe(true);
   });
 
-  it('requires a valid week-5 charge date', () => {
+  it('allows a section with no installment plan (pay-in-full only)', () => {
+    const fullOnly = { ...valid };
+    delete fullOnly.installmentPlan;
+    expect(musicTogetherSectionValidation(fullOnly).hasErrors()).toBe(false);
+  });
+
+  it('rejects a one-row installment plan (that is just pay-in-full)', () => {
     expect(
       musicTogetherSectionValidation({
         ...valid,
-        week5ChargeAt: undefined,
-      }).hasErrors('week5ChargeAt')
+        installmentPlan: [
+          { amountCents: 13200, dueAt: new Date('2026-09-01T14:00:00Z') },
+        ],
+      }).hasErrors('installmentPlan')
     ).toBe(true);
+  });
+
+  it('rejects installments with bad amounts, dates, or order', () => {
+    // zero amount
+    expect(
+      musicTogetherSectionValidation({
+        ...valid,
+        installmentPlan: [
+          { amountCents: 0, dueAt: new Date('2026-09-01T14:00:00Z') },
+          { amountCents: 13200, dueAt: new Date('2026-09-29T14:00:00Z') },
+        ],
+      }).hasErrors('installmentPlan')
+    ).toBe(true);
+    // descending dates
+    expect(
+      musicTogetherSectionValidation({
+        ...valid,
+        installmentPlan: [
+          { amountCents: 13200, dueAt: new Date('2026-09-29T14:00:00Z') },
+          { amountCents: 13200, dueAt: new Date('2026-09-01T14:00:00Z') },
+        ],
+      }).hasErrors('installmentPlan')
+    ).toBe(true);
+  });
+
+  it('accepts an N-installment plan', () => {
+    expect(
+      musicTogetherSectionValidation({
+        ...valid,
+        installmentPlan: [
+          { amountCents: 10500, dueAt: new Date('2026-09-01T14:00:00Z') },
+          { amountCents: 10500, dueAt: new Date('2026-09-22T14:00:00Z') },
+          { amountCents: 10500, dueAt: new Date('2026-10-13T14:00:00Z') },
+        ],
+      }).hasErrors('installmentPlan')
+    ).toBe(false);
   });
 
   it('rejects non-positive prices and bad capacity', () => {

--- a/libs/ts/validation/src/lib/music-together-section.validation.ts
+++ b/libs/ts/validation/src/lib/music-together-section.validation.ts
@@ -1,0 +1,90 @@
+/**
+ * Music Together section validation suite
+ *
+ * Vest validation for the admin section form (create/edit). Mirrors the
+ * partial-field pattern so an update can validate only the changed fields.
+ *
+ * @see https://vestjs.dev/
+ */
+import { staticSuite, test, enforce, only } from 'vest';
+
+/** One session row; `dateTime` may arrive as a Date or ISO string. */
+export interface MusicTogetherSessionInput {
+  dateTime?: Date | string;
+}
+
+export interface MusicTogetherSectionValidationInput {
+  name?: string;
+  description?: string;
+  sessions?: MusicTogetherSessionInput[];
+  capacityFamilies?: number;
+  priceFullCents?: number;
+  installmentCents?: number;
+  installmentCount?: number;
+  week5ChargeAt?: Date | string;
+  status?: string;
+}
+
+const SECTION_STATUSES = ['draft', 'open', 'closed', 'completed'];
+
+function parseDate(value: Date | string | undefined): Date | undefined {
+  if (value === undefined) return undefined;
+  const d = value instanceof Date ? value : new Date(value);
+  return isNaN(d.getTime()) ? undefined : d;
+}
+
+export const musicTogetherSectionValidation = staticSuite(
+  (data: MusicTogetherSectionValidationInput, field?: string | string[]) => {
+    only(field);
+
+    test('name', 'Name is required', () => {
+      enforce(data.name).isNotBlank();
+    });
+    test('name', 'Name must be less than 150 characters', () => {
+      if (data.name) enforce(data.name).shorterThan(150);
+    });
+
+    test('sessions', 'At least one session is required', () => {
+      enforce(data.sessions ?? []).longerThanOrEquals(1);
+    });
+    test('sessions', 'Each session needs a valid date and time', () => {
+      for (const s of data.sessions ?? []) {
+        enforce(parseDate(s.dateTime)).isNotNullish();
+      }
+    });
+
+    test('capacityFamilies', 'Capacity must be at least 1', () => {
+      if (data.capacityFamilies !== undefined) {
+        enforce(data.capacityFamilies).greaterThanOrEquals(1);
+      }
+    });
+
+    test('priceFullCents', 'Full price must be greater than 0', () => {
+      if (data.priceFullCents !== undefined) {
+        enforce(data.priceFullCents).greaterThan(0);
+      }
+    });
+
+    test('installmentCents', 'Installment amount must be greater than 0', () => {
+      if (data.installmentCents !== undefined) {
+        enforce(data.installmentCents).greaterThan(0);
+      }
+    });
+
+    test('installmentCount', 'Installment count must be at least 1', () => {
+      if (data.installmentCount !== undefined) {
+        enforce(data.installmentCount).greaterThanOrEquals(1);
+      }
+    });
+
+    test('week5ChargeAt', 'A valid second-installment charge date is required', () => {
+      enforce(parseDate(data.week5ChargeAt)).isNotNullish();
+    });
+
+    test('status', 'Status must be valid', () => {
+      if (data.status !== undefined) {
+        enforce(data.status).inside(SECTION_STATUSES);
+      }
+    });
+  }
+);

--- a/libs/ts/validation/src/lib/music-together-section.validation.ts
+++ b/libs/ts/validation/src/lib/music-together-section.validation.ts
@@ -13,15 +13,23 @@ export interface MusicTogetherSessionInput {
   dateTime?: Date | string;
 }
 
+/** One configurable installment row from the admin form. */
+export interface MusicTogetherInstallmentInput {
+  amountCents?: number;
+  dueAt?: Date | string;
+}
+
 export interface MusicTogetherSectionValidationInput {
   name?: string;
   description?: string;
   sessions?: MusicTogetherSessionInput[];
   capacityFamilies?: number;
   priceFullCents?: number;
-  installmentCents?: number;
-  installmentCount?: number;
-  week5ChargeAt?: Date | string;
+  /**
+   * Optional configurable installment plan. Absent/empty ⇒ pay-in-full only.
+   * When present it must have 2+ rows (a single charge is just pay-in-full).
+   */
+  installmentPlan?: MusicTogetherInstallmentInput[];
   status?: string;
 }
 
@@ -65,20 +73,36 @@ export const musicTogetherSectionValidation = staticSuite(
       }
     });
 
-    test('installmentCents', 'Installment amount must be greater than 0', () => {
-      if (data.installmentCents !== undefined) {
-        enforce(data.installmentCents).greaterThan(0);
+    // Installment plan is optional. When offered it needs 2+ rows, each with a
+    // positive amount and a valid due date, in ascending date order.
+    test('installmentPlan', 'An installment plan must have at least 2 charges', () => {
+      if (data.installmentPlan !== undefined && data.installmentPlan.length > 0) {
+        enforce(data.installmentPlan.length).greaterThanOrEquals(2);
       }
     });
 
-    test('installmentCount', 'Installment count must be at least 1', () => {
-      if (data.installmentCount !== undefined) {
-        enforce(data.installmentCount).greaterThanOrEquals(1);
+    test('installmentPlan', 'Each installment needs an amount greater than 0', () => {
+      for (const item of data.installmentPlan ?? []) {
+        enforce(item.amountCents).isNotNullish();
+        if (item.amountCents !== undefined) {
+          enforce(item.amountCents).greaterThan(0);
+        }
       }
     });
 
-    test('week5ChargeAt', 'A valid second-installment charge date is required', () => {
-      enforce(parseDate(data.week5ChargeAt)).isNotNullish();
+    test('installmentPlan', 'Each installment needs a valid due date', () => {
+      for (const item of data.installmentPlan ?? []) {
+        enforce(parseDate(item.dueAt)).isNotNullish();
+      }
+    });
+
+    test('installmentPlan', 'Installment due dates must be in ascending order', () => {
+      const dates = (data.installmentPlan ?? [])
+        .map((i) => parseDate(i.dueAt))
+        .filter((d): d is Date => d !== undefined);
+      for (let i = 1; i < dates.length; i++) {
+        enforce(dates[i].getTime()).greaterThan(dates[i - 1].getTime());
+      }
     });
 
     test('status', 'Status must be valid', () => {


### PR DESCRIPTION
## Summary
Phase 1 of the Music Together epic (#508): the **family-shaped data foundation**. Backend only, no external deps — unblocks Phases 3–4.

## Changes
**Domain** (`@maple/ts/domain`)
- `MusicTogetherSection` (`musicTogetherSections`): sessions, **8-family capacity**, full/installment prices, `week5ChargeAt` anchor, status; pricing constants + `mtSectionFirstSessionAt`/`mtSpotsRemaining`/`mtSectionHasAvailability`.
- `MusicTogetherRegistration` (`musicTogetherRegistrations`): one doc per **family** — `parentNames[]`, `children[{name, dob}]` (licensee report), contact, `paymentPlan`, card-on-file fields, and `installment2` carrying the `scheduled→charging→paid/failed/cancelled` **status lease** + stable `idempotencyKey` (the overcharge-safety primitives Phase 4 will drive).

**Repositories** (`@maple/firebase/database`) — section + registration, mirroring `registration.repository` (hydration, filters, CRUD, transaction refs). Registration adds `countBySectionId` (family capacity rollup); section denormalizes `firstSessionAt` as the indexed sort key.

**Validation** (`@maple/ts/validation`) — `musicTogetherRegistrationValidation` (parents, children with past DOB, contact, policies, card-on-file required **only** for installments) + `musicTogetherSectionValidation`.

**Firestore** — 6 composite indexes added via the analyzer (`✓ all 142 queries covered`).

## Heads-up / decision flag
Two installments total **$264** (2×$132) vs **$252** paying in full — a **$12 pay-in-full incentive**. Encoded + documented as intentional per the program spec; flagging in case the intended numbers differ.

## Testing
- [x] 30 new unit tests (domain + validation)
- [x] Full unit coverage **84.26%** (> 80%)
- [x] `nx lint` clean (domain, validation, database); MT files typecheck clean
- [x] Firestore index analyzer passes

Refs #508 · Closes #511