### PR TITLE
feat(music-together): registration + checkout backend (#513)

### DIFF
--- a/apps/functions-square/src/index.ts
+++ b/apps/functions-square/src/index.ts
@@ -44,6 +44,9 @@ export { syncInventoryToSquare } from '@maple/firebase/maple-functions/sync-inve
 
 // Craft Club subscription signup (public; Square customer + card + subscription)
 export { createCraftClubSubscription } from '@maple/firebase/maple-functions/create-craft-club-subscription';
+
+// Music Together public checkout (routes to MT's separate Square account)
+export { createMusicTogetherRegistration } from '@maple/firebase/maple-functions/create-music-together-registration';
 // Craft Club self-service (public, session-gated; Square subscription mutations)
 export { cancelCraftClubSubscription } from '@maple/firebase/maple-functions/cancel-craft-club-subscription';
 export { updateCraftClubPaymentMethod } from '@maple/firebase/maple-functions/update-craft-club-payment-method';

--- a/apps/functions-square/tsconfig.app.json
+++ b/apps/functions-square/tsconfig.app.json
@@ -24,6 +24,7 @@
     "../../libs/firebase/maple-functions/admin-pause-craft-club-subscription/**/*.ts",
     "../../libs/firebase/maple-functions/admin-resume-craft-club-subscription/**/*.ts",
     "../../libs/firebase/maple-functions/admin-cancel-craft-club-subscription/**/*.ts",
+    "../../libs/firebase/maple-functions/create-music-together-registration/**/*.ts",
     "../../libs/firebase/database/src/**/*.ts",
     "../../libs/firebase/functions/src/**/*.ts",
     "../../libs/firebase/square/src/**/*.ts",

--- a/function-codebases.json
+++ b/function-codebases.json
@@ -38,6 +38,7 @@
     "firebase-maple-functions-sync-inventory-to-etsy": "maple-sync",
     "firebase-maple-functions-sync-inventory-to-square": "maple-square",
     "firebase-maple-functions-create-craft-club-subscription": "maple-square",
+    "firebase-maple-functions-create-music-together-registration": "maple-square",
     "firebase-maple-functions-cancel-craft-club-subscription": "maple-square",
     "firebase-maple-functions-update-craft-club-payment-method": "maple-square",
     "firebase-maple-functions-admin-pause-craft-club-subscription": "maple-square",

--- a/libs/firebase/maple-functions/create-music-together-registration/project.json
+++ b/libs/firebase/maple-functions/create-music-together-registration/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-create-music-together-registration",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/create-music-together-registration/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/create-music-together-registration/src/index.ts
+++ b/libs/firebase/maple-functions/create-music-together-registration/src/index.ts
@@ -1,0 +1,1 @@
+export { createMusicTogetherRegistration } from './lib/create-music-together-registration';

--- a/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.spec.ts
+++ b/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.spec.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  capturedHandler: null as
+    | ((d: unknown, c: unknown, s: unknown, st: unknown) => Promise<unknown>)
+    | null,
+  sectionFindById: vi.fn(),
+  chargeCreate: vi.fn(),
+  upsertByEmail: vi.fn(),
+  createCardOnFile: vi.fn(),
+  createPayment: vi.fn(),
+  txGetSize: 0,
+  txSet: vi.fn(),
+  regUpdate: vi.fn(),
+  mailAdd: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/functions', () => {
+  class HttpsError extends Error {
+    constructor(public code: string, message: string) {
+      super(message);
+    }
+  }
+  const endpoint = {
+    usingSecrets: vi.fn(() => endpoint),
+    usingStrings: vi.fn(() => endpoint),
+    handle: vi.fn((h: typeof mocks.capturedHandler) => {
+      mocks.capturedHandler = h;
+      return 'mock-function';
+    }),
+  };
+  return {
+    Functions: { endpoint },
+    throwInvalidArgument: (m: string) => {
+      throw new HttpsError('invalid-argument', m);
+    },
+    throwValidationError: (e: Record<string, string[]>) => {
+      throw new HttpsError(
+        'invalid-argument',
+        `validation: ${Object.keys(e).join(',')}`
+      );
+    },
+    throwNotFound: (entity: string, id: string) => {
+      throw new HttpsError('not-found', `${entity} not found: ${id}`);
+    },
+    throwFailedPrecondition: (m: string) => {
+      throw new HttpsError('failed-precondition', m);
+    },
+  };
+});
+
+vi.mock('@maple/firebase/square', () => {
+  class PaymentError extends Error {
+    constructor(message: string, public squareCode?: string) {
+      super(message);
+    }
+  }
+  return {
+    MT_SQUARE_SECRET_NAMES: ['MT_SQUARE_ACCESS_TOKEN'],
+    MT_SQUARE_STRING_NAMES: [
+      'MT_SQUARE_ENV',
+      'MT_SQUARE_LOCATION_ID',
+      'MT_SALES_TAX_RATE',
+    ],
+    MT_SQUARE_KEYS: { accessTokenSecret: 'MT_SQUARE_ACCESS_TOKEN' },
+    PaymentError,
+    Square: class {
+      locationId = 'MT_LOC';
+      customersService = { upsertByEmail: mocks.upsertByEmail };
+      cardsService = { createCardOnFile: mocks.createCardOnFile };
+      paymentsService = { createPayment: mocks.createPayment };
+    },
+  };
+});
+
+const regRef = { id: 'reg-1', update: mocks.regUpdate };
+
+vi.mock('@maple/firebase/database', () => {
+  const queryStub: Record<string, unknown> = {};
+  queryStub.where = () => queryStub;
+  const db = {
+    collection: () => ({ where: () => queryStub, add: mocks.mailAdd }),
+    runTransaction: async (
+      fn: (tx: {
+        get: () => Promise<{ size: number }>;
+        set: (...a: unknown[]) => void;
+      }) => Promise<void>
+    ) =>
+      fn({
+        get: async () => ({ size: mocks.txGetSize }),
+        set: mocks.txSet,
+      }),
+  };
+  return {
+    getDb: () => db,
+    MusicTogetherSectionRepository: { findById: mocks.sectionFindById },
+    MusicTogetherRegistrationRepository: { getDocRef: () => regRef },
+    MusicTogetherScheduledChargeRepository: { create: mocks.chargeCreate },
+  };
+});
+
+import './create-music-together-registration';
+
+const SECRETS = { MT_SQUARE_ACCESS_TOKEN: 'tok' };
+const STRINGS = {
+  MT_SQUARE_ENV: 'LOCAL',
+  MT_SQUARE_LOCATION_ID: 'MT_LOC',
+  MT_SALES_TAX_RATE: '0.0',
+  ALLOWED_ORIGINS: '*',
+};
+
+function run(data: unknown) {
+  return mocks.capturedHandler!(data, {}, SECRETS, STRINGS);
+}
+
+const openFullOnly = {
+  id: 'sec-1',
+  name: 'Spring 2026',
+  status: 'open',
+  capacityFamilies: 8,
+  priceFullCents: 25200,
+  installmentPlan: undefined,
+};
+
+const openWithInstallments = {
+  ...openFullOnly,
+  installmentPlan: [
+    { amountCents: 13200, dueAt: new Date('2026-09-01T14:00:00Z') },
+    { amountCents: 13200, dueAt: new Date('2026-09-29T14:00:00Z') },
+  ],
+};
+
+const baseFamily = {
+  sectionId: 'sec-1',
+  parentNames: ['Jamie Rivera'],
+  children: [{ name: 'Sky', dob: '2023-04-01' }],
+  email: 'jamie@example.com',
+  phone: '304-555-1212',
+  address: '123 Spruce St, Morgantown, WV',
+  policiesAccepted: true,
+  paymentNonce: 'cnon:card-nonce-abc',
+};
+
+describe('createMusicTogetherRegistration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.txGetSize = 0;
+    mocks.createPayment.mockResolvedValue({
+      paymentId: 'pay-1',
+      receiptUrl: 'https://receipt',
+    });
+    mocks.upsertByEmail.mockResolvedValue('cust-1');
+    mocks.createCardOnFile.mockResolvedValue({ cardId: 'card-1', last4: '4242' });
+    mocks.chargeCreate.mockResolvedValue({ id: 'chg' });
+  });
+
+  it('full pay: charges the nonce once, no card vaulting, no scheduled charges', async () => {
+    mocks.sectionFindById.mockResolvedValue(openFullOnly);
+
+    const result = (await run({
+      ...baseFamily,
+      paymentPlan: 'full',
+    })) as { amountChargedCents: number; scheduledChargeCount: number };
+
+    expect(mocks.upsertByEmail).not.toHaveBeenCalled();
+    expect(mocks.createCardOnFile).not.toHaveBeenCalled();
+    expect(mocks.createPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceId: 'cnon:card-nonce-abc',
+        amountCents: 25200,
+        idempotencyKey: 'mtreg-reg-1',
+      })
+    );
+    expect(mocks.chargeCreate).not.toHaveBeenCalled();
+    expect(result.amountChargedCents).toBe(25200);
+    expect(result.scheduledChargeCount).toBe(0);
+    expect(mocks.regUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'confirmed' })
+    );
+  });
+
+  it('installments: vaults card, charges stored card for installment 1, schedules the rest', async () => {
+    mocks.sectionFindById.mockResolvedValue(openWithInstallments);
+
+    const result = (await run({
+      ...baseFamily,
+      paymentPlan: 'installments',
+      cardOnFileAuth: true,
+    })) as { amountChargedCents: number; scheduledChargeCount: number; cardLast4?: string };
+
+    expect(mocks.upsertByEmail).toHaveBeenCalled();
+    expect(mocks.createCardOnFile).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceId: 'cnon:card-nonce-abc', customerId: 'cust-1' })
+    );
+    // installment 1 charges the STORED card (with customerId), not the nonce
+    expect(mocks.createPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceId: 'card-1',
+        customerId: 'cust-1',
+        amountCents: 13200,
+      })
+    );
+    // one scheduled charge for installment 2
+    expect(mocks.chargeCreate).toHaveBeenCalledTimes(1);
+    expect(mocks.chargeCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        registrationId: 'reg-1',
+        installmentNumber: 2,
+        amountCents: 13200,
+        status: 'scheduled',
+      })
+    );
+    expect(result.amountChargedCents).toBe(13200);
+    expect(result.scheduledChargeCount).toBe(1);
+    expect(result.cardLast4).toBe('4242');
+  });
+
+  it('rejects when the section is full — no payment taken', async () => {
+    mocks.sectionFindById.mockResolvedValue(openFullOnly);
+    mocks.txGetSize = 8; // at capacity
+
+    await expect(run({ ...baseFamily, paymentPlan: 'full' })).rejects.toThrow(
+      /full/i
+    );
+    expect(mocks.createPayment).not.toHaveBeenCalled();
+  });
+
+  it('404s an unknown section before any Square call', async () => {
+    mocks.sectionFindById.mockResolvedValue(undefined);
+    await expect(run({ ...baseFamily, paymentPlan: 'full' })).rejects.toThrow(
+      /not found/i
+    );
+    expect(mocks.createPayment).not.toHaveBeenCalled();
+  });
+
+  it('rejects a section that is not open', async () => {
+    mocks.sectionFindById.mockResolvedValue({ ...openFullOnly, status: 'closed' });
+    await expect(run({ ...baseFamily, paymentPlan: 'full' })).rejects.toThrow(
+      /not open/i
+    );
+  });
+
+  it('rejects installments when the section offers none', async () => {
+    mocks.sectionFindById.mockResolvedValue(openFullOnly); // no plan
+    await expect(
+      run({ ...baseFamily, paymentPlan: 'installments', cardOnFileAuth: true })
+    ).rejects.toThrow(/does not offer an installment plan/i);
+  });
+
+  it('rejects invalid input before loading the section', async () => {
+    await expect(
+      run({ ...baseFamily, paymentPlan: 'full', policiesAccepted: false })
+    ).rejects.toThrow(/validation/);
+    expect(mocks.sectionFindById).not.toHaveBeenCalled();
+  });
+
+  it('requires card-on-file auth for the installment plan', async () => {
+    mocks.sectionFindById.mockResolvedValue(openWithInstallments);
+    await expect(
+      run({ ...baseFamily, paymentPlan: 'installments', cardOnFileAuth: false })
+    ).rejects.toThrow(/validation/);
+  });
+
+  it('cancels the reservation when payment fails', async () => {
+    mocks.sectionFindById.mockResolvedValue(openFullOnly);
+    mocks.createPayment.mockRejectedValue(new Error('card declined'));
+
+    await expect(run({ ...baseFamily, paymentPlan: 'full' })).rejects.toThrow();
+    expect(mocks.regUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'cancelled' })
+    );
+  });
+});

--- a/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.ts
+++ b/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.ts
@@ -1,0 +1,288 @@
+/**
+ * Create Music Together Registration Cloud Function (public, MT Square account)
+ *
+ * The public checkout for a Music Together section. Routes payment to MT's
+ * SEPARATE Square account (MT_SQUARE_KEYS), not Maple & Spruce's.
+ *
+ * Flow:
+ *  1. Validate the family payload (Vest) before any Square write.
+ *  2. Load the section; it must be `open`.
+ *  3. Reserve a `pending` registration inside a transaction that enforces the
+ *     per-section family cap (overbooking-safe).
+ *  4. Charge in MT Square:
+ *       - full pay → one-time nonce charge of the full price.
+ *       - installments → upsert customer, vault the card, charge the *stored*
+ *         card for installment 1, and materialize installments 2..N as
+ *         `musicTogetherScheduledCharges` for the Week-5 auto-charge job.
+ *  5. Confirm the registration and queue a confirmation email.
+ *
+ * On payment failure the reserved registration is cancelled so the seat frees.
+ *
+ * Deployed to us-east4 via CI/CD (maple-square codebase).
+ */
+import {
+  Functions,
+  throwInvalidArgument,
+  throwNotFound,
+  throwFailedPrecondition,
+  throwValidationError,
+} from '@maple/firebase/functions';
+import {
+  Square,
+  MT_SQUARE_SECRET_NAMES,
+  MT_SQUARE_STRING_NAMES,
+  MT_SQUARE_KEYS,
+  PaymentError,
+} from '@maple/firebase/square';
+import {
+  MusicTogetherSectionRepository,
+  MusicTogetherRegistrationRepository,
+  MusicTogetherScheduledChargeRepository,
+  getDb,
+} from '@maple/firebase/database';
+import {
+  MT_CAPACITY_STATUSES,
+  mtSectionOffersInstallments,
+} from '@maple/ts/domain';
+import { musicTogetherRegistrationValidation } from '@maple/ts/validation';
+import type {
+  CreateMusicTogetherRegistrationRequest,
+  CreateMusicTogetherRegistrationResponse,
+} from '@maple/ts/firebase/api-types';
+
+const COLLECTION = 'musicTogetherRegistrations';
+
+export const createMusicTogetherRegistration = Functions.endpoint
+  .usingSecrets(...MT_SQUARE_SECRET_NAMES)
+  .usingStrings(...MT_SQUARE_STRING_NAMES, 'ALLOWED_ORIGINS')
+  .handle<
+    CreateMusicTogetherRegistrationRequest,
+    CreateMusicTogetherRegistrationResponse
+  >(async (data, _context, secrets, strings) => {
+    // 1. Validate the payload before touching Square.
+    const validation = musicTogetherRegistrationValidation({
+      sectionId: data.sectionId,
+      parentNames: data.parentNames,
+      children: data.children,
+      email: data.email,
+      phone: data.phone,
+      address: data.address,
+      paymentPlan: data.paymentPlan,
+      policiesAccepted: data.policiesAccepted,
+      cardOnFileAuth: data.cardOnFileAuth,
+    });
+    if (validation.hasErrors()) {
+      throwValidationError(validation.getErrors());
+    }
+    if (!data.paymentNonce) {
+      throwInvalidArgument('Payment information is required');
+    }
+
+    // 2. Load the section; it must be open for registration.
+    const section = await MusicTogetherSectionRepository.findById(
+      data.sectionId
+    );
+    if (!section) {
+      throwNotFound('Music Together section', data.sectionId);
+    }
+    if (section.status !== 'open') {
+      throwFailedPrecondition('This section is not open for registration.');
+    }
+
+    // 3. Resolve the charge amounts from the section's configurable plan.
+    const offersInstallments = mtSectionOffersInstallments(section);
+    if (data.paymentPlan === 'installments' && !offersInstallments) {
+      throwFailedPrecondition(
+        'This section does not offer an installment plan.'
+      );
+    }
+    const plan = section.installmentPlan ?? [];
+    const firstChargeCents =
+      data.paymentPlan === 'installments'
+        ? plan[0].amountCents
+        : section.priceFullCents;
+    // Installments 2..N become scheduled card-on-file charges.
+    const scheduledItems =
+      data.paymentPlan === 'installments' ? plan.slice(1) : [];
+
+    const square = new Square(secrets, strings, MT_SQUARE_KEYS);
+
+    // 4. Reserve the seat inside a transaction that enforces the family cap.
+    const db = getDb();
+    const regRef = MusicTogetherRegistrationRepository.getDocRef();
+    const now = new Date();
+    const parentNames = data.parentNames
+      .map((n) => n.trim())
+      .filter((n) => n.length > 0);
+    const children = data.children.map((c) => ({
+      name: c.name.trim(),
+      dob: new Date(c.dob),
+    }));
+
+    await db.runTransaction(async (tx) => {
+      const existing = await tx.get(
+        db
+          .collection(COLLECTION)
+          .where('sectionId', '==', data.sectionId)
+          .where('status', 'in', [...MT_CAPACITY_STATUSES])
+      );
+      if (existing.size >= section.capacityFamilies) {
+        // Full — the widget switches to the waitlist (Phase 5).
+        throw new Error('This section is full.');
+      }
+      tx.set(regRef, {
+        sectionId: data.sectionId,
+        parentNames,
+        children,
+        email: data.email,
+        phone: data.phone,
+        address: data.address,
+        paymentPlan: data.paymentPlan,
+        policiesAcceptedAt: now,
+        cardOnFileAuthAt:
+          data.paymentPlan === 'installments' ? now : null,
+        pricePaidCents: firstChargeCents,
+        scheduledChargeCount: scheduledItems.length,
+        status: 'pending',
+        notes: data.notes || null,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    // 5. Charge in MT Square (+ vault a card for the installment plan).
+    let squareCustomerId: string | undefined;
+    let squareCardId: string | undefined;
+    let cardLast4: string | undefined;
+    let squarePaymentId: string | undefined;
+    let squareReceiptUrl: string | undefined;
+    try {
+      if (data.paymentPlan === 'installments') {
+        // The nonce is single-use, so vault the card first, then charge the
+        // STORED card (customerId required) for installment 1. The same card
+        // is used by the scheduled charges later.
+        squareCustomerId = await square.customersService.upsertByEmail({
+          email: data.email,
+          name: parentNames[0],
+          phone: data.phone,
+        });
+        const card = await square.cardsService.createCardOnFile({
+          sourceId: data.paymentNonce,
+          customerId: squareCustomerId,
+          cardholderName: parentNames[0],
+          idempotencyKey: `mtcard-${regRef.id}`,
+        });
+        squareCardId = card.cardId;
+        cardLast4 = card.last4;
+
+        const payment = await square.paymentsService.createPayment({
+          sourceId: squareCardId,
+          customerId: squareCustomerId,
+          amountCents: firstChargeCents,
+          idempotencyKey: `mtreg-${regRef.id}`,
+          locationId: square.locationId,
+          buyerEmailAddress: data.email,
+          note: `Music Together — ${section.name} (installment 1 of ${plan.length})`,
+          referenceId: regRef.id,
+        });
+        squarePaymentId = payment.paymentId;
+        squareReceiptUrl = payment.receiptUrl;
+      } else {
+        // Full pay — a single one-time charge of the nonce.
+        const payment = await square.paymentsService.createPayment({
+          sourceId: data.paymentNonce,
+          amountCents: firstChargeCents,
+          idempotencyKey: `mtreg-${regRef.id}`,
+          locationId: square.locationId,
+          buyerEmailAddress: data.email,
+          note: `Music Together — ${section.name}`,
+          referenceId: regRef.id,
+        });
+        squarePaymentId = payment.paymentId;
+        squareReceiptUrl = payment.receiptUrl;
+      }
+    } catch (paymentError) {
+      const detail =
+        paymentError instanceof Error ? paymentError.message : 'Unknown error';
+      await regRef.update({
+        status: 'cancelled',
+        notes: `Payment failed: ${detail}`,
+        updatedAt: new Date(),
+      });
+      if (paymentError instanceof PaymentError) {
+        throw paymentError;
+      }
+      throw new PaymentError(
+        'Unable to process payment. Please try again or use a different card.',
+        undefined
+      );
+    }
+
+    // 6. Payment succeeded — confirm first so a confirmed, paid family is never
+    //    blocked by a later non-payment hiccup.
+    await regRef.update({
+      status: 'confirmed',
+      squareCustomerId: squareCustomerId || null,
+      squareCardId: squareCardId || null,
+      squarePaymentId: squarePaymentId || null,
+      squareReceiptUrl: squareReceiptUrl || null,
+      updatedAt: new Date(),
+    });
+
+    // 7. Materialize the remaining installments as scheduled charges. If this
+    //    fails after a successful charge, we do NOT fail the request (the
+    //    family is paid + enrolled); record how many were created so admins
+    //    can reconcile.
+    let createdCharges = 0;
+    try {
+      for (let i = 0; i < scheduledItems.length; i++) {
+        const item = scheduledItems[i];
+        await MusicTogetherScheduledChargeRepository.create({
+          registrationId: regRef.id,
+          sectionId: data.sectionId,
+          installmentNumber: i + 2, // installment 1 charged now; these are 2..N
+          amountCents: item.amountCents,
+          dueAt: item.dueAt,
+          status: 'scheduled',
+        });
+        createdCharges++;
+      }
+    } catch (scheduleError) {
+      const detail =
+        scheduleError instanceof Error
+          ? scheduleError.message
+          : 'Unknown error';
+      await regRef.update({
+        scheduledChargeCount: createdCharges,
+        notes: `Confirmed, but scheduling installments failed after ${createdCharges}/${scheduledItems.length}: ${detail}`,
+        updatedAt: new Date(),
+      });
+    }
+
+    // 8. Confirmation email (fire-and-forget via the mail collection).
+    //    Template `music-together-confirmation` is authored separately.
+    await getDb()
+      .collection('mail')
+      .add({
+        to: data.email,
+        template: {
+          name: 'music-together-confirmation',
+          data: {
+            parentName: parentNames[0] ?? '',
+            sectionName: section.name,
+            paymentPlan: data.paymentPlan,
+            amountChargedCents: firstChargeCents,
+            scheduledChargeCount: createdCharges,
+          },
+        },
+      });
+
+    return {
+      registrationId: regRef.id,
+      status: 'confirmed',
+      amountChargedCents: firstChargeCents,
+      scheduledChargeCount: createdCharges,
+      cardLast4,
+      squareReceiptUrl,
+    };
+  });

--- a/libs/firebase/maple-functions/create-music-together-registration/tsconfig.json
+++ b/libs/firebase/maple-functions/create-music-together-registration/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [{ "path": "./tsconfig.lib.json" }]
+}

--- a/libs/firebase/maple-functions/create-music-together-registration/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/create-music-together-registration/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/square/src/lib/payments.service.ts
+++ b/libs/firebase/square/src/lib/payments.service.ts
@@ -110,7 +110,11 @@ export class PaymentError extends Error {
  * Input for creating a payment
  */
 export interface CreatePaymentInput {
-  /** Payment source ID (nonce from Web Payments SDK card.tokenize()) */
+  /**
+   * Payment source ID. Either a single-use nonce from the Web Payments SDK
+   * `card.tokenize()`, OR a stored card-on-file ID (in which case `customerId`
+   * must also be set — Square requires it to charge a saved card).
+   */
   sourceId: string;
   /** Amount to charge in cents (e.g., 2500 = $25.00) */
   amountCents: number;
@@ -118,6 +122,11 @@ export interface CreatePaymentInput {
   idempotencyKey: string;
   /** Square location ID */
   locationId: string;
+  /**
+   * Square customer ID. Required when `sourceId` is a stored card-on-file ID;
+   * optional for one-time nonce payments.
+   */
+  customerId?: string;
   /** Customer email for receipt */
   buyerEmailAddress?: string;
   /** Description/note for the payment */
@@ -214,6 +223,7 @@ export class PaymentsService {
           currency: 'USD',
         },
         locationId: input.locationId,
+        customerId: input.customerId,
         autocomplete: true,
         buyerEmailAddress: input.buyerEmailAddress,
         note: input.note,

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -410,3 +410,12 @@ export type {
   AdminCraftClubSubscriptionActionRequest,
   AdminCraftClubSubscriptionActionResponse,
 } from './craft-club.types';
+
+export type {
+  GetPublicMusicTogetherSectionRequest,
+  GetPublicMusicTogetherSectionResponse,
+  PublicMusicTogetherSection,
+  MusicTogetherChildPayload,
+  CreateMusicTogetherRegistrationRequest,
+  CreateMusicTogetherRegistrationResponse,
+} from './music-together.types';

--- a/libs/ts/firebase/api-types/src/lib/music-together.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/music-together.types.ts
@@ -1,0 +1,73 @@
+/**
+ * Music Together API request/response types
+ *
+ * Shared between the public Webflow checkout widget and the Cloud Functions.
+ * Dates cross the wire as ISO strings (e.g. child DOBs); the server parses them.
+ */
+import type { MusicTogetherSection } from '@maple/ts/domain';
+
+// ============================================================================
+// Get Public Section (public — widget loads section + pricing)
+// ============================================================================
+
+export interface GetPublicMusicTogetherSectionRequest {
+  sectionId: string;
+}
+
+/** Public, customer-safe view of a section plus live availability. */
+export interface PublicMusicTogetherSection {
+  id: string;
+  name: string;
+  description?: string;
+  sessions: { dateTime: string }[];
+  priceFullCents: number;
+  installmentPlan?: { amountCents: number; dueAt: string }[];
+  capacityFamilies: number;
+  spotsRemaining: number;
+  status: MusicTogetherSection['status'];
+  location?: string;
+  room?: string;
+}
+
+export interface GetPublicMusicTogetherSectionResponse {
+  section: PublicMusicTogetherSection;
+}
+
+// ============================================================================
+// Create Registration (public — checkout, with payment)
+// ============================================================================
+
+/** One child on the registration form; `dob` is an ISO date string. */
+export interface MusicTogetherChildPayload {
+  name: string;
+  dob: string;
+}
+
+export interface CreateMusicTogetherRegistrationRequest {
+  sectionId: string;
+  parentNames: string[];
+  children: MusicTogetherChildPayload[];
+  email: string;
+  phone: string;
+  address: string;
+  /** 'full' = one charge; 'installments' = first charge now + scheduled rest. */
+  paymentPlan: 'full' | 'installments';
+  policiesAccepted: boolean;
+  /** Card-on-file authorization — required when paymentPlan is 'installments'. */
+  cardOnFileAuth?: boolean;
+  /** Nonce from the Square Web Payments SDK card tokenization. */
+  paymentNonce: string;
+  notes?: string;
+}
+
+export interface CreateMusicTogetherRegistrationResponse {
+  registrationId: string;
+  status: 'confirmed';
+  /** Amount charged at registration (full price, or the first installment). */
+  amountChargedCents: number;
+  /** Number of scheduled future charges created (0 for pay-in-full). */
+  scheduledChargeCount: number;
+  /** Last 4 of the card on file, when one was stored (installments). */
+  cardLast4?: string;
+  squareReceiptUrl?: string;
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -47,6 +47,9 @@
       "@maple/firebase/maple-functions/create-craft-club-subscription": [
         "libs/firebase/maple-functions/create-craft-club-subscription/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/create-music-together-registration": [
+        "libs/firebase/maple-functions/create-music-together-registration/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/request-craft-club-access": [
         "libs/firebase/maple-functions/request-craft-club-access/src/index.ts"
       ],


### PR DESCRIPTION
## Summary
Phase 3 (backend) of the Music Together epic (#508): the public **checkout Cloud Function**, routing payment to MT's **separate Square account** (`MT_SQUARE_KEYS` from Phase 0). Folds in card-on-file (#512), de-risked by Craft Club's `CardsService`/`CustomersService`.

## `createMusicTogetherRegistration` (maple-square, public)
1. Validates the family payload (Vest) **before** any Square write.
2. Loads the section (must be `open`); resolves amounts from the section's configurable `installmentPlan`.
3. Reserves a `pending` registration in a transaction enforcing the **per-section family cap** (overbooking-safe; full → waitlist in Phase 5).
4. **Full pay** → one-time nonce charge. **Installments** → upsert customer → vault card → charge the **stored** card for installment 1 (the nonce is single-use) → materialize installments 2..N as `musicTogetherScheduledCharges` for the Week-5 job. Payment failure cancels the reservation.
5. Confirms, best-effort schedules the remaining charges, queues a confirmation email.

## Supporting changes
- `payments.service`: added `customerId` to `CreatePaymentInput` — Square requires it to charge a stored card-on-file.
- `api-types`: `music-together.types` (create request/response + public section view).
- Wired into `functions-square` index, `function-codebases.json`, and tsconfig includes (validator green).

## Testing
- [x] 9 unit tests (vi.mock per ADR-017): full / installments / full-section / not-found / not-open / no-plan / invalid input / missing card-auth / payment-failure
- [x] Full unit coverage **84.37%** (no cascade — spec mocks heavy deps)
- [x] `nx lint` clean; `nx affected -t typecheck` green; function-tsconfig validator green

## Follows in Phase 3b
- The Webflow checkout widget (clone of the registration widget, MT app-id/location-id) and `getPublicMusicTogetherSection` read endpoint (api-type already defined).
- Integration test against the Square mock server.

Refs #508, #512 · Closes #513