### PR TITLE
feat(music-together): public section read endpoint (#508)

### DIFF
--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -102,6 +102,7 @@ export { migrateClassSessions } from '@maple/firebase/maple-functions/migrate-cl
 
 // Public class API (no auth required - for Webflow integration)
 export { getPublicClass } from '@maple/firebase/maple-functions/get-public-class';
+export { getPublicMusicTogetherSection } from '@maple/firebase/maple-functions/get-public-music-together-section';
 export { getRelatedPublicClasses } from '@maple/firebase/maple-functions/get-related-public-classes';
 export { addToClassWaitlist } from '@maple/firebase/maple-functions/add-to-class-waitlist';
 export { notifyWaitlistOnSpotOpen } from '@maple/firebase/maple-functions/notify-waitlist-on-spot-open';

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -122,6 +122,7 @@
     "../../libs/firebase/maple-functions/request-craft-club-manage-link/**/*.ts",
     "../../libs/firebase/maple-functions/start-craft-club-session/**/*.ts",
     "../../libs/firebase/maple-functions/get-craft-club-subscription/**/*.ts",
+    "../../libs/firebase/maple-functions/get-public-music-together-section/**/*.ts",
     "../../libs/firebase/database/src/**/*.ts",
     "../../libs/firebase/functions/src/**/*.ts",
     "../../libs/ts/domain/src/**/*.ts",

--- a/libs/firebase/maple-functions/get-public-music-together-section/project.json
+++ b/libs/firebase/maple-functions/get-public-music-together-section/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-get-public-music-together-section",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/get-public-music-together-section/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/get-public-music-together-section/src/index.ts
+++ b/libs/firebase/maple-functions/get-public-music-together-section/src/index.ts
@@ -1,0 +1,1 @@
+export { getPublicMusicTogetherSection } from './lib/get-public-music-together-section';

--- a/libs/firebase/maple-functions/get-public-music-together-section/src/lib/get-public-music-together-section.spec.ts
+++ b/libs/firebase/maple-functions/get-public-music-together-section/src/lib/get-public-music-together-section.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  capturedHandler: null as ((d: unknown) => Promise<unknown>) | null,
+  findById: vi.fn(),
+  countBySectionId: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/functions', () => {
+  const endpoint = {
+    withOptions: vi.fn(() => endpoint),
+    handle: vi.fn((h: typeof mocks.capturedHandler) => {
+      mocks.capturedHandler = h;
+      return 'mock-function';
+    }),
+  };
+  return { Functions: { endpoint } };
+});
+
+vi.mock('@maple/firebase/database', () => ({
+  MusicTogetherSectionRepository: { findById: mocks.findById },
+  MusicTogetherRegistrationRepository: {
+    countBySectionId: mocks.countBySectionId,
+  },
+}));
+
+import './get-public-music-together-section';
+
+function run(data: unknown) {
+  return mocks.capturedHandler!(data);
+}
+
+const section = {
+  id: 'sec-1',
+  name: 'Spring 2026',
+  description: 'Tuesdays 10am',
+  status: 'open',
+  capacityFamilies: 8,
+  priceFullCents: 25200,
+  sessions: [{ dateTime: new Date('2026-09-01T14:00:00Z') }],
+  installmentPlan: [
+    { amountCents: 13200, dueAt: new Date('2026-09-01T14:00:00Z') },
+    { amountCents: 13200, dueAt: new Date('2026-09-29T14:00:00Z') },
+  ],
+  location: 'Studio',
+  room: 'spruce',
+};
+
+describe('getPublicMusicTogetherSection', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns a public projection with computed spotsRemaining and ISO dates', async () => {
+    mocks.findById.mockResolvedValue(section);
+    mocks.countBySectionId.mockResolvedValue(3);
+
+    const result = (await run({ sectionId: 'sec-1' })) as {
+      section: {
+        spotsRemaining: number;
+        sessions: { dateTime: string }[];
+        installmentPlan?: { dueAt: string }[];
+        priceFullCents: number;
+      };
+    };
+
+    expect(result.section.spotsRemaining).toBe(5); // 8 - 3
+    expect(result.section.sessions[0].dateTime).toBe('2026-09-01T14:00:00.000Z');
+    expect(result.section.installmentPlan?.[1].dueAt).toBe(
+      '2026-09-29T14:00:00.000Z'
+    );
+    expect(result.section.priceFullCents).toBe(25200);
+  });
+
+  it('reports 0 spots when full', async () => {
+    mocks.findById.mockResolvedValue(section);
+    mocks.countBySectionId.mockResolvedValue(8);
+    const result = (await run({ sectionId: 'sec-1' })) as {
+      section: { spotsRemaining: number };
+    };
+    expect(result.section.spotsRemaining).toBe(0);
+  });
+
+  it('requires a section id', async () => {
+    await expect(run({})).rejects.toThrow(/required/i);
+    expect(mocks.findById).not.toHaveBeenCalled();
+  });
+
+  it('404s an unknown section', async () => {
+    mocks.findById.mockResolvedValue(undefined);
+    await expect(run({ sectionId: 'nope' })).rejects.toThrow(/not found/i);
+  });
+
+  it('hides draft sections', async () => {
+    mocks.findById.mockResolvedValue({ ...section, status: 'draft' });
+    await expect(run({ sectionId: 'sec-1' })).rejects.toThrow(
+      /not available/i
+    );
+    expect(mocks.countBySectionId).not.toHaveBeenCalled();
+  });
+});

--- a/libs/firebase/maple-functions/get-public-music-together-section/src/lib/get-public-music-together-section.ts
+++ b/libs/firebase/maple-functions/get-public-music-together-section/src/lib/get-public-music-together-section.ts
@@ -1,0 +1,69 @@
+/**
+ * Get Public Music Together Section Cloud Function
+ *
+ * Loads a single Music Together section for the public checkout widget (no
+ * auth). Returns a customer-safe projection plus live family availability so
+ * the widget can show "spots remaining" and switch to the waitlist when full.
+ * Deployed to us-east4 via CI/CD (maple-core codebase).
+ */
+import { Functions } from '@maple/firebase/functions';
+import {
+  MusicTogetherSectionRepository,
+  MusicTogetherRegistrationRepository,
+} from '@maple/firebase/database';
+import { mtSpotsRemaining } from '@maple/ts/domain';
+import type {
+  GetPublicMusicTogetherSectionRequest,
+  GetPublicMusicTogetherSectionResponse,
+  PublicMusicTogetherSection,
+} from '@maple/ts/firebase/api-types';
+
+// Keep warm in prod only — dev/emulator/CI run cold.
+const minInstances =
+  process.env['GCLOUD_PROJECT'] === 'maple-and-spruce' ? 1 : 0;
+
+export const getPublicMusicTogetherSection = Functions.endpoint
+  .withOptions({ minInstances, concurrency: 80 })
+  .handle<
+    GetPublicMusicTogetherSectionRequest,
+    GetPublicMusicTogetherSectionResponse
+  >(async (data) => {
+    if (!data.sectionId) {
+      throw new Error('Section ID is required');
+    }
+
+    const section = await MusicTogetherSectionRepository.findById(
+      data.sectionId
+    );
+    if (!section) {
+      throw new Error(`Music Together section not found: ${data.sectionId}`);
+    }
+    // Draft sections are not publicly visible.
+    if (section.status === 'draft') {
+      throw new Error('This section is not available');
+    }
+
+    const familyCount =
+      await MusicTogetherRegistrationRepository.countBySectionId(section.id);
+
+    const publicSection: PublicMusicTogetherSection = {
+      id: section.id,
+      name: section.name,
+      description: section.description,
+      sessions: section.sessions.map((s) => ({
+        dateTime: s.dateTime.toISOString(),
+      })),
+      priceFullCents: section.priceFullCents,
+      installmentPlan: section.installmentPlan?.map((i) => ({
+        amountCents: i.amountCents,
+        dueAt: i.dueAt.toISOString(),
+      })),
+      capacityFamilies: section.capacityFamilies,
+      spotsRemaining: mtSpotsRemaining(section, familyCount),
+      status: section.status,
+      location: section.location,
+      room: section.room,
+    };
+
+    return { section: publicSection };
+  });

--- a/libs/firebase/maple-functions/get-public-music-together-section/tsconfig.json
+++ b/libs/firebase/maple-functions/get-public-music-together-section/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [{ "path": "./tsconfig.lib.json" }]
+}

--- a/libs/firebase/maple-functions/get-public-music-together-section/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/get-public-music-together-section/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -317,6 +317,9 @@
       "@maple/firebase/maple-functions/get-public-class": [
         "libs/firebase/maple-functions/get-public-class/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/get-public-music-together-section": [
+        "libs/firebase/maple-functions/get-public-music-together-section/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/check-admin-status": [
         "libs/firebase/maple-functions/check-admin-status/src/index.ts"
       ],


### PR DESCRIPTION
## Summary
The public read the Music Together checkout widget calls to load a section + live availability. Completes the **backend** side of registration/checkout (the `createMusicTogetherRegistration` write shipped in #525).

## `getPublicMusicTogetherSection` (maple-core, public, no auth)
- Returns a customer-safe `PublicMusicTogetherSection` projection (dates as ISO strings) with **`spotsRemaining`** computed from `countBySectionId`.
- Hides `draft` sections.
- Mirrors `getPublicClass`. Wired into maple-core (apps/functions index, path alias, tsconfig include — validator green).

## Testing
- [x] 5 unit tests (vi.mock): projection + spotsRemaining math, full section, missing id, 404, draft-hidden
- [x] `nx lint` clean; full unit coverage **84.41%**

## Remaining in Phase 3 (tracked, not in this PR)
- **Webflow checkout widget** (clone of the registration widget with MT app-id/location-id + `verifyBuyer` for card-on-file) — large frontend, best verified with the dev test-harness.
- **Integration test** for `createMusicTogetherRegistration` against the Square mock server (card vault → stored-card charge → scheduled charges) — needs the local emulator harness; kept out of this PR per the run-integration-tests-locally norm.

Refs #508