### PR TITLE
feat(music-together): Week-5 installment auto-charge job (#514)

### DIFF
--- a/apps/functions-square/src/index.ts
+++ b/apps/functions-square/src/index.ts
@@ -47,6 +47,12 @@ export { createCraftClubSubscription } from '@maple/firebase/maple-functions/cre
 
 // Music Together public checkout (routes to MT's separate Square account)
 export { createMusicTogetherRegistration } from '@maple/firebase/maple-functions/create-music-together-registration';
+
+// Music Together Week-5 auto-charge job (scheduled + admin-callable trigger)
+export {
+  chargeMusicTogetherInstallments,
+  triggerMusicTogetherInstallments,
+} from '@maple/firebase/maple-functions/charge-music-together-installments';
 // Craft Club self-service (public, session-gated; Square subscription mutations)
 export { cancelCraftClubSubscription } from '@maple/firebase/maple-functions/cancel-craft-club-subscription';
 export { updateCraftClubPaymentMethod } from '@maple/firebase/maple-functions/update-craft-club-payment-method';

--- a/apps/functions-square/tsconfig.app.json
+++ b/apps/functions-square/tsconfig.app.json
@@ -25,6 +25,7 @@
     "../../libs/firebase/maple-functions/admin-resume-craft-club-subscription/**/*.ts",
     "../../libs/firebase/maple-functions/admin-cancel-craft-club-subscription/**/*.ts",
     "../../libs/firebase/maple-functions/create-music-together-registration/**/*.ts",
+    "../../libs/firebase/maple-functions/charge-music-together-installments/**/*.ts",
     "../../libs/firebase/database/src/**/*.ts",
     "../../libs/firebase/functions/src/**/*.ts",
     "../../libs/firebase/square/src/**/*.ts",

--- a/function-codebases.json
+++ b/function-codebases.json
@@ -39,6 +39,7 @@
     "firebase-maple-functions-sync-inventory-to-square": "maple-square",
     "firebase-maple-functions-create-craft-club-subscription": "maple-square",
     "firebase-maple-functions-create-music-together-registration": "maple-square",
+    "firebase-maple-functions-charge-music-together-installments": "maple-square",
     "firebase-maple-functions-cancel-craft-club-subscription": "maple-square",
     "firebase-maple-functions-update-craft-club-payment-method": "maple-square",
     "firebase-maple-functions-admin-pause-craft-club-subscription": "maple-square",

--- a/libs/firebase/database/src/lib/music-together-scheduled-charge.repository.ts
+++ b/libs/firebase/database/src/lib/music-together-scheduled-charge.repository.ts
@@ -137,6 +137,26 @@ export const MusicTogetherScheduledChargeRepository = {
     await getDb().collection(COLLECTION).doc(id).delete();
   },
 
+  /**
+   * Atomically claim a charge for processing by flipping `scheduled → charging`
+   * in a transaction. Returns `true` if this caller won the lease, `false` if
+   * the charge is already in flight or terminal (another run claimed it, or it
+   * was cancelled). This is the overlap-prevention layer of the overcharge
+   * safety model — a charge can only be claimed once.
+   */
+  async tryClaimLease(id: string): Promise<boolean> {
+    const db = getDb();
+    const docRef = db.collection(COLLECTION).doc(id);
+    return db.runTransaction(async (tx) => {
+      const snap = await tx.get(docRef);
+      if (!snap.exists || snap.data()?.status !== 'scheduled') {
+        return false;
+      }
+      tx.update(docRef, { status: 'charging', updatedAt: new Date() });
+      return true;
+    });
+  },
+
   /** Document reference (for transactional lease claims in the charge job). */
   getDocRef(id?: string) {
     return id

--- a/libs/firebase/maple-functions/charge-music-together-installments/project.json
+++ b/libs/firebase/maple-functions/charge-music-together-installments/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-charge-music-together-installments",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/charge-music-together-installments/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/charge-music-together-installments/src/index.ts
+++ b/libs/firebase/maple-functions/charge-music-together-installments/src/index.ts
@@ -1,0 +1,4 @@
+export {
+  chargeMusicTogetherInstallments,
+  triggerMusicTogetherInstallments,
+} from './lib/charge-music-together-installments';

--- a/libs/firebase/maple-functions/charge-music-together-installments/src/lib/charge-music-together-installments.spec.ts
+++ b/libs/firebase/maple-functions/charge-music-together-installments/src/lib/charge-music-together-installments.spec.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findDue: vi.fn(),
+  tryClaimLease: vi.fn(),
+  chargeUpdate: vi.fn(),
+  regFindById: vi.fn(),
+  mailAdd: vi.fn(),
+  createPayment: vi.fn(),
+}));
+
+// Module-level trigger wiring must not blow up on import.
+vi.mock('firebase-functions/v2/scheduler', () => ({
+  onSchedule: vi.fn(() => 'scheduled-fn'),
+}));
+vi.mock('firebase-functions/params', () => ({
+  defineSecret: (name: string) => ({ name, value: () => 'secret' }),
+  defineString: (name: string) => ({ name, value: () => 'string' }),
+}));
+vi.mock('@maple/firebase/functions', () => {
+  const endpoint = {
+    requiringRole: vi.fn(() => endpoint),
+    usingSecrets: vi.fn(() => endpoint),
+    usingStrings: vi.fn(() => endpoint),
+    handle: vi.fn(() => 'admin-fn'),
+  };
+  return { Functions: { endpoint }, Role: { Admin: 'admin' } };
+});
+vi.mock('@maple/firebase/square', () => {
+  class PaymentError extends Error {}
+  return {
+    PaymentError,
+    MT_SQUARE_SECRET_NAMES: ['MT_SQUARE_ACCESS_TOKEN'],
+    MT_SQUARE_STRING_NAMES: ['MT_SQUARE_ENV', 'MT_SQUARE_LOCATION_ID', 'MT_SALES_TAX_RATE'],
+    MT_SQUARE_KEYS: {},
+    Square: class {},
+  };
+});
+vi.mock('@maple/firebase/database', () => ({
+  getDb: () => ({ collection: () => ({ add: mocks.mailAdd }) }),
+  MusicTogetherScheduledChargeRepository: {
+    findDue: mocks.findDue,
+    tryClaimLease: mocks.tryClaimLease,
+    update: mocks.chargeUpdate,
+  },
+  MusicTogetherRegistrationRepository: { findById: mocks.regFindById },
+}));
+
+import { runDueInstallmentCharges } from './charge-music-together-installments';
+
+const fakeSquare = {
+  locationId: 'MT_LOC',
+  paymentsService: { createPayment: mocks.createPayment },
+} as never;
+
+const charge = {
+  id: 'chg-1',
+  registrationId: 'reg-1',
+  sectionId: 'sec-1',
+  installmentNumber: 2,
+  amountCents: 13200,
+  dueAt: new Date('2026-09-29T13:00:00Z'),
+  status: 'scheduled',
+  idempotencyKey: 'mt-charge-chg-1',
+};
+
+const chargeableReg = {
+  id: 'reg-1',
+  status: 'confirmed',
+  email: 'jamie@example.com',
+  squareCustomerId: 'cust-1',
+  squareCardId: 'card-1',
+};
+
+const NOW = new Date('2026-09-30T13:00:00Z');
+
+describe('runDueInstallmentCharges', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.tryClaimLease.mockResolvedValue(true);
+    mocks.regFindById.mockResolvedValue(chargeableReg);
+    mocks.createPayment.mockResolvedValue({ paymentId: 'pay-1' });
+  });
+
+  it('dry run reports what is due without claiming leases or charging', async () => {
+    mocks.findDue.mockResolvedValue([charge]);
+    const result = await runDueInstallmentCharges(NOW, fakeSquare, {
+      dryRun: true,
+    });
+    expect(result.dryRun).toBe(true);
+    expect(result.due).toBe(1);
+    expect(result.charged).toBe(0);
+    expect(result.wouldCharge?.[0]).toMatchObject({
+      chargeId: 'chg-1',
+      amountCents: 13200,
+    });
+    expect(mocks.tryClaimLease).not.toHaveBeenCalled();
+    expect(mocks.createPayment).not.toHaveBeenCalled();
+  });
+
+  it('charges the stored card with the stable idempotency key, marks paid', async () => {
+    mocks.findDue.mockResolvedValue([charge]);
+    const result = await runDueInstallmentCharges(NOW, fakeSquare);
+
+    expect(mocks.createPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceId: 'card-1',
+        customerId: 'cust-1',
+        amountCents: 13200,
+        idempotencyKey: 'mt-charge-chg-1', // stable, derived from doc id
+      })
+    );
+    expect(mocks.chargeUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'chg-1', status: 'paid', squarePaymentId: 'pay-1' })
+    );
+    expect(result).toMatchObject({ due: 1, charged: 1, failed: 0, skipped: 0 });
+  });
+
+  it('skips a charge whose lease is already taken (no double-charge)', async () => {
+    mocks.findDue.mockResolvedValue([charge]);
+    mocks.tryClaimLease.mockResolvedValue(false);
+
+    const result = await runDueInstallmentCharges(NOW, fakeSquare);
+
+    expect(mocks.createPayment).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ charged: 0, skipped: 1 });
+  });
+
+  it('does not charge a cancelled registration — marks the charge failed', async () => {
+    mocks.findDue.mockResolvedValue([charge]);
+    mocks.regFindById.mockResolvedValue({ ...chargeableReg, status: 'cancelled' });
+
+    const result = await runDueInstallmentCharges(NOW, fakeSquare);
+
+    expect(mocks.createPayment).not.toHaveBeenCalled();
+    expect(mocks.chargeUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'chg-1', status: 'failed' })
+    );
+    expect(result.failed).toBe(1);
+  });
+
+  it('fails a charge whose registration has no card on file', async () => {
+    mocks.findDue.mockResolvedValue([charge]);
+    mocks.regFindById.mockResolvedValue({ ...chargeableReg, squareCardId: undefined });
+    const result = await runDueInstallmentCharges(NOW, fakeSquare);
+    expect(mocks.createPayment).not.toHaveBeenCalled();
+    expect(result.failed).toBe(1);
+  });
+
+  it('on payment failure: marks failed, emails the parent (loud, no retry)', async () => {
+    mocks.findDue.mockResolvedValue([charge]);
+    mocks.createPayment.mockRejectedValue(new Error('card declined'));
+
+    const result = await runDueInstallmentCharges(NOW, fakeSquare);
+
+    expect(mocks.chargeUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'chg-1', status: 'failed', lastError: 'card declined' })
+    );
+    expect(mocks.mailAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ to: 'jamie@example.com' })
+    );
+    expect(result).toMatchObject({ charged: 0, failed: 1 });
+  });
+
+  it('processes a mix and tallies results', async () => {
+    const charge2 = { ...charge, id: 'chg-2', registrationId: 'reg-2', idempotencyKey: 'mt-charge-chg-2' };
+    mocks.findDue.mockResolvedValue([charge, charge2]);
+    // first claims, second loses the lease
+    mocks.tryClaimLease.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    const result = await runDueInstallmentCharges(NOW, fakeSquare);
+
+    expect(result).toMatchObject({ due: 2, charged: 1, skipped: 1 });
+  });
+});

--- a/libs/firebase/maple-functions/charge-music-together-installments/src/lib/charge-music-together-installments.ts
+++ b/libs/firebase/maple-functions/charge-music-together-installments/src/lib/charge-music-together-installments.ts
@@ -1,0 +1,237 @@
+/**
+ * Charge Music Together Installments (scheduled + admin-callable)
+ *
+ * Drains the `musicTogetherScheduledCharges` queue: any charge that is `due`
+ * (status `scheduled`, `dueAt <= now`) is charged against the family's stored
+ * card on MT's separate Square account.
+ *
+ * Overcharge safety — a charge is taken AT MOST ONCE, enforced at three layers:
+ *   1. Firestore lease: `tryClaimLease` flips `scheduled → charging` in a
+ *      transaction, so two overlapping runs can't both process one charge.
+ *   2. Stable Square idempotency key (`charge.idempotencyKey`, derived from the
+ *      doc id): a retry returns the original payment instead of charging again.
+ *   3. Cancel guard: a cancelled registration is never charged (checked below),
+ *      and cancelling flips its charges out of `scheduled`.
+ *
+ * Failures are LOUD: the charge goes `failed`, the parent is emailed, and the
+ * failed charge surfaces to admins (no silent retries — manual resolution).
+ *
+ * Mirrors sendClassReminders' split: a plain `runDueInstallmentCharges` wrapped
+ * by an `onSchedule` trigger AND an admin-callable trigger (the latter drives
+ * integration tests + manual catch-up, and supports a dry run). Both build a
+ * Square client for the MT account and pass it in.
+ *
+ * Deployed to us-east4 via CI/CD (maple-square codebase).
+ */
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+import { defineSecret, defineString } from 'firebase-functions/params';
+import { Functions, Role } from '@maple/firebase/functions';
+import {
+  Square,
+  MT_SQUARE_SECRET_NAMES,
+  MT_SQUARE_STRING_NAMES,
+  MT_SQUARE_KEYS,
+  PaymentError,
+} from '@maple/firebase/square';
+import {
+  MusicTogetherScheduledChargeRepository,
+  MusicTogetherRegistrationRepository,
+  getDb,
+} from '@maple/firebase/database';
+import type { MusicTogetherScheduledCharge } from '@maple/ts/domain';
+import type {
+  ChargeMusicTogetherInstallmentsRequest,
+  MusicTogetherInstallmentChargeResult,
+} from '@maple/ts/firebase/api-types';
+
+const TIMEZONE = 'America/New_York';
+
+// Secret/string params for the MT Square account, declared for the scheduled
+// trigger (the admin-callable trigger gets them via the fluent builder).
+const mtSecretParams = MT_SQUARE_SECRET_NAMES.map((name) => defineSecret(name));
+const mtStringParams = MT_SQUARE_STRING_NAMES.map((name) => defineString(name));
+
+/**
+ * Core logic — pure of the trigger wiring so both triggers (and tests) share
+ * it. Charges every due installment against its registration's stored card.
+ *
+ * @param now    The reference time ("due" = dueAt <= now).
+ * @param square A Square client already bound to the MT account.
+ * @param opts   `dryRun` reports what would be charged without taking payment.
+ */
+export async function runDueInstallmentCharges(
+  now: Date,
+  square: Square,
+  opts: { dryRun?: boolean } = {}
+): Promise<MusicTogetherInstallmentChargeResult> {
+  const due = await MusicTogetherScheduledChargeRepository.findDue(now);
+
+  if (opts.dryRun) {
+    return {
+      due: due.length,
+      charged: 0,
+      failed: 0,
+      skipped: 0,
+      dryRun: true,
+      wouldCharge: due.map((c) => ({
+        chargeId: c.id,
+        registrationId: c.registrationId,
+        amountCents: c.amountCents,
+        installmentNumber: c.installmentNumber,
+      })),
+    };
+  }
+
+  let charged = 0;
+  let failed = 0;
+  let skipped = 0;
+
+  for (const charge of due) {
+    // Layer 1: claim the lease. If we lose it (overlapping run, or no longer
+    // scheduled), skip — never process a charge twice.
+    const claimed = await MusicTogetherScheduledChargeRepository.tryClaimLease(
+      charge.id
+    );
+    if (!claimed) {
+      skipped++;
+      continue;
+    }
+
+    const registration = await MusicTogetherRegistrationRepository.findById(
+      charge.registrationId
+    );
+
+    // Layer 3: never charge a cancelled / non-chargeable registration.
+    if (
+      !registration ||
+      registration.status === 'cancelled' ||
+      registration.status === 'refunded' ||
+      !registration.squareCardId ||
+      !registration.squareCustomerId
+    ) {
+      await markFailed(
+        charge,
+        'Registration is not chargeable (cancelled or no card on file).'
+      );
+      failed++;
+      continue;
+    }
+
+    try {
+      const payment = await square.paymentsService.createPayment({
+        sourceId: registration.squareCardId,
+        customerId: registration.squareCustomerId,
+        amountCents: charge.amountCents,
+        // Layer 2: stable key — a retry can never double-charge.
+        idempotencyKey: charge.idempotencyKey,
+        locationId: square.locationId,
+        buyerEmailAddress: registration.email,
+        note: `Music Together installment ${charge.installmentNumber}`,
+        referenceId: charge.registrationId,
+      });
+
+      await MusicTogetherScheduledChargeRepository.update({
+        id: charge.id,
+        status: 'paid',
+        squarePaymentId: payment.paymentId,
+        resolvedAt: new Date(),
+      });
+      charged++;
+    } catch (error) {
+      const detail =
+        error instanceof PaymentError || error instanceof Error
+          ? error.message
+          : 'Unknown error';
+      await markFailed(charge, detail);
+      // Loud failure: email the parent + leave the failed charge for admins.
+      await queueFailureEmail(registration.email, charge, detail);
+      failed++;
+    }
+  }
+
+  console.log(
+    `[chargeMusicTogetherInstallments] due=${due.length} charged=${charged} failed=${failed} skipped=${skipped}`
+  );
+
+  return { due: due.length, charged, failed, skipped, dryRun: false };
+}
+
+async function markFailed(
+  charge: MusicTogetherScheduledCharge,
+  reason: string
+): Promise<void> {
+  await MusicTogetherScheduledChargeRepository.update({
+    id: charge.id,
+    status: 'failed',
+    lastError: reason,
+    resolvedAt: new Date(),
+  });
+}
+
+async function queueFailureEmail(
+  to: string,
+  charge: MusicTogetherScheduledCharge,
+  reason: string
+): Promise<void> {
+  // Template `music-together-installment-failed` is authored separately.
+  await getDb()
+    .collection('mail')
+    .add({
+      to,
+      template: {
+        name: 'music-together-installment-failed',
+        data: {
+          installmentNumber: charge.installmentNumber,
+          amountCents: charge.amountCents,
+          reason,
+        },
+      },
+    });
+}
+
+/** Build a Square client bound to the MT account from the trigger's params. */
+function buildMtSquare(): Square {
+  const secrets = Object.fromEntries(
+    mtSecretParams.map((s) => [s.name, s.value()])
+  );
+  const strings = Object.fromEntries(
+    mtStringParams.map((s) => [s.name, s.value()])
+  );
+  return new Square(secrets, strings, MT_SQUARE_KEYS);
+}
+
+/**
+ * Scheduled trigger — runs daily at 09:00 America/New_York. Charges every
+ * installment whose due date has arrived.
+ */
+export const chargeMusicTogetherInstallments = onSchedule(
+  {
+    schedule: '0 9 * * *',
+    timeZone: TIMEZONE,
+    region: 'us-east4',
+    secrets: mtSecretParams,
+  },
+  async () => {
+    await runDueInstallmentCharges(new Date(), buildMtSquare());
+  }
+);
+
+/**
+ * Admin-callable manual trigger — same logic on demand, with an optional dry
+ * run. Exists for manual catch-up if the schedule misfires, and because
+ * `onSchedule` triggers aren't reachable over HTTP in the Firebase emulator
+ * (so integration tests go through this).
+ */
+export const triggerMusicTogetherInstallments = Functions.endpoint
+  .requiringRole(Role.Admin)
+  .usingSecrets(...MT_SQUARE_SECRET_NAMES)
+  .usingStrings(...MT_SQUARE_STRING_NAMES)
+  .handle<
+    ChargeMusicTogetherInstallmentsRequest,
+    MusicTogetherInstallmentChargeResult
+  >(async (data, _context, secrets, strings) => {
+    const square = new Square(secrets, strings, MT_SQUARE_KEYS);
+    return runDueInstallmentCharges(new Date(), square, {
+      dryRun: data?.dryRun === true,
+    });
+  });

--- a/libs/firebase/maple-functions/charge-music-together-installments/tsconfig.json
+++ b/libs/firebase/maple-functions/charge-music-together-installments/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [{ "path": "./tsconfig.lib.json" }]
+}

--- a/libs/firebase/maple-functions/charge-music-together-installments/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/charge-music-together-installments/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -418,4 +418,7 @@ export type {
   MusicTogetherChildPayload,
   CreateMusicTogetherRegistrationRequest,
   CreateMusicTogetherRegistrationResponse,
+  ChargeMusicTogetherInstallmentsRequest,
+  MusicTogetherDueChargePreview,
+  MusicTogetherInstallmentChargeResult,
 } from './music-together.types';

--- a/libs/ts/firebase/api-types/src/lib/music-together.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/music-together.types.ts
@@ -71,3 +71,34 @@ export interface CreateMusicTogetherRegistrationResponse {
   cardLast4?: string;
   squareReceiptUrl?: string;
 }
+
+// ============================================================================
+// Charge due installments (admin trigger for the scheduled job)
+// ============================================================================
+
+export interface ChargeMusicTogetherInstallmentsRequest {
+  /** When set, only reports what would be charged — takes no payments. */
+  dryRun?: boolean;
+}
+
+/** One charge a dry run would have processed. */
+export interface MusicTogetherDueChargePreview {
+  chargeId: string;
+  registrationId: string;
+  amountCents: number;
+  installmentNumber: number;
+}
+
+export interface MusicTogetherInstallmentChargeResult {
+  /** Charges that were due (status scheduled, dueAt ≤ now). */
+  due: number;
+  /** Successfully charged. */
+  charged: number;
+  /** Failed (declined/errored) — parent emailed, surfaced to admin. */
+  failed: number;
+  /** Skipped because the lease was already taken or the reg isn't chargeable. */
+  skipped: number;
+  dryRun: boolean;
+  /** Populated only on a dry run. */
+  wouldCharge?: MusicTogetherDueChargePreview[];
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -50,6 +50,9 @@
       "@maple/firebase/maple-functions/create-music-together-registration": [
         "libs/firebase/maple-functions/create-music-together-registration/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/charge-music-together-installments": [
+        "libs/firebase/maple-functions/charge-music-together-installments/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/request-craft-club-access": [
         "libs/firebase/maple-functions/request-craft-club-access/src/index.ts"
       ],


### PR DESCRIPTION
## Summary
The scheduled job that drains `musicTogetherScheduledCharges` — charging each **due** installment against the family's **stored card** on MT's separate Square account. The highest-risk business logic in the program, built backend-first and fully unit-tested.

## Functions (maple-square)
- `runDueInstallmentCharges(now, square, {dryRun})` — trigger-agnostic core. Finds due charges (`status scheduled, dueAt ≤ now`) and charges the stored card (`sourceId=cardId, customerId`).
- `chargeMusicTogetherInstallments` — `onSchedule` daily 09:00 ET (us-east4), MT Square secrets.
- `triggerMusicTogetherInstallments` — admin-callable, same logic + **dry-run** mode (manual catch-up + emulator-reachable for integration tests). Mirrors the `sendClassReminders` split.

## Overcharge safety — at-most-once, three layers
1. **`tryClaimLease`** (new repo method): transactional `scheduled → charging` flip, so two overlapping runs can't both process a charge.
2. **Stable Square idempotency key** (`charge.idempotencyKey`, derived from the doc id) — a retry returns the original payment.
3. **Cancel guard**: cancelled / refunded / cardless registrations are never charged.

## Failure handling (decision: email + admin manual)
On decline/error → charge `failed` + `lastError`, parent emailed (`music-together-installment-failed`), failed charge surfaces to admins. **No silent retries.**

## Testing
- [x] 7 unit tests: dry-run, happy-path (asserts stable idempotency key + stored-card source), lease-already-taken skip, cancelled-reg, no-card, payment-failure (marks failed + emails), mixed tally
- [x] `nx lint` clean · `nx affected -t typecheck` green · validator green · full coverage **84.34%**

## Remaining in Phase 4
`cancelMusicTogetherRegistration` — refund full minus $25 before first class / non-refundable after, and flip the registration's scheduled charges to `cancelled`. Follows next.

Refs #508, #514