### PR TITLE
feat(music-together): cancel + refund registration (#514)

### DIFF
--- a/apps/functions-square/src/index.ts
+++ b/apps/functions-square/src/index.ts
@@ -47,6 +47,7 @@ export { createCraftClubSubscription } from '@maple/firebase/maple-functions/cre
 
 // Music Together public checkout (routes to MT's separate Square account)
 export { createMusicTogetherRegistration } from '@maple/firebase/maple-functions/create-music-together-registration';
+export { cancelMusicTogetherRegistration } from '@maple/firebase/maple-functions/cancel-music-together-registration';
 
 // Music Together Week-5 auto-charge job (scheduled + admin-callable trigger)
 export {

--- a/apps/functions-square/tsconfig.app.json
+++ b/apps/functions-square/tsconfig.app.json
@@ -26,6 +26,7 @@
     "../../libs/firebase/maple-functions/admin-cancel-craft-club-subscription/**/*.ts",
     "../../libs/firebase/maple-functions/create-music-together-registration/**/*.ts",
     "../../libs/firebase/maple-functions/charge-music-together-installments/**/*.ts",
+    "../../libs/firebase/maple-functions/cancel-music-together-registration/**/*.ts",
     "../../libs/firebase/database/src/**/*.ts",
     "../../libs/firebase/functions/src/**/*.ts",
     "../../libs/firebase/square/src/**/*.ts",

--- a/function-codebases.json
+++ b/function-codebases.json
@@ -40,6 +40,7 @@
     "firebase-maple-functions-create-craft-club-subscription": "maple-square",
     "firebase-maple-functions-create-music-together-registration": "maple-square",
     "firebase-maple-functions-charge-music-together-installments": "maple-square",
+    "firebase-maple-functions-cancel-music-together-registration": "maple-square",
     "firebase-maple-functions-cancel-craft-club-subscription": "maple-square",
     "firebase-maple-functions-update-craft-club-payment-method": "maple-square",
     "firebase-maple-functions-admin-pause-craft-club-subscription": "maple-square",

--- a/libs/firebase/maple-functions/cancel-music-together-registration/project.json
+++ b/libs/firebase/maple-functions/cancel-music-together-registration/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-cancel-music-together-registration",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/cancel-music-together-registration/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/cancel-music-together-registration/src/index.ts
+++ b/libs/firebase/maple-functions/cancel-music-together-registration/src/index.ts
@@ -1,0 +1,1 @@
+export { cancelMusicTogetherRegistration } from './lib/cancel-music-together-registration';

--- a/libs/firebase/maple-functions/cancel-music-together-registration/src/lib/cancel-music-together-registration.spec.ts
+++ b/libs/firebase/maple-functions/cancel-music-together-registration/src/lib/cancel-music-together-registration.spec.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  capturedHandler: null as
+    | ((d: unknown, c: unknown, s: unknown, st: unknown) => Promise<unknown>)
+    | null,
+  regFindById: vi.fn(),
+  regUpdate: vi.fn(),
+  sectionFindById: vi.fn(),
+  chargesByReg: vi.fn(),
+  chargeUpdate: vi.fn(),
+  refundPayment: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/functions', () => {
+  class HttpsError extends Error {
+    constructor(public code: string, message: string) {
+      super(message);
+    }
+  }
+  const endpoint = {
+    usingSecrets: vi.fn(() => endpoint),
+    usingStrings: vi.fn(() => endpoint),
+    requiringRole: vi.fn(() => endpoint),
+    handle: vi.fn((h: typeof mocks.capturedHandler) => {
+      mocks.capturedHandler = h;
+      return 'mock-fn';
+    }),
+  };
+  return {
+    Functions: { endpoint },
+    Role: { Admin: 'admin' },
+    throwInvalidArgument: (m: string) => {
+      throw new HttpsError('invalid-argument', m);
+    },
+    throwNotFound: (e: string, id: string) => {
+      throw new HttpsError('not-found', `${e} not found: ${id}`);
+    },
+    throwFailedPrecondition: (m: string) => {
+      throw new HttpsError('failed-precondition', m);
+    },
+  };
+});
+
+vi.mock('@maple/firebase/square', () => ({
+  MT_SQUARE_SECRET_NAMES: ['MT_SQUARE_ACCESS_TOKEN'],
+  MT_SQUARE_STRING_NAMES: ['MT_SQUARE_ENV', 'MT_SQUARE_LOCATION_ID', 'MT_SALES_TAX_RATE'],
+  MT_SQUARE_KEYS: {},
+  Square: class {
+    paymentsService = { refundPayment: mocks.refundPayment };
+  },
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  MusicTogetherRegistrationRepository: {
+    findById: mocks.regFindById,
+    update: mocks.regUpdate,
+  },
+  MusicTogetherSectionRepository: { findById: mocks.sectionFindById },
+  MusicTogetherScheduledChargeRepository: {
+    findByRegistrationId: mocks.chargesByReg,
+    update: mocks.chargeUpdate,
+  },
+}));
+
+import './cancel-music-together-registration';
+
+const SECRETS = { MT_SQUARE_ACCESS_TOKEN: 'tok' };
+const STRINGS = { MT_SQUARE_ENV: 'LOCAL', MT_SQUARE_LOCATION_ID: 'MT_LOC', MT_SALES_TAX_RATE: '0.0' };
+function run(data: unknown) {
+  return mocks.capturedHandler!(data, {}, SECRETS, STRINGS);
+}
+
+// First class far in the future → pre-class (refundable).
+const futureSection = {
+  id: 'sec-1',
+  sessions: [{ dateTime: new Date(Date.now() + 30 * 86_400_000) }],
+};
+// First class in the past → non-refundable.
+const startedSection = {
+  id: 'sec-1',
+  sessions: [{ dateTime: new Date(Date.now() - 30 * 86_400_000) }],
+};
+
+const installmentReg = {
+  id: 'reg-1',
+  sectionId: 'sec-1',
+  status: 'confirmed',
+  pricePaidCents: 13200,
+  squarePaymentId: 'pay-1',
+};
+
+describe('cancelMusicTogetherRegistration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.regFindById.mockResolvedValue(installmentReg);
+    mocks.regUpdate.mockImplementation(async (i) => i);
+    mocks.refundPayment.mockResolvedValue({ refundId: 'ref-1' });
+    mocks.chargesByReg.mockResolvedValue([
+      { id: 'chg-2', status: 'scheduled' },
+    ]);
+  });
+
+  it('before first class: refunds paid amount minus $25, cancels scheduled charges, marks refunded', async () => {
+    mocks.sectionFindById.mockResolvedValue(futureSection);
+
+    const result = (await run({ registrationId: 'reg-1' })) as {
+      status: string;
+      refundCents: number;
+      refundId?: string;
+      cancelledChargeCount: number;
+    };
+
+    expect(mocks.refundPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paymentId: 'pay-1',
+        amountCents: 13200 - 2500,
+        idempotencyKey: 'mtrefund-reg-1', // stable
+      })
+    );
+    expect(mocks.chargeUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'chg-2', status: 'cancelled' })
+    );
+    expect(result.status).toBe('refunded');
+    expect(result.refundCents).toBe(10700);
+    expect(result.cancelledChargeCount).toBe(1);
+    expect(mocks.regUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'reg-1', status: 'refunded' })
+    );
+  });
+
+  it('after first class: no refund, still cancels scheduled charges, marks cancelled', async () => {
+    mocks.sectionFindById.mockResolvedValue(startedSection);
+
+    const result = (await run({ registrationId: 'reg-1' })) as {
+      status: string;
+      refundCents: number;
+      cancelledChargeCount: number;
+    };
+
+    expect(mocks.refundPayment).not.toHaveBeenCalled();
+    expect(mocks.chargeUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'chg-2', status: 'cancelled' })
+    );
+    expect(result.status).toBe('cancelled');
+    expect(result.refundCents).toBe(0);
+    expect(result.cancelledChargeCount).toBe(1);
+  });
+
+  it('leaves already-paid charges alone', async () => {
+    mocks.sectionFindById.mockResolvedValue(futureSection);
+    mocks.chargesByReg.mockResolvedValue([
+      { id: 'chg-paid', status: 'paid' },
+      { id: 'chg-sched', status: 'scheduled' },
+    ]);
+
+    const result = (await run({ registrationId: 'reg-1' })) as {
+      cancelledChargeCount: number;
+    };
+
+    expect(result.cancelledChargeCount).toBe(1);
+    expect(mocks.chargeUpdate).toHaveBeenCalledTimes(1);
+    expect(mocks.chargeUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'chg-sched' })
+    );
+  });
+
+  it('404s an unknown registration', async () => {
+    mocks.regFindById.mockResolvedValue(undefined);
+    await expect(run({ registrationId: 'nope' })).rejects.toThrow(/not found/i);
+  });
+
+  it('rejects an already-cancelled registration', async () => {
+    mocks.regFindById.mockResolvedValue({ ...installmentReg, status: 'cancelled' });
+    await expect(run({ registrationId: 'reg-1' })).rejects.toThrow(/already/i);
+    expect(mocks.refundPayment).not.toHaveBeenCalled();
+  });
+
+  it('requires a registration id', async () => {
+    await expect(run({})).rejects.toThrow(/required/i);
+  });
+});

--- a/libs/firebase/maple-functions/cancel-music-together-registration/src/lib/cancel-music-together-registration.ts
+++ b/libs/firebase/maple-functions/cancel-music-together-registration/src/lib/cancel-music-together-registration.ts
@@ -1,0 +1,125 @@
+/**
+ * Cancel Music Together Registration Cloud Function (admin, MT Square account)
+ *
+ * Admin-only cancellation from the roster. Applies the program's refund policy
+ * and — critically — flips the family's scheduled installment charges to
+ * `cancelled` so the Week-5 auto-charge job never runs them (the cancel-guard
+ * layer of the overcharge-safety model).
+ *
+ * Refund policy:
+ *   - BEFORE the first class → amount paid at registration minus the $25 fee.
+ *   - ON/AFTER the first class → non-refundable.
+ *
+ * Refund routes to MT's separate Square account (MT_SQUARE_KEYS).
+ * Deployed to us-east4 via CI/CD (maple-square codebase).
+ */
+import {
+  Functions,
+  Role,
+  throwInvalidArgument,
+  throwNotFound,
+  throwFailedPrecondition,
+} from '@maple/firebase/functions';
+import {
+  Square,
+  MT_SQUARE_SECRET_NAMES,
+  MT_SQUARE_STRING_NAMES,
+  MT_SQUARE_KEYS,
+} from '@maple/firebase/square';
+import {
+  MusicTogetherRegistrationRepository,
+  MusicTogetherSectionRepository,
+  MusicTogetherScheduledChargeRepository,
+} from '@maple/firebase/database';
+import { mtRefundCents, mtSectionFirstSessionAt } from '@maple/ts/domain';
+import type {
+  CancelMusicTogetherRegistrationRequest,
+  CancelMusicTogetherRegistrationResponse,
+} from '@maple/ts/firebase/api-types';
+
+export const cancelMusicTogetherRegistration = Functions.endpoint
+  .usingSecrets(...MT_SQUARE_SECRET_NAMES)
+  .usingStrings(...MT_SQUARE_STRING_NAMES)
+  .requiringRole(Role.Admin)
+  .handle<
+    CancelMusicTogetherRegistrationRequest,
+    CancelMusicTogetherRegistrationResponse
+  >(async (data, _context, secrets, strings) => {
+    if (!data.registrationId) {
+      throwInvalidArgument('Registration ID is required');
+    }
+
+    const registration = await MusicTogetherRegistrationRepository.findById(
+      data.registrationId
+    );
+    if (!registration) {
+      throwNotFound('Music Together registration', data.registrationId);
+    }
+    if (
+      registration.status === 'cancelled' ||
+      registration.status === 'refunded'
+    ) {
+      throwFailedPrecondition(
+        `Registration is already ${registration.status}`
+      );
+    }
+
+    // Determine the refund from the program policy (section first-class date).
+    const section = await MusicTogetherSectionRepository.findById(
+      registration.sectionId
+    );
+    const firstClassAt = section
+      ? mtSectionFirstSessionAt(section)
+      : undefined;
+    const refundCents = mtRefundCents(
+      registration.pricePaidCents,
+      firstClassAt,
+      new Date()
+    );
+
+    // Issue the refund (if any) against the registration-time payment.
+    let refundId: string | undefined;
+    if (refundCents > 0 && registration.squarePaymentId) {
+      const square = new Square(secrets, strings, MT_SQUARE_KEYS);
+      const refund = await square.paymentsService.refundPayment({
+        paymentId: registration.squarePaymentId,
+        amountCents: refundCents,
+        // Stable key — a retried cancel returns the original refund.
+        idempotencyKey: `mtrefund-${data.registrationId}`,
+        reason: 'Music Together registration cancelled',
+      });
+      refundId = refund.refundId;
+    }
+
+    // Cancel any still-scheduled future charges so the auto-charge job skips
+    // them. Already-paid/failed charges are left as-is for the record.
+    const charges =
+      await MusicTogetherScheduledChargeRepository.findByRegistrationId(
+        data.registrationId
+      );
+    let cancelledChargeCount = 0;
+    for (const charge of charges) {
+      if (charge.status === 'scheduled') {
+        await MusicTogetherScheduledChargeRepository.update({
+          id: charge.id,
+          status: 'cancelled',
+          resolvedAt: new Date(),
+        });
+        cancelledChargeCount++;
+      }
+    }
+
+    const status = refundId ? 'refunded' : 'cancelled';
+    await MusicTogetherRegistrationRepository.update({
+      id: data.registrationId,
+      status,
+    });
+
+    return {
+      registrationId: data.registrationId,
+      status,
+      refundCents: refundId ? refundCents : 0,
+      refundId,
+      cancelledChargeCount,
+    };
+  });

--- a/libs/firebase/maple-functions/cancel-music-together-registration/tsconfig.json
+++ b/libs/firebase/maple-functions/cancel-music-together-registration/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [{ "path": "./tsconfig.lib.json" }]
+}

--- a/libs/firebase/maple-functions/cancel-music-together-registration/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/cancel-music-together-registration/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/ts/domain/src/lib/music-together-registration.spec.ts
+++ b/libs/ts/domain/src/lib/music-together-registration.spec.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   isMtRegistrationConfirmed,
   mtRegistrationHasScheduledCharges,
+  mtRefundCents,
+  MT_CANCELLATION_FEE_CENTS,
   MT_CAPACITY_STATUSES,
 } from './music-together-registration';
 
@@ -16,6 +18,33 @@ describe('isMtRegistrationConfirmed', () => {
 describe('MT_CAPACITY_STATUSES', () => {
   it('counts pending and confirmed toward capacity', () => {
     expect([...MT_CAPACITY_STATUSES]).toEqual(['pending', 'confirmed']);
+  });
+});
+
+describe('mtRefundCents', () => {
+  const firstClass = new Date('2026-09-01T14:00:00Z');
+  const fee = MT_CANCELLATION_FEE_CENTS;
+
+  it('refunds amount paid minus the $25 fee before the first class', () => {
+    const before = new Date('2026-08-25T14:00:00Z');
+    expect(mtRefundCents(25200, firstClass, before)).toBe(25200 - fee); // full pay
+    expect(mtRefundCents(13200, firstClass, before)).toBe(13200 - fee); // installment 1
+  });
+
+  it('is non-refundable on or after the first class', () => {
+    expect(mtRefundCents(25200, firstClass, firstClass)).toBe(0); // exactly at start
+    expect(
+      mtRefundCents(25200, firstClass, new Date('2026-09-02T14:00:00Z'))
+    ).toBe(0);
+  });
+
+  it('never goes negative when the paid amount is below the fee', () => {
+    const before = new Date('2026-08-25T14:00:00Z');
+    expect(mtRefundCents(1000, firstClass, before)).toBe(0);
+  });
+
+  it('treats a section with no first class as pre-class (refundable)', () => {
+    expect(mtRefundCents(25200, undefined, new Date())).toBe(25200 - fee);
   });
 });
 

--- a/libs/ts/domain/src/lib/music-together-registration.ts
+++ b/libs/ts/domain/src/lib/music-together-registration.ts
@@ -116,3 +116,31 @@ export function mtRegistrationHasScheduledCharges(
 ): boolean {
   return (registration.scheduledChargeCount ?? 0) > 0;
 }
+
+/** Non-refundable cancellation fee withheld on a pre-class cancellation, in cents ($25.00). */
+export const MT_CANCELLATION_FEE_CENTS = 2500;
+
+/**
+ * Refund owed when a registration is cancelled:
+ *   - BEFORE the first class → the amount paid at registration minus the $25
+ *     fee (never below 0).
+ *   - ON or AFTER the first class → nothing (non-refundable).
+ *
+ * `firstClassAt` is the section's earliest session. When it is undefined (a
+ * section with no sessions yet) the booking is treated as pre-class.
+ *
+ * Note: this is based on the registration-time charge (`pricePaidCents`). The
+ * second installment is due in week 5 — well after the first class — so a
+ * pre-class cancellation never has a second charge to refund; that charge is
+ * instead cancelled so it never runs.
+ */
+export function mtRefundCents(
+  pricePaidCents: number,
+  firstClassAt: Date | undefined,
+  now: Date
+): number {
+  if (firstClassAt && now.getTime() >= firstClassAt.getTime()) {
+    return 0;
+  }
+  return Math.max(0, pricePaidCents - MT_CANCELLATION_FEE_CENTS);
+}

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -421,4 +421,6 @@ export type {
   ChargeMusicTogetherInstallmentsRequest,
   MusicTogetherDueChargePreview,
   MusicTogetherInstallmentChargeResult,
+  CancelMusicTogetherRegistrationRequest,
+  CancelMusicTogetherRegistrationResponse,
 } from './music-together.types';

--- a/libs/ts/firebase/api-types/src/lib/music-together.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/music-together.types.ts
@@ -102,3 +102,21 @@ export interface MusicTogetherInstallmentChargeResult {
   /** Populated only on a dry run. */
   wouldCharge?: MusicTogetherDueChargePreview[];
 }
+
+// ============================================================================
+// Cancel Registration (admin — refund + cancel scheduled charges)
+// ============================================================================
+
+export interface CancelMusicTogetherRegistrationRequest {
+  registrationId: string;
+}
+
+export interface CancelMusicTogetherRegistrationResponse {
+  registrationId: string;
+  status: 'cancelled' | 'refunded';
+  /** Amount refunded in cents (0 when non-refundable / nothing to refund). */
+  refundCents: number;
+  refundId?: string;
+  /** How many scheduled future charges were cancelled. */
+  cancelledChargeCount: number;
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -53,6 +53,9 @@
       "@maple/firebase/maple-functions/charge-music-together-installments": [
         "libs/firebase/maple-functions/charge-music-together-installments/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/cancel-music-together-registration": [
+        "libs/firebase/maple-functions/cancel-music-together-registration/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/request-craft-club-access": [
         "libs/firebase/maple-functions/request-craft-club-access/src/index.ts"
       ],


### PR DESCRIPTION
## Summary
Completes **Phase 4**: admin cancellation with the program refund policy, plus the **cancel-guard** that stops scheduled installments from running.

## `cancelMusicTogetherRegistration` (maple-square, admin-only, MT Square account)
- **Refund policy** (new domain helper `mtRefundCents`): BEFORE first class → amount paid minus the **$25 fee** (never < 0); ON/AFTER first class → **non-refundable**. First-class date = the section's earliest session.
- Refunds against the registration-time payment with a **stable idempotency key** (`mtrefund-{id}`) so a retried cancel never double-refunds.
- Flips every still-`scheduled` charge to `cancelled` — the **cancel-guard**; the Week-5 job then skips them. Paid/failed charges are left as-is.
- Marks the registration `refunded` (money returned) or `cancelled`.

## Testing
- [x] Domain: `MT_CANCELLATION_FEE_CENTS` + `mtRefundCents` with 4 unit tests (before/after/at first class, floor-at-0, no-session)
- [x] 6 CF unit tests: before first class (refund + cancel charges), after first class (no refund), paid-charge untouched, 404, already-cancelled, missing id
- [x] `nx lint` clean · validator green · full coverage **84.45%**

This closes out Phase 4 (with the charge job in #527). Cancel-guard now completes the 3-layer overcharge-safety story end-to-end.

Refs #508, #514