### PR TITLE
chore(craft-club): fix CRAFT_CLUB_MANAGE_URL domain (#506)

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -63,4 +63,4 @@ META_CAPI_API_VERSION=v20.0
 CRAFT_CLUB_PLAN_VARIATION_ID=RPD5VJVAAQ2CIETBSFPFMP2J
 
 # Craft Club self-service manage page (Webflow); magic-link emails point here.
-CRAFT_CLUB_MANAGE_URL=https://mapleandsprucewv.com/craft-club/manage
+CRAFT_CLUB_MANAGE_URL=https://mapleandsprucefolkarts.com/craft-club/manage

--- a/.env.prod
+++ b/.env.prod
@@ -54,4 +54,4 @@ META_CAPI_API_VERSION=v20.0
 CRAFT_CLUB_PLAN_VARIATION_ID=PROD_PLACEHOLDER_RUN_create-craft-club-plan
 
 # Craft Club self-service manage page (Webflow); magic-link emails point here.
-CRAFT_CLUB_MANAGE_URL=https://mapleandsprucewv.com/craft-club/manage
+CRAFT_CLUB_MANAGE_URL=https://mapleandsprucefolkarts.com/craft-club/manage


### PR DESCRIPTION
Point `CRAFT_CLUB_MANAGE_URL` at the real Webflow domain (`mapleandsprucefolkarts.com/craft-club/manage`) instead of the `mapleandsprucewv.com` placeholder, so the self-service magic-link emails resolve. Adjust the path if the manage page slug differs. Part of #506.