### PR TITLE
feat(music-together): ordered waitlist with availability capture (#515)

### DIFF
--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -103,6 +103,7 @@ export { migrateClassSessions } from '@maple/firebase/maple-functions/migrate-cl
 // Public class API (no auth required - for Webflow integration)
 export { getPublicClass } from '@maple/firebase/maple-functions/get-public-class';
 export { getPublicMusicTogetherSection } from '@maple/firebase/maple-functions/get-public-music-together-section';
+export { addToMusicTogetherWaitlist } from '@maple/firebase/maple-functions/add-to-music-together-waitlist';
 export { getRelatedPublicClasses } from '@maple/firebase/maple-functions/get-related-public-classes';
 export { addToClassWaitlist } from '@maple/firebase/maple-functions/add-to-class-waitlist';
 export { notifyWaitlistOnSpotOpen } from '@maple/firebase/maple-functions/notify-waitlist-on-spot-open';

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -123,6 +123,7 @@
     "../../libs/firebase/maple-functions/start-craft-club-session/**/*.ts",
     "../../libs/firebase/maple-functions/get-craft-club-subscription/**/*.ts",
     "../../libs/firebase/maple-functions/get-public-music-together-section/**/*.ts",
+    "../../libs/firebase/maple-functions/add-to-music-together-waitlist/**/*.ts",
     "../../libs/firebase/database/src/**/*.ts",
     "../../libs/firebase/functions/src/**/*.ts",
     "../../libs/ts/domain/src/**/*.ts",

--- a/libs/firebase/database/src/index.ts
+++ b/libs/firebase/database/src/index.ts
@@ -105,6 +105,10 @@ export {
   MusicTogetherScheduledChargeRepository,
   type MusicTogetherScheduledChargeFilters,
 } from './lib/music-together-scheduled-charge.repository';
+export {
+  MusicTogetherWaitlistRepository,
+  mtWaitlistEmailKey,
+} from './lib/music-together-waitlist.repository';
 
 // Phase 5: Etsy
 export {

--- a/libs/firebase/database/src/lib/music-together-waitlist.repository.ts
+++ b/libs/firebase/database/src/lib/music-together-waitlist.repository.ts
@@ -1,0 +1,106 @@
+/**
+ * Music Together Waitlist Repository
+ *
+ * Stored as a subcollection of the section
+ * (`musicTogetherSections/{sectionId}/waitlist/{emailKey}`) so entries scope
+ * per section and are cleaned up if the section is deleted.
+ *
+ * The doc id is the lowercased email, making signups idempotent. Entries are
+ * read back ORDERED by signup time so admins can make offers in turn.
+ */
+import { getDb, toDate } from './utilities/database.config';
+import type { MusicTogetherWaitlistEntry } from '@maple/ts/domain';
+
+const PARENT_COLLECTION = 'musicTogetherSections';
+const SUBCOLLECTION = 'waitlist';
+
+/** Lowercase + trim an email into an idempotent Firestore-safe document id. */
+export function mtWaitlistEmailKey(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+function waitlistRef(
+  sectionId: string
+): FirebaseFirestore.CollectionReference {
+  return getDb()
+    .collection(PARENT_COLLECTION)
+    .doc(sectionId)
+    .collection(SUBCOLLECTION);
+}
+
+function docToEntry(
+  sectionId: string,
+  doc: FirebaseFirestore.DocumentSnapshot
+): MusicTogetherWaitlistEntry | undefined {
+  if (!doc.exists) return undefined;
+  const data = doc.data()!;
+  return {
+    id: doc.id,
+    sectionId,
+    name: data.name,
+    email: data.email,
+    availability: data.availability,
+    createdAt: toDate(data.createdAt),
+  };
+}
+
+export const MusicTogetherWaitlistRepository = {
+  /**
+   * Idempotent signup. If the email already exists, returns `created: false`
+   * and preserves the original entry (including its place in line).
+   */
+  async add(input: {
+    sectionId: string;
+    name: string;
+    email: string;
+    availability?: string;
+  }): Promise<{ entry: MusicTogetherWaitlistEntry; created: boolean }> {
+    const id = mtWaitlistEmailKey(input.email);
+    const ref = waitlistRef(input.sectionId).doc(id);
+    const existing = await ref.get();
+    if (existing.exists) {
+      return { entry: docToEntry(input.sectionId, existing)!, created: false };
+    }
+    const createdAt = new Date();
+    const entry = {
+      name: input.name.trim(),
+      email: input.email.trim(),
+      availability: input.availability?.trim() || null,
+      createdAt,
+    };
+    await ref.set(entry);
+    return {
+      entry: {
+        id,
+        sectionId: input.sectionId,
+        name: entry.name,
+        email: entry.email,
+        availability: entry.availability ?? undefined,
+        createdAt,
+      },
+      created: true,
+    };
+  },
+
+  /** All entries for a section, ordered by signup time (offer order). */
+  async findBySectionId(
+    sectionId: string
+  ): Promise<MusicTogetherWaitlistEntry[]> {
+    const snapshot = await waitlistRef(sectionId)
+      .orderBy('createdAt', 'asc')
+      .get();
+    return snapshot.docs
+      .map((doc) => docToEntry(sectionId, doc))
+      .filter((e): e is MusicTogetherWaitlistEntry => e !== undefined);
+  },
+
+  async countBySectionId(sectionId: string): Promise<number> {
+    const snapshot = await waitlistRef(sectionId).count().get();
+    return snapshot.data().count;
+  },
+
+  /** Remove a single entry (e.g. once a family is offered and accepts a spot). */
+  async removeByEmail(sectionId: string, email: string): Promise<void> {
+    await waitlistRef(sectionId).doc(mtWaitlistEmailKey(email)).delete();
+  },
+};

--- a/libs/firebase/maple-functions/add-to-music-together-waitlist/project.json
+++ b/libs/firebase/maple-functions/add-to-music-together-waitlist/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-add-to-music-together-waitlist",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/add-to-music-together-waitlist/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/add-to-music-together-waitlist/src/index.ts
+++ b/libs/firebase/maple-functions/add-to-music-together-waitlist/src/index.ts
@@ -1,0 +1,1 @@
+export { addToMusicTogetherWaitlist } from './lib/add-to-music-together-waitlist';

--- a/libs/firebase/maple-functions/add-to-music-together-waitlist/src/lib/add-to-music-together-waitlist.spec.ts
+++ b/libs/firebase/maple-functions/add-to-music-together-waitlist/src/lib/add-to-music-together-waitlist.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  capturedHandler: null as ((d: unknown) => Promise<unknown>) | null,
+  sectionFindById: vi.fn(),
+  waitlistAdd: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/functions', () => {
+  class HttpsError extends Error {
+    constructor(public code: string, message: string) {
+      super(message);
+    }
+  }
+  const endpoint = {
+    withOptions: vi.fn(() => endpoint),
+    handle: vi.fn((h: typeof mocks.capturedHandler) => {
+      mocks.capturedHandler = h;
+      return 'mock-fn';
+    }),
+  };
+  return {
+    Functions: { endpoint },
+    throwInvalidArgument: (m: string) => {
+      throw new HttpsError('invalid-argument', m);
+    },
+    throwNotFound: (e: string, id: string) => {
+      throw new HttpsError('not-found', `${e} not found: ${id}`);
+    },
+    throwValidationError: (errs: Record<string, string[]>) => {
+      throw new HttpsError('invalid-argument', `validation: ${Object.keys(errs).join(',')}`);
+    },
+  };
+});
+
+vi.mock('@maple/firebase/database', () => ({
+  MusicTogetherSectionRepository: { findById: mocks.sectionFindById },
+  MusicTogetherWaitlistRepository: { add: mocks.waitlistAdd },
+}));
+
+import './add-to-music-together-waitlist';
+
+function run(data: unknown) {
+  return mocks.capturedHandler!(data);
+}
+
+const validEntry = {
+  sectionId: 'sec-1',
+  name: 'Jamie Rivera',
+  email: 'jamie@example.com',
+  availability: 'Tuesday mornings',
+};
+
+describe('addToMusicTogetherWaitlist', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.sectionFindById.mockResolvedValue({ id: 'sec-1', status: 'closed' });
+    mocks.waitlistAdd.mockResolvedValue({ created: true });
+  });
+
+  it('adds a family to the waitlist and reports added=true', async () => {
+    const result = (await run(validEntry)) as { added: boolean };
+    expect(mocks.waitlistAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ sectionId: 'sec-1', email: 'jamie@example.com' })
+    );
+    expect(result.added).toBe(true);
+  });
+
+  it('is idempotent — a repeat email reports added=false', async () => {
+    mocks.waitlistAdd.mockResolvedValue({ created: false });
+    const result = (await run(validEntry)) as { added: boolean };
+    expect(result.added).toBe(false);
+  });
+
+  it('works for an open section too (no capacity gate)', async () => {
+    mocks.sectionFindById.mockResolvedValue({ id: 'sec-1', status: 'open' });
+    const result = (await run(validEntry)) as { added: boolean };
+    expect(result.added).toBe(true);
+  });
+
+  it('rejects invalid input before touching the section', async () => {
+    await expect(run({ ...validEntry, email: 'nope' })).rejects.toThrow(/validation/);
+    expect(mocks.sectionFindById).not.toHaveBeenCalled();
+  });
+
+  it('404s an unknown section', async () => {
+    mocks.sectionFindById.mockResolvedValue(undefined);
+    await expect(run(validEntry)).rejects.toThrow(/not found/i);
+    expect(mocks.waitlistAdd).not.toHaveBeenCalled();
+  });
+
+  it('rejects a draft section', async () => {
+    mocks.sectionFindById.mockResolvedValue({ id: 'sec-1', status: 'draft' });
+    await expect(run(validEntry)).rejects.toThrow(/not available/i);
+  });
+});

--- a/libs/firebase/maple-functions/add-to-music-together-waitlist/src/lib/add-to-music-together-waitlist.ts
+++ b/libs/firebase/maple-functions/add-to-music-together-waitlist/src/lib/add-to-music-together-waitlist.ts
@@ -1,0 +1,67 @@
+/**
+ * Add to Music Together Waitlist Cloud Function
+ *
+ * Public (no auth) endpoint the checkout widget calls when a section is full.
+ * Captures the family's name, email, and availability under
+ * `musicTogetherSections/{sectionId}/waitlist/{emailKey}`. Idempotent — a
+ * repeat signup with the same email returns `added: false` and keeps the
+ * family's place in line.
+ *
+ * The section must exist and not be a draft; beyond that there is no capacity
+ * gate (a family may want to be waitlisted even before a section fills).
+ *
+ * Deployed to us-east4 via CI/CD (maple-core codebase).
+ */
+import {
+  Functions,
+  throwInvalidArgument,
+  throwNotFound,
+  throwValidationError,
+} from '@maple/firebase/functions';
+import {
+  MusicTogetherSectionRepository,
+  MusicTogetherWaitlistRepository,
+} from '@maple/firebase/database';
+import { musicTogetherWaitlistValidation } from '@maple/ts/validation';
+import type {
+  AddToMusicTogetherWaitlistRequest,
+  AddToMusicTogetherWaitlistResponse,
+} from '@maple/ts/firebase/api-types';
+
+export const addToMusicTogetherWaitlist = Functions.endpoint
+  .withOptions({ concurrency: 80 })
+  .handle<
+    AddToMusicTogetherWaitlistRequest,
+    AddToMusicTogetherWaitlistResponse
+  >(async (data) => {
+    const result = musicTogetherWaitlistValidation({
+      sectionId: data.sectionId,
+      name: data.name,
+      email: data.email,
+      availability: data.availability,
+    });
+    if (result.hasErrors()) {
+      throwValidationError(result.getErrors());
+    }
+
+    const section = await MusicTogetherSectionRepository.findById(
+      data.sectionId
+    );
+    if (!section) {
+      throwNotFound('Music Together section', data.sectionId);
+    }
+    if (section.status === 'draft') {
+      throwInvalidArgument(
+        'This section is not available for waitlist signup'
+      );
+    }
+
+    const { created } = await MusicTogetherWaitlistRepository.add({
+      sectionId: data.sectionId,
+      name: data.name,
+      email: data.email,
+      availability: data.availability,
+    });
+
+    return { added: created };
+  });

--- a/libs/firebase/maple-functions/add-to-music-together-waitlist/tsconfig.json
+++ b/libs/firebase/maple-functions/add-to-music-together-waitlist/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [{ "path": "./tsconfig.lib.json" }]
+}

--- a/libs/firebase/maple-functions/add-to-music-together-waitlist/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/add-to-music-together-waitlist/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/ts/domain/src/index.ts
+++ b/libs/ts/domain/src/index.ts
@@ -48,6 +48,7 @@ export * from './lib/craft-club-member';
 export * from './lib/music-together-section';
 export * from './lib/music-together-registration';
 export * from './lib/music-together-scheduled-charge';
+export * from './lib/music-together-waitlist';
 
 // User & role administration
 export * from './lib/app-user';

--- a/libs/ts/domain/src/lib/music-together-waitlist.ts
+++ b/libs/ts/domain/src/lib/music-together-waitlist.ts
@@ -1,0 +1,30 @@
+/**
+ * Music Together waitlist domain types
+ *
+ * When a section hits its 8-family cap, the public checkout switches to a
+ * waitlist that captures the family's name, email, and what days/times work
+ * for them. Unlike the class waitlist (unordered, email-only, broadcast), MT's
+ * is ORDERED by signup time so the admin can make offers in turn.
+ *
+ * Stored as a subcollection of the section
+ * (`musicTogetherSections/{sectionId}/waitlist/{emailKey}`) so entries are
+ * auto-scoped per section and cleaned up if the section is deleted.
+ */
+
+export interface MusicTogetherWaitlistEntry {
+  /** Document id — the lowercased email, making signups idempotent. */
+  id: string;
+  sectionId: string;
+  name: string;
+  email: string;
+  /** Free-text answer to "what days/times work for you?" */
+  availability?: string;
+  createdAt: Date;
+}
+
+export type CreateMusicTogetherWaitlistEntryInput = {
+  sectionId: string;
+  name: string;
+  email: string;
+  availability?: string;
+};

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -423,4 +423,6 @@ export type {
   MusicTogetherInstallmentChargeResult,
   CancelMusicTogetherRegistrationRequest,
   CancelMusicTogetherRegistrationResponse,
+  AddToMusicTogetherWaitlistRequest,
+  AddToMusicTogetherWaitlistResponse,
 } from './music-together.types';

--- a/libs/ts/firebase/api-types/src/lib/music-together.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/music-together.types.ts
@@ -120,3 +120,20 @@ export interface CancelMusicTogetherRegistrationResponse {
   /** How many scheduled future charges were cancelled. */
   cancelledChargeCount: number;
 }
+
+// ============================================================================
+// Join Waitlist (public — shown when a section is full)
+// ============================================================================
+
+export interface AddToMusicTogetherWaitlistRequest {
+  sectionId: string;
+  name: string;
+  email: string;
+  /** "What days/times work for you?" */
+  availability?: string;
+}
+
+export interface AddToMusicTogetherWaitlistResponse {
+  /** False when the email was already on the list (idempotent no-op). */
+  added: boolean;
+}

--- a/libs/ts/validation/src/lib/index.ts
+++ b/libs/ts/validation/src/lib/index.ts
@@ -88,3 +88,7 @@ export {
   type MusicTogetherSessionInput,
   type MusicTogetherInstallmentInput,
 } from './music-together-section.validation';
+export {
+  musicTogetherWaitlistValidation,
+  type MusicTogetherWaitlistValidationInput,
+} from './music-together-waitlist.validation';

--- a/libs/ts/validation/src/lib/music-together-waitlist.validation.spec.ts
+++ b/libs/ts/validation/src/lib/music-together-waitlist.validation.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import {
+  musicTogetherWaitlistValidation,
+  type MusicTogetherWaitlistValidationInput,
+} from './music-together-waitlist.validation';
+
+const valid: MusicTogetherWaitlistValidationInput = {
+  sectionId: 'sec-1',
+  name: 'Jamie Rivera',
+  email: 'jamie@example.com',
+  availability: 'Tuesday or Thursday mornings',
+};
+
+describe('musicTogetherWaitlistValidation', () => {
+  it('passes a complete entry', () => {
+    expect(musicTogetherWaitlistValidation(valid).hasErrors()).toBe(false);
+  });
+
+  it('allows omitting availability', () => {
+    const noAvail = { ...valid };
+    delete noAvail.availability;
+    expect(musicTogetherWaitlistValidation(noAvail).hasErrors()).toBe(false);
+  });
+
+  it('requires section, name, and a valid email', () => {
+    expect(
+      musicTogetherWaitlistValidation({ ...valid, sectionId: '' }).hasErrors('sectionId')
+    ).toBe(true);
+    expect(
+      musicTogetherWaitlistValidation({ ...valid, name: '' }).hasErrors('name')
+    ).toBe(true);
+    expect(
+      musicTogetherWaitlistValidation({ ...valid, email: 'nope' }).hasErrors('email')
+    ).toBe(true);
+  });
+
+  it('caps availability length', () => {
+    expect(
+      musicTogetherWaitlistValidation({
+        ...valid,
+        availability: 'x'.repeat(501),
+      }).hasErrors('availability')
+    ).toBe(true);
+  });
+});

--- a/libs/ts/validation/src/lib/music-together-waitlist.validation.ts
+++ b/libs/ts/validation/src/lib/music-together-waitlist.validation.ts
@@ -1,0 +1,49 @@
+/**
+ * Music Together waitlist validation suite
+ *
+ * Used on the public waitlist form (shown when a section is full) and on the
+ * addToMusicTogetherWaitlist cloud function.
+ *
+ * @see https://vestjs.dev/
+ */
+import { staticSuite, test, enforce, only } from 'vest';
+
+export interface MusicTogetherWaitlistValidationInput {
+  sectionId?: string;
+  name?: string;
+  email?: string;
+  availability?: string;
+}
+
+export const musicTogetherWaitlistValidation = staticSuite(
+  (data: MusicTogetherWaitlistValidationInput, field?: string | string[]) => {
+    only(field);
+
+    test('sectionId', 'Section is required', () => {
+      enforce(data.sectionId).isNotBlank();
+    });
+
+    test('name', 'Name is required', () => {
+      enforce(data.name).isNotBlank();
+    });
+    test('name', 'Name must be less than 100 characters', () => {
+      if (data.name) enforce(data.name).shorterThan(100);
+    });
+
+    test('email', 'Email is required', () => {
+      enforce(data.email).isNotBlank();
+    });
+    test('email', 'Email must be a valid email address', () => {
+      if (data.email) {
+        enforce(data.email).matches(/^[^\s@]+@[^\s@]+\.[^\s@]+$/);
+      }
+    });
+
+    // Availability is optional, but cap its length.
+    test('availability', 'Availability must be less than 500 characters', () => {
+      if (data.availability) {
+        enforce(data.availability).shorterThanOrEquals(500);
+      }
+    });
+  }
+);

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -326,6 +326,9 @@
       "@maple/firebase/maple-functions/get-public-music-together-section": [
         "libs/firebase/maple-functions/get-public-music-together-section/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/add-to-music-together-waitlist": [
+        "libs/firebase/maple-functions/add-to-music-together-waitlist/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/check-admin-status": [
         "libs/firebase/maple-functions/check-admin-status/src/index.ts"
       ],


### PR DESCRIPTION
## Summary
Phase 5 of the Music Together epic (#508): when a section hits its **8-family cap**, the public checkout switches to a **waitlist**. Unlike the class waitlist (unordered, email-only, broadcast), MT's is **ordered by signup time** and captures **name + "what days/times work for you?"** so admins can make offers in turn.

## Changes
- **Domain** `MusicTogetherWaitlistEntry` — subcollection `musicTogetherSections/{id}/waitlist/{emailKey}`.
- **Repository** — idempotent `add` (email-keyed; a repeat signup keeps the family's place in line), `findBySectionId` ordered by `createdAt`, `countBySectionId`, `removeByEmail`.
- **Validation** `musicTogetherWaitlistValidation` — section, name, email, capped availability.
- **Public CF** `addToMusicTogetherWaitlist` (maple-core) — validate → section exists & not draft → idempotent add. No capacity gate (a family may waitlist early).
- **api-types** — waitlist request/response.

## Testing
- [x] 10 unit tests (CF: add / idempotent / open-section / invalid / 404 / draft; validation suite)
- [x] Index analyzer green — **no new composite index** (subcollection single-field `orderBy`)
- [x] `nx lint` clean · `nx affected -t typecheck` green · validator green · full coverage **84.46%**

## Frontend
Showing the waitlist form when `spotsRemaining === 0` ships with the Webflow checkout widget (Phase 3 frontend).

Refs #508 · Closes #515