### PR TITLE
fix(ci): 409-aware retry for Firestore index deploys + warn (not fail) on orphans

### DIFF
--- a/.claude/rules/firebase-functions.md
+++ b/.claude/rules/firebase-functions.md
@@ -167,20 +167,27 @@ The analyzer scans `libs/firebase/database/**/*.repository.ts`, `libs/firebase/m
 4. Re-run the analyzer until it passes.
 5. On merge to main, CI runs `firebase deploy --only firestore:indexes` automatically (see `firebase-functions-merge.yml` → `deploy_firestore_indexes` job, gated on the file actually changing). Each new composite index takes a few minutes to build; queries succeed once each one flips to `READY`.
 
-### `firestore.indexes.json` is the source of truth — orphans block deploys
+### `firestore.indexes.json` is the source of truth — orphans warn, 409s retry
 
-The merge-time deploy does NOT pass `--force`. The behavior is fail-loud rather than silently-deletes:
+The merge-time deploy does NOT pass `--force`. Two behaviors to know about:
 
 - New indexes from `firestore.indexes.json` are applied normally.
-- Any index that exists in prod but isn't in the file (an "orphan") is **left untouched** — but the CI job fails after the deploy completes, with the orphan list printed.
-- The next merge that touches `firestore.indexes.json` will fail the same way until the orphan is resolved.
+- Any index that exists in prod but isn't in the file (an "orphan") is **left untouched** and surfaced as a CI **warning** (not a hard fail) — orphans are unused, low-risk indexes, and blocking unrelated merges on pre-existing drift is friction. The real outage risk (a *missing* index) is caught at PR time by the analyzer, not here.
+- A `409 "index already exists"` is **benign** and **auto-retried** (up to 12×) — it means the declared index is already present (a prior partial run, an auto-create-URL, or firebase-tools failing to match an index it just created). The job only fails if it's stuck on the *same* 409 twice (not converging) or hits a non-409 error. This mirrors the functions-deploy 409 retry from #537.
 
-Two ways to resolve an orphan:
+Two ways to resolve an orphan (optional — it only warns):
 
 1. **Add it to `firestore.indexes.json`** (preferred when the query is real and lives somewhere — even if outside the analyzer's scan, like a one-off console query or a script).
-2. **Delete it from prod** with `pnpm exec firebase firestore:indexes:delete --project maple-and-spruce` (if it's stale and nothing queries it).
+2. **Delete it** with gcloud (if it's stale and nothing queries it). There is no `firebase firestore:indexes:delete` command — use gcloud, targeting the index by ID:
 
-Common cause: clicking the auto-create-index URL in a Firestore error message creates an index in prod but not in the file. After doing that, immediately open a tiny PR adding the same index to `firestore.indexes.json` so the next merge isn't blocked.
+   ```bash
+   # list to find the ID
+   gcloud firestore indexes composite list --project maple-and-spruce
+   # delete by ID (add --account=<owner> if your active gcloud account lacks access)
+   gcloud firestore indexes composite delete <INDEX_ID> --project maple-and-spruce
+   ```
+
+Common cause: clicking the auto-create-index URL in a Firestore error message creates an index in prod but not in the file — and Firestore may lay it out with a different `__name__` direction than the declaration, which is what triggers the benign 409 churn. After clicking such a URL, open a tiny PR adding the same index to `firestore.indexes.json`.
 
 The analyzer prevents this gap for **code-derived** queries — it enforces "every required index is declared". It can't see queries that aren't in this repo. Those queries must either be reflected in the file or accepted as ephemeral (and re-added each time prod gets recreated).
 

--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -846,23 +846,53 @@ jobs:
       - name: Deploy Firestore indexes (dev)
         if: steps.changed.outputs.changed == 'true'
         timeout-minutes: 10
-        # No `--force` — same orphan-safety stance as prod (see the prod
-        # job below). On dev an orphan is lower-stakes, but failing loud
-        # keeps dev's declared index set honest and matching prod's.
+        # No `--force` — same orphan-safety stance as prod (see the prod job).
+        # 409-aware retry: see deploy_firestore_indexes (prod) for the full
+        # rationale. Same shape, DEV project.
         run: |
-          set -eo pipefail
+          set -o pipefail
           OUTPUT=$(mktemp)
           trap 'rm -f "$OUTPUT"' EXIT
 
-          npx -y firebase-tools@latest deploy --only firestore:indexes \
-            --project maple-and-spruce-dev \
-            --token "${{ steps.auth.outputs.access_token }}" \
-            < /dev/null 2>&1 | tee "$OUTPUT"
+          # firebase-tools deploys declared indexes one create at a time and
+          # aborts on the FIRST error. A 409 "index already exists" is benign —
+          # the declared index is already present (a prior partial run, an
+          # auto-create-URL, or firebase-tools failing to match an index it
+          # just created). On the next pass it matches that index and moves on
+          # to the rest. So: retry while each attempt errors on a DIFFERENT
+          # index (forward progress); fail only if we're stuck on the same 409
+          # twice, or hit any non-409 error.
+          prev_err=""
+          for attempt in $(seq 1 12); do
+            npx -y firebase-tools@latest deploy --only firestore:indexes \
+              --project maple-and-spruce-dev \
+              --token "${{ steps.auth.outputs.access_token }}" \
+              < /dev/null 2>&1 | tee "$OUTPUT"
+            status=${PIPESTATUS[0]}
+            [ "$status" -eq 0 ] && break
 
-          if grep -q "indexes are defined in your project but are not present" "$OUTPUT"; then
-            echo ""
-            echo "::error title=Firestore index orphans (dev)::Dev has composite indexes that aren't declared in firestore.indexes.json. The new indexes from this merge were applied, but the orphans were NOT deleted. Resolve before the next merge: either add the listed orphans to firestore.indexes.json, or delete them with 'pnpm exec firebase firestore:indexes:delete --project maple-and-spruce-dev'."
-            exit 1
+            if ! grep -qi "index already exists" "$OUTPUT"; then
+              echo "::error::firestore index deploy failed (exit=$status) with a non-409 error"
+              exit 1
+            fi
+            cur_err=$(grep -i "index already exists" "$OUTPUT" | tail -1)
+            if [ "$cur_err" = "$prev_err" ]; then
+              echo "::error::firestore index deploy stuck on the same 409 — not converging: $cur_err"
+              exit 1
+            fi
+            prev_err="$cur_err"
+            echo "::warning::benign 409 (index already exists); declared index is present, retrying ($attempt/12)"
+            sleep 15
+          done
+
+          # Orphans = indexes in the project but not in firestore.indexes.json.
+          # Firebase's wording: "there are N indexes defined in your project
+          # that are not present in your firestore indexes file." Surface as a
+          # warning (not a hard fail) — orphans are unused, low-risk indexes,
+          # and blocking unrelated merges on pre-existing drift is friction.
+          # Resolve by declaring them or deleting with gcloud (see message).
+          if grep -qi "not present in your firestore indexes file" "$OUTPUT"; then
+            echo "::warning title=Firestore index orphans (dev)::Dev has composite indexes not declared in firestore.indexes.json. Resolve by adding them to the file, or delete a stale one with: gcloud firestore indexes composite delete <INDEX_ID> --project maple-and-spruce-dev"
           fi
 
   deploy_firestore_indexes:
@@ -920,30 +950,51 @@ jobs:
         # We DO NOT pass `--force`. In non-TTY (CI) the "delete extra indexes?"
         # prompt defaults to N — so additions from the file are applied, but
         # any index that exists in prod and not in firestore.indexes.json is
-        # left untouched. After the deploy we grep stdout for the orphan
-        # warning Firebase emits when this case triggers, and fail the job.
-        # The user then resolves by either (a) adding the orphan to the file
-        # in a follow-up PR, or (b) deleting from prod with
-        # `firebase firestore:indexes:delete`. The next merge won't deploy
-        # cleanly until the discrepancy is resolved.
+        # left untouched (an "orphan"). Orphans are surfaced as a warning below.
         #
         # Why not `--force`: deletes would be silent and irreversible from
         # this job. A click-the-URL-to-create-an-index workflow (used in
         # incidents) would lose its work on the next unrelated merge.
+        #
+        # 409-aware retry: firebase-tools creates declared indexes one at a
+        # time and aborts on the FIRST error. A 409 "index already exists" is
+        # benign — the declared index is already present (a prior partial run,
+        # an auto-create-URL, or firebase-tools failing to match an index it
+        # just created), which used to fail this job on every merge that
+        # touched firestore.indexes.json. We retry while each attempt errors on
+        # a DIFFERENT index (forward progress) and fail only if stuck on the
+        # same 409 twice or on any non-409 error. Mirrors the functions-deploy
+        # 409 retry added in #537.
         run: |
-          set -eo pipefail
+          set -o pipefail
           OUTPUT=$(mktemp)
           trap 'rm -f "$OUTPUT"' EXIT
 
-          npx -y firebase-tools@latest deploy --only firestore:indexes \
-            --project maple-and-spruce \
-            --token "${{ steps.auth.outputs.access_token }}" \
-            < /dev/null 2>&1 | tee "$OUTPUT"
+          prev_err=""
+          for attempt in $(seq 1 12); do
+            npx -y firebase-tools@latest deploy --only firestore:indexes \
+              --project maple-and-spruce \
+              --token "${{ steps.auth.outputs.access_token }}" \
+              < /dev/null 2>&1 | tee "$OUTPUT"
+            status=${PIPESTATUS[0]}
+            [ "$status" -eq 0 ] && break
 
-          if grep -q "indexes are defined in your project but are not present" "$OUTPUT"; then
-            echo ""
-            echo "::error title=Firestore index orphans::Prod has composite indexes that aren't declared in firestore.indexes.json. The new indexes from this merge were applied, but the orphans were NOT deleted. Resolve before the next merge: either add the listed orphans to firestore.indexes.json, or delete them with 'pnpm exec firebase firestore:indexes:delete --project maple-and-spruce'."
-            exit 1
+            if ! grep -qi "index already exists" "$OUTPUT"; then
+              echo "::error::firestore index deploy failed (exit=$status) with a non-409 error"
+              exit 1
+            fi
+            cur_err=$(grep -i "index already exists" "$OUTPUT" | tail -1)
+            if [ "$cur_err" = "$prev_err" ]; then
+              echo "::error::firestore index deploy stuck on the same 409 — not converging: $cur_err"
+              exit 1
+            fi
+            prev_err="$cur_err"
+            echo "::warning::benign 409 (index already exists); declared index is present, retrying ($attempt/12)"
+            sleep 15
+          done
+
+          if grep -qi "not present in your firestore indexes file" "$OUTPUT"; then
+            echo "::warning title=Firestore index orphans::Prod has composite indexes not declared in firestore.indexes.json. Resolve by adding them to the file, or delete a stale one with: gcloud firestore indexes composite delete <INDEX_ID> --project maple-and-spruce"
           fi
 
   publish_webflow_components:


### PR DESCRIPTION
## Problem

The `deploy_firestore_indexes_{dev,prod}` jobs ran a single `firebase deploy --only firestore:indexes` and failed hard on any non-zero exit. firebase-tools creates declared indexes **one at a time and aborts on the first error** — and a `409 "index already exists"` is **benign**: the declared index is already present (a prior partial run, an auto-create-URL with a different `__name__` direction, or firebase-tools failing to match an index it just created).

Once the Music Together indexes (#511/#523) landed, **every merge that touched `firestore.indexes.json` failed repeatedly** on these 409s — "identifying indices to deploy that have already been deployed." Each rerun created one more index, then died on the next.

This is the index-flavored twin of the Cloud Functions 409 races fixed in **#537** — but #537 only touched the `deploy_functions` jobs; the index jobs were never covered.

## Fix

- **409-aware retry** on both index jobs (mirrors #537): retry while each attempt errors on a *different* index (forward progress); fail only if stuck on the *same* 409 twice, or on any non-409 error. Up to 12 passes.
- **Orphans warn instead of hard-fail.** Orphans (indexes in the project not in the file) are unused, low-risk; the real outage risk — a *missing* index — is caught at PR time by `check-firestore-indexes.ts`. Hard-failing unrelated merges on pre-existing drift was friction. This also **fixes the orphan grep**, which searched for `"indexes are defined in your project but are not present"` — wording Firebase never emits (`"...that are not present..."`), so the check never actually fired.
- **Docs** (`.claude/rules/firebase-functions.md`): the old text told you to run `pnpm exec firebase firestore:indexes:delete`, which **is not a real firebase-tools command**. Replaced with the working `gcloud firestore indexes composite delete <ID>` recipe, and documented the new 409-retry / orphan-warning behavior.

## Context / already done

The live incident (run #340) is separately unblocked: all 10 declared Music Together indexes were materialized directly via `gcloud` in both `maple-and-spruce-dev` and `maple-and-spruce`, so the current deploy is a clean no-op. This PR prevents recurrence on future index additions.

## Testing

- YAML validated (`yaml.safe_load`).
- Behavior is CI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)