### PR TITLE
fix(craft-club): signup payment-form styling + manage URL + welcome email link (#506)

### DIFF
--- a/apps/webflow-components/src/CraftClubSignupWidget.tsx
+++ b/apps/webflow-components/src/CraftClubSignupWidget.tsx
@@ -26,7 +26,7 @@ import {
 } from '@mui/material';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { httpsCallable } from 'firebase/functions';
-import { theme } from '@maple/react/theme';
+import { theme, fonts } from '@maple/react/theme';
 import { SquareCardForm } from '@maple/react/registrations';
 import { CRAFT_CLUB_MONTHLY_PRICE_CENTS } from '@maple/ts/domain';
 import type {
@@ -80,6 +80,7 @@ export function CraftClubSignupWidget({
   const tokenizeRef = useRef<(() => Promise<string>) | null>(null);
 
   const emailValid = EMAIL_RE.test(email.trim());
+  const payDisabled = busy || !cardReady || !name.trim();
 
   const handleCheckEmail = useCallback(
     async (e: React.FormEvent) => {
@@ -229,21 +230,40 @@ export function CraftClubSignupWidget({
               locationId={squareLocationId}
               env={env}
               totalCents={CRAFT_CLUB_MONTHLY_PRICE_CENTS}
+              maxWidth={480}
               onReady={() => setCardReady(true)}
               onTokenizeRef={(fn) => {
                 tokenizeRef.current = fn;
               }}
               afterCardContent={
-                <Button
-                  variant="contained"
-                  fullWidth
-                  disabled={busy || !cardReady || !name.trim()}
+                // Native button with inline brand styling. In Shadow DOM this
+                // content is portaled to the light DOM, where MUI/emotion theme
+                // CSS can't reach it (an MUI <Button> renders unstyled/gray).
+                // Mirrors RegistrationCheckoutForm's submit button.
+                <button
+                  type="button"
                   onClick={handlePay}
+                  disabled={payDisabled}
+                  style={{
+                    width: '100%',
+                    padding: '14px 24px',
+                    fontSize: '16px',
+                    fontWeight: 600,
+                    fontFamily: fonts.button,
+                    color: '#D5D6C8',
+                    backgroundColor: payDisabled ? '#8a7b6e' : '#4A3728',
+                    border: 'none',
+                    borderRadius: '8px',
+                    cursor: payDisabled ? 'not-allowed' : 'pointer',
+                    opacity: payDisabled ? 0.7 : 1,
+                    transition: 'background-color 0.2s, opacity 0.2s',
+                    letterSpacing: '0.02em',
+                  }}
                 >
                   {busy
                     ? 'Starting membership…'
                     : `Subscribe — $${MONTHLY_PRICE}/month`}
-                </Button>
+                </button>
               }
             />
           </Stack>

--- a/apps/webflow-components/src/craft-club-signup.webflow.tsx
+++ b/apps/webflow-components/src/craft-club-signup.webflow.tsx
@@ -31,7 +31,7 @@ export default declareComponent(CraftClubSignupWidget, {
     }),
     manageUrl: props.Text({
       name: 'Manage Membership URL',
-      defaultValue: 'https://mapleandsprucewv.com/craft-club/manage',
+      defaultValue: 'https://mapleandsprucefolkarts.com/craft-club-manage',
     }),
   },
 });

--- a/libs/react/registrations/src/lib/SquareCardForm.tsx
+++ b/libs/react/registrations/src/lib/SquareCardForm.tsx
@@ -84,6 +84,13 @@ interface SquareCardFormProps {
    * Use this for the submit button.
    */
   afterCardContent?: React.ReactNode;
+  /**
+   * Optional max width (px) for the external Shadow-DOM wrapper. In Shadow DOM
+   * the card form is inserted as a sibling of the shadow host with width:100%,
+   * which escapes any maxWidth set inside the shadow root. Pass the host
+   * widget's maxWidth so the card + portaled button stay aligned with it.
+   */
+  maxWidth?: number;
 }
 
 /**
@@ -136,6 +143,7 @@ export function SquareCardForm({
   onTokenizeRef,
   onDigitalWalletToken,
   afterCardContent,
+  maxWidth,
 }: SquareCardFormProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -251,9 +259,19 @@ export function SquareCardForm({
         const shadowHost = findShadowHost(placeholder);
 
         const wrapper = document.createElement('div');
-        wrapper.style.cssText = ['width: 100%', 'box-sizing: border-box'].join(
-          '; '
-        );
+        wrapper.style.cssText = [
+          'width: 100%',
+          'box-sizing: border-box',
+          // Match the host widget's maxWidth so the externally-inserted card
+          // form + portaled button don't stretch full-width past it.
+          ...(maxWidth
+            ? [
+                `max-width: ${maxWidth}px`,
+                'margin-left: auto',
+                'margin-right: auto',
+              ]
+            : []),
+        ].join('; ');
         wrapperRef.current = wrapper;
 
         // Apple Pay container
@@ -385,7 +403,7 @@ export function SquareCardForm({
       setError(message);
       setIsLoading(false);
     }
-  }, [applicationId, locationId, totalCents, showDigitalWallets, onReady, onTokenizeRef]);
+  }, [applicationId, locationId, totalCents, showDigitalWallets, onReady, onTokenizeRef, maxWidth]);
 
   // Initialize payments once SDK is ready AND we have a valid amount
   useEffect(() => {

--- a/tools/seed-email-templates.ts
+++ b/tools/seed-email-templates.ts
@@ -608,8 +608,9 @@ const craftClubWelcomeHtml = `<!DOCTYPE html>
       Materials are billed separately at the register.</p>
     <div class="highlight-box">
       <strong style="color: #4A3728;">Manage your membership anytime</strong><br>
-      <p>Need to update your card or cancel? Visit the membership page and we'll
-        email you a secure link.</p>
+      <p>Need to update your card or cancel? Visit
+        <a href="https://mapleandsprucefolkarts.com/craft-club-manage" style="color: #6B7B5E;">the membership page</a>
+        and we'll email you a secure link.</p>
     </div>
     <p>Questions? Reach out at
       <a href="mailto:katie@mapleandsprucefolkarts.com" style="color: #6B7B5E;">katie@mapleandsprucefolkarts.com</a>


### PR DESCRIPTION
Polish bugs found during live dev testing of the Craft Club signup flow (the flow itself works end-to-end: approve → pay $30 sandbox → "You're in!").

## Changes
1. **Payment form full-width + unstyled Subscribe button.** In Shadow DOM, `SquareCardForm` inserts its card form as a sibling of the shadow host with `width:100%` (escaping the widget's internal `maxWidth:480`) and portals `afterCardContent` into the light DOM where MUI/emotion theme CSS can't reach it.
   - `SquareCardForm`: new optional **`maxWidth`** prop that constrains + centers the external wrapper. Non-breaking — registration doesn't pass it, so its behavior is unchanged.
   - `CraftClubSignupWidget`: pass `maxWidth={480}` and replace the portaled MUI `<Button>` with a **native inline-styled `<button>`** (brand `#4A3728`/`#D5D6C8` + `fonts.button`), mirroring `RegistrationCheckoutForm`'s submit button (the established pattern for portaled content).
2. **`manageUrl` default** in `craft-club-signup.webflow.tsx` → `mapleandsprucefolkarts.com/craft-club-manage` (was the old `mapleandsprucewv.com/craft-club/manage`).
3. **Welcome email** "the membership page" → now a link to the manage page.

## Post-merge steps
- CI republishes the webflow component library → **update the library on the site** in the Designer to pick up the new card/button code.
- The live `/craft-club-join` instance's `manageUrl` **prop** is set separately (via MCP) — the default only affects new/unset instances.
- Re-run `tools/seed-email-templates.ts` (dev + prod) for the welcome-email link.

Part of #506.