### PR TITLE
chore(craft-club): set production plan variation ID (#506)

### DIFF
--- a/.env.prod
+++ b/.env.prod
@@ -51,7 +51,7 @@ META_CAPI_API_VERSION=v20.0
 
 # Craft Club subscription plan variation ID (Square Catalog).
 # Fill at go-live: run `npx tsx tools/create-craft-club-plan.ts --prod` and paste the printed variation ID.
-CRAFT_CLUB_PLAN_VARIATION_ID=PROD_PLACEHOLDER_RUN_create-craft-club-plan
+CRAFT_CLUB_PLAN_VARIATION_ID=C63X5O7RONKQVBAUV5WSCK3B
 
 # Craft Club self-service manage page (Webflow); magic-link emails point here.
 CRAFT_CLUB_MANAGE_URL=https://mapleandsprucefolkarts.com/craft-club-manage


### PR DESCRIPTION
Sets `CRAFT_CLUB_PLAN_VARIATION_ID` in `.env.prod` to the real production plan variation (`C63X5O7RONKQVBAUV5WSCK3B`) created in the live Square catalog via `tools/create-craft-club-plan.ts --prod`. Replaces the placeholder so `createCraftClubSubscription` enrolls production members correctly once deployed. Part of #506 go-live.