### PR TITLE
test(music-together): integration suite — checkout, charge job, cancel/refund (#508)

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -370,7 +370,7 @@ jobs:
           # maple-square: Square mock server URL + fake secrets
           echo "SQUARE_BASE_URL=http://localhost:9997" >> dist/apps/functions-square/.env
           echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions-square/.env
-          printf "SQUARE_ACCESS_TOKEN=mock-token\nSQUARE_WEBHOOK_SIGNATURE_KEY=mock-key\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions-square/.secret.local
+          printf "SQUARE_ACCESS_TOKEN=mock-token\nMT_SQUARE_ACCESS_TOKEN=mock-token\nSQUARE_WEBHOOK_SIGNATURE_KEY=mock-key\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions-square/.secret.local
 
           # maple-sync: Webflow mock server URL + fake secrets
           echo "WEBFLOW_BASE_URL=http://localhost:9996" >> dist/apps/functions-sync/.env

--- a/apps/functions-integration-tests-music-together/project.json
+++ b/apps/functions-integration-tests-music-together/project.json
@@ -1,0 +1,22 @@
+{
+  "name": "functions-integration-tests-music-together",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/functions-integration-tests-music-together/src",
+  "projectType": "application",
+  "tags": ["type:e2e"],
+  "implicitDependencies": [
+    "firebase-maple-functions-create-music-together-registration",
+    "firebase-maple-functions-charge-music-together-installments",
+    "firebase-maple-functions-cancel-music-together-registration",
+    "firebase-integration-test-utils",
+    "firebase-square-test-mock-server"
+  ],
+  "targets": {
+    "test": {
+      "executor": "@nx/vitest:test",
+      "options": {
+        "config": "apps/functions-integration-tests-music-together/vitest.config.ts"
+      }
+    }
+  }
+}

--- a/apps/functions-integration-tests-music-together/src/cancel-music-together-registration.spec.ts
+++ b/apps/functions-integration-tests-music-together/src/cancel-music-together-registration.spec.ts
@@ -1,0 +1,174 @@
+/**
+ * Integration tests for cancelMusicTogetherRegistration (admin).
+ *
+ * Exercises the refund policy (full minus the $25 fee before the first class,
+ * non-refundable after — via the mock Square /v2/refunds), the cancel-guard
+ * (scheduled charges flipped to cancelled), and the auth/domain guards.
+ */
+import {
+  createTestUser,
+  clearAuthEmulator,
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  getFirestoreDoc,
+  callFunction,
+  ADMIN_USER,
+  NON_ADMIN_USER,
+} from '@maple/firebase/integration-test-utils';
+import type { TestUser } from '@maple/firebase/integration-test-utils';
+import type {
+  CancelMusicTogetherRegistrationRequest,
+  CancelMusicTogetherRegistrationResponse,
+} from '@maple/ts/firebase/api-types';
+
+const future = new Date(Date.now() + 7 * 86_400_000);
+const pastDate = new Date(Date.now() - 7 * 86_400_000);
+
+function reg(overrides: Record<string, unknown> = {}) {
+  return {
+    sectionId: 'sec-future',
+    parentNames: ['Jamie Rivera'],
+    children: [{ name: 'Sky', dob: new Date('2023-04-01') }],
+    email: 'cancel@test.com',
+    phone: '304-555-1212',
+    address: 'somewhere',
+    paymentPlan: 'installments',
+    policiesAcceptedAt: new Date(),
+    pricePaidCents: 13200,
+    squarePaymentId: 'mock-payment-cancel',
+    squareCustomerId: 'mock-customer-cancel',
+    squareCardId: 'ccof:mock-card-cancel',
+    status: 'confirmed',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('cancelMusicTogetherRegistration', () => {
+  let admin: TestUser;
+  let nonAdmin: TestUser;
+
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+
+    admin = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
+    nonAdmin = await createTestUser(
+      NON_ADMIN_USER.email,
+      NON_ADMIN_USER.password
+    );
+    await setFirestoreDoc('admins', admin.uid, {
+      userId: admin.uid,
+      email: admin.email,
+    });
+
+    // Sections: one whose first class is in the future (refundable), one past.
+    await setFirestoreDoc('musicTogetherSections', 'sec-future', {
+      name: 'Future Section',
+      sessions: [{ dateTime: future }],
+      capacityFamilies: 8,
+      priceFullCents: 25200,
+      status: 'open',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    await setFirestoreDoc('musicTogetherSections', 'sec-past', {
+      name: 'Started Section',
+      sessions: [{ dateTime: pastDate }],
+      capacityFamilies: 8,
+      priceFullCents: 25200,
+      status: 'open',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  it('rejects a non-admin caller', async () => {
+    await setFirestoreDoc('musicTogetherRegistrations', 'reg-auth', reg());
+    const result = await callFunction<CancelMusicTogetherRegistrationRequest>({
+      functionName: 'cancelMusicTogetherRegistration',
+      data: { registrationId: 'reg-auth' },
+      idToken: nonAdmin.idToken,
+    });
+    expect(result.status).not.toBe(200);
+  });
+
+  it('before first class: refunds paid amount minus $25, cancels scheduled charges', async () => {
+    await setFirestoreDoc('musicTogetherRegistrations', 'reg-refund', reg());
+    await setFirestoreDoc('musicTogetherScheduledCharges', 'chg-refund', {
+      registrationId: 'reg-refund',
+      sectionId: 'sec-future',
+      installmentNumber: 2,
+      amountCents: 13200,
+      dueAt: future,
+      status: 'scheduled',
+      idempotencyKey: 'mt-charge-refund',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const result = await callFunction<
+      CancelMusicTogetherRegistrationRequest,
+      CancelMusicTogetherRegistrationResponse
+    >({
+      functionName: 'cancelMusicTogetherRegistration',
+      data: { registrationId: 'reg-refund' },
+      idToken: admin.idToken,
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data?.status).toBe('refunded');
+    expect(result.data?.refundCents).toBe(13200 - 2500);
+    expect(String(result.data?.refundId)).toMatch(/^mock-refund-/);
+    expect(result.data?.cancelledChargeCount).toBe(1);
+
+    // cancel-guard: the scheduled charge is now cancelled
+    const charge = await getFirestoreDoc(
+      'musicTogetherScheduledCharges',
+      'chg-refund'
+    );
+    expect(charge?.status).toBe('cancelled');
+  });
+
+  it('on/after first class: non-refundable, still cancels', async () => {
+    await setFirestoreDoc(
+      'musicTogetherRegistrations',
+      'reg-started',
+      reg({ sectionId: 'sec-past', email: 'started@test.com' })
+    );
+
+    const result = await callFunction<
+      CancelMusicTogetherRegistrationRequest,
+      CancelMusicTogetherRegistrationResponse
+    >({
+      functionName: 'cancelMusicTogetherRegistration',
+      data: { registrationId: 'reg-started' },
+      idToken: admin.idToken,
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data?.status).toBe('cancelled');
+    expect(result.data?.refundCents).toBe(0);
+    expect(result.data?.refundId).toBeUndefined();
+  });
+
+  it('rejects an already-cancelled registration', async () => {
+    await setFirestoreDoc(
+      'musicTogetherRegistrations',
+      'reg-done',
+      reg({ status: 'cancelled' })
+    );
+    const result = await callFunction<CancelMusicTogetherRegistrationRequest>({
+      functionName: 'cancelMusicTogetherRegistration',
+      data: { registrationId: 'reg-done' },
+      idToken: admin.idToken,
+    });
+    expect(result.status).not.toBe(200);
+  });
+});

--- a/apps/functions-integration-tests-music-together/src/charge-music-together-installments.spec.ts
+++ b/apps/functions-integration-tests-music-together/src/charge-music-together-installments.spec.ts
@@ -1,0 +1,205 @@
+/**
+ * Integration tests for the Week-5 installment charge job, driven through the
+ * admin-callable trigger `triggerMusicTogetherInstallments` (the onSchedule
+ * trigger isn't HTTP-reachable in the emulator). Exercises the dry run, a real
+ * stored-card charge via the Square mock, the lease/at-most-once guarantee, and
+ * failure handling when a registration has no card on file.
+ */
+import {
+  createTestUser,
+  clearAuthEmulator,
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  getFirestoreDoc,
+  callFunction,
+  ADMIN_USER,
+  NON_ADMIN_USER,
+} from '@maple/firebase/integration-test-utils';
+import type { TestUser } from '@maple/firebase/integration-test-utils';
+import type {
+  ChargeMusicTogetherInstallmentsRequest,
+  MusicTogetherInstallmentChargeResult,
+} from '@maple/ts/firebase/api-types';
+
+const past = new Date(Date.now() - 86_400_000);
+
+function confirmedReg(overrides: Record<string, unknown> = {}) {
+  return {
+    sectionId: 'sec-1',
+    parentNames: ['Jamie Rivera'],
+    children: [{ name: 'Sky', dob: new Date('2023-04-01') }],
+    email: 'installments@test.com',
+    phone: '304-555-1212',
+    address: 'somewhere',
+    paymentPlan: 'installments',
+    policiesAcceptedAt: new Date(),
+    cardOnFileAuthAt: new Date(),
+    pricePaidCents: 13200,
+    squareCustomerId: 'mock-customer-seed',
+    squareCardId: 'ccof:mock-card-seed',
+    status: 'confirmed',
+    scheduledChargeCount: 1,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function dueCharge(overrides: Record<string, unknown> = {}) {
+  return {
+    registrationId: 'reg-ok',
+    sectionId: 'sec-1',
+    installmentNumber: 2,
+    amountCents: 13200,
+    dueAt: past,
+    status: 'scheduled',
+    idempotencyKey: 'mt-charge-seed',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+async function seedAdmin(): Promise<TestUser> {
+  const admin = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
+  await setFirestoreDoc('admins', admin.uid, {
+    userId: admin.uid,
+    email: admin.email,
+  });
+  return admin;
+}
+
+describe('triggerMusicTogetherInstallments — due charge', () => {
+  let admin: TestUser;
+  let nonAdmin: TestUser;
+
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+    admin = await seedAdmin();
+    nonAdmin = await createTestUser(
+      NON_ADMIN_USER.email,
+      NON_ADMIN_USER.password
+    );
+    await setFirestoreDoc('musicTogetherRegistrations', 'reg-ok', confirmedReg());
+    await setFirestoreDoc('musicTogetherScheduledCharges', 'chg-due', dueCharge());
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  it('rejects a non-admin caller', async () => {
+    const result = await callFunction<ChargeMusicTogetherInstallmentsRequest>({
+      functionName: 'triggerMusicTogetherInstallments',
+      data: {},
+      idToken: nonAdmin.idToken,
+    });
+    expect(result.status).not.toBe(200);
+  });
+
+  it('dry run reports the due charge without charging', async () => {
+    const result = await callFunction<
+      ChargeMusicTogetherInstallmentsRequest,
+      MusicTogetherInstallmentChargeResult
+    >({
+      functionName: 'triggerMusicTogetherInstallments',
+      data: { dryRun: true },
+      idToken: admin.idToken,
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data?.dryRun).toBe(true);
+    expect(result.data?.due).toBeGreaterThanOrEqual(1);
+    expect(result.data?.charged).toBe(0);
+    expect(
+      result.data?.wouldCharge?.some((c) => c.chargeId === 'chg-due')
+    ).toBe(true);
+
+    // still scheduled — nothing was charged
+    const charge = await getFirestoreDoc('musicTogetherScheduledCharges', 'chg-due');
+    expect(charge?.status).toBe('scheduled');
+  });
+
+  it('charges the stored card and marks the charge paid', async () => {
+    const result = await callFunction<
+      ChargeMusicTogetherInstallmentsRequest,
+      MusicTogetherInstallmentChargeResult
+    >({
+      functionName: 'triggerMusicTogetherInstallments',
+      data: {},
+      idToken: admin.idToken,
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data?.charged).toBe(1);
+    expect(result.data?.failed).toBe(0);
+
+    const charge = await getFirestoreDoc('musicTogetherScheduledCharges', 'chg-due');
+    expect(charge?.status).toBe('paid');
+    expect(String(charge?.squarePaymentId)).toMatch(/^mock-payment-/);
+  });
+
+  it('is at-most-once — a second run finds nothing due (lease guard)', async () => {
+    const result = await callFunction<
+      ChargeMusicTogetherInstallmentsRequest,
+      MusicTogetherInstallmentChargeResult
+    >({
+      functionName: 'triggerMusicTogetherInstallments',
+      data: {},
+      idToken: admin.idToken,
+    });
+    expect(result.status).toBe(200);
+    expect(result.data?.due).toBe(0);
+    expect(result.data?.charged).toBe(0);
+  });
+});
+
+describe('triggerMusicTogetherInstallments — failure handling', () => {
+  let admin: TestUser;
+
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+    admin = await seedAdmin();
+    // A due charge whose registration has no card on file → not chargeable.
+    await setFirestoreDoc(
+      'musicTogetherRegistrations',
+      'reg-nocard',
+      confirmedReg({ squareCardId: undefined, squareCustomerId: undefined })
+    );
+    await setFirestoreDoc(
+      'musicTogetherScheduledCharges',
+      'chg-nocard',
+      dueCharge({ registrationId: 'reg-nocard', idempotencyKey: 'mt-charge-nocard' })
+    );
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  it('marks an uncharageable charge failed (loud, not silently skipped)', async () => {
+    const result = await callFunction<
+      ChargeMusicTogetherInstallmentsRequest,
+      MusicTogetherInstallmentChargeResult
+    >({
+      functionName: 'triggerMusicTogetherInstallments',
+      data: {},
+      idToken: admin.idToken,
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data?.failed).toBe(1);
+    expect(result.data?.charged).toBe(0);
+
+    const charge = await getFirestoreDoc(
+      'musicTogetherScheduledCharges',
+      'chg-nocard'
+    );
+    expect(charge?.status).toBe('failed');
+    expect(charge?.lastError).toBeDefined();
+  });
+});

--- a/apps/functions-integration-tests-music-together/src/create-music-together-registration.spec.ts
+++ b/apps/functions-integration-tests-music-together/src/create-music-together-registration.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * Integration tests for createMusicTogetherRegistration.
+ *
+ * Runs the real function in the Firebase emulator; MT Square customer/card/
+ * payment calls are intercepted by the mock server via SQUARE_BASE_URL (the
+ * base-URL override applies to the MT Square client too). Exercises full-pay
+ * and the installments flow (customer upsert → card vault → stored-card charge
+ * → materialized scheduled charges), the 8-family cap, and validation guards.
+ */
+import {
+  clearAuthEmulator,
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  getFirestoreDoc,
+  listFirestoreDocs,
+  callFunction,
+} from '@maple/firebase/integration-test-utils';
+import type {
+  CreateMusicTogetherRegistrationRequest,
+  CreateMusicTogetherRegistrationResponse,
+} from '@maple/ts/firebase/api-types';
+
+const week1 = new Date(Date.now() + 7 * 86_400_000);
+const week5 = new Date(Date.now() + 35 * 86_400_000);
+
+function sectionDoc(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'Spring MT — Tuesdays',
+    sessions: [{ dateTime: week1 }],
+    capacityFamilies: 8,
+    priceFullCents: 25200,
+    installmentPlan: [
+      { amountCents: 13200, dueAt: week1 },
+      { amountCents: 13200, dueAt: week5 },
+    ],
+    status: 'open',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function family(
+  overrides: Partial<CreateMusicTogetherRegistrationRequest> = {}
+): CreateMusicTogetherRegistrationRequest {
+  return {
+    sectionId: 'sec-open',
+    parentNames: ['Jamie Rivera'],
+    children: [{ name: 'Sky', dob: '2023-04-01' }],
+    email: 'jamie@test.com',
+    phone: '304-555-1212',
+    address: '123 Spruce St, Morgantown, WV',
+    paymentPlan: 'full',
+    policiesAccepted: true,
+    paymentNonce: 'cnon:card-nonce-ok',
+    ...overrides,
+  };
+}
+
+describe('createMusicTogetherRegistration', () => {
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+    await setFirestoreDoc('musicTogetherSections', 'sec-open', sectionDoc());
+    await setFirestoreDoc(
+      'musicTogetherSections',
+      'sec-draft',
+      sectionDoc({ status: 'draft' })
+    );
+    await setFirestoreDoc(
+      'musicTogetherSections',
+      'sec-full',
+      sectionDoc({ capacityFamilies: 1 })
+    );
+    // Fill sec-full with one confirmed family so the cap is reached.
+    await setFirestoreDoc('musicTogetherRegistrations', 'existing-full', {
+      sectionId: 'sec-full',
+      parentNames: ['Existing Family'],
+      children: [{ name: 'Kid', dob: new Date('2023-01-01') }],
+      email: 'existing@test.com',
+      phone: '304-555-0000',
+      address: 'somewhere',
+      paymentPlan: 'full',
+      policiesAcceptedAt: new Date(),
+      pricePaidCents: 25200,
+      status: 'confirmed',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  it('full pay: charges once, confirms, persists the registration + confirmation email', async () => {
+    const result = await callFunction<
+      CreateMusicTogetherRegistrationRequest,
+      CreateMusicTogetherRegistrationResponse
+    >({ functionName: 'createMusicTogetherRegistration', data: family() });
+
+    expect(result.status).toBe(200);
+    expect(result.data?.status).toBe('confirmed');
+    expect(result.data?.amountChargedCents).toBe(25200);
+    expect(result.data?.scheduledChargeCount).toBe(0);
+
+    const reg = await getFirestoreDoc(
+      'musicTogetherRegistrations',
+      result.data!.registrationId
+    );
+    expect(reg?.status).toBe('confirmed');
+    expect(String(reg?.squarePaymentId)).toMatch(/^mock-payment-/);
+
+    const mail = await listFirestoreDocs('mail');
+    expect(
+      mail.some((m) => (m.data as { to?: string }).to === 'jamie@test.com')
+    ).toBe(true);
+  });
+
+  it('installments: vaults a card, charges installment 1, materializes the rest as scheduled charges', async () => {
+    const result = await callFunction<
+      CreateMusicTogetherRegistrationRequest,
+      CreateMusicTogetherRegistrationResponse
+    >({
+      functionName: 'createMusicTogetherRegistration',
+      data: family({
+        email: 'installments@test.com',
+        paymentPlan: 'installments',
+        cardOnFileAuth: true,
+      }),
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data?.status).toBe('confirmed');
+    expect(result.data?.amountChargedCents).toBe(13200); // installment 1
+    expect(result.data?.cardLast4).toBe('1111'); // from the mock card
+    expect(result.data?.scheduledChargeCount).toBe(1); // installment 2
+
+    const reg = await getFirestoreDoc(
+      'musicTogetherRegistrations',
+      result.data!.registrationId
+    );
+    expect(String(reg?.squareCardId)).toMatch(/^ccof:mock-card-/);
+    expect(String(reg?.squareCustomerId)).toMatch(/^mock-customer-/);
+
+    const charges = (await listFirestoreDocs('musicTogetherScheduledCharges'))
+      .map((c) => c.data as Record<string, unknown>)
+      .filter((c) => c.registrationId === result.data!.registrationId);
+    expect(charges).toHaveLength(1);
+    expect(charges[0].status).toBe('scheduled');
+    expect(charges[0].amountCents).toBe(13200);
+    expect(String(charges[0].idempotencyKey)).toMatch(/^mt-charge-/);
+  });
+
+  it('rejects a section that is not open', async () => {
+    const result = await callFunction<CreateMusicTogetherRegistrationRequest>({
+      functionName: 'createMusicTogetherRegistration',
+      data: family({ sectionId: 'sec-draft', email: 'draft@test.com' }),
+    });
+    expect(result.status).not.toBe(200);
+  });
+
+  it('rejects when the section is at its family cap', async () => {
+    const result = await callFunction<CreateMusicTogetherRegistrationRequest>({
+      functionName: 'createMusicTogetherRegistration',
+      data: family({ sectionId: 'sec-full', email: 'overflow@test.com' }),
+    });
+    expect(result.status).not.toBe(200);
+  });
+
+  it('rejects installments without card-on-file authorization', async () => {
+    const result = await callFunction<CreateMusicTogetherRegistrationRequest>({
+      functionName: 'createMusicTogetherRegistration',
+      data: family({
+        email: 'noauth@test.com',
+        paymentPlan: 'installments',
+        cardOnFileAuth: false,
+      }),
+    });
+    expect(result.status).not.toBe(200);
+  });
+
+  it('rejects when policies are not accepted', async () => {
+    const result = await callFunction<CreateMusicTogetherRegistrationRequest>({
+      functionName: 'createMusicTogetherRegistration',
+      data: family({ email: 'nopolicy@test.com', policiesAccepted: false }),
+    });
+    expect(result.status).not.toBe(200);
+  });
+});

--- a/apps/functions-integration-tests-music-together/tsconfig.json
+++ b/apps/functions-integration-tests-music-together/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/apps/functions-integration-tests-music-together/tsconfig.spec.json
+++ b/apps/functions-integration-tests-music-together/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "types": ["vitest/globals", "node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/functions-integration-tests-music-together/vitest.config.ts
+++ b/apps/functions-integration-tests-music-together/vitest.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@maple/firebase/integration-test-utils': path.resolve(
+        __dirname,
+        '../../libs/firebase/integration-test-utils/src/index.ts'
+      ),
+      '@maple/firebase/square-test-mock-server': path.resolve(
+        __dirname,
+        '../../libs/firebase/square-test-mock-server/src/index.ts'
+      ),
+      '@maple/ts/firebase/api-types': path.resolve(
+        __dirname,
+        '../../libs/ts/firebase/api-types/src/index.ts'
+      ),
+      '@maple/ts/domain': path.resolve(
+        __dirname,
+        '../../libs/ts/domain/src/index.ts'
+      ),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    root: path.resolve(__dirname),
+    include: ['src/**/*.spec.ts'],
+    setupFiles: ['../../libs/firebase/integration-test-utils/src/lib/setup.ts'],
+    testTimeout: 30000,
+    fileParallelism: false,
+    sequence: {
+      concurrent: false,
+    },
+  },
+});

--- a/tools/run-integration-tests.sh
+++ b/tools/run-integration-tests.sh
@@ -84,7 +84,7 @@ printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\nTALLY_WEBHOOK_SECRET=test-ta
 # maple-square: Square mock server URL + fake secrets
 echo "SQUARE_BASE_URL=http://localhost:$SQUARE_MOCK_SERVER_PORT" >> dist/apps/functions-square/.env
 echo "ETSY_API_BASE=http://localhost:$ETSY_MOCK_SERVER_PORT/v3/application" >> dist/apps/functions-square/.env
-printf "SQUARE_ACCESS_TOKEN=mock-token\nSQUARE_WEBHOOK_SIGNATURE_KEY=mock-key\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions-square/.secret.local
+printf "SQUARE_ACCESS_TOKEN=mock-token\nMT_SQUARE_ACCESS_TOKEN=mock-token\nSQUARE_WEBHOOK_SIGNATURE_KEY=mock-key\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions-square/.secret.local
 
 # maple-sync: Webflow mock server URL + fake secrets
 echo "WEBFLOW_BASE_URL=http://localhost:$WEBFLOW_MOCK_SERVER_PORT" >> dist/apps/functions-sync/.env


### PR DESCRIPTION
## Summary
Closes the biggest verification gap for Music Together: an **integration test suite** that runs the real MT Cloud Functions in the Firebase emulator against emulated Firestore, with the **Square mock server** intercepting customer/card/payment/refund calls. This is automated, real-feedback verification of the payment paths — no human needed to exercise them.

## What it covers (end-to-end, real functions + emulated Firestore + mock Square)
- **`createMusicTogetherRegistration`** — full-pay (one charge → confirmed + queued email); **installments** (customer upsert → card vault → stored-card charge → materialized `musicTogetherScheduledCharges`); the **8-family cap**; card-on-file + policies validation guards.
- **`triggerMusicTogetherInstallments`** (Week-5 job via the admin trigger) — dry-run; a real stored-card charge marking the charge `paid`; the **at-most-once lease** (second run charges nothing); no-card → `failed`.
- **`cancelMusicTogetherRegistration`** — refund minus **$25** before first class (mock refund); non-refundable after; the **cancel-guard** flipping scheduled charges to `cancelled`; admin/domain guards.

## Wiring
- Added `MT_SQUARE_ACCESS_TOKEN=mock-token` to the maple-square `.secret.local` in `tools/run-integration-tests.sh` and the CI integration job (`build-check.yml`). MT's `SQUARE_BASE_URL` is shared, so MT Square calls route to the mock automatically.
- **No mock-server changes** — every route MT needs (customers, cards, payments, refunds) already exists (added for Craft Club/registration).
- Auto-discovered by the CI suite matrix via the `functions-integration-tests-*` naming convention; `implicitDependencies` list the MT function projects so `--affected` picks it up.

## Verification
- [x] **Ran locally against the emulator: 3 files, 15 tests, all pass.** Charge-job logs confirm `due=1 charged=1` → `due=0` (idempotency) → `failed=1` (no-card).
- [x] Suite typechecks, `nx lint` clean.

Refs #508