### PR TITLE
test(music-together): storybook interaction tests for admin UI (#516)

### DIFF
--- a/apps/maple-spruce/src/app/(admin)/music-together/RosterDialog.stories.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/RosterDialog.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { fn } from 'storybook/test';
+import { fn, expect, within, userEvent, waitFor } from 'storybook/test';
 import type {
   MusicTogetherRegistration,
   MusicTogetherScheduledCharge,
@@ -114,5 +114,70 @@ export const Loading: Story = {
 export const ErrorState: Story = {
   args: {
     rosterState: { status: 'error', error: 'Failed to fetch roster' },
+  },
+};
+
+// ============================================================
+// INTERACTIONS (exercised automatically in CI)
+// ============================================================
+
+const body = () => within(document.body);
+
+/**
+ * Renders the roster and drives the licensee-CSV download. Verifies the
+ * past-due badge, a child's DOB, the confirmed count on the button, and that
+ * clicking the download triggers an anchor download without error.
+ */
+export const RostersAndDownloadsCsv: Story = {
+  args: { rosterState: { status: 'success', data: withFamilies } },
+  play: async ({ args }) => {
+    const canvas = body();
+    await waitFor(() =>
+      expect(canvas.getByRole('dialog')).toBeInTheDocument()
+    );
+
+    // Renders enrolled families with past-due + child DOBs.
+    await expect(canvas.getByText('Past due')).toBeInTheDocument();
+    await expect(
+      canvas.getByText(/Wren \(2022-01-10\)/)
+    ).toBeInTheDocument();
+
+    // Download button counts the 3 confirmed families and is enabled.
+    const download = canvas.getByRole('button', { name: /licensee csv \(3\)/i });
+    await expect(download).toBeEnabled();
+
+    // Clicking triggers a blob download via a temporary anchor — assert the
+    // anchor is created + clicked (spy the prototype so no file actually saves).
+    const clickSpy = fn();
+    const orig = HTMLAnchorElement.prototype.click;
+    HTMLAnchorElement.prototype.click = clickSpy;
+    try {
+      await userEvent.click(download);
+      await waitFor(() => expect(clickSpy).toHaveBeenCalled());
+    } finally {
+      HTMLAnchorElement.prototype.click = orig;
+    }
+
+    await userEvent.click(canvas.getByRole('button', { name: /close/i }));
+    await expect(args.onClose).toHaveBeenCalled();
+  },
+};
+
+/** Empty roster disables the CSV export. */
+export const EmptyDisablesExport: Story = {
+  args: {
+    rosterState: {
+      status: 'success',
+      data: { section: withFamilies.section, entries: [] },
+    },
+  },
+  play: async () => {
+    const canvas = body();
+    await waitFor(() =>
+      expect(canvas.getByRole('dialog')).toBeInTheDocument()
+    );
+    await expect(
+      canvas.getByRole('button', { name: /licensee csv \(0\)/i })
+    ).toBeDisabled();
   },
 };

--- a/apps/maple-spruce/src/app/(admin)/music-together/SectionFormDialog.stories.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/SectionFormDialog.stories.tsx
@@ -1,7 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { fn } from 'storybook/test';
+import { fn, expect, within, userEvent, waitFor } from 'storybook/test';
 import type { MusicTogetherSection } from '@maple/ts/domain';
 import { SectionFormDialog } from './SectionFormDialog';
+
+// The dialog renders in a portal, so query document.body.
+const dialog = () => within(document.body);
+async function waitForDialog() {
+  const canvas = dialog();
+  await waitFor(
+    () => expect(canvas.getByRole('dialog')).toBeInTheDocument(),
+    { timeout: 5000 }
+  );
+  return canvas;
+}
 
 const mockSection: MusicTogetherSection = {
   id: 'sec-1',
@@ -49,4 +60,57 @@ export const Edit: Story = {
 
 export const Submitting: Story = {
   args: { section: mockSection, isSubmitting: true },
+};
+
+// ============================================================
+// INTERACTIONS (exercised automatically in CI)
+// ============================================================
+
+/**
+ * Fill the required name and submit — asserts the form builds the right
+ * CreateMusicTogetherSectionInput (prefilled defaults: $252 full, cap 8, draft).
+ */
+export const CreateSubmits: Story = {
+  play: async ({ args }) => {
+    const canvas = await waitForDialog();
+
+    const nameInput = canvas.getByLabelText(/section name/i);
+    await userEvent.type(nameInput, 'Fall 2026');
+
+    const save = canvas.getByRole('button', { name: /save/i });
+    await waitFor(() => expect(save).toBeEnabled());
+    await userEvent.click(save);
+
+    await waitFor(() =>
+      expect(args.onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Fall 2026',
+          status: 'draft',
+          capacityFamilies: 8,
+          priceFullCents: 25200,
+          sessions: [],
+        })
+      )
+    );
+  },
+};
+
+/** Save stays disabled until a name is entered (required-field guard). */
+export const SaveDisabledWithoutName: Story = {
+  play: async () => {
+    const canvas = await waitForDialog();
+    await expect(
+      canvas.getByRole('button', { name: /save/i })
+    ).toBeDisabled();
+  },
+};
+
+/** Cancel closes without submitting. */
+export const CancelCloses: Story = {
+  play: async ({ args }) => {
+    const canvas = await waitForDialog();
+    await userEvent.click(canvas.getByRole('button', { name: /cancel/i }));
+    await expect(args.onClose).toHaveBeenCalledTimes(1);
+    await expect(args.onSubmit).not.toHaveBeenCalled();
+  },
 };


### PR DESCRIPTION
## Summary
Completes the self-verification picture for Music Together: the admin UI now **exercises itself** in CI (Storybook browser tests), not just renders. Frontend analog of the integration suite (#544) for the backend.

## What it drives
- **SectionFormDialog**
  - `CreateSubmits` — type a name → click Save → assert the built `CreateMusicTogetherSectionInput` (prefilled defaults: $252 full, capacity 8, `draft`, empty sessions).
  - `SaveDisabledWithoutName` — Save stays disabled until the required name is entered.
  - `CancelCloses` — Cancel calls `onClose`, never `onSubmit`.
- **RosterDialog**
  - `RostersAndDownloadsCsv` — asserts the **Past due** badge, a child's DOB, and the confirmed count on the export button; clicks the **licensee CSV** download and verifies the anchor click fires (spied, so no file saved).
  - `EmptyDisablesExport` — no confirmed families → export disabled.

## Verification
- [x] **Ran locally** via vitest storybook browser mode (real Chromium): **12 tests pass.**

Refs #508, #516