### PR TITLE
test(music-together): integration coverage for read/CRUD/waitlist/roster (#508)

### DIFF
--- a/apps/functions-integration-tests-music-together/project.json
+++ b/apps/functions-integration-tests-music-together/project.json
@@ -8,6 +8,12 @@
     "firebase-maple-functions-create-music-together-registration",
     "firebase-maple-functions-charge-music-together-installments",
     "firebase-maple-functions-cancel-music-together-registration",
+    "firebase-maple-functions-get-public-music-together-section",
+    "firebase-maple-functions-add-to-music-together-waitlist",
+    "firebase-maple-functions-get-music-together-sections",
+    "firebase-maple-functions-create-music-together-section",
+    "firebase-maple-functions-update-music-together-section",
+    "firebase-maple-functions-get-music-together-roster",
     "firebase-integration-test-utils",
     "firebase-square-test-mock-server"
   ],

--- a/apps/functions-integration-tests-music-together/src/music-together-admin.spec.ts
+++ b/apps/functions-integration-tests-music-together/src/music-together-admin.spec.ts
@@ -1,0 +1,251 @@
+/**
+ * Integration tests for the MT admin functions (maple-core, no Square):
+ * section CRUD (get/create/update) and the roster read. Exercises auth guards,
+ * validation, the create→read round-trip, and roster grouping + past-due.
+ */
+import {
+  createTestUser,
+  clearAuthEmulator,
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  callFunction,
+  ADMIN_USER,
+  NON_ADMIN_USER,
+} from '@maple/firebase/integration-test-utils';
+import type { TestUser } from '@maple/firebase/integration-test-utils';
+import type {
+  CreateMusicTogetherSectionRequest,
+  CreateMusicTogetherSectionResponse,
+  GetMusicTogetherSectionsResponse,
+  UpdateMusicTogetherSectionResponse,
+  GetMusicTogetherRosterRequest,
+  GetMusicTogetherRosterResponse,
+} from '@maple/ts/firebase/api-types';
+
+const week1 = new Date(Date.now() + 7 * 86_400_000);
+const week5 = new Date(Date.now() + 35 * 86_400_000);
+
+function createInput(
+  overrides: Partial<CreateMusicTogetherSectionRequest> = {}
+): CreateMusicTogetherSectionRequest {
+  return {
+    name: 'Created Section',
+    sessions: [{ dateTime: week1 }],
+    capacityFamilies: 8,
+    priceFullCents: 25200,
+    installmentPlan: [
+      { amountCents: 13200, dueAt: week1 },
+      { amountCents: 13200, dueAt: week5 },
+    ],
+    status: 'open',
+    ...overrides,
+  };
+}
+
+describe('MT section admin CRUD', () => {
+  let admin: TestUser;
+  let nonAdmin: TestUser;
+
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+    admin = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
+    nonAdmin = await createTestUser(
+      NON_ADMIN_USER.email,
+      NON_ADMIN_USER.password
+    );
+    await setFirestoreDoc('admins', admin.uid, {
+      userId: admin.uid,
+      email: admin.email,
+    });
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  let createdId: string;
+
+  it('creates a section (admin), round-trips through the list', async () => {
+    const created = await callFunction<
+      CreateMusicTogetherSectionRequest,
+      CreateMusicTogetherSectionResponse
+    >({
+      functionName: 'createMusicTogetherSection',
+      data: createInput(),
+      idToken: admin.idToken,
+    });
+
+    expect(created.status).toBe(200);
+    expect(created.data?.section.id).toBeDefined();
+    expect(created.data?.section.name).toBe('Created Section');
+    createdId = created.data!.section.id;
+
+    const list = await callFunction<
+      Record<string, never>,
+      GetMusicTogetherSectionsResponse
+    >({
+      functionName: 'getMusicTogetherSections',
+      data: {},
+      idToken: admin.idToken,
+    });
+    expect(list.status).toBe(200);
+    expect(list.data?.sections.some((s) => s.id === createdId)).toBe(true);
+  });
+
+  it('updates a section (admin)', async () => {
+    const updated = await callFunction<
+      { id: string; name: string },
+      UpdateMusicTogetherSectionResponse
+    >({
+      functionName: 'updateMusicTogetherSection',
+      data: { id: createdId, name: 'Renamed Section' },
+      idToken: admin.idToken,
+    });
+    expect(updated.status).toBe(200);
+    expect(updated.data?.section.name).toBe('Renamed Section');
+  });
+
+  it('rejects create for a non-admin', async () => {
+    const result = await callFunction<CreateMusicTogetherSectionRequest>({
+      functionName: 'createMusicTogetherSection',
+      data: createInput(),
+      idToken: nonAdmin.idToken,
+    });
+    expect(result.status).not.toBe(200);
+  });
+
+  it('rejects create for an unauthenticated caller', async () => {
+    const result = await callFunction<CreateMusicTogetherSectionRequest>({
+      functionName: 'createMusicTogetherSection',
+      data: createInput(),
+    });
+    expect(result.status).not.toBe(200);
+  });
+
+  it('rejects an invalid section (blank name)', async () => {
+    const result = await callFunction<CreateMusicTogetherSectionRequest>({
+      functionName: 'createMusicTogetherSection',
+      data: createInput({ name: '' }),
+      idToken: admin.idToken,
+    });
+    expect(result.status).not.toBe(200);
+  });
+
+  it('404s an update to an unknown section', async () => {
+    const result = await callFunction<{ id: string; name: string }>({
+      functionName: 'updateMusicTogetherSection',
+      data: { id: 'does-not-exist', name: 'X' },
+      idToken: admin.idToken,
+    });
+    expect(result.status).not.toBe(200);
+  });
+});
+
+describe('getMusicTogetherRoster', () => {
+  let admin: TestUser;
+  let nonAdmin: TestUser;
+
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+    admin = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
+    nonAdmin = await createTestUser(
+      NON_ADMIN_USER.email,
+      NON_ADMIN_USER.password
+    );
+    await setFirestoreDoc('admins', admin.uid, {
+      userId: admin.uid,
+      email: admin.email,
+    });
+
+    await setFirestoreDoc('musicTogetherSections', 'sec-roster', {
+      name: 'Roster Section',
+      sessions: [{ dateTime: week1 }],
+      capacityFamilies: 8,
+      priceFullCents: 25200,
+      status: 'open',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    // Two families; one has a failed scheduled charge → past due.
+    for (const [id, email] of [
+      ['reg-a', 'a@test.com'],
+      ['reg-b', 'b@test.com'],
+    ]) {
+      await setFirestoreDoc('musicTogetherRegistrations', id, {
+        sectionId: 'sec-roster',
+        parentNames: ['Fam ' + id],
+        children: [{ name: 'Kid', dob: new Date('2023-01-01') }],
+        email,
+        phone: '1',
+        address: 'a',
+        paymentPlan: 'installments',
+        policiesAcceptedAt: new Date(),
+        pricePaidCents: 13200,
+        status: 'confirmed',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+    }
+    await setFirestoreDoc('musicTogetherScheduledCharges', 'chg-failed', {
+      registrationId: 'reg-b',
+      sectionId: 'sec-roster',
+      installmentNumber: 2,
+      amountCents: 13200,
+      dueAt: week5,
+      status: 'failed',
+      lastError: 'card declined',
+      idempotencyKey: 'mt-charge-b',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  it('returns the roster with grouped charges + past-due flag (admin)', async () => {
+    const result = await callFunction<
+      GetMusicTogetherRosterRequest,
+      GetMusicTogetherRosterResponse
+    >({
+      functionName: 'getMusicTogetherRoster',
+      data: { sectionId: 'sec-roster' },
+      idToken: admin.idToken,
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data?.entries).toHaveLength(2);
+    const regB = result.data!.entries.find(
+      (e) => e.registration.id === 'reg-b'
+    )!;
+    const regA = result.data!.entries.find(
+      (e) => e.registration.id === 'reg-a'
+    )!;
+    expect(regB.pastDue).toBe(true);
+    expect(regB.charges).toHaveLength(1);
+    expect(regA.pastDue).toBe(false);
+  });
+
+  it('rejects a non-admin caller', async () => {
+    const result = await callFunction<GetMusicTogetherRosterRequest>({
+      functionName: 'getMusicTogetherRoster',
+      data: { sectionId: 'sec-roster' },
+      idToken: nonAdmin.idToken,
+    });
+    expect(result.status).not.toBe(200);
+  });
+
+  it('404s an unknown section', async () => {
+    const result = await callFunction<GetMusicTogetherRosterRequest>({
+      functionName: 'getMusicTogetherRoster',
+      data: { sectionId: 'nope' },
+      idToken: admin.idToken,
+    });
+    expect(result.status).not.toBe(200);
+  });
+});

--- a/apps/functions-integration-tests-music-together/src/public-music-together.spec.ts
+++ b/apps/functions-integration-tests-music-together/src/public-music-together.spec.ts
@@ -1,0 +1,195 @@
+/**
+ * Integration tests for the public MT read + waitlist functions
+ * (getPublicMusicTogetherSection, addToMusicTogetherWaitlist — maple-core,
+ * no auth). Runs the real functions in the emulator; no Square involved.
+ */
+import {
+  clearAuthEmulator,
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  getFirestoreDoc,
+  callFunction,
+} from '@maple/firebase/integration-test-utils';
+import type {
+  GetPublicMusicTogetherSectionRequest,
+  GetPublicMusicTogetherSectionResponse,
+  AddToMusicTogetherWaitlistRequest,
+  AddToMusicTogetherWaitlistResponse,
+} from '@maple/ts/firebase/api-types';
+
+const week1 = new Date(Date.now() + 7 * 86_400_000);
+const week5 = new Date(Date.now() + 35 * 86_400_000);
+
+function sectionDoc(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'Public Section',
+    sessions: [{ dateTime: week1 }],
+    capacityFamilies: 8,
+    priceFullCents: 25200,
+    installmentPlan: [
+      { amountCents: 13200, dueAt: week1 },
+      { amountCents: 13200, dueAt: week5 },
+    ],
+    status: 'open',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function confirmedReg(sectionId: string, email: string) {
+  return {
+    sectionId,
+    parentNames: ['Family'],
+    children: [{ name: 'Kid', dob: new Date('2023-01-01') }],
+    email,
+    phone: '1',
+    address: 'a',
+    paymentPlan: 'full',
+    policiesAcceptedAt: new Date(),
+    pricePaidCents: 25200,
+    status: 'confirmed',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+describe('getPublicMusicTogetherSection', () => {
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+    await setFirestoreDoc('musicTogetherSections', 'sec-pub', sectionDoc());
+    await setFirestoreDoc(
+      'musicTogetherSections',
+      'sec-pub-draft',
+      sectionDoc({ status: 'draft' })
+    );
+    // two confirmed families → 6 of 8 spots remaining
+    await setFirestoreDoc(
+      'musicTogetherRegistrations',
+      'pub-reg-1',
+      confirmedReg('sec-pub', 'a@test.com')
+    );
+    await setFirestoreDoc(
+      'musicTogetherRegistrations',
+      'pub-reg-2',
+      confirmedReg('sec-pub', 'b@test.com')
+    );
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  it('returns the public projection with computed spotsRemaining + ISO dates', async () => {
+    const result = await callFunction<
+      GetPublicMusicTogetherSectionRequest,
+      GetPublicMusicTogetherSectionResponse
+    >({
+      functionName: 'getPublicMusicTogetherSection',
+      data: { sectionId: 'sec-pub' },
+    });
+
+    expect(result.status).toBe(200);
+    const section = result.data!.section;
+    expect(section.id).toBe('sec-pub');
+    expect(section.priceFullCents).toBe(25200);
+    expect(section.spotsRemaining).toBe(6); // 8 - 2 confirmed
+    expect(section.installmentPlan).toHaveLength(2);
+    expect(typeof section.sessions[0].dateTime).toBe('string'); // serialized ISO
+  });
+
+  it('hides draft sections', async () => {
+    const result = await callFunction<GetPublicMusicTogetherSectionRequest>({
+      functionName: 'getPublicMusicTogetherSection',
+      data: { sectionId: 'sec-pub-draft' },
+    });
+    expect(result.status).not.toBe(200);
+  });
+
+  it('404s an unknown section', async () => {
+    const result = await callFunction<GetPublicMusicTogetherSectionRequest>({
+      functionName: 'getPublicMusicTogetherSection',
+      data: { sectionId: 'nope' },
+    });
+    expect(result.status).not.toBe(200);
+  });
+});
+
+describe('addToMusicTogetherWaitlist', () => {
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+    await setFirestoreDoc(
+      'musicTogetherSections',
+      'sec-wl',
+      sectionDoc({ status: 'closed' })
+    );
+    await setFirestoreDoc(
+      'musicTogetherSections',
+      'sec-wl-draft',
+      sectionDoc({ status: 'draft' })
+    );
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  it('adds a family and persists the waitlist entry', async () => {
+    const result = await callFunction<
+      AddToMusicTogetherWaitlistRequest,
+      AddToMusicTogetherWaitlistResponse
+    >({
+      functionName: 'addToMusicTogetherWaitlist',
+      data: {
+        sectionId: 'sec-wl',
+        name: 'Wait Family',
+        email: 'Wait@test.com',
+        availability: 'Tuesday mornings',
+      },
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data?.added).toBe(true);
+
+    // stored under the section's waitlist subcollection, keyed by lowercased email
+    const entry = await getFirestoreDoc(
+      'musicTogetherSections/sec-wl/waitlist',
+      'wait@test.com'
+    );
+    expect(entry).not.toBeNull();
+    expect(entry?.name).toBe('Wait Family');
+    expect(entry?.availability).toBe('Tuesday mornings');
+  });
+
+  it('is idempotent — a repeat email reports added=false', async () => {
+    const result = await callFunction<
+      AddToMusicTogetherWaitlistRequest,
+      AddToMusicTogetherWaitlistResponse
+    >({
+      functionName: 'addToMusicTogetherWaitlist',
+      data: { sectionId: 'sec-wl', name: 'Wait Family', email: 'wait@test.com' },
+    });
+    expect(result.status).toBe(200);
+    expect(result.data?.added).toBe(false);
+  });
+
+  it('rejects a draft section', async () => {
+    const result = await callFunction<AddToMusicTogetherWaitlistRequest>({
+      functionName: 'addToMusicTogetherWaitlist',
+      data: { sectionId: 'sec-wl-draft', name: 'X', email: 'x@test.com' },
+    });
+    expect(result.status).not.toBe(200);
+  });
+
+  it('rejects an invalid email', async () => {
+    const result = await callFunction<AddToMusicTogetherWaitlistRequest>({
+      functionName: 'addToMusicTogetherWaitlist',
+      data: { sectionId: 'sec-wl', name: 'X', email: 'not-an-email' },
+    });
+    expect(result.status).not.toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
Rounds out the MT integration suite to the **full function surface**. The payment functions were covered in #544; this adds the maple-core read/admin functions (served by the same emulator run — no new suite).

## Added coverage
- **`getPublicMusicTogetherSection`** — public projection + computed `spotsRemaining` + ISO-serialized dates; draft hidden; 404.
- **`addToMusicTogetherWaitlist`** — adds + **persists the section subcollection entry**; idempotent repeat; draft rejected; invalid email rejected.
- **Section CRUD** — `createMusicTogetherSection` (admin) → `getMusicTogetherSections` round-trip (confirms the **ISO-string date round-trip** through Firestore); `updateMusicTogetherSection`; auth + validation + 404 guards.
- **`getMusicTogetherRoster`** — grouped charges + past-due flag; admin guard; 404.

Added the maple-core MT function projects to the suite's `implicitDependencies` so `--affected` selects it when they change.

## Verification
- [x] **Ran locally: 5 files, 31 tests, all pass.** Both flagged edges (create→read date round-trip, subcollection waitlist read) behave correctly against real Firestore.

Refs #508