### PR TITLE
feat(music-together): public registration Code Component for Webflow (#508)

### DIFF
--- a/apps/webflow-components/src/MusicTogetherRegistrationWidget.spec.tsx
+++ b/apps/webflow-components/src/MusicTogetherRegistrationWidget.spec.tsx
@@ -1,0 +1,254 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  fireEvent,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useEffect } from 'react';
+import type { PublicMusicTogetherSection } from '@maple/ts/firebase/api-types';
+
+// Canned section returned by getPublicMusicTogetherSection for the next render.
+let nextSection: PublicMusicTogetherSection = makeSection();
+// Records the last payload sent to each callable, by name.
+const calls: Record<string, unknown> = {};
+
+function makeSection(
+  overrides: Partial<PublicMusicTogetherSection> = {}
+): PublicMusicTogetherSection {
+  return {
+    id: 'sec-thu',
+    name: 'Thursday Morning — Mixed Age (0–5)',
+    sessions: [{ dateTime: '2026-09-10T14:00:00.000Z' }],
+    priceFullCents: 25200,
+    installmentPlan: [
+      { amountCents: 13200, dueAt: '2026-09-10T14:00:00.000Z' },
+      { amountCents: 13200, dueAt: '2026-10-08T14:00:00.000Z' },
+    ],
+    capacityFamilies: 8,
+    spotsRemaining: 5,
+    status: 'open',
+    ...overrides,
+  };
+}
+
+vi.mock('./firebase-init', () => ({
+  getWidgetFunctions: () => ({ __mock: true }),
+}));
+
+vi.mock('./lib/warmup', () => ({ warmup: vi.fn() }));
+
+vi.mock('firebase/functions', () => ({
+  httpsCallable:
+    (_fns: unknown, name: string) => (payload: unknown) => {
+      calls[name] = payload;
+      if (name === 'getPublicMusicTogetherSection') {
+        return Promise.resolve({ data: { section: nextSection } });
+      }
+      if (name === 'createMusicTogetherRegistration') {
+        const plan = (payload as { paymentPlan: string }).paymentPlan;
+        return Promise.resolve({
+          data: {
+            registrationId: 'reg-1',
+            status: 'confirmed',
+            amountChargedCents: plan === 'installments' ? 13200 : 25200,
+            scheduledChargeCount: plan === 'installments' ? 1 : 0,
+            cardLast4: plan === 'installments' ? '4242' : undefined,
+          },
+        });
+      }
+      if (name === 'addToMusicTogetherWaitlist') {
+        return Promise.resolve({ data: { added: true } });
+      }
+      return Promise.resolve({ data: {} });
+    },
+}));
+
+// Stub the Square card form: immediately ready with a fake tokenizer, and
+// render the submit button passed via afterCardContent.
+vi.mock('@maple/react/registrations', () => ({
+  SquareCardForm: ({
+    onReady,
+    onTokenizeRef,
+    afterCardContent,
+  }: {
+    onReady?: () => void;
+    onTokenizeRef: (fn: () => Promise<string>) => void;
+    afterCardContent?: React.ReactNode;
+  }) => {
+    useEffect(() => {
+      onTokenizeRef(async () => 'cnon:test-nonce');
+      onReady?.();
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return <div data-testid="mock-card-form">{afterCardContent}</div>;
+  },
+}));
+
+import { MusicTogetherRegistrationWidget } from './MusicTogetherRegistrationWidget';
+
+function renderWidget() {
+  return render(
+    <MusicTogetherRegistrationWidget
+      sectionId="sec-thu"
+      squareAppId="sandbox-app"
+      squareLocationId="LOC1"
+      env="dev"
+      policiesUrl="https://example.com/music-together/policies"
+    />
+  );
+}
+
+/** Fill every required family field so the Register button can enable. */
+async function fillFamily(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText(/^Name/i), 'Jane Doe');
+  await user.type(screen.getByLabelText(/Child's name/i), 'Baby Doe');
+  fireEvent.change(screen.getByLabelText(/Date of birth/i), {
+    target: { value: '2024-03-15' },
+  });
+  await user.type(screen.getByLabelText(/^Email/i), 'jane@example.com');
+  await user.type(screen.getByLabelText(/^Phone/i), '304-555-0100');
+  await user.type(screen.getByLabelText(/Mailing address/i), '1 Main St');
+}
+
+describe('MusicTogetherRegistrationWidget', () => {
+  beforeEach(() => {
+    nextSection = makeSection();
+    for (const k of Object.keys(calls)) delete calls[k];
+  });
+  afterEach(() => cleanup());
+
+  it('registers a family paying in full', async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    // Section header renders once loaded.
+    expect(
+      await screen.findByText(/Register — Thursday Morning/i)
+    ).toBeInTheDocument();
+
+    await fillFamily(user);
+    // Accept the policies (required).
+    await user.click(screen.getByRole('checkbox'));
+
+    const registerBtn = await screen.findByRole('button', {
+      name: /Register — \$252\.00/i,
+    });
+    await waitFor(() => expect(registerBtn).toBeEnabled());
+    await user.click(registerBtn);
+
+    expect(await screen.findByText(/You're registered!/i)).toBeInTheDocument();
+    expect(screen.getByText(/\$252\.00 paid today/i)).toBeInTheDocument();
+
+    expect(calls['createMusicTogetherRegistration']).toMatchObject({
+      sectionId: 'sec-thu',
+      parentNames: ['Jane Doe'],
+      email: 'jane@example.com',
+      phone: '304-555-0100',
+      address: '1 Main St',
+      paymentPlan: 'full',
+      policiesAccepted: true,
+      paymentNonce: 'cnon:test-nonce',
+    });
+    const payload = calls['createMusicTogetherRegistration'] as {
+      children: { name: string; dob: string }[];
+    };
+    expect(payload.children).toHaveLength(1);
+    expect(payload.children[0].name).toBe('Baby Doe');
+    expect(payload.children[0].dob).toMatch(/^2024-03-15/);
+  });
+
+  it('requires card-on-file authorization for the installment plan', async () => {
+    const user = userEvent.setup();
+    renderWidget();
+    await screen.findByText(/Register — Thursday Morning/i);
+    await fillFamily(user);
+    await user.click(screen.getByLabelText(/I have read and agree/i));
+
+    // Switch to the two-installment plan.
+    await user.click(screen.getByRole('radio', { name: /Two installments/i }));
+
+    const registerBtn = screen.getByRole('button', {
+      name: /Register — \$132\.00/i,
+    });
+    // Still disabled — the card-on-file authorization hasn't been given.
+    expect(registerBtn).toBeDisabled();
+
+    await user.click(screen.getByLabelText(/I authorize Music Together/i));
+    await waitFor(() => expect(registerBtn).toBeEnabled());
+    await user.click(registerBtn);
+
+    expect(await screen.findByText(/You're registered!/i)).toBeInTheDocument();
+    // Confirmation surfaces the scheduled second installment.
+    expect(screen.getByText(/\$132\.00 paid today/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/automatically charged for your remaining installment/i)
+    ).toBeInTheDocument();
+
+    expect(calls['createMusicTogetherRegistration']).toMatchObject({
+      paymentPlan: 'installments',
+      cardOnFileAuth: true,
+    });
+  });
+
+  it('keeps Register disabled until the policies are accepted', async () => {
+    const user = userEvent.setup();
+    renderWidget();
+    await screen.findByText(/Register — Thursday Morning/i);
+    await fillFamily(user);
+
+    const registerBtn = screen.getByRole('button', {
+      name: /Register — \$252\.00/i,
+    });
+    expect(registerBtn).toBeDisabled();
+
+    await user.click(screen.getByRole('checkbox'));
+    await waitFor(() => expect(registerBtn).toBeEnabled());
+  });
+
+  it('supports adding a second child', async () => {
+    const user = userEvent.setup();
+    renderWidget();
+    await screen.findByText(/Register — Thursday Morning/i);
+
+    await user.click(
+      screen.getByRole('button', { name: /Add another child/i })
+    );
+    const nameInputs = screen.getAllByLabelText(/Child's name/i);
+    expect(nameInputs).toHaveLength(2);
+  });
+
+  it('shows the waitlist when the section is full', async () => {
+    nextSection = makeSection({ spotsRemaining: 0 });
+    const user = userEvent.setup();
+    renderWidget();
+
+    expect(
+      await screen.findByText(/is full \(8 families\)/i)
+    ).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(/Your name/i), 'Wait Family');
+    await user.type(screen.getByLabelText(/^Email/i), 'wait@example.com');
+    await user.type(
+      screen.getByLabelText(/What days and times/i),
+      'weekday mornings'
+    );
+    await user.click(
+      screen.getByRole('button', { name: /Join the waitlist/i })
+    );
+
+    expect(
+      await screen.findByText(/You're on the waitlist/i)
+    ).toBeInTheDocument();
+    expect(calls['addToMusicTogetherWaitlist']).toMatchObject({
+      sectionId: 'sec-thu',
+      name: 'Wait Family',
+      email: 'wait@example.com',
+      availability: 'weekday mornings',
+    });
+  });
+});

--- a/apps/webflow-components/src/MusicTogetherRegistrationWidget.tsx
+++ b/apps/webflow-components/src/MusicTogetherRegistrationWidget.tsx
@@ -1,0 +1,730 @@
+/**
+ * Music Together Registration Widget — self-contained family enrollment +
+ * payment component for embedding in Webflow via Code Components.
+ *
+ * Loads a single MT section by `sectionId`, collects the family's details
+ * (parent name(s), child name(s) + DOB, contact, mailing address), lets the
+ * family pick pay-in-full or the two-installment plan, takes the Square card
+ * nonce, and calls `createMusicTogetherRegistration`. When the section is at
+ * capacity it swaps to a waitlist form instead.
+ *
+ * No Next.js dependencies — Firebase is initialized explicitly from the `env`
+ * prop (see firebase-init.ts). Payment routes to MT's own Square account,
+ * configured via the widget's Square App ID / Location ID props.
+ */
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import {
+  Box,
+  Typography,
+  CircularProgress,
+  Alert,
+  Button,
+  Divider,
+  TextField,
+  Stack,
+  Link,
+  Checkbox,
+  FormControlLabel,
+  FormControl,
+  FormLabel,
+  RadioGroup,
+  Radio,
+  IconButton,
+  ThemeProvider,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import CloseIcon from '@mui/icons-material/Close';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import { httpsCallable } from 'firebase/functions';
+import { theme, fonts } from '@maple/react/theme';
+import { SquareCardForm } from '@maple/react/registrations';
+import type {
+  GetPublicMusicTogetherSectionRequest,
+  GetPublicMusicTogetherSectionResponse,
+  PublicMusicTogetherSection,
+  CreateMusicTogetherRegistrationRequest,
+  CreateMusicTogetherRegistrationResponse,
+  AddToMusicTogetherWaitlistRequest,
+  AddToMusicTogetherWaitlistResponse,
+} from '@maple/ts/firebase/api-types';
+import { getWidgetFunctions } from './firebase-init';
+import { warmup } from './lib/warmup';
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const WIDGET_MAX_WIDTH = 560;
+
+function formatMoney(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+/** Full date + time, e.g. "Thursday, September 10, 2026 at 10:00 AM". */
+function formatSessionDateTime(iso: string): string {
+  return new Date(iso).toLocaleString('en-US', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+/** Short date only, e.g. "October 8, 2026" — used for the installment due date. */
+function formatDueDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+type PaymentPlan = 'full' | 'installments';
+
+interface FamilyChild {
+  name: string;
+  /** ISO date (yyyy-mm-dd) from the native date input, or '' when unset. */
+  dob: string;
+}
+
+type WidgetState =
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'ready'; section: PublicMusicTogetherSection }
+  | {
+      status: 'confirmed';
+      section: PublicMusicTogetherSection;
+      amountChargedCents: number;
+      scheduledChargeCount: number;
+      cardLast4?: string;
+      email: string;
+    };
+
+export interface MusicTogetherRegistrationWidgetProps {
+  /** The MT section (class time) this widget registers for. */
+  sectionId: string;
+  /** Square application ID for MT's account (sandbox or production). */
+  squareAppId: string;
+  /** Square location ID for MT's account. */
+  squareLocationId: string;
+  /** 'dev' | 'prod' | 'emulator' — selects Firebase project + Square SDK. */
+  env: string;
+  /** URL of the public Policies & FAQs page (linked from the consent checkbox). */
+  policiesUrl: string;
+}
+
+/**
+ * Waitlist form shown when a section is full. Captures name + email and the
+ * "what days/times work for you?" answer that feeds the section-expansion call.
+ */
+function WaitlistPanel({
+  section,
+  functions,
+}: {
+  section: PublicMusicTogetherSection;
+  functions: ReturnType<typeof getWidgetFunctions>;
+}) {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [availability, setAvailability] = useState('');
+  const [state, setState] = useState<
+    | { status: 'idle' }
+    | { status: 'submitting' }
+    | { status: 'success'; alreadyOnList: boolean }
+    | { status: 'error'; message: string }
+  >({ status: 'idle' });
+
+  const emailValid = EMAIL_RE.test(email.trim());
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || !emailValid) {
+      setState({
+        status: 'error',
+        message: 'Please enter your name and a valid email.',
+      });
+      return;
+    }
+    setState({ status: 'submitting' });
+    try {
+      const call = httpsCallable<
+        AddToMusicTogetherWaitlistRequest,
+        AddToMusicTogetherWaitlistResponse
+      >(functions, 'addToMusicTogetherWaitlist');
+      const result = await call({
+        sectionId: section.id,
+        name: name.trim(),
+        email: email.trim(),
+        availability: availability.trim() || undefined,
+      });
+      setState({ status: 'success', alreadyOnList: !result.data.added });
+    } catch (err) {
+      setState({
+        status: 'error',
+        message:
+          err instanceof Error
+            ? err.message
+            : 'Something went wrong. Please try again.',
+      });
+    }
+  };
+
+  if (state.status === 'success') {
+    return (
+      <Alert severity="success">
+        {state.alreadyOnList
+          ? "You're already on the waitlist for this class — we'll email you if a spot opens."
+          : "You're on the waitlist. We'll email you if a spot opens up, and your answer helps us decide whether to add another class time."}
+      </Alert>
+    );
+  }
+
+  return (
+    <Box component="form" onSubmit={handleSubmit}>
+      <Alert severity="info" sx={{ mb: 2 }}>
+        <strong>{section.name}</strong> is full ({section.capacityFamilies}{' '}
+        families). Join the waitlist and we&apos;ll be in touch if a spot opens.
+      </Alert>
+      <Stack spacing={2}>
+        <TextField
+          label="Your name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          fullWidth
+        />
+        <TextField
+          label="Email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          fullWidth
+        />
+        <TextField
+          label="What days and times work for you?"
+          value={availability}
+          onChange={(e) => setAvailability(e.target.value)}
+          placeholder="e.g. weekday mornings, Saturday late morning"
+          fullWidth
+          multiline
+          minRows={2}
+        />
+        {state.status === 'error' && (
+          <Alert severity="error">{state.message}</Alert>
+        )}
+        <Button
+          type="submit"
+          variant="contained"
+          disabled={state.status === 'submitting'}
+        >
+          {state.status === 'submitting' ? 'Joining…' : 'Join the waitlist'}
+        </Button>
+      </Stack>
+    </Box>
+  );
+}
+
+export function MusicTogetherRegistrationWidget({
+  sectionId,
+  squareAppId,
+  squareLocationId,
+  env,
+  policiesUrl,
+}: MusicTogetherRegistrationWidgetProps) {
+  const functions = useMemo(() => getWidgetFunctions(env), [env]);
+  const [state, setState] = useState<WidgetState>({ status: 'loading' });
+
+  // Family form state
+  const [parentNames, setParentNames] = useState<string[]>(['']);
+  const [children, setChildren] = useState<FamilyChild[]>([
+    { name: '', dob: '' },
+  ]);
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [address, setAddress] = useState('');
+  const [paymentPlan, setPaymentPlan] = useState<PaymentPlan>('full');
+  const [policiesAccepted, setPoliciesAccepted] = useState(false);
+  const [cardOnFileAuth, setCardOnFileAuth] = useState(false);
+
+  const [busy, setBusy] = useState(false);
+  const [payError, setPayError] = useState<string | null>(null);
+  const [cardReady, setCardReady] = useState(false);
+  const tokenizeRef = useRef<(() => Promise<string>) | null>(null);
+
+  // Load the section on mount
+  useEffect(() => {
+    if (!sectionId) {
+      setState({ status: 'error', message: 'No section ID provided.' });
+      return;
+    }
+    // Warm the create function — the family will submit shortly after filling
+    // out the form, by which point the container is up.
+    warmup(functions, 'createMusicTogetherRegistration');
+
+    const load = async () => {
+      setState({ status: 'loading' });
+      try {
+        const call = httpsCallable<
+          GetPublicMusicTogetherSectionRequest,
+          GetPublicMusicTogetherSectionResponse
+        >(functions, 'getPublicMusicTogetherSection');
+        const result = await call({ sectionId });
+        setState({ status: 'ready', section: result.data.section });
+      } catch (err) {
+        console.error('Failed to load section:', err);
+        setState({
+          status: 'error',
+          message:
+            'Unable to load this class right now. Please refresh and try again.',
+        });
+      }
+    };
+    load();
+  }, [sectionId, functions]);
+
+  const section = state.status === 'ready' ? state.section : null;
+
+  // Two-installment plan is offered only when the section defines 2+ installments.
+  const installments = section?.installmentPlan ?? [];
+  const offersInstallments = installments.length >= 2;
+  const firstInstallment = installments[0];
+  const secondInstallment = installments[1];
+
+  // Amount charged at registration: full price, or the first installment.
+  const amountNowCents =
+    section == null
+      ? 0
+      : paymentPlan === 'installments' && firstInstallment
+        ? firstInstallment.amountCents
+        : section.priceFullCents;
+
+  // Trimmed / cleaned form values
+  const cleanParents = parentNames.map((n) => n.trim()).filter(Boolean);
+  const cleanChildren = children
+    .map((c) => ({ name: c.name.trim(), dob: c.dob }))
+    .filter((c) => c.name && c.dob);
+  const emailValid = EMAIL_RE.test(email.trim());
+
+  const formValid =
+    cleanParents.length > 0 &&
+    cleanChildren.length > 0 &&
+    emailValid &&
+    phone.trim().length > 0 &&
+    address.trim().length > 0 &&
+    policiesAccepted &&
+    (paymentPlan === 'full' || cardOnFileAuth);
+
+  const payDisabled = busy || !cardReady || !formValid;
+
+  const addParent = () => setParentNames((p) => [...p, '']);
+  const removeParent = (i: number) =>
+    setParentNames((p) => (p.length > 1 ? p.filter((_, idx) => idx !== i) : p));
+  const setParent = (i: number, value: string) =>
+    setParentNames((p) => p.map((n, idx) => (idx === i ? value : n)));
+
+  const addChild = () =>
+    setChildren((c) => [...c, { name: '', dob: '' }]);
+  const removeChild = (i: number) =>
+    setChildren((c) => (c.length > 1 ? c.filter((_, idx) => idx !== i) : c));
+  const setChild = (i: number, patch: Partial<FamilyChild>) =>
+    setChildren((c) => c.map((ch, idx) => (idx === i ? { ...ch, ...patch } : ch)));
+
+  const handlePay = useCallback(async () => {
+    if (!tokenizeRef.current || section == null) return;
+    setPayError(null);
+    setBusy(true);
+    try {
+      const nonce = await tokenizeRef.current();
+      const call = httpsCallable<
+        CreateMusicTogetherRegistrationRequest,
+        CreateMusicTogetherRegistrationResponse
+      >(functions, 'createMusicTogetherRegistration');
+      const result = await call({
+        sectionId: section.id,
+        parentNames: cleanParents,
+        children: cleanChildren.map((c) => ({
+          name: c.name,
+          // Native date input is yyyy-mm-dd (local); send as an ISO date the
+          // server parses. Anchor to midday UTC so it doesn't slip a day.
+          dob: new Date(`${c.dob}T12:00:00Z`).toISOString(),
+        })),
+        email: email.trim(),
+        phone: phone.trim(),
+        address: address.trim(),
+        paymentPlan,
+        policiesAccepted,
+        cardOnFileAuth: paymentPlan === 'installments' ? cardOnFileAuth : undefined,
+        paymentNonce: nonce,
+      });
+      setState({
+        status: 'confirmed',
+        section,
+        amountChargedCents: result.data.amountChargedCents,
+        scheduledChargeCount: result.data.scheduledChargeCount,
+        cardLast4: result.data.cardLast4,
+        email: email.trim(),
+      });
+    } catch (err) {
+      setPayError(
+        err instanceof Error
+          ? err.message
+          : 'We could not complete your registration. Please try again.'
+      );
+    } finally {
+      setBusy(false);
+    }
+  }, [
+    functions,
+    section,
+    cleanParents,
+    cleanChildren,
+    email,
+    phone,
+    address,
+    paymentPlan,
+    policiesAccepted,
+    cardOnFileAuth,
+  ]);
+
+  return (
+    <ThemeProvider theme={theme}>
+      <Box sx={{ maxWidth: WIDGET_MAX_WIDTH, mx: 'auto', width: '100%' }}>
+        {state.status === 'loading' && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+            <CircularProgress />
+          </Box>
+        )}
+
+        {state.status === 'error' && (
+          <Alert severity="error">{state.message}</Alert>
+        )}
+
+        {section && section.spotsRemaining <= 0 && (
+          <WaitlistPanel section={section} functions={functions} />
+        )}
+
+        {section && section.spotsRemaining > 0 && (
+          <Stack spacing={3}>
+            {/* Section summary */}
+            <Box>
+              <Typography variant="h5" component="h2" gutterBottom>
+                Register — {section.name}
+              </Typography>
+              {section.sessions[0] && (
+                <Typography variant="body2" color="text.secondary">
+                  First class: {formatSessionDateTime(section.sessions[0].dateTime)}
+                </Typography>
+              )}
+              <Typography variant="body2" color="text.secondary">
+                {section.spotsRemaining} of {section.capacityFamilies} family
+                spots remaining
+              </Typography>
+            </Box>
+
+            {!squareAppId ? (
+              <Alert severity="warning">
+                Registration isn&apos;t available right now. Please email{' '}
+                <Link href="mailto:musictogether@mapleandsprucefolkarts.com">
+                  musictogether@mapleandsprucefolkarts.com
+                </Link>{' '}
+                to register.
+              </Alert>
+            ) : (
+              <>
+                {payError && <Alert severity="error">{payError}</Alert>}
+
+                {/* Parents / caregivers */}
+                <Box>
+                  <Typography variant="subtitle1" gutterBottom>
+                    Parent / caregiver name(s)
+                  </Typography>
+                  <Stack spacing={1.5}>
+                    {parentNames.map((name, i) => (
+                      <Stack key={i} direction="row" spacing={1} alignItems="center">
+                        <TextField
+                          label={i === 0 ? 'Name' : `Name ${i + 1}`}
+                          value={name}
+                          onChange={(e) => setParent(i, e.target.value)}
+                          required={i === 0}
+                          fullWidth
+                        />
+                        {parentNames.length > 1 && (
+                          <IconButton
+                            aria-label="Remove caregiver"
+                            onClick={() => removeParent(i)}
+                            size="small"
+                          >
+                            <CloseIcon fontSize="small" />
+                          </IconButton>
+                        )}
+                      </Stack>
+                    ))}
+                    <Button
+                      startIcon={<AddIcon />}
+                      onClick={addParent}
+                      size="small"
+                      sx={{ alignSelf: 'flex-start' }}
+                    >
+                      Add another caregiver
+                    </Button>
+                  </Stack>
+                </Box>
+
+                {/* Children */}
+                <Box>
+                  <Typography variant="subtitle1" gutterBottom>
+                    Child / children
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+                    Music Together is for children birth through age 5.
+                  </Typography>
+                  <Stack spacing={2}>
+                    {children.map((child, i) => (
+                      <Stack
+                        key={i}
+                        direction={{ xs: 'column', sm: 'row' }}
+                        spacing={1.5}
+                        alignItems={{ sm: 'center' }}
+                      >
+                        <TextField
+                          label="Child's name"
+                          value={child.name}
+                          onChange={(e) => setChild(i, { name: e.target.value })}
+                          required={i === 0}
+                          fullWidth
+                        />
+                        <TextField
+                          label="Date of birth"
+                          type="date"
+                          value={child.dob}
+                          onChange={(e) => setChild(i, { dob: e.target.value })}
+                          required={i === 0}
+                          fullWidth
+                          InputLabelProps={{ shrink: true }}
+                        />
+                        {children.length > 1 && (
+                          <IconButton
+                            aria-label="Remove child"
+                            onClick={() => removeChild(i)}
+                            size="small"
+                          >
+                            <CloseIcon fontSize="small" />
+                          </IconButton>
+                        )}
+                      </Stack>
+                    ))}
+                    <Button
+                      startIcon={<AddIcon />}
+                      onClick={addChild}
+                      size="small"
+                      sx={{ alignSelf: 'flex-start' }}
+                    >
+                      Add another child
+                    </Button>
+                  </Stack>
+                </Box>
+
+                {/* Contact + address */}
+                <Box>
+                  <Typography variant="subtitle1" gutterBottom>
+                    Contact
+                  </Typography>
+                  <Stack spacing={2}>
+                    <TextField
+                      label="Email"
+                      type="email"
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                      required
+                      fullWidth
+                    />
+                    <TextField
+                      label="Phone"
+                      value={phone}
+                      onChange={(e) => setPhone(e.target.value)}
+                      required
+                      fullWidth
+                    />
+                    <TextField
+                      label="Mailing address"
+                      value={address}
+                      onChange={(e) => setAddress(e.target.value)}
+                      required
+                      fullWidth
+                      multiline
+                      minRows={2}
+                      helperText="Where we should send your Music Together songbook and materials."
+                    />
+                  </Stack>
+                </Box>
+
+                {/* Payment plan */}
+                <FormControl>
+                  <FormLabel sx={{ mb: 1 }}>Tuition</FormLabel>
+                  <RadioGroup
+                    value={paymentPlan}
+                    onChange={(e) => setPaymentPlan(e.target.value as PaymentPlan)}
+                  >
+                    <FormControlLabel
+                      value="full"
+                      control={<Radio />}
+                      label={`Pay in full — ${formatMoney(section.priceFullCents)}`}
+                    />
+                    {offersInstallments && firstInstallment && secondInstallment && (
+                      <FormControlLabel
+                        value="installments"
+                        control={<Radio />}
+                        label={`Two installments — ${formatMoney(
+                          firstInstallment.amountCents
+                        )} now, ${formatMoney(secondInstallment.amountCents)} on ${formatDueDate(
+                          secondInstallment.dueAt
+                        )}`}
+                      />
+                    )}
+                  </RadioGroup>
+                </FormControl>
+
+                {/* Policies consent */}
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={policiesAccepted}
+                      onChange={(e) => setPoliciesAccepted(e.target.checked)}
+                    />
+                  }
+                  label={
+                    <Typography variant="body2">
+                      I have read and agree to the{' '}
+                      <Link href={policiesUrl} target="_blank" rel="noopener">
+                        Policies &amp; FAQs
+                      </Link>
+                      , including the cancellation and refund policy.
+                    </Typography>
+                  }
+                />
+
+                {/* Card-on-file authorization (installments only) */}
+                {paymentPlan === 'installments' &&
+                  secondInstallment && (
+                    <FormControlLabel
+                      control={
+                        <Checkbox
+                          checked={cardOnFileAuth}
+                          onChange={(e) => setCardOnFileAuth(e.target.checked)}
+                        />
+                      }
+                      label={
+                        <Typography variant="body2">
+                          I authorize Music Together at Maple &amp; Spruce to
+                          securely store my card and automatically charge the
+                          second installment of{' '}
+                          <strong>{formatMoney(secondInstallment.amountCents)}</strong>{' '}
+                          on <strong>{formatDueDate(secondInstallment.dueAt)}</strong>.
+                        </Typography>
+                      }
+                    />
+                  )}
+
+                <Divider />
+
+                {/* Payment */}
+                <Box>
+                  <Typography variant="subtitle1" gutterBottom>
+                    Payment — {formatMoney(amountNowCents)} today
+                  </Typography>
+                  <SquareCardForm
+                    applicationId={squareAppId}
+                    locationId={squareLocationId}
+                    env={env}
+                    totalCents={amountNowCents}
+                    maxWidth={WIDGET_MAX_WIDTH}
+                    onReady={() => setCardReady(true)}
+                    onTokenizeRef={(fn) => {
+                      tokenizeRef.current = fn;
+                    }}
+                    afterCardContent={
+                      // Native button with inline brand styling — in Shadow DOM
+                      // this is portaled to the light DOM where MUI's emotion
+                      // theme can't reach it. Mirrors the Craft Club widget.
+                      <button
+                        type="button"
+                        onClick={handlePay}
+                        disabled={payDisabled}
+                        style={{
+                          width: '100%',
+                          padding: '14px 24px',
+                          fontSize: '16px',
+                          fontWeight: 600,
+                          fontFamily: fonts.button,
+                          color: '#D5D6C8',
+                          backgroundColor: payDisabled ? '#8a7b6e' : '#4A3728',
+                          border: 'none',
+                          borderRadius: '8px',
+                          cursor: payDisabled ? 'not-allowed' : 'pointer',
+                          opacity: payDisabled ? 0.7 : 1,
+                          transition: 'background-color 0.2s, opacity 0.2s',
+                          letterSpacing: '0.02em',
+                        }}
+                      >
+                        {busy
+                          ? 'Registering…'
+                          : `Register — ${formatMoney(amountNowCents)}`}
+                      </button>
+                    }
+                  />
+                  {!formValid && (
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ display: 'block', mt: 1 }}
+                    >
+                      Complete the form above and accept the policies to register.
+                    </Typography>
+                  )}
+                </Box>
+              </>
+            )}
+          </Stack>
+        )}
+
+        {state.status === 'confirmed' && (
+          <Stack spacing={2} alignItems="center" sx={{ py: 2, textAlign: 'center' }}>
+            <CheckCircleOutlineIcon color="success" sx={{ fontSize: 48 }} />
+            <Typography variant="h5">You&apos;re registered!</Typography>
+            <Typography variant="body1" color="text.secondary">
+              {state.section.name}
+            </Typography>
+            {state.section.sessions[0] && (
+              <Typography variant="body2" color="text.secondary">
+                First class:{' '}
+                {formatSessionDateTime(state.section.sessions[0].dateTime)}
+              </Typography>
+            )}
+            <Typography variant="body1" fontWeight={500}>
+              {formatMoney(state.amountChargedCents)} paid today
+            </Typography>
+            {state.scheduledChargeCount > 0 && (
+              <Alert severity="info" sx={{ textAlign: 'left' }}>
+                Your card ending{' '}
+                {state.cardLast4 ? `in ${state.cardLast4}` : 'on file'} will be
+                automatically charged for your remaining installment
+                {state.scheduledChargeCount === 1 ? '' : 's'}. No action needed.
+              </Alert>
+            )}
+            <Typography variant="body2" color="text.secondary">
+              A confirmation email has been sent to{' '}
+              <strong>{state.email}</strong>.
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Questions? Email{' '}
+              <Link href="mailto:musictogether@mapleandsprucefolkarts.com">
+                musictogether@mapleandsprucefolkarts.com
+              </Link>{' '}
+              or call (304) 314-4506.
+            </Typography>
+          </Stack>
+        )}
+      </Box>
+    </ThemeProvider>
+  );
+}

--- a/apps/webflow-components/src/music-together-registration.webflow.tsx
+++ b/apps/webflow-components/src/music-together-registration.webflow.tsx
@@ -1,0 +1,42 @@
+/**
+ * Webflow Code Component: Music Together Registration
+ *
+ * Wraps the MusicTogetherRegistrationWidget for use in the Webflow Designer.
+ * Place one per section (Thursday / Saturday), each pointed at its own
+ * Section ID. Payment routes to Music Together's own Square account, set via
+ * the Square App ID / Location ID props (separate from Maple & Spruce's).
+ */
+import { declareComponent } from '@webflow/react';
+import { props } from '@webflow/data-types';
+import { emotionShadowDomDecorator } from '@webflow/emotion-utils';
+import { MusicTogetherRegistrationWidget } from './MusicTogetherRegistrationWidget';
+
+export default declareComponent(MusicTogetherRegistrationWidget, {
+  name: 'Music Together Registration',
+  description:
+    'Family enrollment + payment for a Music Together section. Collects parent/child details, offers pay-in-full or two installments (card-on-file), and shows a waitlist when full. Routes payment to MT’s Square account.',
+  decorators: [emotionShadowDomDecorator],
+  props: {
+    sectionId: props.Text({
+      name: 'Section ID',
+      defaultValue: '',
+    }),
+    squareAppId: props.Text({
+      name: 'Square App ID',
+      defaultValue: '',
+    }),
+    squareLocationId: props.Text({
+      name: 'Square Location ID',
+      defaultValue: '',
+    }),
+    env: props.Variant({
+      name: 'Environment',
+      options: ['dev', 'prod'],
+      defaultValue: 'prod',
+    }),
+    policiesUrl: props.Text({
+      name: 'Policies URL',
+      defaultValue: 'https://mapleandsprucefolkarts.com/music-together/policies',
+    }),
+  },
+});


### PR DESCRIPTION
## Music Together — Phase 3 frontend (registration widget)

Adds the public **Music Together registration** widget as a Webflow Code Component — the "register" half of the `/music-together` landing + registration page. The MT backend (create/charge/cancel, public read, waitlist) is already merged and integration-tested; this is the customer-facing checkout that drives it.

### What it does
- **Loads a section** by `Section ID` via `getPublicMusicTogetherSection` (live `spotsRemaining`, pricing, installment plan).
- **Family form:** parent name(s) + child name(s)/DOB (both dynamically add/remove), email, phone, mailing address.
- **Tuition choice:** pay-in-full (`$252`) or two installments (`$132` now + `$132` on the section's Week-5 due date), driven by the section's configured `installmentPlan`.
- **Consent gating:** a required Policies & FAQs checkbox, plus — for installments only — a card-on-file authorization checkbox that names the exact second-charge amount and date.
- **Payment:** Square Web Payments card form → nonce → `createMusicTogetherRegistration`. Routes to **MT's own Square account** via the widget's Square App/Location ID props (separate creds from M&S).
- **Full section → waitlist:** swaps to a name/email/"what days/times work?" form calling `addToMusicTogetherWaitlist`.
- **Confirmation:** amount paid today, scheduled-installment notice (with card last-4), confirmation-email + contact.

### Files
- `MusicTogetherRegistrationWidget.tsx` — the widget (mirrors `RegistrationWidget` + `CraftClubSignupWidget` card-on-file patterns).
- `music-together-registration.webflow.tsx` — Designer wrapper (Section ID, Square App/Location ID, env, Policies URL).
- `MusicTogetherRegistrationWidget.spec.tsx` — 5 jsdom interaction tests.

### Verification (self-checked locally)
- `tsc --noEmit -p apps/webflow-components/tsconfig.json` — clean.
- `eslint` — 0 errors (3 pre-existing-style warnings; CI allows warnings).
- `vitest apps/webflow-components/` — **45/45** (5 new): full-pay payload incl. DOB→ISO conversion, installment card-on-file gating, policies gating, dynamic child add, waitlist submit.

### Not in this PR (follow-ups)
- The `/music-together` **landing page** in Webflow (content is paste-ready from Stephanie's spec; needs the MT purple licensee logo + MT-supplied photos from the Drive asset bundle, and goes out as a draft pending MT `marketingreview@` approval).
- Publishing the component to the Webflow library + embedding it per section, and the Music → Music Together nav item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)