### PR TITLE
feat(music-together): auto-populate calendar from MT sections + MT feed (#508)

### DIFF
--- a/apps/functions-calendar/src/index.ts
+++ b/apps/functions-calendar/src/index.ts
@@ -18,3 +18,4 @@ export { calendarEventsFeed } from '@maple/firebase/maple-functions/calendar-eve
 export { calendarHoursFeed } from '@maple/firebase/maple-functions/calendar-hours-feed';
 export { calendarAllFeed } from '@maple/firebase/maple-functions/calendar-all-feed';
 export { calendarAdhocProxy } from '@maple/firebase/maple-functions/calendar-adhoc-proxy';
+export { calendarMusicTogetherFeed } from '@maple/firebase/maple-functions/calendar-music-together-feed';

--- a/apps/functions-calendar/tsconfig.app.json
+++ b/apps/functions-calendar/tsconfig.app.json
@@ -12,6 +12,7 @@
     "../../libs/firebase/maple-functions/calendar-hours-feed/**/*.ts",
     "../../libs/firebase/maple-functions/calendar-all-feed/**/*.ts",
     "../../libs/firebase/maple-functions/calendar-adhoc-proxy/**/*.ts",
+    "../../libs/firebase/maple-functions/calendar-music-together-feed/**/*.ts",
     "../../libs/firebase/database/src/**/*.ts",
     "../../libs/firebase/functions/src/**/*.ts",
     "../../libs/ts/calendar/src/**/*.ts",

--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -144,6 +144,7 @@ export { deleteCalendarEvent } from '@maple/firebase/maple-functions/delete-cale
 // Calendar triggers (Firestore)
 export { onClassWrite } from '@maple/firebase/maple-functions/on-class-write';
 export { onLessonWrite } from '@maple/firebase/maple-functions/on-lesson-write';
+export { onMusicTogetherSectionWrite } from '@maple/firebase/maple-functions/on-music-together-section-write';
 
 // Room availability
 export { getRoomSchedule } from '@maple/firebase/maple-functions/get-room-schedule';

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -59,6 +59,7 @@
     "../../libs/firebase/maple-functions/delete-calendar-event/**/*.ts",
     "../../libs/firebase/maple-functions/on-class-write/**/*.ts",
     "../../libs/firebase/maple-functions/on-lesson-write/**/*.ts",
+    "../../libs/firebase/maple-functions/on-music-together-section-write/**/*.ts",
     "../../libs/firebase/maple-functions/get-room-schedule/**/*.ts",
     "../../libs/firebase/maple-functions/get-calendar-embed-config/**/*.ts",
     "../../libs/firebase/maple-functions/update-calendar-embed-config/**/*.ts",

--- a/docs/reference/deployed-functions.md
+++ b/docs/reference/deployed-functions.md
@@ -57,6 +57,7 @@ Core CRUD operations, auth, triggers, and admin functions. No heavy third-party 
 ### Calendar Triggers
 - `onClassWrite` — Firestore trigger: auto-generates CalendarEvents from published classes
 - `onLessonWrite` — Firestore trigger: auto-generates a private (`public: false`) Spruce Room CalendarEvent per scheduled lesson; removes it on cancel/delete
+- `onMusicTogetherSectionWrite` — Firestore trigger: auto-generates a public `musictogether` CalendarEvent per session of a live (`open`/`closed`) MT section; reconciles on edit and removes on draft/completed/delete
 
 ### Room Availability (#467)
 - `getRoomSchedule` — admin-only: busy windows for a room over a time range (powers the dashboard "Spruce Room" widget and booking conflict checks)
@@ -121,6 +122,7 @@ ICS feed generation. Isolates `ical-generator` and `@touch4it/ical-timezones`.
 - `calendarHoursFeed` — HTTP: `/calendar/hours.ics` _(concurrency: 80)_
 - `calendarAllFeed` — HTTP: `/calendar/all.ics` _(concurrency: 80)_
 - `calendarAdhocProxy` — HTTP: `/calendar/adhoc.ics` _(concurrency: 80)_
+- `calendarMusicTogetherFeed` — HTTP: `/calendar/musictogether.ics` — public Music Together events feed _(concurrency: 80; CDN-cached 5min)_
 
 ---
 

--- a/firebase.json
+++ b/firebase.json
@@ -55,6 +55,7 @@
         { "source": "/calendar/hours.ics", "function": "calendarHoursFeed" },
         { "source": "/calendar/all.ics", "function": "calendarAllFeed" },
         { "source": "/calendar/adhoc.ics", "function": "calendarAdhocProxy" },
+        { "source": "/calendar/musictogether.ics", "function": "calendarMusicTogetherFeed" },
         { "source": "/calendar/embed", "function": "calendarEmbed" },
         { "source": "/catalog/classes.xml", "function": "classCatalogFeed" }
       ]

--- a/function-codebases.json
+++ b/function-codebases.json
@@ -12,6 +12,7 @@
     "firebase-maple-functions-calendar-hours-feed": "maple-calendar",
     "firebase-maple-functions-calendar-all-feed": "maple-calendar",
     "firebase-maple-functions-calendar-adhoc-proxy": "maple-calendar",
+    "firebase-maple-functions-calendar-music-together-feed": "maple-calendar",
     "firebase-maple-functions-create-product": "maple-square",
     "firebase-maple-functions-update-product": "maple-square",
     "firebase-maple-functions-upload-product-image": "maple-square",

--- a/libs/firebase/maple-functions/calendar-music-together-feed/project.json
+++ b/libs/firebase/maple-functions/calendar-music-together-feed/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-calendar-music-together-feed",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/calendar-music-together-feed/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/calendar-music-together-feed/src/index.ts
+++ b/libs/firebase/maple-functions/calendar-music-together-feed/src/index.ts
@@ -1,0 +1,1 @@
+export { calendarMusicTogetherFeed } from './lib/calendar-music-together-feed';

--- a/libs/firebase/maple-functions/calendar-music-together-feed/src/lib/calendar-music-together-feed.spec.ts
+++ b/libs/firebase/maple-functions/calendar-music-together-feed/src/lib/calendar-music-together-feed.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findPublicByType: vi.fn(),
+  generateIcsFeed: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  CalendarEventRepository: { findPublicByType: mocks.findPublicByType },
+}));
+
+vi.mock('@maple/ts/calendar', () => ({
+  generateIcsFeed: mocks.generateIcsFeed,
+  ICS_FEED_HEADERS: { 'Content-Type': 'text/calendar; charset=utf-8' },
+}));
+
+// Unwrap the onRequest handler so it can be invoked with a plain req/res.
+vi.mock('firebase-functions/v2/https', () => ({
+  onRequest: vi.fn((_config, handler) => handler),
+}));
+
+import { calendarMusicTogetherFeed } from './calendar-music-together-feed';
+
+const handler = calendarMusicTogetherFeed as unknown as (
+  req: unknown,
+  res: unknown
+) => Promise<void>;
+
+function makeRes() {
+  return {
+    statusCode: 0,
+    body: undefined as unknown,
+    headers: {} as Record<string, string>,
+    setHeader(k: string, v: string) {
+      this.headers[k] = v;
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    send(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+describe('calendarMusicTogetherFeed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('serves an ICS feed of public Music Together events', async () => {
+    mocks.findPublicByType.mockResolvedValue([{ id: 'e1' }]);
+    mocks.generateIcsFeed.mockReturnValue('BEGIN:VCALENDAR');
+    const res = makeRes();
+
+    await handler({ method: 'GET' }, res);
+
+    expect(mocks.findPublicByType).toHaveBeenCalledWith('musictogether');
+    expect(mocks.generateIcsFeed).toHaveBeenCalledWith(
+      [{ id: 'e1' }],
+      'Music Together with Maple & Spruce'
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('BEGIN:VCALENDAR');
+    expect(res.headers['Content-Type']).toBe('text/calendar; charset=utf-8');
+  });
+
+  it('short-circuits an OPTIONS preflight', async () => {
+    const res = makeRes();
+    await handler({ method: 'OPTIONS' }, res);
+    expect(res.statusCode).toBe(204);
+    expect(mocks.findPublicByType).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when the repository throws', async () => {
+    mocks.findPublicByType.mockRejectedValue(new Error('boom'));
+    const res = makeRes();
+    await handler({ method: 'GET' }, res);
+    expect(res.statusCode).toBe(500);
+  });
+});

--- a/libs/firebase/maple-functions/calendar-music-together-feed/src/lib/calendar-music-together-feed.ts
+++ b/libs/firebase/maple-functions/calendar-music-together-feed/src/lib/calendar-music-together-feed.ts
@@ -1,0 +1,39 @@
+/**
+ * Calendar Music Together ICS Feed
+ *
+ * HTTP endpoint serving an ICS feed of all public Music Together events
+ * (type `musictogether`), which are auto-generated from MT sections by
+ * `onMusicTogetherSectionWrite` plus any ad-hoc MT events (demo classes,
+ * makeups) tagged in the admin calendar. Powers the public Music Together
+ * calendar embed.
+ *
+ * Subscribe via: /calendar/musictogether.ics
+ */
+import { onRequest } from 'firebase-functions/v2/https';
+import { CalendarEventRepository } from '@maple/firebase/database';
+import { generateIcsFeed, ICS_FEED_HEADERS } from '@maple/ts/calendar';
+
+export const calendarMusicTogetherFeed = onRequest(
+  // No minInstances — the 5-minute CDN cache from ICS_FEED_HEADERS absorbs cold starts.
+  { region: 'us-east4', cors: true, concurrency: 80 },
+  async (request, response) => {
+    if (request.method === 'OPTIONS') {
+      response.status(204).send('');
+      return;
+    }
+
+    try {
+      const events =
+        await CalendarEventRepository.findPublicByType('musictogether');
+      const ics = generateIcsFeed(events, 'Music Together with Maple & Spruce');
+
+      Object.entries(ICS_FEED_HEADERS).forEach(([key, value]) => {
+        response.setHeader(key, value);
+      });
+      response.status(200).send(ics);
+    } catch (error) {
+      console.error('Error generating Music Together feed:', error);
+      response.status(500).json({ error: 'Failed to generate feed' });
+    }
+  }
+);

--- a/libs/firebase/maple-functions/calendar-music-together-feed/tsconfig.json
+++ b/libs/firebase/maple-functions/calendar-music-together-feed/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/calendar-music-together-feed/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/calendar-music-together-feed/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/on-music-together-section-write/project.json
+++ b/libs/firebase/maple-functions/on-music-together-section-write/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-on-music-together-section-write",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/on-music-together-section-write/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/on-music-together-section-write/src/index.ts
+++ b/libs/firebase/maple-functions/on-music-together-section-write/src/index.ts
@@ -1,0 +1,1 @@
+export { onMusicTogetherSectionWrite } from './lib/on-music-together-section-write';

--- a/libs/firebase/maple-functions/on-music-together-section-write/src/lib/on-music-together-section-write.spec.ts
+++ b/libs/firebase/maple-functions/on-music-together-section-write/src/lib/on-music-together-section-write.spec.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CalendarEvent } from '@maple/ts/domain';
+
+/**
+ * Tests for the onMusicTogetherSectionWrite Firestore trigger.
+ *
+ * Verifies that MT section create/update/delete reconciles CalendarEvents —
+ * one per session, type `musictogether`, 45-minute duration — using
+ * deterministic IDs of the form `mt-{sectionId}-{timestampMs}`, and that
+ * events exist only while the section is live (status `open` or `closed`).
+ */
+
+const mocks = vi.hoisted(() => ({
+  findAllBySourceRef: vi.fn(),
+  upsertWithId: vi.fn(),
+  delete: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  CalendarEventRepository: {
+    findAllBySourceRef: mocks.findAllBySourceRef,
+    upsertWithId: mocks.upsertWithId,
+    delete: mocks.delete,
+  },
+}));
+
+vi.mock('firebase-functions/v2/firestore', () => ({
+  onDocumentWritten: vi.fn((_config, handler) => handler),
+}));
+
+import { onMusicTogetherSectionWrite } from './on-music-together-section-write';
+
+const handler = onMusicTogetherSectionWrite as unknown as (
+  event: unknown
+) => Promise<void>;
+
+function makeSnapshot(
+  exists: boolean,
+  data?: Record<string, unknown>,
+  id = 'sec-1'
+) {
+  return { exists, id, data: () => (exists ? data : undefined) };
+}
+
+function ts(date: Date) {
+  return { toDate: () => date };
+}
+
+const sessionDates = [
+  new Date('2030-09-10T14:00:00Z'),
+  new Date('2030-09-17T14:00:00Z'),
+  new Date('2030-09-24T14:00:00Z'),
+];
+
+const openSection = {
+  name: 'Thursday Morning — Mixed Age (0–5)',
+  description: 'Fall 2026',
+  sessions: sessionDates.map((d) => ({ dateTime: ts(d) })),
+  status: 'open',
+  location: 'Spruce Room',
+  room: 'spruce',
+  capacityFamilies: 8,
+  priceFullCents: 25200,
+  createdAt: ts(new Date('2026-01-01')),
+  updatedAt: ts(new Date('2026-01-01')),
+};
+
+function eventId(sectionId: string, date: Date): string {
+  return `mt-${sectionId}-${date.getTime()}`;
+}
+
+function makeCalendarEvent(sectionId: string, date: Date): CalendarEvent {
+  return {
+    id: eventId(sectionId, date),
+    title: 'Thursday Morning — Mixed Age (0–5)',
+    description: 'Fall 2026',
+    startDateTime: date,
+    endDateTime: new Date(date.getTime() + 45 * 60 * 1000),
+    recurrenceRule: null,
+    location: 'Spruce Room',
+    type: 'musictogether',
+    public: true,
+    room: 'spruce',
+    sourceRef: `musicTogetherSections/${sectionId}`,
+    createdBy: 'system',
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+  };
+}
+
+describe('onMusicTogetherSectionWrite', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findAllBySourceRef.mockResolvedValue([]);
+    mocks.upsertWithId.mockResolvedValue(undefined);
+    mocks.delete.mockResolvedValue(undefined);
+  });
+
+  it('upserts one musictogether event per session for an open section', async () => {
+    await handler({
+      params: { sectionId: 'sec-1' },
+      data: { before: makeSnapshot(false), after: makeSnapshot(true, openSection) },
+    });
+
+    expect(mocks.upsertWithId).toHaveBeenCalledTimes(3);
+    for (let i = 0; i < 3; i++) {
+      const [id, input] = mocks.upsertWithId.mock.calls[i];
+      expect(id).toBe(eventId('sec-1', sessionDates[i]));
+      expect(input.type).toBe('musictogether');
+      expect(input.public).toBe(true);
+      expect(input.title).toBe('Thursday Morning — Mixed Age (0–5)');
+      expect(input.sourceRef).toBe('musicTogetherSections/sec-1');
+      expect(input.startDateTime).toEqual(sessionDates[i]);
+      // 45-minute default duration
+      expect(input.endDateTime).toEqual(
+        new Date(sessionDates[i].getTime() + 45 * 60 * 1000)
+      );
+      expect(input.room).toBe('spruce');
+    }
+    expect(mocks.delete).not.toHaveBeenCalled();
+  });
+
+  it('still creates events for a closed (full) section', async () => {
+    await handler({
+      params: { sectionId: 'sec-1' },
+      data: {
+        before: makeSnapshot(true, openSection),
+        after: makeSnapshot(true, { ...openSection, status: 'closed' }),
+      },
+    });
+    expect(mocks.upsertWithId).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not create events for a draft section', async () => {
+    await handler({
+      params: { sectionId: 'sec-1' },
+      data: {
+        before: makeSnapshot(false),
+        after: makeSnapshot(true, { ...openSection, status: 'draft' }),
+      },
+    });
+    expect(mocks.upsertWithId).not.toHaveBeenCalled();
+  });
+
+  it('removes events when a section is completed', async () => {
+    const existing = sessionDates.map((d) => makeCalendarEvent('sec-1', d));
+    mocks.findAllBySourceRef.mockResolvedValue(existing);
+
+    await handler({
+      params: { sectionId: 'sec-1' },
+      data: {
+        before: makeSnapshot(true, openSection),
+        after: makeSnapshot(true, { ...openSection, status: 'completed' }),
+      },
+    });
+
+    expect(mocks.upsertWithId).not.toHaveBeenCalled();
+    expect(mocks.delete).toHaveBeenCalledTimes(3);
+    for (const e of existing) {
+      expect(mocks.delete).toHaveBeenCalledWith(e.id);
+    }
+  });
+
+  it('deletes ALL events when a section is deleted', async () => {
+    const existing = sessionDates.map((d) => makeCalendarEvent('sec-1', d));
+    mocks.findAllBySourceRef.mockResolvedValue(existing);
+
+    await handler({
+      params: { sectionId: 'sec-1' },
+      data: { before: makeSnapshot(true, openSection), after: makeSnapshot(false) },
+    });
+
+    expect(mocks.findAllBySourceRef).toHaveBeenCalledWith(
+      'musicTogetherSections/sec-1'
+    );
+    expect(mocks.delete).toHaveBeenCalledTimes(3);
+  });
+
+  it('deletes stale events when sessions are removed', async () => {
+    mocks.findAllBySourceRef.mockResolvedValue(
+      sessionDates.map((d) => makeCalendarEvent('sec-1', d))
+    );
+
+    await handler({
+      params: { sectionId: 'sec-1' },
+      data: {
+        before: makeSnapshot(true, openSection),
+        after: makeSnapshot(true, {
+          ...openSection,
+          sessions: [{ dateTime: ts(sessionDates[0]) }],
+        }),
+      },
+    });
+
+    expect(mocks.upsertWithId).toHaveBeenCalledOnce();
+    expect(mocks.delete).toHaveBeenCalledTimes(2);
+    expect(mocks.delete).toHaveBeenCalledWith(eventId('sec-1', sessionDates[1]));
+    expect(mocks.delete).toHaveBeenCalledWith(eventId('sec-1', sessionDates[2]));
+  });
+
+  it('maps an unknown room to null', async () => {
+    await handler({
+      params: { sectionId: 'sec-1' },
+      data: {
+        before: makeSnapshot(false),
+        after: makeSnapshot(true, {
+          ...openSection,
+          room: 'somewhere-else',
+          sessions: [{ dateTime: ts(sessionDates[0]) }],
+        }),
+      },
+    });
+    const [, input] = mocks.upsertWithId.mock.calls[0];
+    expect(input.room).toBeNull();
+  });
+
+  it('uses stable IDs of the form mt-{sectionId}-{timestampMs}', async () => {
+    await handler({
+      params: { sectionId: 'thu-fall' },
+      data: {
+        before: makeSnapshot(false, undefined, 'thu-fall'),
+        after: makeSnapshot(
+          true,
+          { ...openSection, sessions: [{ dateTime: ts(sessionDates[0]) }] },
+          'thu-fall'
+        ),
+      },
+    });
+    const [id] = mocks.upsertWithId.mock.calls[0];
+    expect(id).toBe(`mt-thu-fall-${sessionDates[0].getTime()}`);
+  });
+
+  it('parses ISO-string session dates (emulator REST format)', async () => {
+    const iso = '2030-10-08T14:00:00.000Z';
+    await handler({
+      params: { sectionId: 'sec-1' },
+      data: {
+        before: makeSnapshot(false),
+        after: makeSnapshot(true, {
+          ...openSection,
+          sessions: [{ dateTime: iso }],
+        }),
+      },
+    });
+    const [, input] = mocks.upsertWithId.mock.calls[0];
+    expect(input.startDateTime).toEqual(new Date(iso));
+  });
+});

--- a/libs/firebase/maple-functions/on-music-together-section-write/src/lib/on-music-together-section-write.ts
+++ b/libs/firebase/maple-functions/on-music-together-section-write/src/lib/on-music-together-section-write.ts
@@ -1,0 +1,189 @@
+/**
+ * onMusicTogetherSectionWrite Firestore Trigger
+ *
+ * Keeps the CalendarEvent collection in sync with the musicTogetherSections
+ * collection, creating one `CalendarEvent` (type `musictogether`) per section
+ * session — the same "one entity drives registration AND the calendar" pattern
+ * as `onClassWrite` does for classes.
+ *
+ * - Create/Update: if the section is live (status `open` or `closed`), upserts
+ *   one event per session at a stable ID and deletes events whose session no
+ *   longer exists.
+ * - Not live (`draft` / `completed`) or deleted: removes every CalendarEvent
+ *   tied to this section.
+ *
+ * MT classes are always 45 minutes (`MT_CLASS_DURATION_MINUTES`), so sections
+ * carry no per-session duration; the end time is derived here.
+ */
+import {
+  onDocumentWritten,
+  type Change,
+  type DocumentSnapshot,
+} from 'firebase-functions/v2/firestore';
+import { CalendarEventRepository } from '@maple/firebase/database';
+import type { MusicTogetherSession, Room } from '@maple/ts/domain';
+import {
+  DEFAULT_EVENT_LOCATION,
+  MT_CLASS_DURATION_MINUTES,
+  ROOMS,
+} from '@maple/ts/domain';
+
+/** Minimal shape we read off the section snapshot. */
+interface SectionData {
+  name: string;
+  description?: string;
+  sessions: MusicTogetherSession[];
+  status: string;
+  location?: string;
+  room?: string;
+}
+
+function toDateLike(value: unknown): Date | undefined {
+  if (!value) return undefined;
+  if (value instanceof Date) return value;
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    'toDate' in value &&
+    typeof (value as { toDate: unknown }).toDate === 'function'
+  ) {
+    return (value as { toDate: () => Date }).toDate();
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    const d = new Date(value);
+    return isNaN(d.getTime()) ? undefined : d;
+  }
+  return undefined;
+}
+
+/** Parse and sort session start times off a raw section document. */
+function extractSessions(raw: Record<string, unknown>): MusicTogetherSession[] {
+  const rawSessions = raw['sessions'];
+  if (!Array.isArray(rawSessions)) return [];
+  return rawSessions
+    .map((entry) => {
+      const dateField =
+        entry && typeof entry === 'object' && 'dateTime' in entry
+          ? (entry as { dateTime: unknown }).dateTime
+          : entry;
+      return { dateTime: toDateLike(dateField) };
+    })
+    .filter((s): s is MusicTogetherSession => s.dateTime instanceof Date)
+    .sort((a, b) => a.dateTime.getTime() - b.dateTime.getTime());
+}
+
+function extractSection(
+  snapshot: DocumentSnapshot | undefined
+): SectionData | null {
+  if (!snapshot || !snapshot.exists) return null;
+  const data = snapshot.data();
+  if (!data) return null;
+  return {
+    name: typeof data['name'] === 'string' ? data['name'] : 'Music Together',
+    description:
+      typeof data['description'] === 'string' ? data['description'] : undefined,
+    sessions: extractSessions(data),
+    status: typeof data['status'] === 'string' ? data['status'] : 'draft',
+    location:
+      typeof data['location'] === 'string' ? data['location'] : undefined,
+    room: typeof data['room'] === 'string' ? data['room'] : undefined,
+  };
+}
+
+/**
+ * Deterministic event ID keyed by the session's timestamp (not array index),
+ * so reordering/inserting sessions doesn't rewrite every downstream event.
+ */
+function sessionEventId(
+  sectionId: string,
+  session: MusicTogetherSession
+): string {
+  return `mt-${sectionId}-${session.dateTime.getTime()}`;
+}
+
+/** Map a section's free-text room to a bookable Room, or null. */
+function resolveRoom(room: string | undefined): Room | null {
+  return room && (ROOMS as string[]).includes(room) ? (room as Room) : null;
+}
+
+/** A section shows on the public calendar once it's live (open or closed). */
+function isLive(status: string): boolean {
+  return status === 'open' || status === 'closed';
+}
+
+export const onMusicTogetherSectionWrite = onDocumentWritten(
+  {
+    document: 'musicTogetherSections/{sectionId}',
+    region: 'us-east4',
+  },
+  async (event) => {
+    const change: Change<DocumentSnapshot> = event.data!;
+    const after = extractSection(change.after);
+    const sectionId = event.params.sectionId;
+    const sourceRef = `musicTogetherSections/${sectionId}`;
+
+    try {
+      const existingEvents =
+        await CalendarEventRepository.findAllBySourceRef(sourceRef);
+
+      // Deleted, not-live, or no sessions → remove all its events.
+      if (!after || !isLive(after.status) || after.sessions.length === 0) {
+        await Promise.all(
+          existingEvents.map((e) => CalendarEventRepository.delete(e.id))
+        );
+        if (existingEvents.length > 0) {
+          console.log(
+            `onMusicTogetherSectionWrite: removed ${existingEvents.length} event(s) for section ${sectionId}`
+          );
+        }
+        return;
+      }
+
+      const room = resolveRoom(after.room);
+      const desiredIds = new Set(
+        after.sessions.map((s) => sessionEventId(sectionId, s))
+      );
+
+      // Upsert one event per session.
+      await Promise.all(
+        after.sessions.map((session) =>
+          CalendarEventRepository.upsertWithId(
+            sessionEventId(sectionId, session),
+            {
+              title: after.name,
+              description: after.description || '',
+              startDateTime: session.dateTime,
+              endDateTime: new Date(
+                session.dateTime.getTime() +
+                  MT_CLASS_DURATION_MINUTES * 60 * 1000
+              ),
+              recurrenceRule: null,
+              location: after.location || DEFAULT_EVENT_LOCATION,
+              type: 'musictogether',
+              public: true,
+              room,
+              sourceRef,
+              createdBy: 'system',
+            }
+          )
+        )
+      );
+
+      // Delete events for sessions that no longer exist.
+      const staleIds = existingEvents
+        .map((e) => e.id)
+        .filter((id) => !desiredIds.has(id));
+      await Promise.all(
+        staleIds.map((id) => CalendarEventRepository.delete(id))
+      );
+
+      console.log('onMusicTogetherSectionWrite reconciled:', {
+        sectionId,
+        upserted: after.sessions.length,
+        deleted: staleIds.length,
+      });
+    } catch (error) {
+      console.error('Error in onMusicTogetherSectionWrite:', error);
+    }
+  }
+);

--- a/libs/firebase/maple-functions/on-music-together-section-write/tsconfig.json
+++ b/libs/firebase/maple-functions/on-music-together-section-write/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/on-music-together-section-write/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/on-music-together-section-write/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/react/events/src/lib/CalendarEventList.tsx
+++ b/libs/react/events/src/lib/CalendarEventList.tsx
@@ -33,6 +33,7 @@ const typeColors: Record<string, 'primary' | 'secondary' | 'warning' | 'info' | 
   event: 'warning',
   jam: 'info',
   hours: 'default',
+  musictogether: 'secondary',
 };
 
 function formatDateTime(date: Date): string {

--- a/libs/react/rooms/src/lib/RoomScheduleAgenda.tsx
+++ b/libs/react/rooms/src/lib/RoomScheduleAgenda.tsx
@@ -39,6 +39,7 @@ const TYPE_CHIP: Record<
   event: { label: 'Booking', color: 'secondary' },
   jam: { label: 'Jam', color: 'success' },
   hours: { label: 'Hours', color: 'default' },
+  musictogether: { label: 'Music Together', color: 'secondary' },
 };
 
 /** Format a time as "4:30 PM". */

--- a/libs/ts/domain/src/lib/calendar-event.ts
+++ b/libs/ts/domain/src/lib/calendar-event.ts
@@ -10,7 +10,13 @@ import type { Room } from './room';
 /**
  * Type of calendar event, used for filtering and color-coding on the public calendar.
  */
-export type CalendarEventType = 'class' | 'lesson' | 'event' | 'jam' | 'hours';
+export type CalendarEventType =
+  | 'class'
+  | 'lesson'
+  | 'event'
+  | 'jam'
+  | 'hours'
+  | 'musictogether';
 
 /**
  * All valid calendar event types for validation
@@ -21,6 +27,7 @@ export const CALENDAR_EVENT_TYPES: CalendarEventType[] = [
   'event',
   'jam',
   'hours',
+  'musictogether',
 ];
 
 /**
@@ -90,6 +97,7 @@ export function getCalendarEventTypeLabel(type: CalendarEventType): string {
     event: 'Event',
     jam: 'Jam Session',
     hours: 'Store Hours',
+    musictogether: 'Music Together',
   };
   return labels[type];
 }

--- a/libs/ts/domain/src/lib/music-together-section.ts
+++ b/libs/ts/domain/src/lib/music-together-section.ts
@@ -26,6 +26,14 @@ export const MT_DEFAULT_INSTALLMENT_CENTS = 13200;
 /** Default number of installments used to prefill the plan. */
 export const MT_DEFAULT_INSTALLMENT_COUNT = 2;
 
+/**
+ * Length of a single Music Together class, in minutes. MT classes are always
+ * 45 minutes, so sections don't store a per-session duration; the calendar
+ * sync (`onMusicTogetherSectionWrite`) uses this to compute each event's end
+ * time.
+ */
+export const MT_CLASS_DURATION_MINUTES = 45;
+
 /** One scheduled weekly meeting of a section. */
 export interface MusicTogetherSession {
   dateTime: Date;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -380,8 +380,14 @@
       "@maple/firebase/maple-functions/calendar-adhoc-proxy": [
         "libs/firebase/maple-functions/calendar-adhoc-proxy/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/calendar-music-together-feed": [
+        "libs/firebase/maple-functions/calendar-music-together-feed/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/on-class-write": [
         "libs/firebase/maple-functions/on-class-write/src/index.ts"
+      ],
+      "@maple/firebase/maple-functions/on-music-together-section-write": [
+        "libs/firebase/maple-functions/on-music-together-section-write/src/index.ts"
       ],
       "@maple/firebase/maple-functions/on-lesson-write": [
         "libs/firebase/maple-functions/on-lesson-write/src/index.ts"


### PR DESCRIPTION
## Music Together calendar — sections drive the calendar (like classes)

Makes an MT **section the single source of truth for both registration and the calendar**, mirroring how classes already work via `onClassWrite`. Sets up the backend the public MT Calendar page will consume.

### What it does
1. **`musictogether` event type** — one enum value + label in `calendar-event.ts`. Auto-surfaces in the admin **Calendar Events** form dropdown, the filter toolbar, and validation (all data-driven off `CALENDAR_EVENT_TYPES`). Also a distinct chip color in the admin list.
2. **`onMusicTogetherSectionWrite`** (maple-core) — Firestore trigger on `musicTogetherSections/{id}`, mirroring `onClassWrite`:
   - Live section (`open`/`closed`) → upserts one **public** `musictogether` CalendarEvent per session, **45-min** default duration (`MT_CLASS_DURATION_MINUTES`), stable id `mt-{sectionId}-{ms}`, `sourceRef: musicTogetherSections/{id}`.
   - Reconciles on edit (deletes stale-session events); removes all events on `draft`/`completed`/delete.
   - Maps `section.room` → bookable `Room` (`spruce`) or null, so MT events participate in Spruce Room conflict checks.
3. **`calendarMusicTogetherFeed`** (maple-calendar) → **`/calendar/musictogether.ics`** (`findPublicByType('musictogether')`). The MT Webflow calendar page will embed the OWC view pointed at just this feed; the main `/calendar` is unaffected.

So Stephanie sets up a semester's sections for registration (as she already does) and the public MT calendar fills in automatically — plus **ad-hoc MT events** (summer demos, makeups, weather notes) can still be tagged manually in the admin calendar.

### Notes
- **No new Firestore index** — the feed reuses the existing `type + public` composite (same shape as every other feed); `findAllBySourceRef` is single-field. Analyzer confirms all 159 index-requiring queries are covered.
- Firestore is schemaless, so the new `type` value needs no migration.

### Verification (self-checked locally)
- **12 unit tests pass** — `onMusicTogetherSectionWrite` (open/closed create, draft/completed/delete remove, stale-session reconcile, room mapping, stable ids, ISO-date parsing) + `calendarMusicTogetherFeed` (200 ICS, OPTIONS 204, 500 on error).
- `tsc --noEmit` clean for **maple-core** and **maple-calendar** app tsconfigs.
- `eslint` 0 errors (1 pre-existing-style `event.data!` warning, same as `onClassWrite`).
- `./tools/validate-function-tsconfigs.sh` OK; `check-firestore-indexes.ts` OK.

### Follow-up (not in this PR)
- The MT **Calendar Webflow page** (`/music-together-calendar`) embedding the OWC view of this feed + a static session-dates reference table. Once merged + deployed, admins can create a `Music Together` event and it flows straight to the MT feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)