### PR TITLE
fix(functions): accept any localhost origin in the emulator (CORS)

### DIFF
--- a/libs/firebase/functions/src/lib/functions.utility.spec.ts
+++ b/libs/firebase/functions/src/lib/functions.utility.spec.ts
@@ -64,6 +64,7 @@ import {
   createPublicFunction,
   createAuthenticatedFunction,
   createAdminFunction,
+  isOriginAllowed,
 } from './functions.utility';
 import {
   throwNotFound,
@@ -739,5 +740,34 @@ describe('legacy wrappers', () => {
       makeReq({ headers: { origin: 'https://example.test', authorization: 'Bearer t' } })
     );
     expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('isOriginAllowed', () => {
+  const allow = ['http://localhost:3000', 'https://mapleandsprucefolkarts.com'];
+
+  it('allows an origin on the configured allowlist (any environment)', () => {
+    expect(isOriginAllowed('http://localhost:3000', allow, false)).toBe(true);
+    expect(
+      isOriginAllowed('https://mapleandsprucefolkarts.com', allow, false)
+    ).toBe(true);
+  });
+
+  it('allows any localhost / 127.0.0.1 port in the emulator', () => {
+    // Worktree offset ports (e.g. 3000+2610) aren't on the allowlist.
+    expect(isOriginAllowed('http://localhost:5610', allow, true)).toBe(true);
+    expect(isOriginAllowed('http://127.0.0.1:8123', allow, true)).toBe(true);
+  });
+
+  it('rejects off-allowlist localhost ports outside the emulator', () => {
+    expect(isOriginAllowed('http://localhost:5610', allow, false)).toBe(false);
+  });
+
+  it('rejects non-localhost origins even in the emulator', () => {
+    expect(isOriginAllowed('https://evil.example.com', allow, true)).toBe(false);
+    // Guard against a localhost-lookalike hostname.
+    expect(
+      isOriginAllowed('http://localhost.evil.com', allow, true)
+    ).toBe(false);
   });
 });

--- a/libs/firebase/functions/src/lib/functions.utility.ts
+++ b/libs/firebase/functions/src/lib/functions.utility.ts
@@ -200,6 +200,28 @@ async function verifyAuthToken(
  * IMPORTANT: ALLOWED_ORIGINS is passed in as a parameter, not accessed
  * from module scope. This avoids cold start delays from defineString.
  */
+/**
+ * Decide whether a request Origin passes CORS.
+ *
+ * Beyond the configured allowlist, the Functions emulator additionally accepts
+ * any localhost / 127.0.0.1 origin regardless of port: worktree-based local dev
+ * and integration tests run the web app + emulators on offset ports
+ * (EMULATOR_PORT_OFFSET), so the request Origin is http://localhost:{3000+offset}
+ * — which the fixed ALLOWED_ORIGINS list can't enumerate. Guarded by
+ * `isEmulator` so production CORS is unchanged.
+ */
+export function isOriginAllowed(
+  origin: string,
+  allowedOrigins: string[],
+  isEmulator: boolean
+): boolean {
+  if (allowedOrigins.includes(origin)) return true;
+  if (isEmulator) {
+    return /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin);
+  }
+  return false;
+}
+
 function createCorsMiddleware(allowedOriginsParam: StringParam) {
   return (req: Request, res: Response, next: () => void) => {
     const origin = req.headers.origin;
@@ -215,7 +237,9 @@ function createCorsMiddleware(allowedOriginsParam: StringParam) {
       .split(',')
       .map((o) => o.trim());
 
-    if (allowedOrigins.includes(origin)) {
+    const isEmulator = process.env['FUNCTIONS_EMULATOR'] === 'true';
+
+    if (isOriginAllowed(origin, allowedOrigins, isEmulator)) {
       res.setHeader('Access-Control-Allow-Origin', origin);
       res.setHeader(
         'Access-Control-Allow-Methods',


### PR DESCRIPTION
## Local integration tests / dev in a worktree were blanket-403'd

Running integration tests (or the web app) in a **git worktree** uses `EMULATOR_PORT_OFFSET` to isolate emulator ports — so the request `Origin` is `http://localhost:{3000+offset}` (e.g. `:5610`). That port isn't in the fixed `ALLOWED_ORIGINS` allowlist, so the CORS middleware returned **403 "Origin not allowed by CORS policy"** on **every** callable — including public ones — *before the function ran*. Result: every 200-expecting integration test failed `expected 403 to be 200`, in every suite. (Main checkout, offset 0 → `localhost:3000` → allowlisted → fine, which is why it only bites in worktrees.)

## Fix
- Extract the origin decision into an exported pure `isOriginAllowed(origin, allowedOrigins, isEmulator)`.
- In the **Functions emulator only** (`FUNCTIONS_EMULATOR === 'true'`), additionally accept any `http(s)://localhost` / `127.0.0.1` origin regardless of port. **Production CORS is unchanged** (still the exact allowlist).

## Verification
- The MT integration suite now **passes in a worktree** (offset origin `localhost:5610`) where it previously blanket-403'd — 0 remaining 403s.
- 45 unit tests pass, including 4 new `isOriginAllowed` cases (allowlist hit; localhost-any-port in emulator; localhost rejected outside emulator; non-localhost + localhost-lookalike rejected even in emulator).
- eslint 0 errors.

Unblocks the local integration loop (`.claude/rules/verification.md`) for worktree-based development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)