### PR TITLE
docs(git-workflow): always fetch/branch/verify off origin/main

### DIFF
--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -29,6 +29,27 @@ Patterns:
 - `fix/[issue-number]-[short-description]`
 - `chore/[description]`
 
+## Always Branch Off (and Verify Against) a Fresh `origin/main`
+
+**The local `main` checkout — and any `maple-and-spruce-*` worktree — can be far behind `origin/main`.** This repo moves fast and the local working copy is often not pulled. Merged work (Cloud Functions, domain entities, admin UI) will be *missing* from a stale local tree, which silently sends work down the wrong path — e.g. rebuilding something already merged, or a subagent reporting that merged code "doesn't exist" because it read the stale checkout.
+
+**Rules:**
+1. **`git fetch origin main` first**, and base new branches/worktrees on `origin/main`, not local `main`:
+   ```bash
+   git fetch origin main
+   git worktree add -b feature/{n}-{desc} ../maple-and-spruce-{desc} origin/main
+   # or, in-repo:  git checkout -B work origin/main
+   ```
+2. **To check whether code exists or a PR is merged, inspect `origin/main` — never the local worktree:**
+   ```bash
+   git ls-tree -r origin/main --name-only | grep <file>
+   git show origin/main:<path>
+   git log origin/main --oneline | grep <topic>
+   ```
+   Do not rely on `ls` or `git log HEAD` in a possibly-stale local checkout.
+3. **The many `feat/*` sibling worktrees may be stale duplicates of already-merged work** — diff against `origin/main` before assuming a branch still needs a PR.
+4. **When spawning subagents (Explore or implementation), tell them explicitly:** _"run `git fetch origin main` first; the local main worktree may be stale; verify code presence and branch off `origin/main`."_
+
 ## Commit Conventions
 
 **Format:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 2. **Keep documentation current** -- Follow the self-updating doc workflow in .claude/CLAUDE.md and the `session-management` skill.
 3. **Read before acting** -- Start sessions by reading AGENTS.md, .claude/CLAUDE.md, and `docs/sessions/SESSION.md`.
 4. **Check GitHub issues** -- Run `gh issue list` for current work. Issues are the source of truth.
-5. **Use feature branches** -- Never commit directly to main. See `git-workflow` skill.
+5. **Use feature branches** -- Never commit directly to main. Local `main`/worktrees can lag `origin/main`; `git fetch` and branch/verify off `origin/main`, and instruct spawned subagents to do the same. See `git-workflow` skill.
 6. **Always write tests** -- Unit tests for new functions/utilities. Run `pnpm test` before PRs. Use `vi.mock()` for Cloud Functions (ADR-017). Aim for **~85% coverage on new code** — the 80% CI threshold is a floor, not a target. See `docs/reference/code-standards.md` for per-file-type guidance.
 7. **Use GitHub issues for tracking** -- Reference issues in PRs (`Closes #XX`).
 8. **Never deploy manually** -- CI/CD deploys on merge to main. Claude writes code and creates PRs.


### PR DESCRIPTION
## Summary
Codifies a workflow guardrail in the `git-workflow` skill: **always `git fetch origin main` and base branches/worktrees/verification on `origin/main`, because the local `main` checkout (and `maple-and-spruce-*` worktrees) can be far behind.**

## Why
The local working copy is often not pulled. A stale local tree makes merged code look missing and sends work down the wrong path. This session an Explore subagent concluded already-merged Music Together work (semester construct #549, registration widget #547, calendar feed #548) "doesn't exist anywhere" — because it read the stale local `main` (pinned at `8af7fac` while `origin/main` was at `cc91704`). That nearly triggered re-PRing already-merged branches.

## Changes
- New "Always Branch Off (and Verify Against) a Fresh `origin/main`" section in `.claude/skills/git-workflow/SKILL.md`:
  - fetch + branch/worktree off `origin/main`
  - verify code/merge status via `git ls-tree/show/log origin/main`, not the local checkout
  - `feat/*` sibling worktrees may be stale duplicates of merged work
  - instruct spawned subagents to fetch + verify against `origin/main`

## Testing
- [x] Docs-only change; self-reviewed diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)