### PR TITLE
fix(ci): vercel --archive=tgz to avoid free-tier upload limit

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -567,7 +567,7 @@ jobs:
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_DEV }}
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt --prod --archive=tgz --token=${{ secrets.VERCEL_TOKEN }}
 
   e2e_dev:
     # The gate: run the registration E2E suite against the deployed dev
@@ -1085,4 +1085,4 @@ jobs:
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt --prod --archive=tgz --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Problem
The **prod Vercel deploy** in \`Deploy on merge\` fails:
\`\`\`
Error: Too many requests - try again in 24 hours (more than 5000, code: "api-upload-free").
Try using \`--archive=tgz\` to limit the amount of files you upload.
\`\`\`
The \`maple-spruce\` app uploads thousands of individual files per deploy. Repeated deploys blow past Vercel's **5000-uploads/24h free-tier cap**, so \`deploy_vercel_prod\` fails and the admin frontend — including the **Music Together semesters admin UI** — never reaches production. (Functions deploy fine; this is frontend-only.)

## Fix
Add **\`--archive=tgz\`** to both \`vercel deploy --prebuilt\` steps (dev + prod). Vercel uploads a single compressed tarball (~1 upload) instead of thousands of files, staying well under the cap. Works **immediately** — the archive path isn't blocked by the 24h reset.

## Testing
- [x] One-line-per-step CI change; verified both invocations updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)