### PR TITLE
fix(cors): allow webflow.io staging origin for MT widget

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,4 +1,4 @@
-ALLOWED_ORIGINS=http://localhost:3000,http://localhost:4200,http://127.0.0.1:3000,http://127.0.0.1:4200,https://business-dev.mapleandsprucefolkarts.com,https://mapleandsprucefolkarts.com,https://www.mapleandsprucefolkarts.com,https://mapleandsprucewv.com,https://www.mapleandsprucewv.com,https://maple-spruce-registration-test.web.app,https://maple-spruce-registration-test.firebaseapp.com
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:4200,http://127.0.0.1:3000,http://127.0.0.1:4200,https://business-dev.mapleandsprucefolkarts.com,https://mapleandsprucefolkarts.com,https://www.mapleandsprucefolkarts.com,https://mapleandsprucewv.com,https://www.mapleandsprucewv.com,https://maple-spruce-registration-test.web.app,https://maple-spruce-registration-test.firebaseapp.com,https://maple-spruce-folk-arts-collective.webflow.io
 
 # Square Integration
 # SQUARE_ENV determines SDK environment (LOCAL=sandbox, PROD=production)

--- a/.env.prod
+++ b/.env.prod
@@ -1,5 +1,5 @@
 # Production environment for Firebase Functions
-ALLOWED_ORIGINS=https://business.mapleandsprucefolkarts.com,https://business.mapleandsprucewv.com,https://maple-and-spruce-maple-spruce.vercel.app,https://mapleandsprucefolkarts.com,https://www.mapleandsprucefolkarts.com,https://mapleandsprucewv.com,https://www.mapleandsprucewv.com
+ALLOWED_ORIGINS=https://business.mapleandsprucefolkarts.com,https://business.mapleandsprucewv.com,https://maple-and-spruce-maple-spruce.vercel.app,https://mapleandsprucefolkarts.com,https://www.mapleandsprucefolkarts.com,https://mapleandsprucewv.com,https://www.mapleandsprucewv.com,https://maple-spruce-folk-arts-collective.webflow.io
 
 # Square Integration
 # SQUARE_ENV determines SDK environment (LOCAL=sandbox, PROD=production)


### PR DESCRIPTION
## Problem
The Music Together registration widget fails on the **Webflow staging** subdomain with a CORS `TypeError: Failed to fetch` → "Unable to load this class". The public MT callables exact-match `Origin` against `ALLOWED_ORIGINS`, which lists the production domains but **not** `maple-spruce-folk-arts-collective.webflow.io`. The MT pages are drafts reviewed on staging, so the widget can't load a section there.

## Fix
Add `https://maple-spruce-folk-arts-collective.webflow.io` to `ALLOWED_ORIGINS` in `.env.dev` and `.env.prod`. Production domains were already allowed, so the live site is unaffected; this only unblocks staging review/testing.

## Testing
- [x] Confirmed the CF returns no ACAO for the staging origin today (direct fetch → Failed to fetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)