### PR TITLE
feat(music-together): richer time-display in Webflow sync

### DIFF
--- a/libs/firebase/webflow/src/lib/mt-section.service.spec.ts
+++ b/libs/firebase/webflow/src/lib/mt-section.service.spec.ts
@@ -99,6 +99,56 @@ describe('mapSectionToFieldData', () => {
     expect(typeof fd['time-display']).toBe('string');
   });
 
+  it('renders time-display as day-of-week + time range (Thursday 10am ET)', () => {
+    // 2026-03-05T15:00:00Z is a Thursday; still EST (DST starts 2026-03-08),
+    // so 15:00 UTC = 10:00 AM America/New_York.
+    const fd = mapSectionToFieldData(
+      {
+        ...baseSection,
+        sessions: [
+          { dateTime: new Date('2026-03-05T15:00:00Z') },
+          { dateTime: new Date('2026-03-12T14:00:00Z') },
+        ],
+      },
+      prodOptions
+    );
+    expect(fd['time-display']).toBe('Thursdays, 10:00–10:45 AM');
+  });
+
+  it('renders time-display for a Saturday session', () => {
+    // 2026-03-07T15:00:00Z is a Saturday, still EST → 10:00 AM ET.
+    const fd = mapSectionToFieldData(
+      {
+        ...baseSection,
+        sessions: [{ dateTime: new Date('2026-03-07T15:00:00Z') }],
+      },
+      prodOptions
+    );
+    expect(fd['time-display']).toBe('Saturdays, 10:00–10:45 AM');
+  });
+
+  it('computes time-display correctly during EST (November session)', () => {
+    // 2026-11-05T15:00:00Z is a Thursday in EST (UTC-5) → 10:00 AM ET.
+    const fd = mapSectionToFieldData(
+      {
+        ...baseSection,
+        sessions: [{ dateTime: new Date('2026-11-05T15:00:00Z') }],
+      },
+      prodOptions
+    );
+    expect(fd['time-display']).toBe('Thursdays, 10:00–10:45 AM');
+  });
+
+  it('falls back to plain start-time display when there are no sessions', () => {
+    const fd = mapSectionToFieldData(
+      { ...baseSection, sessions: [] },
+      prodOptions
+    );
+    // No first session → formatSectionTimeDisplay returns the formatSessions
+    // fallback (empty string for an empty session list).
+    expect(fd['time-display']).toBe('');
+  });
+
   it('includes location, room, and description when present', () => {
     const fd = mapSectionToFieldData(baseSection, prodOptions);
     expect(fd['location']).toBe('Maple & Spruce Studio');

--- a/libs/firebase/webflow/src/lib/mt-section.service.ts
+++ b/libs/firebase/webflow/src/lib/mt-section.service.ts
@@ -22,6 +22,7 @@ import {
   mtSectionFirstSessionAt,
   mtSpotsRemaining,
   mtSectionOffersInstallments,
+  MT_CLASS_DURATION_MINUTES,
 } from '@maple/ts/domain';
 import { generateSlug } from './artist.service';
 
@@ -90,6 +91,54 @@ function formatDollars(cents: number): string {
 }
 
 /**
+ * Format the recurring day-of-week + class time range for the Webflow
+ * `time-display` field, e.g. "Thursdays, 10:00–10:45 AM".
+ *
+ * Derived from the section's first session in America/New_York (DST-correct
+ * via `Intl.DateTimeFormat`, so November EST sessions render correctly). The
+ * end time is the start plus `MT_CLASS_DURATION_MINUTES`. Falls back to
+ * `fallback` (the plain start-time display) when the section has no sessions.
+ */
+export function formatSectionTimeDisplay(
+  section: Pick<MusicTogetherSection, 'sessions'>,
+  fallback = ''
+): string {
+  const firstStart = mtSectionFirstSessionAt(section);
+  if (!firstStart) return fallback;
+
+  const timeZone = 'America/New_York';
+
+  const weekday = new Intl.DateTimeFormat('en-US', {
+    weekday: 'long',
+    timeZone,
+  }).format(firstStart);
+  const weekdayPlural = `${weekday}s`;
+
+  // Intl emits a narrow no-break space (U+202F) before AM/PM in modern ICU;
+  // normalize it to a plain space so output is stable across runtimes.
+  const formatTime = (date: Date): string =>
+    new Intl.DateTimeFormat('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+      timeZone,
+    })
+      .format(date)
+      // Normalize narrow no-break (U+202F) / no-break (U+00A0) spaces to plain.
+      .replace(/[\u202f\u00a0]/g, ' ');
+
+  // Start time without its meridiem — the range carries a single "AM"/"PM".
+  const startHM = formatTime(firstStart).replace(/\s*[AP]M$/i, '');
+
+  const end = new Date(
+    firstStart.getTime() + MT_CLASS_DURATION_MINUTES * 60_000
+  );
+  const endHM = formatTime(end);
+
+  return `${weekdayPlural}, ${startHM}–${endHM}`;
+}
+
+/**
  * Map a Firebase Music Together section to Webflow CMS field data.
  */
 export function mapSectionToFieldData(
@@ -124,7 +173,9 @@ export function mapSectionToFieldData(
     'price-display': priceDisplay,
     'spots-display': spotsDisplay,
     'date-display': dateDisplay,
-    'time-display': timeDisplay,
+    // Day-of-week + class time range, e.g. "Thursdays, 10:00–10:45 AM".
+    // Falls back to the plain start-time display when there are no sessions.
+    'time-display': formatSectionTimeDisplay(section, timeDisplay),
   };
 
   // The `date-time` Webflow field is a native DateTime — use the first


### PR DESCRIPTION
## What

The MT section → Webflow sync wrote the `time-display` field as a bare start time (e.g. `10:00 AM`). This makes it a day-of-week + time range instead: **`Thursdays, 10:00–10:45 AM`**.

## How

- New pure helper `formatSectionTimeDisplay(section, fallback)` in `mt-section.service.ts`:
  - Weekday from the **first session** (`mtSectionFirstSessionAt`), pluralized (`Thursday` → `Thursdays`).
  - Start time formatted `h:mm` (meridiem stripped — the range carries a single AM/PM).
  - End time = start + `MT_CLASS_DURATION_MINUTES` (45), formatted `h:mm A`.
  - All parts use `Intl.DateTimeFormat` with explicit `timeZone: 'America/New_York'`, so it's DST-correct (November EST sessions render right). Narrow no-break spaces from modern ICU are normalized to plain spaces.
  - Falls back to the old plain start-time display (empty string when no sessions) — never throws.
- `date-display` is unchanged; only the `time-display` value changed.

## Tests

- `mt-section.service.spec.ts`: asserts Thursday and Saturday 10am ET → `Thursdays/Saturdays, 10:00–10:45 AM`, a November EST case, and the no-sessions fallback to `''`.
- Webflow unit suite: 26/26 pass.
- `tsc --noEmit -p apps/functions-sync/tsconfig.app.json`: clean.
- Did not touch `nx lint webflow` (pre-existing red on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)