### PR TITLE
fix(music-together): drive Square SDK env by App ID, not data env

### DIFF
--- a/.env.prod
+++ b/.env.prod
@@ -13,9 +13,19 @@ SALES_TAX_RATE=6.0
 # Music Together — SEPARATE Square account (Stephanie's LLC). MT checkouts
 # route here, not to the M&S account above. See docs/reference/music-together-plan.md.
 # The MT access token is a Firebase Secret (MT_SQUARE_ACCESS_TOKEN), NOT here.
-MT_SQUARE_ENV=PROD
-# TODO(#510/#517): MT PRODUCTION location ID — fill once the MT prod Square account exists (before Phase 7)
-MT_SQUARE_LOCATION_ID=
+#
+# INTERIM (pre-launch): MT's PRODUCTION Square account isn't provisioned yet, so
+# the prod project points at the MT SANDBOX account. This lets us complete real
+# sandbox charges on the real prod MT section pages for end-to-end testing while
+# reading live section data. The MT_SQUARE_ACCESS_TOKEN secret in the prod
+# project's Secret Manager must be set to the MT SANDBOX token to match.
+# ⚠️ AT LAUNCH: flip MT_SQUARE_ENV back to PROD, set MT_SQUARE_LOCATION_ID to the
+# real MT production location, and set the prod MT_SQUARE_ACCESS_TOKEN secret to
+# the live MT token — otherwise real families would be charged against sandbox.
+MT_SQUARE_ENV=LOCAL
+# MT SANDBOX location (Stephanie's MT sandbox account). Replace with the MT
+# PRODUCTION location at launch — see TODO(#510/#517).
+MT_SQUARE_LOCATION_ID=LKZXV01GJ3SZP
 # MT tuition is a non-taxable service (mirrors music-lesson exemption)
 MT_SALES_TAX_RATE=0.0
 

--- a/apps/webflow-components/src/MusicTogetherRegistrationWidget.tsx
+++ b/apps/webflow-components/src/MusicTogetherRegistrationWidget.tsx
@@ -102,11 +102,20 @@ type WidgetState =
 export interface MusicTogetherRegistrationWidgetProps {
   /** The MT section (class time) this widget registers for. */
   sectionId: string;
-  /** Square application ID for MT's account (sandbox or production). */
+  /**
+   * Square application ID for MT's account. Its prefix (`sandbox-sq0idb…` vs
+   * `sq0idp…`) is what selects the Square SDK environment — independent of
+   * `env` below — so you can read prod section data while taking payment
+   * through a sandbox Square app for end-to-end testing.
+   */
   squareAppId: string;
-  /** Square location ID for MT's account. */
+  /** Square location ID for MT's account (must match squareAppId's environment). */
   squareLocationId: string;
-  /** 'dev' | 'prod' | 'emulator' — selects Firebase project + Square SDK. */
+  /**
+   * 'dev' | 'prod' | 'emulator' — selects the Firebase project that serves
+   * section data + registration. Does NOT drive the Square SDK environment;
+   * that follows `squareAppId`'s prefix (see SquareCardForm).
+   */
   env: string;
   /** URL of the public Policies & FAQs page (linked from the consent checkbox). */
   policiesUrl: string;
@@ -635,7 +644,10 @@ export function MusicTogetherRegistrationWidget({
                   <SquareCardForm
                     applicationId={squareAppId}
                     locationId={squareLocationId}
-                    env={env}
+                    // No `env` — the Square SDK environment is derived from the
+                    // App ID prefix (sandbox- vs production), decoupled from the
+                    // data `env`. Lets us pair prod section data with a sandbox
+                    // Square app for testing.
                     totalCents={amountNowCents}
                     maxWidth={WIDGET_MAX_WIDTH}
                     onReady={() => setCardReady(true)}

--- a/apps/webflow-components/src/RegistrationWidget.tsx
+++ b/apps/webflow-components/src/RegistrationWidget.tsx
@@ -607,7 +607,6 @@ export function RegistrationWidget({
                   publicClass={state.publicClass}
                   squareApplicationId={squareAppId}
                   squareLocationId={squareLocationId}
-                  env={env}
                   applePayCheckoutUrl={digitalWalletsEnabled ? applePayCheckoutUrl : undefined}
                   showDigitalWallets={digitalWalletsEnabled}
                   requiredAgreements={state.requiredAgreements}

--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
@@ -104,7 +104,11 @@ interface RegistrationCheckoutFormProps {
   publicClass: PublicClass;
   squareApplicationId: string;
   squareLocationId: string;
-  /** Square environment — passed through to SquareCardForm */
+  /**
+   * @deprecated No longer used. The Square SDK environment is derived from
+   * `squareApplicationId`'s prefix (sandbox- vs production), so it can differ
+   * from the data backend. Accepted for backwards compatibility only.
+   */
   env?: string;
   /** URL of the Apple Pay checkout page hosted on a domain verified for Apple Pay */
   applePayCheckoutUrl?: string;
@@ -143,7 +147,6 @@ export function RegistrationCheckoutForm({
   publicClass,
   squareApplicationId,
   squareLocationId,
-  env,
   applePayCheckoutUrl,
   showDigitalWallets = false,
   requiredAgreements = [],
@@ -898,7 +901,8 @@ export function RegistrationCheckoutForm({
         <SquareCardForm
           applicationId={squareApplicationId}
           locationId={squareLocationId}
-          env={env}
+          // No `env` — Square SDK environment follows the App ID prefix,
+          // decoupled from the data backend.
           totalCents={costBreakdown.value?.totalCents}
           showDigitalWallets={showDigitalWallets}
           onReady={() => (isCardReady.value = true)}

--- a/libs/react/registrations/src/lib/SquareCardForm.spec.tsx
+++ b/libs/react/registrations/src/lib/SquareCardForm.spec.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import { SquareCardForm } from './SquareCardForm';
+
+/**
+ * Guards the Square SDK environment-selection contract that the Webflow
+ * widgets rely on: when no `env` is passed, the sandbox-vs-production CDN is
+ * chosen from the Square App ID prefix. This is what lets a widget read prod
+ * section data while taking payment through a sandbox Square app.
+ */
+function injectedSquareScriptSrcs(): string[] {
+  return Array.from(document.head.querySelectorAll('script'))
+    .map((s) => s.src)
+    .filter((src) => src.includes('squarecdn.com'));
+}
+
+afterEach(() => {
+  cleanup();
+  document.head
+    .querySelectorAll('script')
+    .forEach((s) => s.src.includes('squarecdn.com') && s.remove());
+  // Ensure each case takes the "load the SDK script" path.
+  delete (window as { Square?: unknown }).Square;
+});
+
+const SANDBOX_CDN = 'https://sandbox.web.squarecdn.com/v1/square.js';
+const PROD_CDN = 'https://web.squarecdn.com/v1/square.js';
+
+const noop = () => undefined;
+
+describe('SquareCardForm SDK environment selection', () => {
+  it('loads the SANDBOX CDN for a sandbox App ID when no env is given', () => {
+    render(
+      <SquareCardForm
+        applicationId="sandbox-sq0idb-abc123"
+        locationId="LOC1"
+        onTokenizeRef={noop}
+      />
+    );
+    expect(injectedSquareScriptSrcs()).toContain(SANDBOX_CDN);
+    expect(injectedSquareScriptSrcs()).not.toContain(PROD_CDN);
+  });
+
+  it('loads the PRODUCTION CDN for a production App ID when no env is given', () => {
+    render(
+      <SquareCardForm
+        applicationId="sq0idp-xyz789"
+        locationId="LOC1"
+        onTokenizeRef={noop}
+      />
+    );
+    expect(injectedSquareScriptSrcs()).toContain(PROD_CDN);
+    expect(injectedSquareScriptSrcs()).not.toContain(SANDBOX_CDN);
+  });
+
+  it('is decoupled from the data backend: a sandbox App ID stays on the sandbox CDN even though the widget reads prod data (no env prop)', () => {
+    // Mirrors the MT widget's usage: env drives the Firebase project, not this
+    // form. With env omitted, only the App ID decides the SDK environment.
+    render(
+      <SquareCardForm
+        applicationId="sandbox-sq0idb-mt-account"
+        locationId="LKZXV01GJ3SZP"
+        onTokenizeRef={noop}
+      />
+    );
+    expect(injectedSquareScriptSrcs()).toContain(SANDBOX_CDN);
+  });
+
+  it('still honors an explicit env override for backwards compatibility', () => {
+    // Legacy behavior: an explicit env wins over the App ID prefix.
+    render(
+      <SquareCardForm
+        applicationId="sandbox-sq0idb-abc123"
+        locationId="LOC1"
+        env="prod"
+        onTokenizeRef={noop}
+      />
+    );
+    expect(injectedSquareScriptSrcs()).toContain(PROD_CDN);
+  });
+});


### PR DESCRIPTION
## Why

The Webflow registration widgets used a single `env` prop for two unrelated jobs:
- which **Firebase project** serves section data + registration (`dev`/`prod`), and
- which **Square SDK/CDN** loads (`sandbox`/`production`).

That coupling made it impossible to read **real prod section data** while paying through a **sandbox Square app**: `env=prod` forced the prod Square CDN, and a sandbox App ID then threw the SDK `"sandbox appId but you are using production"` mismatch. This is why the real MT section pages (e.g. `/mt-sections/thursday-morning-mixed-age-0-5`) couldn't be used to test the dev flow — the only way to get sandbox payment was `env=dev`, which pointed data at the dev DB where prod sections don't exist.

## What changed

**Decouple the two concerns.** The Square SDK environment now follows the **Square App ID prefix** (`sandbox-sq0idb…` vs `sq0idp…`), independent of the data `env`. `SquareCardForm` already supported this via its appId-prefix fallback when `env` is omitted — the widgets just stop forcing `env` onto it.

| Concern | Now driven by |
|---|---|
| Firebase project (data/registration) | `env` (dev/prod) |
| Square SDK/CDN (sandbox/prod) | the Square **App ID** you configure |

- `MusicTogetherRegistrationWidget` — drop `env` from `SquareCardForm`.
- `RegistrationCheckoutForm` (class flow, backported for consistency) — drop the `env` passthrough; keep the now-unused `env?` prop marked `@deprecated`.
- `RegistrationWidget` — stop forwarding the deprecated `env`.
- **New** `SquareCardForm.spec.tsx` — locks in the appId→CDN contract (previously untested): sandbox App ID → sandbox CDN, prod App ID → prod CDN, explicit `env` still overrides.
- `.env.prod` — point prod MT Square at the **sandbox** account (interim), so real prod MT section pages can complete real sandbox charges end-to-end while MT's production Square is still unprovisioned.

**Result:** `env=prod` (real MT section data) + a sandbox MT App ID (sandbox card form + sandbox charge), **no data copying**.

## ⚠️ Required manual step (before this works)

Set the **prod** project's `MT_SQUARE_ACCESS_TOKEN` secret to the **MT sandbox** access token (it must match `MT_SQUARE_ENV=LOCAL`). Secret values aren't in the repo. Without it, MT checkouts on prod will 401.

## ⚠️ Launch checklist (do NOT ship MT to real families until)

Flip `.env.prod` back: `MT_SQUARE_ENV=PROD`, real `MT_SQUARE_LOCATION_ID`, and set the prod `MT_SQUARE_ACCESS_TOKEN` secret to the **live** MT token — otherwise real families would be charged against sandbox. (Loud comment added in `.env.prod`.)

## After merge / deploy

- Set the MT Webflow widget's **Environment** prop to `prod` so it reads real section data; the sandbox App ID keeps the card form + charge on sandbox.
- Prod deploy redeploys the `maple-square` codebase (MT param change) and waits on the production approval gate.

## Tests

- `SquareCardForm.spec.tsx` (new, 4 cases) + full `react-registrations` and `webflow-components` suites: **69 passed**.
- `tsc` clean on both changed projects (3 remaining errors are pre-existing in `RegistrationCheckoutForm.spec.tsx`, untouched here).

Refs #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)