### PR TITLE
fix(deps): override @xhmikosr/decompress to patch critical Zip Slip vuln

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,7 @@ overrides:
   form-data@>=2.0.0 <2.5.6: '>=2.5.6'
   http-proxy-middleware@>=3.0.4 <3.0.7: '>=3.0.7'
   piscina@<4.9.3: '>=4.9.3'
+  '@xhmikosr/decompress@>=11.0.0 <11.1.3': '>=11.1.3'
 
 importers:
 
@@ -4668,12 +4669,12 @@ packages:
     resolution: {integrity: sha512-1JXu2b6yrpm5EuBoOzMU57B4qrHXJKWQQ7LlMynNEiz85mEjDciO3ayf//GXaTLLCEKiHjWlU3q3THjgf7uODA==}
     engines: {node: '>=20'}
 
-  '@xhmikosr/decompress-unzip@8.1.0':
-    resolution: {integrity: sha512-hVcpEZIS8avXU1ioR0Pb2LcBYHfah1lzzTQPDItkBi3W+kSE/DxSeEgOoHJB8rn+Izm0ArWZxxlpsvEK4ySjaw==}
+  '@xhmikosr/decompress-unzip@8.2.1':
+    resolution: {integrity: sha512-2MS94QnmXQwjkKN8WyFiu1sU7J3rcWJcMze4kRYsX7tN+CXpUGECgkh4YSOhujpkWPuVlFudIziJHO/TxOqkQQ==}
     engines: {node: '>=20'}
 
-  '@xhmikosr/decompress@11.1.1':
-    resolution: {integrity: sha512-KdjwFbTzcpGaTIPncNaPLOHocBSF1hHo4s7gr+ZzzoB2bzVzFumzawqKTij0Vpw0idM4C2FZFPktIfyznkeJTQ==}
+  '@xhmikosr/decompress@11.1.3':
+    resolution: {integrity: sha512-NiyhJq6z7ERsYghcnXZUI6ooDXgZtoB+G9eUsYhfSM4VLp2rKx9UxhKI1NEf1PqosrNPxG3bnSsr2UBVbNurlg==}
     engines: {node: '>=20'}
 
   '@xhmikosr/downloader@16.1.2':
@@ -10939,8 +10940,8 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
-  yauzl@3.3.0:
-    resolution: {integrity: sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==}
+  yauzl@3.4.0:
+    resolution: {integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==}
     engines: {node: '>=12'}
 
   yn@3.1.1:
@@ -16132,20 +16133,20 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@xhmikosr/decompress-unzip@8.1.0':
+  '@xhmikosr/decompress-unzip@8.2.1':
     dependencies:
       file-type: 21.3.4
       get-stream: 9.0.1
-      yauzl: 3.3.0
+      yauzl: 3.4.0
     transitivePeerDependencies:
       - supports-color
 
-  '@xhmikosr/decompress@11.1.1':
+  '@xhmikosr/decompress@11.1.3':
     dependencies:
       '@xhmikosr/decompress-tar': 9.0.1
       '@xhmikosr/decompress-tarbz2': 9.0.1
       '@xhmikosr/decompress-targz': 9.0.1
-      '@xhmikosr/decompress-unzip': 8.1.0
+      '@xhmikosr/decompress-unzip': 8.2.1
       graceful-fs: 4.2.11
       strip-dirs: 3.0.0
     transitivePeerDependencies:
@@ -16156,7 +16157,7 @@ snapshots:
   '@xhmikosr/downloader@16.1.2':
     dependencies:
       '@xhmikosr/archive-type': 8.0.1
-      '@xhmikosr/decompress': 11.1.1
+      '@xhmikosr/decompress': 11.1.3
       content-disposition: 1.1.0
       ext-name: 5.0.0
       file-type: 21.3.4
@@ -23296,9 +23297,8 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  yauzl@3.3.0:
+  yauzl@3.4.0:
     dependencies:
-      buffer-crc32: 0.2.13
       pend: 1.2.0
 
   yn@3.1.1: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -141,3 +141,8 @@ overrides:
   # inherited options.filename (patched in 4.9.3). Transitive dep of @nx/*.
   # Added 2026-06-20.
   piscina@<4.9.3: '>=4.9.3'
+  # GHSA-mp2f-45pm-3cg9 (critical): @xhmikosr/decompress archive extraction
+  # can create files and links outside the target directory (Zip Slip)
+  # (patched in 11.1.3). Transitive dep of @swc/cli > @xhmikosr/bin-wrapper >
+  # @xhmikosr/downloader > @xhmikosr/decompress. Added 2026-07-06.
+  '@xhmikosr/decompress@>=11.0.0 <11.1.3': '>=11.1.3'


### PR DESCRIPTION
## Problem

The **Security Audit** CI check (`pnpm audit --audit-level=high`) is failing on a **critical** advisory:

> **[GHSA-mp2f-45pm-3cg9](https://github.com/advisories/GHSA-mp2f-45pm-3cg9)** — `@xhmikosr/decompress`: archive extraction can create files and links outside the target directory (Zip Slip)
> - Vulnerable: `>=11.0.0 <11.1.3` · Patched: `>=11.1.3`
> - Path: `@swc/cli > @xhmikosr/bin-wrapper > @xhmikosr/downloader > @xhmikosr/decompress`

## Fix

Add a documented `pnpm-workspace.yaml` override pinning `@xhmikosr/decompress` to `>=11.1.3`, matching the existing override-with-comment pattern used for every other transitive advisory in this repo. Regenerated `pnpm-lock.yaml` (now resolves `@xhmikosr/decompress@11.1.3`).

## Verification

`pnpm audit --audit-level=high` now exits **0** (13 remaining: 3 low, 10 moderate — none at the `high` gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)