### PR TITLE
feat(music-together): author confirmation + installment-failed emails

### DIFF
--- a/libs/firebase/maple-functions/charge-music-together-installments/src/lib/charge-music-together-installments.ts
+++ b/libs/firebase/maple-functions/charge-music-together-installments/src/lib/charge-music-together-installments.ts
@@ -173,7 +173,9 @@ async function queueFailureEmail(
   charge: MusicTogetherScheduledCharge,
   reason: string
 ): Promise<void> {
-  // Template `music-together-installment-failed` is authored separately.
+  // Template `music-together-installment-failed` is seeded via
+  // tools/seed-email-templates.ts. The extension's Handlebars can't format
+  // currency, so pass a template-ready amount string (raw cents kept too).
   await getDb()
     .collection('mail')
     .add({
@@ -183,6 +185,7 @@ async function queueFailureEmail(
         data: {
           installmentNumber: charge.installmentNumber,
           amountCents: charge.amountCents,
+          amountLabel: `$${(charge.amountCents / 100).toFixed(2)}`,
           reason,
         },
       },

--- a/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.ts
+++ b/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.ts
@@ -260,7 +260,19 @@ export const createMusicTogetherRegistration = Functions.endpoint
     }
 
     // 8. Confirmation email (fire-and-forget via the mail collection).
-    //    Template `music-together-confirmation` is authored separately.
+    //    Template `music-together-confirmation` is seeded via
+    //    tools/seed-email-templates.ts. The extension's Handlebars can't format
+    //    currency/dates, so pass template-ready strings (raw cents/plan kept for
+    //    any downstream consumers).
+    const fmtMoney = (cents: number) => `$${(cents / 100).toFixed(2)}`;
+    const fmtDate = (d: Date) =>
+      d.toLocaleDateString('en-US', {
+        month: 'long',
+        day: 'numeric',
+        year: 'numeric',
+        timeZone: 'America/New_York',
+      });
+    const secondInstallment = scheduledItems[0];
     await getDb()
       .collection('mail')
       .add({
@@ -273,6 +285,17 @@ export const createMusicTogetherRegistration = Functions.endpoint
             paymentPlan: data.paymentPlan,
             amountChargedCents: firstChargeCents,
             scheduledChargeCount: createdCharges,
+            // Template-ready presentation fields:
+            amountChargedLabel: fmtMoney(firstChargeCents),
+            isInstallments: data.paymentPlan === 'installments',
+            secondInstallmentLabel: secondInstallment
+              ? fmtMoney(secondInstallment.amountCents)
+              : '',
+            secondInstallmentDate: secondInstallment
+              ? fmtDate(new Date(secondInstallment.dueAt))
+              : '',
+            cardLast4: cardLast4 ?? '',
+            receiptUrl: squareReceiptUrl ?? '',
           },
         },
       });

--- a/tools/seed-email-templates.ts
+++ b/tools/seed-email-templates.ts
@@ -671,6 +671,134 @@ const craftClubCancelledHtml = `<!DOCTYPE html>
 </html>`;
 
 // ---------------------------------------------------------------------------
+// Template: music-together-confirmation
+//
+// Sent when a family registers for a Music Together section. Transactional.
+// Routes payment to MT's Square account. Data: parentName, sectionName,
+// amountChargedLabel, isInstallments, secondInstallmentLabel,
+// secondInstallmentDate, cardLast4, receiptUrl.
+// ---------------------------------------------------------------------------
+
+const musicTogetherConfirmationSubject =
+  "You're registered for {{sectionName}}!";
+
+const musicTogetherConfirmationHtml = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Music Together Registration Confirmed</title>
+<style>${styles}</style>
+</head>
+<body>
+<div class="wrapper">
+  <div class="header">
+    <h1>Music Together with Maple &amp; Spruce</h1>
+  </div>
+  <div class="content">
+    <h2>You're registered!</h2>
+    <p>{{#if parentName}}Hi {{parentName}},{{else}}Hello,{{/if}}</p>
+    <p>Your family is enrolled in <strong>{{sectionName}}</strong>. We can't wait
+      to make music with you!</p>
+
+    <table class="detail-table">
+      <tr>
+        <td class="label">Class</td>
+        <td>{{sectionName}}</td>
+      </tr>
+      <tr>
+        <td class="label">Paid today</td>
+        <td><strong>{{amountChargedLabel}}</strong></td>
+      </tr>
+    </table>
+
+    {{#if isInstallments}}
+    <div class="highlight-box">
+      <strong style="color: #4A3728;">Your second installment</strong><br>
+      <p>We'll automatically charge <strong>{{secondInstallmentLabel}}</strong>
+        on <strong>{{secondInstallmentDate}}</strong>{{#if cardLast4}} to the card
+        ending in {{cardLast4}}{{/if}}. No action is needed — you're all set.</p>
+    </div>
+    {{/if}}
+
+    {{#if receiptUrl}}
+    <p><a href="{{receiptUrl}}" style="color: #6B7B5E; font-weight: bold;">View Payment Receipt</a></p>
+    {{/if}}
+
+    <div class="highlight-box">
+      <strong style="color: #4A3728;">What's next</strong><br>
+      <p>Watch your inbox for class details before your first session. Your
+        Music Together songbook and materials will be mailed to the address you
+        provided.</p>
+    </div>
+
+    <p>Questions? Reach out at
+      <a href="mailto:musictogether@mapleandsprucefolkarts.com" style="color: #6B7B5E;">musictogether@mapleandsprucefolkarts.com</a>
+      or call <a href="tel:+13043144506" style="color: #6B7B5E;">304-314-4506</a>.</p>
+  </div>
+  <div class="footer">
+    <strong style="color: #4A3728;">Music Together with Maple &amp; Spruce</strong><br>
+    Morgantown, WV<br>
+    <a href="mailto:musictogether@mapleandsprucefolkarts.com">musictogether@mapleandsprucefolkarts.com</a> | <a href="tel:+13043144506">304-314-4506</a><br>
+    <span style="font-size: 12px; color: #999;">Music Together with Maple &amp; Spruce LLC is licensed by Music Together Worldwide. Music Together is a registered trademark.</span>
+  </div>
+</div>
+</body>
+</html>`;
+
+// ---------------------------------------------------------------------------
+// Template: music-together-installment-failed
+//
+// Sent when a scheduled installment charge (card on file) fails. Transactional,
+// loud, no dunning. Data: installmentNumber, amountLabel, reason.
+// ---------------------------------------------------------------------------
+
+const musicTogetherInstallmentFailedSubject =
+  'Action needed: your Music Together payment didn’t go through';
+
+const musicTogetherInstallmentFailedHtml = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Music Together payment failed</title>
+<style>${styles}</style>
+</head>
+<body>
+<div class="wrapper">
+  <div class="header">
+    <h1>Music Together with Maple &amp; Spruce</h1>
+  </div>
+  <div class="content">
+    <h2>We couldn't process your payment</h2>
+    <p>Hello,</p>
+    <p>We tried to charge installment {{installmentNumber}} of
+      <strong>{{amountLabel}}</strong> to the card on file, but it didn't go
+      through.</p>
+    {{#if reason}}
+    <div class="highlight-box">
+      <strong style="color: #4A3728;">Reason</strong><br>
+      {{reason}}
+    </div>
+    {{/if}}
+    <p>Please get in touch so we can update your payment details and keep your
+      spot. Your enrollment isn't affected yet — we just need to sort out this
+      charge.</p>
+    <p>Reach out at
+      <a href="mailto:musictogether@mapleandsprucefolkarts.com" style="color: #6B7B5E;">musictogether@mapleandsprucefolkarts.com</a>
+      or call <a href="tel:+13043144506" style="color: #6B7B5E;">304-314-4506</a>.</p>
+  </div>
+  <div class="footer">
+    <strong style="color: #4A3728;">Music Together with Maple &amp; Spruce</strong><br>
+    Morgantown, WV<br>
+    <a href="mailto:musictogether@mapleandsprucefolkarts.com">musictogether@mapleandsprucefolkarts.com</a> | <a href="tel:+13043144506">304-314-4506</a><br>
+    <span style="font-size: 12px; color: #999;">Music Together with Maple &amp; Spruce LLC is licensed by Music Together Worldwide. Music Together is a registered trademark.</span>
+  </div>
+</div>
+</body>
+</html>`;
+
+// ---------------------------------------------------------------------------
 // Seed to Firestore
 // ---------------------------------------------------------------------------
 
@@ -715,6 +843,14 @@ const templates: Record<string, EmailTemplate> = {
   'craft-club-cancelled': {
     subject: craftClubCancelledSubject,
     html: craftClubCancelledHtml,
+  },
+  'music-together-confirmation': {
+    subject: musicTogetherConfirmationSubject,
+    html: musicTogetherConfirmationHtml,
+  },
+  'music-together-installment-failed': {
+    subject: musicTogetherInstallmentFailedSubject,
+    html: musicTogetherInstallmentFailedHtml,
   },
 };
 


### PR DESCRIPTION
## Why

The MT functions queue mail with `template: { name: 'music-together-confirmation' }` (registration) and `'music-together-installment-failed'` (failed Week-5 charge), but **those templates were never authored**. The `firestore-send-email` extension renders from the `email-templates` collection, which only held the 9 class/Craft-Club templates. Net effect: **no Music Together email has ever sent**, in dev or prod. (This is why a test registration produced no confirmation — that, plus the test used a placeholder recipient address.)

## What changed

- **`tools/seed-email-templates.ts`** — add `music-together-confirmation` and `music-together-installment-failed`. MT-branded header ("Music Together with Maple & Spruce"), licensee credit line in the footer, reusing the shared M&S email styles.
- **`create-music-together-registration.ts`** — the extension's Handlebars can't format currency/dates, so pass **template-ready** fields alongside the raw ones (additive, so existing `objectContaining` specs stay green): `amountChargedLabel`, `isInstallments`, `secondInstallmentLabel`, `secondInstallmentDate`, `cardLast4`, `receiptUrl`.
- **`charge-music-together-installments.ts`** — pass `amountLabel` (formatted) for the failure email.

Scope per decision: **parent confirmation only** (no admin copy), **default sender** (no extension change).

## Required after merge — seed the templates

Templates are Firestore data, not deployed code, so they must be seeded separately (needs `gcloud auth application-default login` first):

```bash
npx tsx tools/seed-email-templates.ts          # dev
npx tsx tools/seed-email-templates.ts --prod   # prod
```

Seed **prod** after this merges + deploys so the confirmation's amount/date fields are populated by the updated function. (Seeding earlier is harmless — the template just renders blank amounts until the function deploys.)

## Tests

- `create-music-together-registration` + `charge-music-together-installments` specs: **16 passed** (additive fields, `objectContaining` assertions intact).

## Follow-ups (not in this PR)
- Minor UX: the registration form shows a generic "complete the form" hint instead of naming the missing field (the DOB gotcha).
- Admin: show registered-children count directly in the admin Sections table (currently requires opening the roster).

🤖 Generated with [Claude Code](https://claude.com/claude-code)