### PR TITLE
chore(worktrees): create worktrees outside the repo tree via hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-$PWD}/tools/claude-worktree-create.sh\"",
+            "timeout": 120
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-$PWD}/tools/claude-worktree-remove.sh\"",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/guides/worktree-setup.md
+++ b/docs/guides/worktree-setup.md
@@ -8,13 +8,32 @@ test work already in progress there.
 This repo is configured so that emulators, mock servers, and integration
 tests can run in two or more trees at once without colliding.
 
+## Location: keep worktrees OUTSIDE the repo tree
+
+Worktrees live in a sibling directory next to the repo, **not** nested inside
+it: `../maple-and-spruce-worktrees/<name>` (i.e. `<repo>-worktrees/<name>`),
+not `.claude/worktrees/<name>`. Nesting worktrees inside the repo's own working
+tree confuses tooling (git status, coverage globs, file watchers) and clutters
+the checkout.
+
+- **Claude Code agents**: `EnterWorktree` places worktrees in the external dir
+  automatically via the `WorktreeCreate` hook wired in `.claude/settings.json`
+  (`tools/claude-worktree-create.sh` / `tools/claude-worktree-remove.sh`). No
+  action needed — new worktrees land in `<repo>-worktrees/` on branch
+  `worktree-<name>`, and removing one also deletes that branch.
+- **Manual `git worktree add`**: target the external dir yourself (see below).
+
+Existing `.claude/worktrees/*` trees are fine to leave in place; they age out as
+their branches merge. This is a forward-only convention — don't relocate a
+worktree that has live work.
+
 ## Quick start
 
 ```bash
 # From the main checkout
 git fetch origin main
-git worktree add -b feature/my-change .claude/worktrees/my-change origin/main
-cd .claude/worktrees/my-change
+git worktree add -b feature/my-change ../maple-and-spruce-worktrees/my-change origin/main
+cd ../maple-and-spruce-worktrees/my-change
 
 # Bootstrap: deterministic port offset + NX_DAEMON=false
 ./tools/bootstrap-worktree.sh

--- a/tools/claude-worktree-create.sh
+++ b/tools/claude-worktree-create.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Claude Code WorktreeCreate hook.
+#
+# Places new worktrees OUTSIDE the repo working tree, in a sibling directory
+# "<repo>-worktrees/<name>", instead of Claude's default ".claude/worktrees/"
+# inside the repo. Keeps the repo tree clean and avoids nested-worktree tooling
+# confusion (git status, coverage globs, file watchers, etc.).
+#
+# This hook REPLACES Claude's built-in worktree creation, so it re-implements
+# the default behavior: a new branch "worktree-<name>" created from the repo's
+# default "fresh" base ref (origin's default branch).
+#
+# Contract (Claude Code):
+#   stdin : JSON { cwd, worktree_name, base_path, ... }
+#   stdout: the absolute worktree path, and ONLY that (Claude uses it)
+#   stderr: everything else (git chatter, diagnostics)
+#   exit 0 on success; non-zero aborts creation and shows stderr to the user.
+#
+set -euo pipefail
+
+input="$(cat)"
+cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
+name="$(printf '%s' "$input" | jq -r '.worktree_name // empty')"
+
+if [ -z "$cwd" ] || [ -z "$name" ]; then
+  echo "claude-worktree-create: missing cwd/worktree_name in hook input" >&2
+  exit 1
+fi
+
+# Sibling of the repo: /path/to/foo -> /path/to/foo-worktrees/<name>
+base="$(dirname "$cwd")/$(basename "$cwd")-worktrees"
+path="$base/$name"
+branch="worktree-$name"
+
+mkdir -p "$base"
+cd "$cwd"
+
+# Honor the default "fresh" baseRef: branch from origin's default branch.
+# Fetch is best-effort so offline creation still works (falls back to HEAD).
+git fetch origin --quiet 2>/dev/null || true
+base_ref="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+[ -n "$base_ref" ] || base_ref="HEAD"
+
+# All git output to stderr; stdout must carry ONLY the resulting path.
+git worktree add "$path" -b "$branch" "$base_ref" 1>&2
+
+printf '%s\n' "$path"

--- a/tools/claude-worktree-remove.sh
+++ b/tools/claude-worktree-remove.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Claude Code WorktreeRemove hook.
+#
+# Cleans up the external worktree created by claude-worktree-create.sh. Runs for
+# side effects only (Claude ignores the exit code), and is idempotent: if Claude
+# already removed the worktree, this is a harmless no-op.
+#
+# Contract (Claude Code):
+#   stdin : JSON { cwd, worktree_path, ... }
+#   exit code is ignored.
+#
+set -euo pipefail
+
+input="$(cat)"
+path="$(printf '%s' "$input" | jq -r '.worktree_path // empty')"
+cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
+
+[ -n "$path" ] || exit 0
+[ -n "$cwd" ] && cd "$cwd" 2>/dev/null || true
+
+git worktree remove --force "$path" >/dev/null 2>&1 || true
+
+# Also delete the branch, but ONLY for worktrees this hook created: those live
+# in a sibling "<repo>-worktrees/" dir and use a "worktree-<name>" branch.
+# Scoping to that convention avoids ever force-deleting an unrelated branch.
+case "$(basename "$(dirname "$path")")" in
+  *-worktrees)
+    git branch -D "worktree-$(basename "$path")" >/dev/null 2>&1 || true
+    ;;
+esac


### PR DESCRIPTION
## Why

Agents and manual `git worktree add` had been creating worktrees **inside** the repo at `.claude/worktrees/<name>`. That clutters the working tree and confuses tooling (git status, coverage globs, file watchers) — 100+ had accumulated (a companion cleanup removed the merged ones). Going forward, new worktrees live in a sibling **`<repo>-worktrees/<name>`** dir, outside the repo's own working tree.

## How

Claude Code has **no built-in setting** for worktree location (only `worktree.baseRef`). The only supported override is the `WorktreeCreate` / `WorktreeRemove` hooks, so:

- **`tools/claude-worktree-create.sh`** — replaces the default creation. Derives `<parent>/<repo>-worktrees/<name>` from the hook's `cwd` (portable — no hardcoded paths), re-implements the default `fresh` baseRef (branch `worktree-<name>` from origin's default branch), and emits **only** the resulting path on stdout (all git output → stderr).
- **`tools/claude-worktree-remove.sh`** — idempotent cleanup; also deletes the `worktree-<name>` branch, **scoped to `*-worktrees/` paths** so it can never force-delete an unrelated branch.
- **`.claude/settings.json`** — wires both hooks via `${CLAUDE_PROJECT_DIR}`.
- **`docs/guides/worktree-setup.md`** — documents the convention and fixes the quick-start example.

## Scope / safety

- **Forward-only.** Existing `.claude/worktrees/*` trees are untouched and age out as their branches merge. Nothing is relocated (relocating a worktree with live work is risky).
- **Manual adds** still work — just target the external dir (documented).

## Tested end-to-end

Ran the scripts against real `git worktree add`/`remove`:
- create → lands in `…/maple-and-spruce-worktrees/<name>` on branch `worktree-<name>`; stdout is only the path ✅
- remove → worktree **and** branch gone ✅
- safety: remove on a non-`*-worktrees` path leaves a same-named unrelated branch intact ✅

The Claude→hook wiring itself takes effect once merged (settings load at session start); the script logic is fully verified above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)