### PR TITLE
fix(music-together): name the missing field in the registration widget hint

### DIFF
--- a/apps/webflow-components/src/MusicTogetherRegistrationWidget.spec.tsx
+++ b/apps/webflow-components/src/MusicTogetherRegistrationWidget.spec.tsx
@@ -162,6 +162,28 @@ describe('MusicTogetherRegistrationWidget', () => {
     expect(payload.children[0].dob).toMatch(/^2024-03-15/);
   });
 
+  it('names the specific missing field(s) instead of a generic hint', async () => {
+    const user = userEvent.setup();
+    renderWidget();
+    await screen.findByText(/Register — Thursday Morning/i);
+
+    // Fill everything EXCEPT the child's date of birth, and accept policies —
+    // so the only thing missing is the DOB (the easiest field to overlook).
+    await user.type(screen.getByLabelText(/^Name/i), 'Jane Doe');
+    await user.type(screen.getByLabelText(/Child's name/i), 'Baby Doe');
+    await user.type(screen.getByLabelText(/^Email/i), 'jane@example.com');
+    await user.type(screen.getByLabelText(/^Phone/i), '304-555-0100');
+    await user.type(screen.getByLabelText(/Mailing address/i), '1 Main St');
+    await user.click(screen.getByLabelText(/I have read and agree/i));
+
+    expect(
+      await screen.findByText(/Still needed:.*date of birth/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Register — \$252\.00/i })
+    ).toBeDisabled();
+  });
+
   it('requires card-on-file authorization for the installment plan', async () => {
     const user = userEvent.setup();
     renderWidget();

--- a/apps/webflow-components/src/MusicTogetherRegistrationWidget.tsx
+++ b/apps/webflow-components/src/MusicTogetherRegistrationWidget.tsx
@@ -78,6 +78,13 @@ function formatDueDate(iso: string): string {
   });
 }
 
+/** Join a list into prose: ["a"] → "a", ["a","b"] → "a and b", more → "a, b, and c". */
+function joinList(items: string[]): string {
+  if (items.length <= 1) return items[0] ?? '';
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(', ')}, and ${items[items.length - 1]}`;
+}
+
 type PaymentPlan = 'full' | 'installments';
 
 interface FamilyChild {
@@ -324,6 +331,26 @@ export function MusicTogetherRegistrationWidget({
     (paymentPlan === 'full' || cardOnFileAuth);
 
   const payDisabled = busy || !cardReady || !formValid;
+
+  // Name exactly what's still missing so the disabled button isn't a mystery —
+  // the empty date-of-birth field is the easiest one to miss.
+  const missingFields: string[] = [];
+  if (cleanParents.length === 0)
+    missingFields.push('a parent or caregiver name');
+  if (cleanChildren.length === 0) {
+    const hasChildName = children.some((c) => c.name.trim().length > 0);
+    const hasChildDob = children.some((c) => c.dob);
+    if (!hasChildName) missingFields.push("your child's name");
+    else if (!hasChildDob) missingFields.push("your child's date of birth");
+    else missingFields.push("your child's name and date of birth");
+  }
+  if (!emailValid) missingFields.push('a valid email address');
+  if (phone.trim().length === 0) missingFields.push('your phone number');
+  if (address.trim().length === 0) missingFields.push('your mailing address');
+  if (!policiesAccepted)
+    missingFields.push('agreement to the Policies & FAQs');
+  if (paymentPlan === 'installments' && !cardOnFileAuth)
+    missingFields.push('authorization for the second installment');
 
   const addParent = () => setParentNames((p) => [...p, '']);
   const removeParent = (i: number) =>
@@ -684,13 +711,13 @@ export function MusicTogetherRegistrationWidget({
                       </button>
                     }
                   />
-                  {!formValid && (
+                  {!formValid && missingFields.length > 0 && (
                     <Typography
                       variant="caption"
                       color="text.secondary"
                       sx={{ display: 'block', mt: 1 }}
                     >
-                      Complete the form above and accept the policies to register.
+                      Still needed: {joinList(missingFields)}.
                     </Typography>
                   )}
                 </Box>


### PR DESCRIPTION
## Why
The MT registration widget showed a generic **"Complete the form above and accept the policies to register"** whenever the form was incomplete. A disabled Register button was then a mystery — most often because the child's **Date of Birth** (empty by default, required) was overlooked. (This came up while testing on the live page.)

## What
List exactly what's still missing:

> Still needed: your child's date of birth.

Covers each required field with human wording — parent/caregiver name, child name vs. date of birth (distinguished, since DOB is the common miss), a valid email, phone, mailing address, policies agreement, and the installment card-on-file authorization. Multiple gaps read naturally ("… your phone number and your mailing address").

## Tests
Added a spec that fills everything **except** the DOB and asserts the hint names it and the button stays disabled. Full widget spec: **6 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)