### PR TITLE
feat(music-together): show registered count in admin Sections table

### DIFF
--- a/apps/maple-spruce/src/app/(admin)/music-together/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/page.tsx
@@ -47,7 +47,7 @@ const fmtDay = (d?: Date) =>
 const fmtPrice = (cents: number) => `$${(cents / 100).toFixed(0)}`;
 
 export default function MusicTogetherPage() {
-  const { sectionsState, createSection, updateSection } =
+  const { sectionsState, countsBySection, createSection, updateSection } =
     useMusicTogetherSections();
   const { semestersState, createSemester, updateSemester } =
     useMusicTogetherSemesters();
@@ -257,6 +257,7 @@ export default function MusicTogetherPage() {
               <TableCell>Status</TableCell>
               <TableCell>First session</TableCell>
               <TableCell>Capacity</TableCell>
+              <TableCell>Registered</TableCell>
               <TableCell>Full price</TableCell>
               <TableCell>Installments</TableCell>
               <TableCell align="right">Actions</TableCell>
@@ -280,6 +281,24 @@ export default function MusicTogetherPage() {
                 </TableCell>
                 <TableCell>{fmtDate(section.sessions?.[0]?.dateTime)}</TableCell>
                 <TableCell>{section.capacityFamilies} families</TableCell>
+                <TableCell>
+                  {(() => {
+                    const counts = countsBySection[section.id];
+                    const families = counts?.families ?? 0;
+                    const childCount = counts?.children ?? 0;
+                    return (
+                      <>
+                        <Typography variant="body2">
+                          {childCount}{' '}
+                          {childCount === 1 ? 'child' : 'children'}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          {families} / {section.capacityFamilies} families
+                        </Typography>
+                      </>
+                    );
+                  })()}
+                </TableCell>
                 <TableCell>{fmtPrice(section.priceFullCents)}</TableCell>
                 <TableCell>
                   {section.installmentPlan?.length

--- a/libs/firebase/maple-functions/get-music-together-sections/src/lib/get-music-together-sections.spec.ts
+++ b/libs/firebase/maple-functions/get-music-together-sections/src/lib/get-music-together-sections.spec.ts
@@ -1,12 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const mocks = vi.hoisted(() => ({ findAll: vi.fn() }));
+const mocks = vi.hoisted(() => ({
+  findAll: vi.fn(),
+  regFindAll: vi.fn(),
+}));
 
 vi.mock('@maple/firebase/functions', () => ({
   createAuthenticatedFunction: (h: unknown) => h,
 }));
 vi.mock('@maple/firebase/database', () => ({
   MusicTogetherSectionRepository: { findAll: mocks.findAll },
+  MusicTogetherRegistrationRepository: { findAll: mocks.regFindAll },
 }));
 
 import { getMusicTogetherSections } from './get-music-together-sections';
@@ -14,10 +18,16 @@ import { getMusicTogetherSections } from './get-music-together-sections';
 const handler = getMusicTogetherSections as unknown as (
   d: unknown,
   c?: unknown
-) => Promise<{ sections: unknown[] }>;
+) => Promise<{
+  sections: unknown[];
+  counts: Record<string, { families: number; children: number }>;
+}>;
 
 describe('getMusicTogetherSections', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.regFindAll.mockResolvedValue([]);
+  });
 
   it('returns sections, passing the status filter through', async () => {
     mocks.findAll.mockResolvedValue([{ id: 'sec-1' }]);
@@ -31,5 +41,37 @@ describe('getMusicTogetherSections', () => {
     const result = await handler({}, {});
     expect(mocks.findAll).toHaveBeenCalledWith({ status: undefined });
     expect(result.sections).toEqual([]);
+  });
+
+  it('counts registered families + children per section (capacity statuses only)', async () => {
+    mocks.findAll.mockResolvedValue([{ id: 'sec-1' }, { id: 'sec-2' }]);
+    mocks.regFindAll.mockResolvedValue([
+      // sec-1: 2 confirmed families, 3 children total
+      { sectionId: 'sec-1', status: 'confirmed', children: [{}, {}] },
+      { sectionId: 'sec-1', status: 'confirmed', children: [{}] },
+      // pending counts toward capacity too (1 more family, 1 child)
+      { sectionId: 'sec-1', status: 'pending', children: [{}] },
+      // cancelled / refunded do NOT count
+      { sectionId: 'sec-1', status: 'cancelled', children: [{}, {}] },
+      { sectionId: 'sec-1', status: 'refunded', children: [{}] },
+      // sec-2: 1 confirmed family, 1 child
+      { sectionId: 'sec-2', status: 'confirmed', children: [{}] },
+      // registration for a section not in the result set is ignored
+      { sectionId: 'sec-other', status: 'confirmed', children: [{}, {}] },
+    ]);
+
+    const result = await handler({}, {});
+
+    expect(result.counts).toEqual({
+      'sec-1': { families: 3, children: 4 },
+      'sec-2': { families: 1, children: 1 },
+    });
+  });
+
+  it('reports zero counts for a section with no registrations', async () => {
+    mocks.findAll.mockResolvedValue([{ id: 'sec-empty' }]);
+    mocks.regFindAll.mockResolvedValue([]);
+    const result = await handler({}, {});
+    expect(result.counts).toEqual({ 'sec-empty': { families: 0, children: 0 } });
   });
 });

--- a/libs/firebase/maple-functions/get-music-together-sections/src/lib/get-music-together-sections.ts
+++ b/libs/firebase/maple-functions/get-music-together-sections/src/lib/get-music-together-sections.ts
@@ -2,13 +2,20 @@
  * Get Music Together Sections Cloud Function
  *
  * Lists Music Together sections for the admin app (authenticated). Optional
- * status filter. Deployed to us-east4 via CI/CD (maple-core codebase).
+ * status filter. Also returns per-section registration counts so the admin
+ * table can show how full each section is without opening the roster.
+ * Deployed to us-east4 via CI/CD (maple-core codebase).
  */
 import { createAuthenticatedFunction } from '@maple/firebase/functions';
-import { MusicTogetherSectionRepository } from '@maple/firebase/database';
+import {
+  MusicTogetherSectionRepository,
+  MusicTogetherRegistrationRepository,
+} from '@maple/firebase/database';
+import { MT_CAPACITY_STATUSES } from '@maple/ts/domain';
 import type {
   GetMusicTogetherSectionsRequest,
   GetMusicTogetherSectionsResponse,
+  MusicTogetherSectionCounts,
 } from '@maple/ts/firebase/api-types';
 
 export const getMusicTogetherSections = createAuthenticatedFunction<
@@ -18,5 +25,22 @@ export const getMusicTogetherSections = createAuthenticatedFunction<
   const sections = await MusicTogetherSectionRepository.findAll({
     status: data.status,
   });
-  return { sections };
+
+  // Per-section registration counts in one query, grouped in memory. Count the
+  // same statuses as capacity/spotsRemaining (pending + confirmed) so
+  // "registered" matches the section's taken spots.
+  const registrations = await MusicTogetherRegistrationRepository.findAll();
+  const counts: Record<string, MusicTogetherSectionCounts> = {};
+  for (const section of sections) {
+    counts[section.id] = { families: 0, children: 0 };
+  }
+  for (const reg of registrations) {
+    if (!MT_CAPACITY_STATUSES.includes(reg.status)) continue;
+    const entry = counts[reg.sectionId];
+    if (!entry) continue; // registration for a section not in this result set
+    entry.families += 1;
+    entry.children += reg.children.length;
+  }
+
+  return { sections, counts };
 });

--- a/libs/react/data/src/lib/useMusicTogetherSections.ts
+++ b/libs/react/data/src/lib/useMusicTogetherSections.ts
@@ -14,6 +14,7 @@ import type {
 import type {
   GetMusicTogetherSectionsRequest,
   GetMusicTogetherSectionsResponse,
+  MusicTogetherSectionCounts,
   CreateMusicTogetherSectionRequest,
   CreateMusicTogetherSectionResponse,
   UpdateMusicTogetherSectionRequest,
@@ -55,6 +56,10 @@ export function useMusicTogetherSections(
   const [sectionsState, setSectionsState] = useState<
     RequestState<MusicTogetherSection[]>
   >({ status: 'idle' });
+  // Per-section registration counts (families + children), keyed by section id.
+  const [countsBySection, setCountsBySection] = useState<
+    Record<string, MusicTogetherSectionCounts>
+  >({});
 
   const fetchSections = useCallback(async () => {
     setSectionsState({ status: 'loading' });
@@ -69,6 +74,7 @@ export function useMusicTogetherSections(
           .map(hydrateSection)
           .sort((a, b) => firstSessionMs(a) - firstSessionMs(b)),
       });
+      setCountsBySection(result.data.counts ?? {});
     } catch (error) {
       console.error('Failed to fetch Music Together sections:', error);
       setSectionsState({
@@ -133,5 +139,11 @@ export function useMusicTogetherSections(
     fetchSections();
   }, [fetchSections]);
 
-  return { sectionsState, fetchSections, createSection, updateSection };
+  return {
+    sectionsState,
+    countsBySection,
+    fetchSections,
+    createSection,
+    updateSection,
+  };
 }

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -420,6 +420,7 @@ export type {
   UpdateMusicTogetherSemesterResponse,
   GetMusicTogetherSectionsRequest,
   GetMusicTogetherSectionsResponse,
+  MusicTogetherSectionCounts,
   CreateMusicTogetherSectionRequest,
   CreateMusicTogetherSectionResponse,
   UpdateMusicTogetherSectionRequest,

--- a/libs/ts/firebase/api-types/src/lib/music-together.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/music-together.types.ts
@@ -51,8 +51,18 @@ export interface GetMusicTogetherSectionsRequest {
   status?: MusicTogetherSectionStatus;
 }
 
+/** Per-section registration counts (capacity statuses: pending + confirmed). */
+export interface MusicTogetherSectionCounts {
+  /** Registered families (one per registration). */
+  families: number;
+  /** Registered children summed across those families. */
+  children: number;
+}
+
 export interface GetMusicTogetherSectionsResponse {
   sections: MusicTogetherSection[];
+  /** Registration counts keyed by section id; sections with none are omitted. */
+  counts: Record<string, MusicTogetherSectionCounts>;
 }
 
 export type CreateMusicTogetherSectionRequest = CreateMusicTogetherSectionInput;


### PR DESCRIPTION
## Why
Admins had to open the roster (person icon) to see how full a Music Together section was. Surface it in the table directly.

## What
New **"Registered"** column showing **registered children** and **families** per section.

- `getMusicTogetherSections` now returns per-section counts: one `MusicTogetherRegistrationRepository.findAll()` grouped in memory (no N+1), counting the same statuses as capacity / `spotsRemaining` (**pending + confirmed**, `MT_CAPACITY_STATUSES`) so "registered" matches the section's taken spots. Families = registrations; children = sum of `children` across them.
- New `MusicTogetherSectionCounts` type + `counts` map on the response (added to the api-types barrel), carried through `useMusicTogetherSections` as `countsBySection`.
- Admin table row renders `N children` + `F / capacity families`.

## Decision
Counts use **pending + confirmed** (capacity semantics, matching the existing "family spots remaining" logic) rather than confirmed-only. In practice MT confirms synchronously, so the difference is negligible — happy to switch to confirmed-only if you'd rather the number match the roster/CSV "enrolled" view exactly.

## Tests
- `get-music-together-sections` spec covers the grouping: capacity statuses only (cancelled/refunded excluded), children summed, registrations for out-of-result sections ignored, empty sections → zero. **4 passed.**
- Firestore index analyzer clean — the added query is a filter-less `findAll()` (orderBy only), no composite index.

Closes the "show registered children in the sections view" ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)