### PR TITLE
feat(music-together): Room dropdown defaulting to spruce

### DIFF
--- a/apps/maple-spruce/src/app/(admin)/music-together/SectionFormDialog.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/SectionFormDialog.tsx
@@ -25,6 +25,8 @@ import {
   type MusicTogetherSemester,
   type CreateMusicTogetherSectionInput,
   type MusicTogetherSectionStatus,
+  ROOMS,
+  getRoomLabel,
 } from '@maple/ts/domain';
 
 const STATUSES: MusicTogetherSectionStatus[] = [
@@ -72,7 +74,11 @@ export function SectionFormDialog({
   const [capacity, setCapacity] = useState(String(MT_DEFAULT_CAPACITY_FAMILIES));
   const [priceFull, setPriceFull] = useState(dollars(MT_PRICE_FULL_CENTS));
   const [location, setLocation] = useState('');
-  const [room, setRoom] = useState('');
+  // Defaults to 'spruce' so MT-generated calendar events reliably carry
+  // room=='spruce' and surface on the /room-schedule. Constrained to a
+  // dropdown (ROOMS) — a free-text value that isn't exactly a Room string
+  // resolves to null and silently drops off the room schedule.
+  const [room, setRoom] = useState<string>('spruce');
   const [sessions, setSessions] = useState<string[]>([]);
   const [installments, setInstallments] = useState<
     { amount: string; dueAt: string }[]
@@ -107,7 +113,7 @@ export function SectionFormDialog({
       setCapacity(String(MT_DEFAULT_CAPACITY_FAMILIES));
       setPriceFull(dollars(MT_PRICE_FULL_CENTS));
       setLocation('');
-      setRoom('');
+      setRoom('spruce');
       setSessions([]);
       setInstallments([]);
     }
@@ -249,10 +255,18 @@ export function SectionFormDialog({
             />
             <TextField
               label="Room"
+              select
               value={room}
               onChange={(e) => setRoom(e.target.value)}
               sx={{ flex: 1 }}
-            />
+            >
+              <MenuItem value="">None</MenuItem>
+              {ROOMS.map((r) => (
+                <MenuItem key={r} value={r}>
+                  {getRoomLabel(r)}
+                </MenuItem>
+              ))}
+            </TextField>
           </Box>
 
           <Divider />


### PR DESCRIPTION
## Why

The MT section **Room** was a free-text `TextField`. `resolveRoom()` in `onMusicTogetherSectionWrite` only maps a section's room to the bookable `Room` union (`'spruce'`) when the string matches **exactly** — so `"Spruce"`, `"Spruce Room"`, or a blank value resolve to `null`, and the auto-generated calendar events silently drop off the business `/room-schedule`.

## Change

- Room is now a `select` over `ROOMS` (from `@maple/ts/domain`), with an explicit **None** option.
- New sections default to **spruce** (both initial state and the create-reset path).
- Submit logic unchanged (`room.trim() || undefined` → `'spruce'` or `undefined`).
- Mirrors the existing **Status** select in the same dialog.

## Follow-up (manual)

The two live Fall sections were created under the old free-text field. After this merges, re-save each in the admin UI so Room = Spruce Room; that re-fires the trigger and stamps `room: 'spruce'` on their calendar events so they appear on `/room-schedule`.

## Testing

- `nx typecheck maple-spruce` ✅
- `eslint SectionFormDialog.tsx` ✅ (clean)
- Existing Storybook play test unaffected (it fills Name + Save; never touches Room).

🤖 Generated with [Claude Code](https://claude.com/claude-code)