### PR TITLE
feat(calendar): unauthenticated private planning ICS feed

### DIFF
--- a/apps/functions-calendar/src/index.ts
+++ b/apps/functions-calendar/src/index.ts
@@ -19,3 +19,4 @@ export { calendarHoursFeed } from '@maple/firebase/maple-functions/calendar-hour
 export { calendarAllFeed } from '@maple/firebase/maple-functions/calendar-all-feed';
 export { calendarAdhocProxy } from '@maple/firebase/maple-functions/calendar-adhoc-proxy';
 export { calendarMusicTogetherFeed } from '@maple/firebase/maple-functions/calendar-music-together-feed';
+export { calendarPrivateFeed } from '@maple/firebase/maple-functions/calendar-private-feed';

--- a/apps/functions-calendar/tsconfig.app.json
+++ b/apps/functions-calendar/tsconfig.app.json
@@ -13,6 +13,7 @@
     "../../libs/firebase/maple-functions/calendar-all-feed/**/*.ts",
     "../../libs/firebase/maple-functions/calendar-adhoc-proxy/**/*.ts",
     "../../libs/firebase/maple-functions/calendar-music-together-feed/**/*.ts",
+    "../../libs/firebase/maple-functions/calendar-private-feed/**/*.ts",
     "../../libs/firebase/database/src/**/*.ts",
     "../../libs/firebase/functions/src/**/*.ts",
     "../../libs/ts/calendar/src/**/*.ts",

--- a/firebase.json
+++ b/firebase.json
@@ -56,6 +56,7 @@
         { "source": "/calendar/all.ics", "function": "calendarAllFeed" },
         { "source": "/calendar/adhoc.ics", "function": "calendarAdhocProxy" },
         { "source": "/calendar/musictogether.ics", "function": "calendarMusicTogetherFeed" },
+        { "source": "/calendar/private.ics", "function": "calendarPrivateFeed" },
         { "source": "/calendar/embed", "function": "calendarEmbed" },
         { "source": "/catalog/classes.xml", "function": "classCatalogFeed" }
       ]

--- a/function-codebases.json
+++ b/function-codebases.json
@@ -13,6 +13,7 @@
     "firebase-maple-functions-calendar-all-feed": "maple-calendar",
     "firebase-maple-functions-calendar-adhoc-proxy": "maple-calendar",
     "firebase-maple-functions-calendar-music-together-feed": "maple-calendar",
+    "firebase-maple-functions-calendar-private-feed": "maple-calendar",
     "firebase-maple-functions-create-product": "maple-square",
     "firebase-maple-functions-update-product": "maple-square",
     "firebase-maple-functions-upload-product-image": "maple-square",

--- a/libs/firebase/database/src/lib/calendar-event.repository.ts
+++ b/libs/firebase/database/src/lib/calendar-event.repository.ts
@@ -51,6 +51,8 @@ export interface CalendarEventFilters {
   type?: CalendarEventType;
   /** Only return public events */
   publicOnly?: boolean;
+  /** Only return private (public == false) events */
+  privateOnly?: boolean;
 }
 
 /**
@@ -69,6 +71,10 @@ export const CalendarEventRepository = {
 
     if (filters?.publicOnly) {
       query = query.where('public', '==', true);
+    }
+
+    if (filters?.privateOnly) {
+      query = query.where('public', '==', false);
     }
 
     query = query.orderBy('startDateTime', 'asc');
@@ -92,6 +98,17 @@ export const CalendarEventRepository = {
    */
   async findPublic(): Promise<CalendarEvent[]> {
     return this.findAll({ publicOnly: true });
+  },
+
+  /**
+   * Find all private (public == false) calendar events.
+   *
+   * Backs the unauthenticated /calendar/private.ics planning feed. These are
+   * the room-occupying events that never reach the public feeds — lessons
+   * (auto-titled "Music Lesson", no student names) and ad-hoc private blocks.
+   */
+  async findPrivate(): Promise<CalendarEvent[]> {
+    return this.findAll({ privateOnly: true });
   },
 
   /**

--- a/libs/firebase/maple-functions/calendar-private-feed/project.json
+++ b/libs/firebase/maple-functions/calendar-private-feed/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-calendar-private-feed",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/calendar-private-feed/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/calendar-private-feed/src/index.ts
+++ b/libs/firebase/maple-functions/calendar-private-feed/src/index.ts
@@ -1,0 +1,1 @@
+export { calendarPrivateFeed } from './lib/calendar-private-feed';

--- a/libs/firebase/maple-functions/calendar-private-feed/src/lib/calendar-private-feed.spec.ts
+++ b/libs/firebase/maple-functions/calendar-private-feed/src/lib/calendar-private-feed.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findPrivate: vi.fn(),
+  generateIcsFeed: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  CalendarEventRepository: { findPrivate: mocks.findPrivate },
+}));
+
+vi.mock('@maple/ts/calendar', () => ({
+  generateIcsFeed: mocks.generateIcsFeed,
+  ICS_FEED_HEADERS: { 'Content-Type': 'text/calendar; charset=utf-8' },
+}));
+
+// Unwrap the onRequest handler so it can be invoked with a plain req/res.
+vi.mock('firebase-functions/v2/https', () => ({
+  onRequest: vi.fn((_config, handler) => handler),
+}));
+
+import { calendarPrivateFeed } from './calendar-private-feed';
+
+const handler = calendarPrivateFeed as unknown as (
+  req: unknown,
+  res: unknown
+) => Promise<void>;
+
+function makeRes() {
+  return {
+    statusCode: 0,
+    body: undefined as unknown,
+    headers: {} as Record<string, string>,
+    setHeader(k: string, v: string) {
+      this.headers[k] = v;
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    send(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+describe('calendarPrivateFeed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('serves an ICS feed of private events', async () => {
+    mocks.findPrivate.mockResolvedValue([{ id: 'e1' }]);
+    mocks.generateIcsFeed.mockReturnValue('BEGIN:VCALENDAR');
+    const res = makeRes();
+
+    await handler({ method: 'GET' }, res);
+
+    expect(mocks.findPrivate).toHaveBeenCalledWith();
+    expect(mocks.generateIcsFeed).toHaveBeenCalledWith(
+      [{ id: 'e1' }],
+      'Maple & Spruce Planning'
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('BEGIN:VCALENDAR');
+    expect(res.headers['Content-Type']).toBe('text/calendar; charset=utf-8');
+  });
+
+  it('short-circuits an OPTIONS preflight', async () => {
+    const res = makeRes();
+    await handler({ method: 'OPTIONS' }, res);
+    expect(res.statusCode).toBe(204);
+    expect(mocks.findPrivate).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when the repository throws', async () => {
+    mocks.findPrivate.mockRejectedValue(new Error('boom'));
+    const res = makeRes();
+    await handler({ method: 'GET' }, res);
+    expect(res.statusCode).toBe(500);
+  });
+});

--- a/libs/firebase/maple-functions/calendar-private-feed/src/lib/calendar-private-feed.ts
+++ b/libs/firebase/maple-functions/calendar-private-feed/src/lib/calendar-private-feed.ts
@@ -1,0 +1,46 @@
+/**
+ * Calendar Private Planning ICS Feed
+ *
+ * HTTP endpoint serving an ICS feed of all PRIVATE (public == false) calendar
+ * events — the room-occupying blocks the public feeds omit: music lessons
+ * (auto-titled "Music Lesson", no student names) and any ad-hoc private events
+ * tagged in the admin calendar.
+ *
+ * Intended as a SUPPLEMENT to /calendar/all.ics: subscribe to both in Google
+ * Calendar and they overlay into a complete planning view (public events from
+ * all.ics + private room bookings from here), with no duplication.
+ *
+ * Unauthenticated but unlisted. It carries no student names by construction —
+ * lesson events are pre-sanitized upstream, and the admin policy is to keep
+ * personal data out of private event titles. Do NOT add authentication-gated
+ * data here.
+ *
+ * Subscribe via: /calendar/private.ics
+ */
+import { onRequest } from 'firebase-functions/v2/https';
+import { CalendarEventRepository } from '@maple/firebase/database';
+import { generateIcsFeed, ICS_FEED_HEADERS } from '@maple/ts/calendar';
+
+export const calendarPrivateFeed = onRequest(
+  // No minInstances — the 5-minute CDN cache from ICS_FEED_HEADERS absorbs cold starts.
+  { region: 'us-east4', cors: true, concurrency: 80 },
+  async (request, response) => {
+    if (request.method === 'OPTIONS') {
+      response.status(204).send('');
+      return;
+    }
+
+    try {
+      const events = await CalendarEventRepository.findPrivate();
+      const ics = generateIcsFeed(events, 'Maple & Spruce Planning');
+
+      Object.entries(ICS_FEED_HEADERS).forEach(([key, value]) => {
+        response.setHeader(key, value);
+      });
+      response.status(200).send(ics);
+    } catch (error) {
+      console.error('Error generating private planning feed:', error);
+      response.status(500).json({ error: 'Failed to generate feed' });
+    }
+  }
+);

--- a/libs/firebase/maple-functions/calendar-private-feed/tsconfig.json
+++ b/libs/firebase/maple-functions/calendar-private-feed/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/calendar-private-feed/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/calendar-private-feed/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -398,6 +398,9 @@
       "@maple/firebase/maple-functions/calendar-music-together-feed": [
         "libs/firebase/maple-functions/calendar-music-together-feed/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/calendar-private-feed": [
+        "libs/firebase/maple-functions/calendar-private-feed/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/on-class-write": [
         "libs/firebase/maple-functions/on-class-write/src/index.ts"
       ],


### PR DESCRIPTION
## Why

Katie subscribes to `/calendar/all.ics` (all **public** events) in Google Calendar. It deliberately omits **private** events — music lessons and ad-hoc private blocks (`public == false`) — so her planning view doesn't show when the Spruce room is actually booked. There's no feed today that exposes those.

## What

A new **supplemental** feed `/calendar/private.ics` containing only private events. Subscribe to it *alongside* `all.ics` and Google overlays both → complete planning view, no duplication:

- `all.ics` → public events (classes, events/jams, hours, Music Together)
- `private.ics` → private room bookings (lessons, ad-hoc private blocks)

### Privacy

Unauthenticated but unlisted, and carries **no personal data by construction**: lesson events are auto-titled `"Music Lesson"` with empty descriptions (sanitized upstream in `onLessonWrite`), and the standing admin policy is no student names in event titles. The feed passes events through like `all.ics` does — the guardrail is content-authoring, not the transport.

## Implementation

- `CalendarEventRepository.findPrivate()` — new `privateOnly` filter (`where('public','==',false)`). **Reuses** the existing `public + startDateTime` composite index — no new index (analyzer confirms).
- `calendarPrivateFeed` Cloud Function in the `maple-calendar` codebase; a near-verbatim mirror of `calendarAllFeed` / `calendarMusicTogetherFeed`.
- Wiring: `firebase.json` rewrite, `function-codebases.json` mapping, `functions-calendar` entry export + tsconfig include, `tsconfig.base.json` path alias.

## Testing

- 3 unit tests (serves feed / OPTIONS preflight / 500 on repo throw) ✅
- `tsc` on `functions-calendar` + `firebase-database` ✅
- `tools/validate-function-tsconfigs.sh` ✅
- `tools/check-firestore-indexes.ts` ✅ (165 queries covered, no new index)
- `eslint` on changed files ✅ (0 errors)

## Deploy note

Depends on #565 (the `hosting:api` CI job) to make the new rewrite live. This PR changes `firebase.json`, so — once #565 has merged — merging this PR auto-triggers the hosting deploy, which also flushes the still-404ing `/calendar/musictogether.ics` rewrite at the same time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)