### PR TITLE
feat(admin): day-of-week + time-block columns in classes & students tables

### DIFF
--- a/apps/maple-spruce/src/app/(admin)/students/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/students/page.tsx
@@ -13,7 +13,7 @@ import AddIcon from '@mui/icons-material/Add';
 import type { CreateStudentInput, RequestState, Student } from '@maple/ts/domain';
 import { DeleteConfirmDialog } from '@maple/react/ui';
 import { StudentForm, StudentList } from '@maple/react/students';
-import { useInstructors, useStudents } from '../../../hooks';
+import { useInstructors, useLessons, useStudents } from '../../../hooks';
 
 type HopeFilter = 'all' | 'hope' | 'private';
 
@@ -25,9 +25,15 @@ export default function StudentsPage() {
     deleteStudent: deleteStudentApi,
   } = useStudents();
   const { instructorsState } = useInstructors();
+  // All lessons — the table derives each student's recurring day/time slot
+  // from their scheduled lessons. The roster is small, so one unscoped fetch
+  // is fine.
+  const { lessonsState } = useLessons({});
 
   const instructors =
     instructorsState.status === 'success' ? instructorsState.data : [];
+  const lessons =
+    lessonsState.status === 'success' ? lessonsState.data : undefined;
 
   // Form dialog state
   const [isFormOpen, setIsFormOpen] = useState(false);
@@ -155,6 +161,7 @@ export default function StudentsPage() {
       <StudentList
         studentsState={filteredStudentsState}
         instructors={instructors}
+        lessons={lessons}
         onEdit={handleOpenForm}
         onDelete={handleOpenDelete}
         detailHrefBase="/students"

--- a/libs/react/classes/src/lib/ClassTable.tsx
+++ b/libs/react/classes/src/lib/ClassTable.tsx
@@ -28,12 +28,7 @@ import type {
   Instructor,
   RequestState,
 } from '@maple/ts/domain';
-import {
-  asPublishable,
-  formatClassPrice,
-  formatSessions,
-  getFirstSession,
-} from '@maple/ts/domain';
+import { formatClassPrice, formatWeekdayTimeBlock } from '@maple/ts/domain';
 import { surfaces, borders, radii, shadows } from '@maple/react/theme';
 
 interface ClassTableProps {
@@ -64,30 +59,19 @@ interface ClassRow {
   classItem: Class;
   name: string;
   imageUrl?: string;
-  scheduleSortKey: number;
-  scheduleDisplay: string;
+  /** Weekly-planning schedule summary — day(s) of week + time block, dates secondary. */
+  dayDisplay: string;
+  timeBlockDisplay: string;
+  dateRangeDisplay: string;
+  sessionCount: number;
+  weekdaySortKey: number;
+  dateSortKey: number;
   instructorName: string;
   categoryName: string;
   filled: number;
   capacity: number;
   priceCents: number;
   status: Class['status'];
-}
-
-function buildScheduleDisplay(classItem: Class): {
-  sortKey: number;
-  display: string;
-} {
-  const publishable = asPublishable(classItem);
-  if (!publishable) {
-    return { sortKey: Number.POSITIVE_INFINITY, display: 'No dates set' };
-  }
-  const first = getFirstSession(publishable).dateTime;
-  const sortKey = (first instanceof Date ? first : new Date(first)).getTime();
-  const { dateDisplay, timeDisplay } = formatSessions(classItem.sessions);
-  const timeSuffix =
-    timeDisplay && timeDisplay !== 'Varies' ? ` · ${timeDisplay}` : '';
-  return { sortKey, display: `${dateDisplay}${timeSuffix}` };
 }
 
 export function ClassTable({
@@ -113,14 +97,21 @@ export function ClassTable({
   const rows = useMemo<ClassRow[]>(() => {
     if (classesState.status !== 'success') return [];
     return classesState.data.map((classItem) => {
-      const { sortKey, display } = buildScheduleDisplay(classItem);
+      const schedule = formatWeekdayTimeBlock(
+        classItem.sessions.map((s) => s.dateTime),
+        classItem.durationMinutes
+      );
       return {
         id: classItem.id,
         classItem,
         name: classItem.name,
         imageUrl: classItem.imageUrl,
-        scheduleSortKey: sortKey,
-        scheduleDisplay: display,
+        dayDisplay: schedule.dayDisplay,
+        timeBlockDisplay: schedule.timeBlockDisplay,
+        dateRangeDisplay: schedule.dateRangeDisplay,
+        sessionCount: schedule.count,
+        weekdaySortKey: schedule.weekdaySortKey,
+        dateSortKey: schedule.dateSortKey,
         instructorName: classItem.instructorId
           ? instructorMap.get(classItem.instructorId) ?? '—'
           : '—',
@@ -164,17 +155,58 @@ export function ClassTable({
         ),
       },
       {
-        field: 'scheduleSortKey',
-        headerName: 'Schedule',
+        field: 'weekdaySortKey',
+        headerName: 'Day / Time',
         flex: 1,
-        minWidth: 200,
+        minWidth: 150,
         sortComparator: (a: number, b: number) => a - b,
-        valueGetter: (_value, row) => row.scheduleSortKey,
-        renderCell: (params: GridRenderCellParams<ClassRow>) => (
-          <Typography variant="body2" color="text.secondary">
-            {params.row.scheduleDisplay}
-          </Typography>
-        ),
+        valueGetter: (_value, row) => row.weekdaySortKey,
+        renderCell: (params: GridRenderCellParams<ClassRow>) =>
+          params.row.dayDisplay ? (
+            <Box sx={{ py: 0.5 }}>
+              <Typography variant="body2" sx={{ fontWeight: 500, lineHeight: 1.3 }}>
+                {params.row.dayDisplay}
+              </Typography>
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ lineHeight: 1.3 }}
+              >
+                {params.row.timeBlockDisplay}
+              </Typography>
+            </Box>
+          ) : (
+            <Typography variant="body2" color="text.secondary">
+              No dates set
+            </Typography>
+          ),
+      },
+      {
+        field: 'dateSortKey',
+        headerName: 'Dates',
+        width: 160,
+        sortComparator: (a: number, b: number) => a - b,
+        valueGetter: (_value, row) => row.dateSortKey,
+        renderCell: (params: GridRenderCellParams<ClassRow>) =>
+          params.row.sessionCount > 0 ? (
+            <Box sx={{ py: 0.5 }}>
+              <Typography variant="body2" sx={{ lineHeight: 1.3 }}>
+                {params.row.dateRangeDisplay}
+              </Typography>
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ lineHeight: 1.3 }}
+              >
+                {params.row.sessionCount} session
+                {params.row.sessionCount === 1 ? '' : 's'}
+              </Typography>
+            </Box>
+          ) : (
+            <Typography variant="body2" color="text.secondary">
+              —
+            </Typography>
+          ),
       },
       {
         field: 'instructorName',
@@ -334,7 +366,7 @@ export function ClassTable({
         pageSizeOptions={[10, 25, 50, 100]}
         initialState={{
           pagination: { paginationModel: { pageSize: 25 } },
-          sorting: { sortModel: [{ field: 'scheduleSortKey', sort: 'asc' }] },
+          sorting: { sortModel: [{ field: 'weekdaySortKey', sort: 'asc' }] },
         }}
         disableRowSelectionOnClick
         autoHeight

--- a/libs/react/students/src/lib/StudentList.stories.tsx
+++ b/libs/react/students/src/lib/StudentList.stories.tsx
@@ -9,6 +9,7 @@ import {
   mockInstructor,
   mockInstructor2,
   mockInstructorPercentage,
+  mockLessons,
 } from '../../../../../apps/maple-spruce/.storybook/fixtures';
 import type { RequestState, Student } from '@maple/ts/domain';
 
@@ -22,6 +23,7 @@ const meta = {
     onEdit: fn(),
     onDelete: fn(),
     instructors,
+    lessons: mockLessons,
   },
 } satisfies Meta<typeof StudentList>;
 
@@ -159,10 +161,26 @@ export const TeacherNameRenderedFromInstructors: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
+    // The Teacher column shows the resolved instructor name.
     await waitFor(() => {
-      expect(
-        canvas.getByText(new RegExp(`Teacher: ${mockInstructor.name}`))
-      ).toBeInTheDocument();
+      expect(canvas.getByText(mockInstructor.name)).toBeInTheDocument();
+    });
+  },
+};
+
+export const LessonDayTimeRendered: Story = {
+  args: {
+    studentsState: {
+      status: 'success',
+      data: [mockStudent],
+    } as RequestState<Student[]>,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Olive's scheduled lessons (Sundays, 11:00 AM ET) drive the Day/Time cell.
+    await waitFor(() => {
+      expect(canvas.getByText(/Sundays/)).toBeInTheDocument();
     });
   },
 };

--- a/libs/react/students/src/lib/StudentList.tsx
+++ b/libs/react/students/src/lib/StudentList.tsx
@@ -1,21 +1,34 @@
 'use client';
 
+import { useMemo } from 'react';
 import Link from 'next/link';
 import {
+  Alert,
   Box,
-  Card,
-  CardContent,
-  Typography,
   Chip,
   IconButton,
-  Grid2 as Grid,
-  Skeleton,
-  Alert,
+  Paper,
+  Stack,
+  Tooltip,
+  Typography,
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import StarsIcon from '@mui/icons-material/Stars';
-import type { Instructor, RequestState, Student } from '@maple/ts/domain';
+import {
+  DataGrid,
+  type GridColDef,
+  type GridRenderCellParams,
+} from '@mui/x-data-grid';
+import type {
+  Instructor,
+  Lesson,
+  RequestState,
+  Student,
+  WeekdayTimeBlock,
+} from '@maple/ts/domain';
+import { formatWeekdayTimeBlock } from '@maple/ts/domain';
+import { surfaces, borders, radii, shadows } from '@maple/react/theme';
 import { INSTRUMENT_LABELS, LESSON_LENGTH_LABELS } from './labels';
 
 interface StudentListProps {
@@ -24,11 +37,16 @@ interface StudentListProps {
   onEdit: (student: Student) => void;
   onDelete: (student: Student) => void;
   /**
-   * If provided, student name becomes a link to this path plus the
-   * student's id (e.g. `/students`). Leave undefined to render a plain
-   * name (used in some Storybook contexts).
+   * If provided, the student name links to this path plus the student's id
+   * (e.g. `/students`). Leave undefined to render a plain name.
    */
   detailHrefBase?: string;
+  /**
+   * All lessons (any student). The table derives each student's recurring
+   * weekly slot (day-of-week + time block) from their `scheduled` lessons.
+   * Omit to leave the Day/Time column blank.
+   */
+  lessons?: Lesson[];
 }
 
 const statusColors: Record<string, 'success' | 'default'> = {
@@ -36,136 +54,55 @@ const statusColors: Record<string, 'success' | 'default'> = {
   inactive: 'default',
 };
 
-function StudentCard({
-  student,
-  teacherName,
-  detailHrefBase,
-  onEdit,
-  onDelete,
-}: {
+interface StudentRow {
+  id: string;
   student: Student;
+  name: string;
+  instrumentLabel: string;
+  lessonLengthLabel: string;
+  dayDisplay: string;
+  timeBlockDisplay: string;
+  weekdaySortKey: number;
   teacherName: string;
-  detailHrefBase?: string;
-  onEdit: () => void;
-  onDelete: () => void;
-}) {
-  const nameContent = (
-    <Typography variant="h6" component="h3" noWrap>
-      {student.name}
-    </Typography>
-  );
-  const detailHref = detailHrefBase
-    ? `${detailHrefBase}/${student.id}`
-    : undefined;
-
-  return (
-    <Card>
-      <CardContent>
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'flex-start',
-          }}
-        >
-          <Box sx={{ flex: 1, minWidth: 0 }}>
-            {detailHref ? (
-              <Link
-                href={detailHref}
-                style={{ textDecoration: 'none', color: 'inherit' }}
-              >
-                {nameContent}
-              </Link>
-            ) : (
-              nameContent
-            )}
-            <Typography
-              variant="body2"
-              color="text.secondary"
-              sx={{ mb: 0.5 }}
-            >
-              {INSTRUMENT_LABELS[student.instrument]}
-              {student.registeredLessonLength &&
-                ` • ${LESSON_LENGTH_LABELS[student.registeredLessonLength]}`}
-            </Typography>
-            <Typography
-              variant="body2"
-              color="text.secondary"
-              sx={{ mb: 0.5 }}
-            >
-              Teacher: {teacherName}
-            </Typography>
-            <Typography
-              variant="body2"
-              color="text.secondary"
-              sx={{ mb: 1 }}
-              noWrap
-            >
-              {student.isAdultStudent ? 'Contact' : 'Parent/guardian'}:{' '}
-              {student.primaryContactName} · {student.primaryContactEmail}
-            </Typography>
-            <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
-              <Chip
-                label={student.status}
-                size="small"
-                color={statusColors[student.status]}
-              />
-              {student.isHopeScholarship && (
-                <Chip
-                  label="Hope Scholarship"
-                  size="small"
-                  color="info"
-                  variant="outlined"
-                  icon={<StarsIcon />}
-                />
-              )}
-              {student.isAdultStudent && (
-                <Chip
-                  label="Adult"
-                  size="small"
-                  variant="outlined"
-                />
-              )}
-            </Box>
-          </Box>
-          <Box sx={{ display: 'flex', gap: 0.5 }}>
-            <IconButton onClick={onEdit} size="small" aria-label="Edit">
-              <EditIcon />
-            </IconButton>
-            <IconButton
-              onClick={onDelete}
-              size="small"
-              aria-label="Delete"
-              color="error"
-            >
-              <DeleteIcon />
-            </IconButton>
-          </Box>
-        </Box>
-      </CardContent>
-    </Card>
-  );
+  contactName: string;
+  contactEmail: string;
+  status: Student['status'];
+  isHopeScholarship: boolean;
+  isAdultStudent: boolean;
 }
 
-function LoadingSkeleton() {
-  return (
-    <Grid container spacing={2}>
-      {[1, 2, 3].map((i) => (
-        <Grid size={{ xs: 12, sm: 6, md: 4 }} key={i}>
-          <Card>
-            <CardContent>
-              <Skeleton variant="text" width="60%" height={32} />
-              <Skeleton variant="text" width="80%" />
-              <Skeleton variant="text" width="50%" />
-              <Box sx={{ display: 'flex', gap: 1, mt: 1 }}>
-                <Skeleton variant="rounded" width={80} height={24} />
-              </Box>
-            </CardContent>
-          </Card>
-        </Grid>
-      ))}
-    </Grid>
-  );
+/**
+ * Group `scheduled` lessons by student and summarize each student's recurring
+ * slot. Uses scheduled (not strictly future) lessons so the slot is stable
+ * between terms and deterministic in tests. Each student's block duration is
+ * taken from their earliest scheduled lesson.
+ */
+function buildScheduleByStudent(
+  lessons: Lesson[]
+): Map<string, WeekdayTimeBlock> {
+  const byStudent = new Map<string, Lesson[]>();
+  for (const lesson of lessons) {
+    if (lesson.status !== 'scheduled') continue;
+    const list = byStudent.get(lesson.studentId);
+    if (list) list.push(lesson);
+    else byStudent.set(lesson.studentId, [lesson]);
+  }
+
+  const result = new Map<string, WeekdayTimeBlock>();
+  for (const [studentId, studentLessons] of byStudent) {
+    const sorted = [...studentLessons].sort(
+      (a, b) =>
+        new Date(a.scheduledAt).getTime() - new Date(b.scheduledAt).getTime()
+    );
+    result.set(
+      studentId,
+      formatWeekdayTimeBlock(
+        sorted.map((l) => l.scheduledAt),
+        sorted[0].durationMinutes
+      )
+    );
+  }
+  return result;
 }
 
 export function StudentList({
@@ -174,10 +111,206 @@ export function StudentList({
   onEdit,
   onDelete,
   detailHrefBase,
+  lessons,
 }: StudentListProps) {
-  if (studentsState.status === 'loading') {
-    return <LoadingSkeleton />;
-  }
+  const teacherNameById = useMemo(
+    () => new Map(instructors.map((i) => [i.id, i.name])),
+    [instructors]
+  );
+
+  const scheduleByStudent = useMemo(
+    () => buildScheduleByStudent(lessons ?? []),
+    [lessons]
+  );
+
+  const rows = useMemo<StudentRow[]>(() => {
+    if (studentsState.status !== 'success') return [];
+    return studentsState.data.map((student) => {
+      const schedule = scheduleByStudent.get(student.id);
+      return {
+        id: student.id,
+        student,
+        name: student.name,
+        instrumentLabel: INSTRUMENT_LABELS[student.instrument],
+        lessonLengthLabel: student.registeredLessonLength
+          ? LESSON_LENGTH_LABELS[student.registeredLessonLength]
+          : '',
+        dayDisplay: schedule?.dayDisplay ?? '',
+        timeBlockDisplay: schedule?.timeBlockDisplay ?? '',
+        weekdaySortKey: schedule?.weekdaySortKey ?? Number.POSITIVE_INFINITY,
+        teacherName:
+          teacherNameById.get(student.primaryTeacherId) ?? 'Unassigned',
+        contactName: student.primaryContactName,
+        contactEmail: student.primaryContactEmail,
+        status: student.status,
+        isHopeScholarship: student.isHopeScholarship,
+        isAdultStudent: student.isAdultStudent,
+      };
+    });
+  }, [studentsState, scheduleByStudent, teacherNameById]);
+
+  const columns: GridColDef<StudentRow>[] = useMemo(
+    () => [
+      {
+        field: 'name',
+        headerName: 'Student',
+        flex: 1,
+        minWidth: 160,
+        renderCell: (params: GridRenderCellParams<StudentRow>) => {
+          const { student } = params.row;
+          const name = (
+            <Typography variant="body2" sx={{ fontWeight: 500 }}>
+              {student.name}
+            </Typography>
+          );
+          return detailHrefBase ? (
+            <Link
+              href={`${detailHrefBase}/${student.id}`}
+              style={{ textDecoration: 'none', color: 'inherit' }}
+            >
+              {name}
+            </Link>
+          ) : (
+            name
+          );
+        },
+      },
+      {
+        field: 'instrumentLabel',
+        headerName: 'Instrument',
+        width: 140,
+        renderCell: (params: GridRenderCellParams<StudentRow>) => (
+          <Box sx={{ py: 0.5 }}>
+            <Typography variant="body2" sx={{ lineHeight: 1.3 }}>
+              {params.row.instrumentLabel}
+            </Typography>
+            {params.row.lessonLengthLabel && (
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ lineHeight: 1.3 }}
+              >
+                {params.row.lessonLengthLabel}
+              </Typography>
+            )}
+          </Box>
+        ),
+      },
+      {
+        field: 'weekdaySortKey',
+        headerName: 'Lesson Day / Time',
+        flex: 1,
+        minWidth: 150,
+        sortComparator: (a: number, b: number) => a - b,
+        valueGetter: (_value, row) => row.weekdaySortKey,
+        renderCell: (params: GridRenderCellParams<StudentRow>) =>
+          params.row.dayDisplay ? (
+            <Box sx={{ py: 0.5 }}>
+              <Typography variant="body2" sx={{ fontWeight: 500, lineHeight: 1.3 }}>
+                {params.row.dayDisplay}
+              </Typography>
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ lineHeight: 1.3 }}
+              >
+                {params.row.timeBlockDisplay}
+              </Typography>
+            </Box>
+          ) : (
+            <Typography variant="body2" color="text.secondary">
+              —
+            </Typography>
+          ),
+      },
+      {
+        field: 'teacherName',
+        headerName: 'Teacher',
+        width: 140,
+      },
+      {
+        field: 'contactName',
+        headerName: 'Contact',
+        flex: 1,
+        minWidth: 170,
+        renderCell: (params: GridRenderCellParams<StudentRow>) => (
+          <Box sx={{ py: 0.5, minWidth: 0 }}>
+            <Typography variant="body2" noWrap sx={{ lineHeight: 1.3 }}>
+              {params.row.contactName}
+            </Typography>
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              noWrap
+              sx={{ lineHeight: 1.3, display: 'block' }}
+            >
+              {params.row.contactEmail}
+            </Typography>
+          </Box>
+        ),
+      },
+      {
+        field: 'status',
+        headerName: 'Status',
+        width: 170,
+        renderCell: (params: GridRenderCellParams<StudentRow>) => (
+          <Stack direction="row" spacing={0.5} sx={{ flexWrap: 'wrap' }}>
+            <Chip
+              label={params.row.status}
+              size="small"
+              color={statusColors[params.row.status]}
+            />
+            {params.row.isHopeScholarship && (
+              <Chip
+                label="Hope Scholarship"
+                size="small"
+                color="info"
+                variant="outlined"
+                icon={<StarsIcon />}
+              />
+            )}
+            {params.row.isAdultStudent && (
+              <Chip label="Adult" size="small" variant="outlined" />
+            )}
+          </Stack>
+        ),
+      },
+      {
+        field: 'actions',
+        headerName: 'Actions',
+        width: 110,
+        sortable: false,
+        filterable: false,
+        disableColumnMenu: true,
+        align: 'right',
+        headerAlign: 'right',
+        renderCell: (params: GridRenderCellParams<StudentRow>) => (
+          <Stack direction="row" spacing={0.5}>
+            <Tooltip title="Edit">
+              <IconButton
+                onClick={() => onEdit(params.row.student)}
+                size="small"
+                aria-label="Edit"
+              >
+                <EditIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Delete">
+              <IconButton
+                onClick={() => onDelete(params.row.student)}
+                size="small"
+                aria-label="Delete"
+                color="error"
+              >
+                <DeleteIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </Stack>
+        ),
+      },
+    ],
+    [detailHrefBase, onEdit, onDelete]
+  );
 
   if (studentsState.status === 'error') {
     return (
@@ -191,9 +324,7 @@ export function StudentList({
     return null;
   }
 
-  const students = studentsState.data;
-
-  if (students.length === 0) {
+  if (studentsState.status === 'success' && rows.length === 0) {
     return (
       <Box sx={{ textAlign: 'center', py: 8, color: 'text.secondary' }}>
         <Typography variant="h6">No students yet</Typography>
@@ -204,25 +335,50 @@ export function StudentList({
     );
   }
 
-  const teacherNameById = new Map(
-    instructors.map((i) => [i.id, i.name])
-  );
-
   return (
-    <Grid container spacing={2}>
-      {students.map((student) => (
-        <Grid size={{ xs: 12, sm: 6, md: 4 }} key={student.id}>
-          <StudentCard
-            student={student}
-            teacherName={
-              teacherNameById.get(student.primaryTeacherId) ?? 'Unassigned'
-            }
-            detailHrefBase={detailHrefBase}
-            onEdit={() => onEdit(student)}
-            onDelete={() => onDelete(student)}
-          />
-        </Grid>
-      ))}
-    </Grid>
+    <Paper
+      elevation={0}
+      sx={{
+        width: '100%',
+        backgroundColor: surfaces.paper,
+        borderRadius: `${radii.lg}px`,
+        border: `1px solid ${borders.default}`,
+        boxShadow: shadows.sm,
+        overflow: 'hidden',
+      }}
+    >
+      <DataGrid
+        rows={rows}
+        columns={columns}
+        loading={studentsState.status === 'loading'}
+        pageSizeOptions={[10, 25, 50, 100]}
+        initialState={{
+          pagination: { paginationModel: { pageSize: 25 } },
+          sorting: { sortModel: [{ field: 'name', sort: 'asc' }] },
+        }}
+        disableRowSelectionOnClick
+        autoHeight
+        sx={{
+          border: 'none',
+          backgroundColor: surfaces.paper,
+          '--DataGrid-containerBackground': surfaces.tableHeader,
+          '& .MuiDataGrid-columnHeaders': {
+            backgroundColor: surfaces.tableHeader,
+            borderBottom: `1px solid ${borders.subtle}`,
+          },
+          '& .MuiDataGrid-columnHeaderTitle': {
+            fontWeight: 600,
+          },
+          '& .MuiDataGrid-cell': {
+            display: 'flex',
+            alignItems: 'center',
+            borderColor: borders.subtle,
+          },
+          '& .MuiDataGrid-row:last-child .MuiDataGrid-cell': {
+            borderBottom: 'none',
+          },
+        }}
+      />
+    </Paper>
   );
 }

--- a/libs/ts/domain/src/index.ts
+++ b/libs/ts/domain/src/index.ts
@@ -18,6 +18,7 @@ export * from './lib/etsy-import';
 // Phase 3: Classes & Workshops
 export * from './lib/instructor';
 export * from './lib/class';
+export * from './lib/schedule-format';
 export * from './lib/class-category';
 export * from './lib/registration';
 export * from './lib/discount';

--- a/libs/ts/domain/src/lib/schedule-format.spec.ts
+++ b/libs/ts/domain/src/lib/schedule-format.spec.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { formatWeekdayTimeBlock } from './schedule-format';
+
+// All fixtures use explicit UTC instants and assert against America/New_York
+// output, so the tests are deterministic regardless of the machine's zone.
+// 2026-04-13 is a Monday, 2026-04-15 a Wednesday.
+const mon6pmET = '2026-04-13T22:00:00.000Z'; // 6:00 PM EDT
+const wed6pmET = '2026-04-15T22:00:00.000Z'; // 6:00 PM EDT
+const mon6pmWeek2 = '2026-04-20T22:00:00.000Z'; // next Monday, 6:00 PM EDT
+
+describe('formatWeekdayTimeBlock', () => {
+  it('returns empties for no starts', () => {
+    const r = formatWeekdayTimeBlock([], 60);
+    expect(r.dayDisplay).toBe('');
+    expect(r.timeBlockDisplay).toBe('');
+    expect(r.dateRangeDisplay).toBe('');
+    expect(r.count).toBe(0);
+    expect(r.weekdaySortKey).toBe(Number.POSITIVE_INFINITY);
+    expect(r.dateSortKey).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it('single session keeps the weekday singular and a single date', () => {
+    const r = formatWeekdayTimeBlock([mon6pmET], 90);
+    expect(r.dayDisplay).toBe('Monday');
+    expect(r.timeBlockDisplay).toBe('6:00–7:30 PM');
+    expect(r.dateRangeDisplay).toBe('Apr 13');
+    expect(r.count).toBe(1);
+  });
+
+  it('pluralizes a recurring single-weekday class and shows a date range', () => {
+    const r = formatWeekdayTimeBlock([mon6pmET, mon6pmWeek2], 60);
+    expect(r.dayDisplay).toBe('Mondays');
+    expect(r.timeBlockDisplay).toBe('6:00–7:00 PM');
+    expect(r.dateRangeDisplay).toBe('Apr 13 – Apr 20');
+    expect(r.count).toBe(2);
+  });
+
+  it('joins multiple weekdays with an ampersand, ordered by weekday index', () => {
+    // pass out of order to confirm sorting
+    const r = formatWeekdayTimeBlock([wed6pmET, mon6pmET], 90);
+    expect(r.dayDisplay).toBe('Mon & Wed');
+    expect(r.timeBlockDisplay).toBe('6:00–7:30 PM');
+  });
+
+  it('reports "Varies" when start times differ across sessions', () => {
+    const wed7pmET = '2026-04-15T23:00:00.000Z'; // 7:00 PM EDT
+    const r = formatWeekdayTimeBlock([mon6pmET, wed7pmET], 60);
+    expect(r.dayDisplay).toBe('Mon & Wed');
+    expect(r.timeBlockDisplay).toBe('Varies');
+  });
+
+  it('keeps both meridiems when the block crosses noon', () => {
+    const mon1130amET = '2026-04-13T15:30:00.000Z'; // 11:30 AM EDT
+    const r = formatWeekdayTimeBlock([mon1130amET], 60);
+    expect(r.timeBlockDisplay).toBe('11:30 AM–12:30 PM');
+  });
+
+  it('derives the weekday in ET, not UTC (late-night ET session)', () => {
+    // 2026-04-14T01:30Z is still Monday 9:30 PM in ET (not Tuesday).
+    const r = formatWeekdayTimeBlock(['2026-04-14T01:30:00.000Z'], 60);
+    expect(r.dayDisplay).toBe('Monday');
+    expect(r.timeBlockDisplay).toBe('9:30–10:30 PM');
+  });
+
+  it('sort keys order by weekday then start time, and by first date', () => {
+    const mon = formatWeekdayTimeBlock([mon6pmET], 60);
+    const wed = formatWeekdayTimeBlock([wed6pmET], 60);
+    expect(mon.weekdaySortKey).toBeLessThan(wed.weekdaySortKey);
+    expect(mon.dateSortKey).toBeLessThan(wed.dateSortKey);
+  });
+
+  it('accepts Date instances and ignores invalid dates', () => {
+    const r = formatWeekdayTimeBlock(
+      [new Date(mon6pmET), new Date('nonsense')],
+      60
+    );
+    expect(r.count).toBe(1);
+    expect(r.dayDisplay).toBe('Monday');
+  });
+});

--- a/libs/ts/domain/src/lib/schedule-format.ts
+++ b/libs/ts/domain/src/lib/schedule-format.ts
@@ -1,0 +1,187 @@
+/**
+ * Weekly-planning schedule summaries.
+ *
+ * Admin table views (classes, students/lessons) think "day of week + time
+ * block first, dates second". Given a set of session start times plus a
+ * duration, `formatWeekdayTimeBlock` derives:
+ *   - the day(s) of week occupied — "Mondays", "Tue & Thu"
+ *   - the time block — "6:00–7:30 PM" (or "Varies" when starts differ)
+ *   - a secondary date range — "Apr 15 – May 20"
+ *   - sort keys for a weekday-first or date-first column sort
+ *
+ * All derivation is timezone-aware and defaults to America/New_York — the
+ * weekday of a late-evening session can differ between ET and the browser's
+ * local zone, so the shop timezone is pinned (matching `formatSessions`).
+ */
+
+const DEFAULT_TIME_ZONE = 'America/New_York';
+
+const WEEKDAY_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const WEEKDAY_LONG = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+];
+
+export interface WeekdayTimeBlock {
+  /** Day(s) of week — "Mondays", "Monday", "Tue & Thu". Empty when no starts. */
+  dayDisplay: string;
+  /** Time block — "6:00–7:30 PM", or "Varies" when starts differ. Empty when no starts. */
+  timeBlockDisplay: string;
+  /** Secondary date range — "Apr 15 – May 20", or a single "Apr 15". Empty when no starts. */
+  dateRangeDisplay: string;
+  /** Number of occurrences. */
+  count: number;
+  /**
+   * Sort key for a weekday-first column: earliest occupied weekday index
+   * (Sun=0..Sat=6) scaled by minutes-of-day, so same-weekday rows order by
+   * start time. POSITIVE_INFINITY when empty (sorts last).
+   */
+  weekdaySortKey: number;
+  /** Sort key for a date-first column: epoch ms of the first start. POSITIVE_INFINITY when empty. */
+  dateSortKey: number;
+}
+
+function toDate(value: Date | string): Date {
+  return value instanceof Date ? value : new Date(value);
+}
+
+function weekdayIndexInZone(date: Date, timeZone: string): number {
+  const name = new Intl.DateTimeFormat('en-US', {
+    weekday: 'short',
+    timeZone,
+  }).format(date);
+  return WEEKDAY_SHORT.indexOf(name);
+}
+
+function minutesOfDayInZone(date: Date, timeZone: string): number {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+    timeZone,
+  }).formatToParts(date);
+  const hour = Number(parts.find((p) => p.type === 'hour')?.value ?? '0');
+  const minute = Number(parts.find((p) => p.type === 'minute')?.value ?? '0');
+  return hour * 60 + minute;
+}
+
+function timeLabel(date: Date, timeZone: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+    timeZone,
+  })
+    .format(date)
+    // Intl emits a narrow no-break space (U+202F) before AM/PM in modern ICU;
+    // normalize to a plain space so output is stable across runtimes.
+    .replace(/[\u202f\u00a0]/g, ' ');
+}
+
+function dateLabel(date: Date, timeZone: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    timeZone,
+  }).format(date);
+}
+
+/** Join short weekday names with ampersands: "Mon", "Mon & Wed", "Mon, Wed & Fri". */
+function joinWeekdays(names: string[]): string {
+  if (names.length <= 1) return names[0] ?? '';
+  if (names.length === 2) return `${names[0]} & ${names[1]}`;
+  return `${names.slice(0, -1).join(', ')} & ${names[names.length - 1]}`;
+}
+
+/**
+ * Build a start–end block from two time labels, dropping the start's meridiem
+ * only when both share it: "6:00–7:30 PM", but "11:30 AM–12:30 PM".
+ */
+function timeBlock(startLabel: string, endLabel: string): string {
+  const startMer = startLabel.match(/[AP]M$/i)?.[0]?.toUpperCase();
+  const endMer = endLabel.match(/[AP]M$/i)?.[0]?.toUpperCase();
+  const start =
+    startMer && endMer && startMer === endMer
+      ? startLabel.replace(/\s*[AP]M$/i, '')
+      : startLabel;
+  return `${start}–${endLabel}`;
+}
+
+const EMPTY: WeekdayTimeBlock = {
+  dayDisplay: '',
+  timeBlockDisplay: '',
+  dateRangeDisplay: '',
+  count: 0,
+  weekdaySortKey: Number.POSITIVE_INFINITY,
+  dateSortKey: Number.POSITIVE_INFINITY,
+};
+
+/**
+ * Summarize a set of session start times (+ shared duration) as a
+ * weekly-planning schedule. See {@link WeekdayTimeBlock}.
+ *
+ * @param starts session/occurrence start times (any order)
+ * @param durationMinutes length of each occurrence, for the block end time
+ * @param timeZone IANA zone, defaults to America/New_York
+ */
+export function formatWeekdayTimeBlock(
+  starts: Array<Date | string>,
+  durationMinutes: number,
+  timeZone: string = DEFAULT_TIME_ZONE
+): WeekdayTimeBlock {
+  const sorted = starts
+    .map(toDate)
+    .filter((d) => !Number.isNaN(d.getTime()))
+    .sort((a, b) => a.getTime() - b.getTime());
+
+  if (sorted.length === 0) return { ...EMPTY };
+
+  const first = sorted[0];
+  const last = sorted[sorted.length - 1];
+
+  // Distinct occupied weekdays, ordered by weekday index.
+  const weekdayIndexes = Array.from(
+    new Set(sorted.map((d) => weekdayIndexInZone(d, timeZone)))
+  ).sort((a, b) => a - b);
+
+  let dayDisplay: string;
+  if (weekdayIndexes.length === 1) {
+    const full = WEEKDAY_LONG[weekdayIndexes[0]];
+    // Pluralize only when it actually recurs; a one-off keeps the singular.
+    dayDisplay = sorted.length > 1 ? `${full}s` : full;
+  } else {
+    dayDisplay = joinWeekdays(weekdayIndexes.map((i) => WEEKDAY_SHORT[i]));
+  }
+
+  // Time block — shared when every start lands on the same HH:mm in-zone.
+  const firstTime = timeLabel(first, timeZone);
+  const sharedTime = sorted.every((d) => timeLabel(d, timeZone) === firstTime);
+  let timeBlockDisplay: string;
+  if (sharedTime) {
+    const end = new Date(first.getTime() + durationMinutes * 60_000);
+    timeBlockDisplay = timeBlock(firstTime, timeLabel(end, timeZone));
+  } else {
+    timeBlockDisplay = 'Varies';
+  }
+
+  // Secondary date range.
+  const firstDate = dateLabel(first, timeZone);
+  const lastDate = dateLabel(last, timeZone);
+  const dateRangeDisplay =
+    firstDate === lastDate ? firstDate : `${firstDate} – ${lastDate}`;
+
+  return {
+    dayDisplay,
+    timeBlockDisplay,
+    dateRangeDisplay,
+    count: sorted.length,
+    weekdaySortKey:
+      weekdayIndexes[0] * 1440 + minutesOfDayInZone(first, timeZone),
+    dateSortKey: first.getTime(),
+  };
+}


### PR DESCRIPTION
## Why

Katie plans **weekly-first** — "what day of week is this on?" and "what time block does it take up?" — with the actual dates secondary (but still visible). The admin tables led with dates and never showed the day of week.

## What

**Shared formatter** — `formatWeekdayTimeBlock()` in `@maple/ts/domain`. From a set of session start times + a duration it derives:
- day(s) of week — `"Mondays"`, `"Monday"` (one-off), `"Tue & Thu"`
- time block — `"6:00–7:30 PM"`, or `"Varies"` when starts differ
- secondary date range — `"Apr 15 – May 20"` + a session count
- weekday / date sort keys

Pinned to **America/New_York** so a late-evening session's weekday never shifts vs. the browser zone (matches `formatSessions`).

**Classes table** — the single date-first "Schedule" column becomes two sortable columns:

```
DAY / TIME        DATES
Mondays           Apr 15 – May 20
6:00–7:30 PM      6 sessions
```

Default sort is now weekday-first.

**Students table** — the card grid becomes a DataGrid with a **"Lesson Day / Time"** column, derived from each student's `scheduled` lessons (loaded once via `useLessons({})` on the page and grouped by student). Name (link), instrument, teacher, contact, and status/Hope/Adult chips are preserved as columns.

Deriving from `scheduled` lessons (rather than a live "upcoming" filter) keeps a student's slot stable between terms and makes stories/tests deterministic.

## Testing

- **9 unit tests** for the formatter (single/recurring, multi-weekday, "Varies", noon-crossing meridiem, ET-vs-UTC weekday, sort keys, invalid dates).
- **18 Storybook interaction tests** across both tables pass in browser mode — including edit/delete on the new student DataGrid, the Hope chip, teacher-name resolution, and the new Day/Time cell (`Sundays`).
- `nx typecheck maple-spruce` clean.

## Notes

- No schema change — day-of-week is always derived from `ClassSession.dateTime` / `Lesson.scheduledAt`.
- Lessons already show the weekday in the student detail view; this brings the same weekly-planning lens to the list tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)