### PR TITLE
fix(admin): tighten two-line table cells (day/time spacing)

### DIFF
--- a/libs/react/classes/src/lib/ClassTable.tsx
+++ b/libs/react/classes/src/lib/ClassTable.tsx
@@ -163,14 +163,28 @@ export function ClassTable({
         valueGetter: (_value, row) => row.weekdaySortKey,
         renderCell: (params: GridRenderCellParams<ClassRow>) =>
           params.row.dayDisplay ? (
-            <Box sx={{ py: 0.5 }}>
-              <Typography variant="body2" sx={{ fontWeight: 500, lineHeight: 1.3 }}>
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'center',
+                minWidth: 0,
+              }}
+            >
+              <Typography
+                component="span"
+                variant="body2"
+                noWrap
+                sx={{ fontWeight: 500, lineHeight: 1.35 }}
+              >
                 {params.row.dayDisplay}
               </Typography>
               <Typography
+                component="span"
                 variant="caption"
                 color="text.secondary"
-                sx={{ lineHeight: 1.3 }}
+                noWrap
+                sx={{ lineHeight: 1.35 }}
               >
                 {params.row.timeBlockDisplay}
               </Typography>
@@ -189,14 +203,23 @@ export function ClassTable({
         valueGetter: (_value, row) => row.dateSortKey,
         renderCell: (params: GridRenderCellParams<ClassRow>) =>
           params.row.sessionCount > 0 ? (
-            <Box sx={{ py: 0.5 }}>
-              <Typography variant="body2" sx={{ lineHeight: 1.3 }}>
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'center',
+                minWidth: 0,
+              }}
+            >
+              <Typography component="span" variant="body2" noWrap sx={{ lineHeight: 1.35 }}>
                 {params.row.dateRangeDisplay}
               </Typography>
               <Typography
+                component="span"
                 variant="caption"
                 color="text.secondary"
-                sx={{ lineHeight: 1.3 }}
+                noWrap
+                sx={{ lineHeight: 1.35 }}
               >
                 {params.row.sessionCount} session
                 {params.row.sessionCount === 1 ? '' : 's'}

--- a/libs/react/students/src/lib/StudentList.tsx
+++ b/libs/react/students/src/lib/StudentList.tsx
@@ -180,15 +180,24 @@ export function StudentList({
         headerName: 'Instrument',
         width: 140,
         renderCell: (params: GridRenderCellParams<StudentRow>) => (
-          <Box sx={{ py: 0.5 }}>
-            <Typography variant="body2" sx={{ lineHeight: 1.3 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+              minWidth: 0,
+            }}
+          >
+            <Typography component="span" variant="body2" noWrap sx={{ lineHeight: 1.35 }}>
               {params.row.instrumentLabel}
             </Typography>
             {params.row.lessonLengthLabel && (
               <Typography
+                component="span"
                 variant="caption"
                 color="text.secondary"
-                sx={{ lineHeight: 1.3 }}
+                noWrap
+                sx={{ lineHeight: 1.35 }}
               >
                 {params.row.lessonLengthLabel}
               </Typography>
@@ -205,14 +214,28 @@ export function StudentList({
         valueGetter: (_value, row) => row.weekdaySortKey,
         renderCell: (params: GridRenderCellParams<StudentRow>) =>
           params.row.dayDisplay ? (
-            <Box sx={{ py: 0.5 }}>
-              <Typography variant="body2" sx={{ fontWeight: 500, lineHeight: 1.3 }}>
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'center',
+                minWidth: 0,
+              }}
+            >
+              <Typography
+                component="span"
+                variant="body2"
+                noWrap
+                sx={{ fontWeight: 500, lineHeight: 1.35 }}
+              >
                 {params.row.dayDisplay}
               </Typography>
               <Typography
+                component="span"
                 variant="caption"
                 color="text.secondary"
-                sx={{ lineHeight: 1.3 }}
+                noWrap
+                sx={{ lineHeight: 1.35 }}
               >
                 {params.row.timeBlockDisplay}
               </Typography>
@@ -234,15 +257,23 @@ export function StudentList({
         flex: 1,
         minWidth: 170,
         renderCell: (params: GridRenderCellParams<StudentRow>) => (
-          <Box sx={{ py: 0.5, minWidth: 0 }}>
-            <Typography variant="body2" noWrap sx={{ lineHeight: 1.3 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+              minWidth: 0,
+            }}
+          >
+            <Typography component="span" variant="body2" noWrap sx={{ lineHeight: 1.35 }}>
               {params.row.contactName}
             </Typography>
             <Typography
+              component="span"
               variant="caption"
               color="text.secondary"
               noWrap
-              sx={{ lineHeight: 1.3, display: 'block' }}
+              sx={{ lineHeight: 1.35 }}
             >
               {params.row.contactEmail}
             </Typography>


### PR DESCRIPTION
## Problem

Follow-up to #569. In the classes & students tables, the two-line cells (Day/Time, Dates, Instrument, Contact) rendered their primary line as MUI `body2` — which is a `<p>`. The `<p>`'s default browser margin pushed the two lines apart and past the 52px DataGrid row height, so the top line clipped into the row above:

> "Thursday" floating at the top of the row, "6:49–8:49 PM" at the bottom, big gap between.

## Fix

Render both lines as `component="span"` inside an explicit centered flex column, so they stack tightly within the row (no `<p>` margin, no overflow).

## Verified

- Visually in Storybook — classes (`Sunday` / `6:00–9:00 AM`) and students (`Sundays` / `11:00–11:30 AM`, plus Instrument & Contact) now stack cleanly with no clipping.
- 18 interaction tests + `nx typecheck maple-spruce` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)