### PR TITLE
feat(music-together): split CSV exports — MTW licensee (adults only) vs internal roster (#573)

### DIFF
--- a/apps/maple-spruce/src/app/(admin)/music-together/RosterDialog.stories.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/RosterDialog.stories.tsx
@@ -142,24 +142,35 @@ export const RostersAndDownloadsCsv: Story = {
       expect(canvas.getByRole('dialog')).toBeInTheDocument()
     );
 
-    // Renders enrolled families with past-due + child DOBs.
+    // Renders enrolled families with past-due, child DOBs, and the internal
+    // accommodations/notes column.
     await expect(canvas.getByText('Past due')).toBeInTheDocument();
     await expect(
       canvas.getByText(/Wren \(2022-01-10\)/)
     ).toBeInTheDocument();
+    await expect(
+      canvas.getByText(/peanut allergy/i)
+    ).toBeInTheDocument();
 
-    // Download button counts the 3 confirmed families and is enabled.
-    const download = canvas.getByRole('button', { name: /licensee csv \(3\)/i });
-    await expect(download).toBeEnabled();
+    // Both export buttons count the 3 confirmed families and are enabled.
+    const licensee = canvas.getByRole('button', {
+      name: /licensee csv[^(]*\(3\)/i,
+    });
+    const internal = canvas.getByRole('button', {
+      name: /internal roster \(3\)/i,
+    });
+    await expect(licensee).toBeEnabled();
+    await expect(internal).toBeEnabled();
 
-    // Clicking triggers a blob download via a temporary anchor — assert the
-    // anchor is created + clicked (spy the prototype so no file actually saves).
+    // Clicking either triggers a blob download via a temporary anchor — assert
+    // the anchor is created + clicked (spy the prototype so no file saves).
     const clickSpy = fn();
     const orig = HTMLAnchorElement.prototype.click;
     HTMLAnchorElement.prototype.click = clickSpy;
     try {
-      await userEvent.click(download);
-      await waitFor(() => expect(clickSpy).toHaveBeenCalled());
+      await userEvent.click(licensee);
+      await userEvent.click(internal);
+      await waitFor(() => expect(clickSpy).toHaveBeenCalledTimes(2));
     } finally {
       HTMLAnchorElement.prototype.click = orig;
     }
@@ -183,7 +194,10 @@ export const EmptyDisablesExport: Story = {
       expect(canvas.getByRole('dialog')).toBeInTheDocument()
     );
     await expect(
-      canvas.getByRole('button', { name: /licensee csv \(0\)/i })
+      canvas.getByRole('button', { name: /licensee csv[^(]*\(0\)/i })
+    ).toBeDisabled();
+    await expect(
+      canvas.getByRole('button', { name: /internal roster \(0\)/i })
     ).toBeDisabled();
   },
 };

--- a/apps/maple-spruce/src/app/(admin)/music-together/RosterDialog.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/RosterDialog.tsx
@@ -21,6 +21,7 @@ import {
 import DownloadIcon from '@mui/icons-material/Download';
 import {
   buildMusicTogetherLicenseeCsv,
+  buildMusicTogetherInternalRosterCsv,
   mtFormatDob,
   type RequestState,
 } from '@maple/ts/domain';
@@ -55,12 +56,22 @@ export function RosterDialog({ open, onClose, sectionName, rosterState }: Props)
     [entries]
   );
 
-  const handleDownload = () => {
+  const safeName = sectionName.replace(/[^a-z0-9]+/gi, '-').toLowerCase();
+
+  // Licensee report → shared with Music Together Worldwide: adult contact only.
+  const handleDownloadLicensee = () => {
     const csv = buildMusicTogetherLicenseeCsv(
       confirmed.map((e) => e.registration)
     );
-    const safe = sectionName.replace(/[^a-z0-9]+/gi, '-').toLowerCase();
-    downloadCsv(`music-together-licensee-${safe}.csv`, csv);
+    downloadCsv(`music-together-licensee-${safeName}.csv`, csv);
+  };
+
+  // Internal roster → Maple & Spruce only: includes children + accommodations.
+  const handleDownloadInternal = () => {
+    const csv = buildMusicTogetherInternalRosterCsv(
+      confirmed.map((e) => e.registration)
+    );
+    downloadCsv(`music-together-internal-roster-${safeName}.csv`, csv);
   };
 
   return (
@@ -143,10 +154,17 @@ export function RosterDialog({ open, onClose, sectionName, rosterState }: Props)
       <DialogActions>
         <Button
           startIcon={<DownloadIcon />}
-          onClick={handleDownload}
+          onClick={handleDownloadInternal}
           disabled={confirmed.length === 0}
         >
-          Licensee CSV ({confirmed.length})
+          Internal roster ({confirmed.length})
+        </Button>
+        <Button
+          startIcon={<DownloadIcon />}
+          onClick={handleDownloadLicensee}
+          disabled={confirmed.length === 0}
+        >
+          Licensee CSV — MTW ({confirmed.length})
         </Button>
         <Button onClick={onClose}>Close</Button>
       </DialogActions>

--- a/libs/ts/domain/src/lib/music-together-licensee.spec.ts
+++ b/libs/ts/domain/src/lib/music-together-licensee.spec.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import {
   buildMusicTogetherLicenseeCsv,
+  buildMusicTogetherInternalRosterCsv,
   mtCsvEscape,
   mtFormatDob,
   MT_LICENSEE_CSV_HEADERS,
+  MT_INTERNAL_ROSTER_CSV_HEADERS,
 } from './music-together-licensee';
 
 describe('mtCsvEscape', () => {
@@ -23,39 +25,92 @@ describe('mtFormatDob', () => {
   });
 });
 
-describe('buildMusicTogetherLicenseeCsv', () => {
-  it('emits a header and one row per child', () => {
+describe('buildMusicTogetherLicenseeCsv (Music Together Worldwide)', () => {
+  it('emits a header and one row per family — adult contact only, no children', () => {
     const csv = buildMusicTogetherLicenseeCsv([
       {
-        parentNames: ['Jamie Rivera'],
-        children: [
-          { name: 'Sky', dob: new Date('2023-04-01T00:00:00Z') },
-          { name: 'River', dob: new Date('2021-08-15T00:00:00Z') },
-        ],
+        adultFirstName: 'Jamie',
+        adultLastName: 'Rivera',
+        email: 'jamie@example.com',
+        address: '123 Spruce St, Morgantown WV',
       },
       {
-        parentNames: ['Pat Lee', 'Sam Lee'],
-        children: [{ name: 'Wren', dob: new Date('2022-01-10T00:00:00Z') }],
+        adultFirstName: 'Pat',
+        adultLastName: 'Lee',
+        email: 'pat@example.com',
+        address: '9 Oak Ave, Morgantown WV',
       },
     ]);
     const lines = csv.trimEnd().split('\r\n');
     expect(lines[0]).toBe(MT_LICENSEE_CSV_HEADERS.join(','));
-    expect(lines).toHaveLength(4); // header + 3 children
-    expect(lines[1]).toBe('Jamie Rivera,Sky,2023-04-01');
-    expect(lines[2]).toBe('Jamie Rivera,River,2021-08-15');
-    expect(lines[3]).toBe('Pat Lee; Sam Lee,Wren,2022-01-10');
+    expect(lines).toHaveLength(3); // header + 2 families
+    expect(lines[1]).toBe('Jamie,Rivera,jamie@example.com,"123 Spruce St, Morgantown WV"');
+    expect(lines[2]).toBe('Pat,Lee,pat@example.com,"9 Oak Ave, Morgantown WV"');
   });
 
-  it('escapes names containing commas', () => {
+  it('never includes any child information', () => {
     const csv = buildMusicTogetherLicenseeCsv([
-      { parentNames: ['Doe, Jane'], children: [{ name: 'Kid', dob: new Date('2023-01-01T00:00:00Z') }] },
+      {
+        adultFirstName: 'Jamie',
+        adultLastName: 'Rivera',
+        email: 'jamie@example.com',
+        address: '123 Spruce St',
+      },
     ]);
-    expect(csv).toContain('"Doe, Jane",Kid,2023-01-01');
+    expect(csv).not.toContain('Child');
+    expect(csv.toLowerCase()).not.toContain('dob');
   });
 
   it('returns just the header for no registrations', () => {
     expect(buildMusicTogetherLicenseeCsv([])).toBe(
       MT_LICENSEE_CSV_HEADERS.join(',') + '\r\n'
+    );
+  });
+});
+
+describe('buildMusicTogetherInternalRosterCsv (Maple & Spruce only)', () => {
+  it('emits a header and one row per child, with accommodations/notes', () => {
+    const csv = buildMusicTogetherInternalRosterCsv([
+      {
+        adultFirstName: 'Jamie',
+        adultLastName: 'Rivera',
+        email: 'jamie@example.com',
+        phone: '304-555-1212',
+        children: [
+          { name: 'Sky', dob: new Date('2023-04-01T00:00:00Z') },
+          { name: 'River', dob: new Date('2021-08-15T00:00:00Z') },
+        ],
+        accommodations: 'Peanut allergy',
+        notes: 'Prefers Saturdays',
+      },
+      {
+        adultFirstName: 'Pat',
+        adultLastName: 'Lee',
+        email: 'pat@example.com',
+        phone: '304-555-0000',
+        children: [{ name: 'Wren', dob: new Date('2022-01-10T00:00:00Z') }],
+        accommodations: undefined,
+        notes: undefined,
+      },
+    ]);
+    const lines = csv.trimEnd().split('\r\n');
+    expect(lines[0]).toBe(MT_INTERNAL_ROSTER_CSV_HEADERS.join(','));
+    expect(lines).toHaveLength(4); // header + 3 children
+    expect(lines[1]).toBe(
+      'Jamie,Rivera,jamie@example.com,304-555-1212,Sky,2023-04-01,Peanut allergy,Prefers Saturdays'
+    );
+    expect(lines[2]).toBe(
+      'Jamie,Rivera,jamie@example.com,304-555-1212,River,2021-08-15,Peanut allergy,Prefers Saturdays'
+    );
+    // Missing accommodations/notes render as empty fields.
+    expect(lines[3]).toBe(
+      'Pat,Lee,pat@example.com,304-555-0000,Wren,2022-01-10,,'
+    );
+  });
+
+  it('returns just the header for no registrations', () => {
+    expect(buildMusicTogetherInternalRosterCsv([])).toBe(
+      MT_INTERNAL_ROSTER_CSV_HEADERS.join(',') + '\r\n'
     );
   });
 });

--- a/libs/ts/domain/src/lib/music-together-licensee.ts
+++ b/libs/ts/domain/src/lib/music-together-licensee.ts
@@ -1,12 +1,21 @@
 /**
- * Music Together licensee report
+ * Music Together CSV exports
  *
- * The Music Together license requires a per-section export of every enrolled
- * child: the parent/guardian name(s), the child's name, and the child's date
- * of birth. This builds that report as CSV — one row per child.
+ * Two distinct exports with different audiences and privacy boundaries:
  *
- * Pure and dependency-free so it can be unit-tested and reused on the server
- * (a CSV-returning endpoint) or the client (a download button).
+ * 1. **Licensee report (Music Together Worldwide).** Enrolling families agree
+ *    that the *adult's* name, email, and street address may be shared with MTW
+ *    as a licensed center. Children's information is NEVER shared outside Maple
+ *    & Spruce, so this export carries adult contact details only — one row per
+ *    family. (This replaced an earlier child-level report; see the privacy
+ *    notice in the Policies page.)
+ *
+ * 2. **Internal roster (Maple & Spruce only).** Everything staff need to run
+ *    the class, including each child's first name and DOB plus any
+ *    accommodations/notes — one row per child. Never leaves Maple & Spruce.
+ *
+ * Both are pure and dependency-free so they can be unit-tested and reused on
+ * the server (a CSV-returning endpoint) or the client (a download button).
  */
 import type { MusicTogetherRegistration } from './music-together-registration';
 
@@ -20,27 +29,98 @@ export function mtFormatDob(dob: Date): string {
   return dob.toISOString().slice(0, 10);
 }
 
-/** Column headers for the licensee report, in order. */
+function toCsv(rows: string[][]): string {
+  return rows.map((row) => row.map(mtCsvEscape).join(',')).join('\r\n') + '\r\n';
+}
+
+// ============================================================================
+// Licensee report — shared with Music Together Worldwide (adults only)
+// ============================================================================
+
+/** Column headers for the licensee report, in order. Adult contact only. */
 export const MT_LICENSEE_CSV_HEADERS = [
-  'Parent(s)',
-  'Child Name',
-  'Child DOB',
+  'Adult First Name',
+  'Adult Last Name',
+  'Email',
+  'Street Address',
 ] as const;
 
+/** The registration fields the licensee report is allowed to include. */
+export type MtLicenseeRegistration = Pick<
+  MusicTogetherRegistration,
+  'adultFirstName' | 'adultLastName' | 'email' | 'address'
+>;
+
 /**
- * Build the licensee CSV for a set of registrations — one row per child.
- * Parents are joined with '; '. Caller decides which registrations to include
- * (typically confirmed enrollments).
+ * Build the licensee CSV for Music Together Worldwide — one row per family,
+ * adult contact details only. NO child information is included. Caller decides
+ * which registrations to include (typically confirmed enrollments).
  */
 export function buildMusicTogetherLicenseeCsv(
-  registrations: Pick<MusicTogetherRegistration, 'parentNames' | 'children'>[]
+  registrations: MtLicenseeRegistration[]
 ): string {
   const rows: string[][] = [[...MT_LICENSEE_CSV_HEADERS]];
   for (const reg of registrations) {
-    const parents = reg.parentNames.join('; ');
+    rows.push([
+      reg.adultFirstName,
+      reg.adultLastName,
+      reg.email,
+      reg.address,
+    ]);
+  }
+  return toCsv(rows);
+}
+
+// ============================================================================
+// Internal roster — Maple & Spruce only (includes children)
+// ============================================================================
+
+/** Column headers for the internal roster, in order. Never shared with MTW. */
+export const MT_INTERNAL_ROSTER_CSV_HEADERS = [
+  'Adult First Name',
+  'Adult Last Name',
+  'Email',
+  'Phone',
+  'Child First Name',
+  'Child DOB',
+  'Accommodations',
+  'Notes',
+] as const;
+
+/** The registration fields the internal roster includes. */
+export type MtInternalRosterRegistration = Pick<
+  MusicTogetherRegistration,
+  | 'adultFirstName'
+  | 'adultLastName'
+  | 'email'
+  | 'phone'
+  | 'children'
+  | 'accommodations'
+  | 'notes'
+>;
+
+/**
+ * Build the internal roster CSV for Maple & Spruce staff — one row per child,
+ * with the child's first name + DOB and the family's accommodations/notes.
+ * This never leaves Maple & Spruce; do not send it to Music Together Worldwide.
+ */
+export function buildMusicTogetherInternalRosterCsv(
+  registrations: MtInternalRosterRegistration[]
+): string {
+  const rows: string[][] = [[...MT_INTERNAL_ROSTER_CSV_HEADERS]];
+  for (const reg of registrations) {
     for (const child of reg.children) {
-      rows.push([parents, child.name, mtFormatDob(child.dob)]);
+      rows.push([
+        reg.adultFirstName,
+        reg.adultLastName,
+        reg.email,
+        reg.phone,
+        child.name,
+        mtFormatDob(child.dob),
+        reg.accommodations ?? '',
+        reg.notes ?? '',
+      ]);
     }
   }
-  return rows.map((row) => row.map(mtCsvEscape).join(',')).join('\r\n') + '\r\n';
+  return toCsv(rows);
 }


### PR DESCRIPTION
Follow-up to #579 (which added the registration fields). Addresses the privacy conflict flagged there.

## Why
The licensee export previously emitted **child name + DOB to Music Together Worldwide**, which conflicts with the new privacy policy — *"children's information is never shared outside Maple & Spruce"* — and with Patricia's requirement that MTLLC receive only the adult's name, email, and address.

## Change
Split the single export into two, with clear audiences:

| Export | Audience | Contents |
|---|---|---|
| **Licensee CSV — MTW** (`buildMusicTogetherLicenseeCsv`) | Music Together Worldwide | Adult First/Last name, Email, Street Address — one row per family, **no child data** |
| **Internal roster** (`buildMusicTogetherInternalRosterCsv`, new) | Maple & Spruce only | One row per child: first name + DOB + accommodations + notes |

- `RosterDialog` now exposes two clearly-labelled download buttons.
- Licensee spec asserts **no child data leaks** into the MTW export; added an internal-roster spec; updated the RosterDialog Storybook play-test to drive both buttons and verify the accommodations column.

This intentionally overrides the original epic #508 licensee-report spec (parent + child + DOB) per Patricia's newer guidance and the published privacy notice.

## Verification
- `vitest` licensee spec: 8 passed · maple-spruce typecheck: clean · eslint: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)