### PR TITLE
feat: sync classes to Square catalog for in-person POS registration (PR A of 3)

### DIFF
--- a/apps/functions-integration-tests-class-square/project.json
+++ b/apps/functions-integration-tests-class-square/project.json
@@ -1,0 +1,20 @@
+{
+  "name": "functions-integration-tests-class-square",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/functions-integration-tests-class-square/src",
+  "projectType": "application",
+  "tags": ["type:e2e"],
+  "implicitDependencies": [
+    "firebase-maple-functions-sync-class-to-square",
+    "firebase-integration-test-utils",
+    "firebase-square-test-mock-server"
+  ],
+  "targets": {
+    "test": {
+      "executor": "@nx/vitest:test",
+      "options": {
+        "config": "apps/functions-integration-tests-class-square/vitest.config.ts"
+      }
+    }
+  }
+}

--- a/apps/functions-integration-tests-class-square/src/sync-class-to-square.spec.ts
+++ b/apps/functions-integration-tests-class-square/src/sync-class-to-square.spec.ts
@@ -1,0 +1,193 @@
+/**
+ * Integration tests for the `syncClassToSquare` Firestore trigger.
+ *
+ * Exercises the REAL chain end-to-end against the Firebase emulator:
+ *
+ *   Firestore write (classes/{id})  →  syncClassToSquare fires in the
+ *   maple-square functions emulator  →  its `new Square(...)` client hits the
+ *   Square mock server (redirected via SQUARE_BASE_URL)  →  the returned
+ *   catalog IDs are written back onto the class doc.
+ *
+ * We assert the write-back (the backbone — it can only happen if the whole
+ * chain worked) AND the actual payloads the trigger sent to Square, read back
+ * from the mock via its `/_mock/requests` introspection route.
+ *
+ * NOTE: requires the maple-square codebase to be built and loaded in the
+ * emulator, and the Square mock server running on 9997(+offset). The harness
+ * (`tools/run-integration-tests.sh class-square`) sets all of this up.
+ */
+import {
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  getFirestoreDoc,
+  EMULATOR_CONFIG,
+  PUBLISHED_CLASS,
+} from '@maple/firebase/integration-test-utils';
+
+const squareMockUrl = EMULATOR_CONFIG.squareMockServerUrl;
+
+interface RecordedRequest {
+  method: string;
+  path: string;
+  body: unknown;
+}
+
+/** Wait for the async Firestore trigger + Square round-trip to complete. */
+function waitForTrigger(ms = 5000): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function resetSquareMock(): Promise<void> {
+  const res = await fetch(`${squareMockUrl}/_mock/reset`, { method: 'POST' });
+  if (!res.ok) {
+    throw new Error(`Square mock reset failed: ${res.status}`);
+  }
+}
+
+async function getSquareRequests(pathPrefix?: string): Promise<RecordedRequest[]> {
+  const res = await fetch(`${squareMockUrl}/_mock/requests`);
+  if (!res.ok) {
+    throw new Error(`Square mock requests failed: ${res.status}`);
+  }
+  const body = (await res.json()) as { requests: RecordedRequest[] };
+  const requests = body.requests ?? [];
+  return pathPrefix
+    ? requests.filter((r) => r.path.startsWith(pathPrefix))
+    : requests;
+}
+
+/**
+ * Recursively collect every object of a given catalog `type` (ITEM,
+ * ITEM_VARIATION, MODIFIER_LIST) found anywhere in a batch-upsert body.
+ * Tolerant of snake_case vs camelCase — we only key off the `type` field.
+ */
+function collectByType(node: unknown, type: string, out: Record<string, unknown>[]): void {
+  if (Array.isArray(node)) {
+    for (const el of node) collectByType(el, type, out);
+    return;
+  }
+  if (node && typeof node === 'object') {
+    const obj = node as Record<string, unknown>;
+    if (obj['type'] === type) out.push(obj);
+    for (const value of Object.values(obj)) collectByType(value, type, out);
+  }
+}
+
+/** Pull `item_data` / `itemData` off a catalog object regardless of casing. */
+function dataFor(obj: Record<string, unknown>, snake: string, camel: string): Record<string, unknown> | undefined {
+  return (obj[snake] ?? obj[camel]) as Record<string, unknown> | undefined;
+}
+
+const PUBLISHED = {
+  ...PUBLISHED_CLASS,
+  name: 'Integration Pottery 101',
+  priceCents: 5500,
+  capacity: 8,
+  status: 'published',
+};
+
+describe('syncClassToSquare (emulator + Square mock)', () => {
+  beforeEach(async () => {
+    await clearFirestoreEmulator();
+    await resetSquareMock();
+  });
+
+  it('creates a Square catalog item, writes the IDs back, and seeds inventory on publish', async () => {
+    const id = 'class-square-test-1';
+    await setFirestoreDoc('classes', id, { ...PUBLISHED, id });
+
+    await waitForTrigger(5000);
+
+    // --- Backbone: IDs written back onto the class doc ---
+    const doc = await getFirestoreDoc('classes', id);
+    expect(doc).toBeDefined();
+    expect(doc!['squareCatalogItemId']).toBeDefined();
+    expect(doc!['squareVariationId']).toBeDefined();
+    expect(doc!['squareModifierListId']).toBeDefined();
+
+    // --- Actual payloads sent to Square ---
+    const upserts = await getSquareRequests('/v2/catalog/batch-upsert');
+    expect(upserts.length).toBeGreaterThanOrEqual(1);
+
+    const items: Record<string, unknown>[] = [];
+    const modLists: Record<string, unknown>[] = [];
+    for (const req of upserts) {
+      collectByType(req.body, 'ITEM', items);
+      collectByType(req.body, 'MODIFIER_LIST', modLists);
+    }
+
+    // Log the actual recorded shape once for debugging shape assumptions.
+    if (process.env['DEBUG_SQUARE_MOCK']) {
+      console.log('ITEMS', JSON.stringify(items, null, 2));
+      console.log('MODLISTS', JSON.stringify(modLists, null, 2));
+    }
+
+    // An ITEM with the class name was upserted.
+    const namedItem = items.find((item) => {
+      const d = dataFor(item, 'item_data', 'itemData');
+      return d?.['name'] === PUBLISHED.name;
+    });
+    expect(namedItem).toBeDefined();
+
+    // The required single-option modifier list with the exact name exists.
+    const requiredModList = modLists.find((ml) => {
+      const d = dataFor(ml, 'modifier_list_data', 'modifierListData');
+      return d?.['name'] === 'Added customer email (required)?';
+    });
+    expect(requiredModList).toBeDefined();
+
+    // Inventory seeded to capacity (8) - registrations (0) = 8.
+    const invReqs = await getSquareRequests('/v2/inventory/changes/batch-create');
+    expect(invReqs.length).toBeGreaterThanOrEqual(1);
+
+    const quantities: unknown[] = [];
+    for (const req of invReqs) {
+      const body = req.body as Record<string, unknown>;
+      const changes = (body['changes'] as Record<string, unknown>[]) ?? [];
+      for (const change of changes) {
+        const pc = dataFor(change, 'physical_count', 'physicalCount');
+        if (pc && pc['quantity'] != null) quantities.push(pc['quantity']);
+      }
+    }
+    // Square serializes quantity as a string; tolerate string or number.
+    expect(quantities.map(String)).toContain('8');
+  });
+
+  it('deletes the Square catalog item and clears the IDs on unpublish', async () => {
+    const id = 'class-square-test-2';
+    await setFirestoreDoc('classes', id, { ...PUBLISHED, id });
+    await waitForTrigger(5000);
+
+    const published = await getFirestoreDoc('classes', id);
+    const itemId = published!['squareCatalogItemId'] as string | undefined;
+    expect(itemId).toBeDefined();
+
+    // Reset the recorded requests so we only see the unpublish traffic.
+    await fetch(`${squareMockUrl}/_mock/reset`, { method: 'POST' });
+
+    // Flip to draft. `setFirestoreDoc` PATCHes without an updateMask, which
+    // replaces the whole doc — so carry the written-back Square IDs forward
+    // to mirror a real partial update (updateClass preserves them). Without
+    // them the trigger's `after` would have no squareCatalogItemId and would
+    // never issue the delete.
+    await setFirestoreDoc('classes', id, {
+      ...PUBLISHED,
+      id,
+      status: 'draft',
+      squareCatalogItemId: itemId,
+      squareVariationId: published!['squareVariationId'],
+      squareModifierListId: published!['squareModifierListId'],
+      squareCatalogVersion: published!['squareCatalogVersion'],
+    });
+    await waitForTrigger(5000);
+
+    const deletes = await getSquareRequests('/v2/catalog/object/');
+    const matched = deletes.find(
+      (r) => r.method === 'DELETE' && r.path.includes(itemId as string)
+    );
+    expect(matched).toBeDefined();
+
+    const after = await getFirestoreDoc('classes', id);
+    expect(after!['squareCatalogItemId']).toBeFalsy();
+  });
+});

--- a/apps/functions-integration-tests-class-square/tsconfig.json
+++ b/apps/functions-integration-tests-class-square/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/apps/functions-integration-tests-class-square/tsconfig.spec.json
+++ b/apps/functions-integration-tests-class-square/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "types": ["vitest/globals", "node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/functions-integration-tests-class-square/vitest.config.ts
+++ b/apps/functions-integration-tests-class-square/vitest.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@maple/firebase/integration-test-utils': path.resolve(
+        __dirname,
+        '../../libs/firebase/integration-test-utils/src/index.ts'
+      ),
+      '@maple/firebase/square-test-mock-server': path.resolve(
+        __dirname,
+        '../../libs/firebase/square-test-mock-server/src/index.ts'
+      ),
+      '@maple/ts/firebase/api-types': path.resolve(
+        __dirname,
+        '../../libs/ts/firebase/api-types/src/index.ts'
+      ),
+      '@maple/ts/domain': path.resolve(
+        __dirname,
+        '../../libs/ts/domain/src/index.ts'
+      ),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    root: path.resolve(__dirname),
+    include: ['src/**/*.spec.ts'],
+    setupFiles: ['../../libs/firebase/integration-test-utils/src/lib/setup.ts'],
+    testTimeout: 60000,
+    fileParallelism: false,
+    sequence: {
+      concurrent: false,
+    },
+  },
+});

--- a/apps/functions-square/src/index.ts
+++ b/apps/functions-square/src/index.ts
@@ -61,3 +61,8 @@ export { updateCraftClubPaymentMethod } from '@maple/firebase/maple-functions/up
 export { adminPauseCraftClubSubscription } from '@maple/firebase/maple-functions/admin-pause-craft-club-subscription';
 export { adminResumeCraftClubSubscription } from '@maple/firebase/maple-functions/admin-resume-craft-club-subscription';
 export { adminCancelCraftClubSubscription } from '@maple/firebase/maple-functions/admin-cancel-craft-club-subscription';
+
+// Class → Square catalog sync (Firestore trigger on classes/{id})
+// Mirrors a published class as a Square catalog item + variation + required
+// modifier list so it can be rung up on POS in person.
+export { syncClassToSquare } from '@maple/firebase/maple-functions/sync-class-to-square';

--- a/apps/functions-square/tsconfig.app.json
+++ b/apps/functions-square/tsconfig.app.json
@@ -18,6 +18,7 @@
     "../../libs/firebase/maple-functions/sync-invoice-to-square/**/*.ts",
     "../../libs/firebase/maple-functions/import-etsy-listings/**/*.ts",
     "../../libs/firebase/maple-functions/sync-inventory-to-square/**/*.ts",
+    "../../libs/firebase/maple-functions/sync-class-to-square/**/*.ts",
     "../../libs/firebase/maple-functions/create-craft-club-subscription/**/*.ts",
     "../../libs/firebase/maple-functions/cancel-craft-club-subscription/**/*.ts",
     "../../libs/firebase/maple-functions/update-craft-club-payment-method/**/*.ts",

--- a/function-codebases.json
+++ b/function-codebases.json
@@ -41,6 +41,7 @@
     "firebase-maple-functions-poll-etsy-orders": "maple-sync",
     "firebase-maple-functions-sync-inventory-to-etsy": "maple-sync",
     "firebase-maple-functions-sync-inventory-to-square": "maple-square",
+    "firebase-maple-functions-sync-class-to-square": "maple-square",
     "firebase-maple-functions-create-craft-club-subscription": "maple-square",
     "firebase-maple-functions-create-music-together-registration": "maple-square",
     "firebase-maple-functions-charge-music-together-installments": "maple-square",

--- a/libs/firebase/database/src/lib/class.repository.ts
+++ b/libs/firebase/database/src/lib/class.repository.ts
@@ -94,6 +94,13 @@ function docToClass(
     minimumAge: data.minimumAge,
     webflowItemId: data.webflowItemId,
     webflowSlug: data.webflowSlug,
+    squareCatalogItemId: data.squareCatalogItemId,
+    squareVariationId: data.squareVariationId,
+    squareModifierListId: data.squareModifierListId,
+    squareCatalogVersion:
+      typeof data.squareCatalogVersion === 'number'
+        ? data.squareCatalogVersion
+        : undefined,
     referralDiscount:
       data.referralDiscount &&
       typeof data.referralDiscount.percent === 'number' &&
@@ -298,6 +305,73 @@ export const ClassRepository = {
       payload.webflowSlug = webflowSlug;
     }
     await docRef.update(payload);
+  },
+
+  /**
+   * Stamp the Square sync IDs onto a class after a successful sync.
+   *
+   * Deliberately bare update with NO `updatedAt` bump — the class document
+   * triggers `syncClassToSquare` on every write, and bumping `updatedAt`
+   * would re-fire the trigger in a loop. Same back-reference pattern as
+   * `updateWebflowItemId`.
+   */
+  async updateSquareSyncIds(
+    id: string,
+    ids: {
+      squareCatalogItemId?: string;
+      squareVariationId?: string;
+      squareModifierListId?: string;
+      squareCatalogVersion?: number;
+    }
+  ): Promise<void> {
+    const docRef = db.collection(COLLECTION).doc(id);
+    const update: Record<string, unknown> = {};
+    if (ids.squareCatalogItemId !== undefined) {
+      update.squareCatalogItemId = ids.squareCatalogItemId;
+    }
+    if (ids.squareVariationId !== undefined) {
+      update.squareVariationId = ids.squareVariationId;
+    }
+    if (ids.squareModifierListId !== undefined) {
+      update.squareModifierListId = ids.squareModifierListId;
+    }
+    if (ids.squareCatalogVersion !== undefined) {
+      update.squareCatalogVersion = ids.squareCatalogVersion;
+    }
+    if (Object.keys(update).length === 0) return;
+    await docRef.update(update);
+  },
+
+  /**
+   * Clear all Square sync IDs (called after deleting the catalog item, e.g.
+   * when a class is unpublished). Not bumping `updatedAt` for the same
+   * reason as `updateSquareSyncIds`.
+   */
+  async clearSquareSyncIds(id: string): Promise<void> {
+    const docRef = db.collection(COLLECTION).doc(id);
+    await docRef.update({
+      squareCatalogItemId: null,
+      squareVariationId: null,
+      squareModifierListId: null,
+      squareCatalogVersion: null,
+    });
+  },
+
+  /**
+   * List the Square catalog ITEM ids of every class that has been mirrored
+   * to Square. Used by `processCatalogSyncRequest` to skip class-owned
+   * catalog items so they aren't reflected back as phantom draft Products.
+   *
+   * Intentionally implemented via `findAll()` + in-memory filter rather than
+   * a Firestore `.where('squareCatalogItemId', '!=', null)` query — the
+   * latter would require a composite index and there's no scale concern here
+   * (class count is small).
+   */
+  async listSquareCatalogItemIds(): Promise<string[]> {
+    const classes = await this.findAll();
+    return classes
+      .map((c) => c.squareCatalogItemId)
+      .filter((itemId): itemId is string => Boolean(itemId));
   },
 
   /**

--- a/libs/firebase/maple-functions/process-catalog-sync-request/src/lib/process-catalog-sync-request.spec.ts
+++ b/libs/firebase/maple-functions/process-catalog-sync-request/src/lib/process-catalog-sync-request.spec.ts
@@ -21,6 +21,8 @@ const mocks = vi.hoisted(() => ({
   productFindAll: vi.fn(),
   updateSquareCache: vi.fn(),
   createProduct: vi.fn(),
+  // ClassRepository
+  listSquareCatalogItemIds: vi.fn(),
   // Square catalog service
   listItems: vi.fn(),
   getItemImageUrl: vi.fn(),
@@ -49,6 +51,9 @@ vi.mock('@maple/firebase/database', () => ({
     findAll: mocks.productFindAll,
     updateSquareCache: mocks.updateSquareCache,
     create: mocks.createProduct,
+  },
+  ClassRepository: {
+    listSquareCatalogItemIds: mocks.listSquareCatalogItemIds,
   },
 }));
 
@@ -92,6 +97,7 @@ beforeEach(() => {
   });
   mocks.productFindAll.mockResolvedValue([]);
   mocks.listItems.mockResolvedValue([]);
+  mocks.listSquareCatalogItemIds.mockResolvedValue([]);
 });
 
 describe('processCatalogSyncRequest — lease coordination', () => {
@@ -225,6 +231,62 @@ describe('processCatalogSyncRequest — catalog sync correctness', () => {
     expect(mocks.createProduct).toHaveBeenCalled();
     expect(mocks.markCompleted).toHaveBeenCalledWith(
       expect.stringContaining('scanned 2')
+    );
+  });
+
+  it('skips class catalog items — never mirrors them back as draft products', async () => {
+    // A Square ITEM whose id is a class mirror (owned by syncClassToSquare).
+    // It is untracked as a Product, so without the guard it would be created
+    // as a phantom draft. The guard must skip it instead.
+    mocks.productFindAll.mockResolvedValue([]);
+    mocks.listSquareCatalogItemIds.mockResolvedValue(['CLASS_ITEM_1']);
+    mocks.listItems.mockResolvedValue([
+      {
+        id: 'CLASS_ITEM_1',
+        type: 'ITEM',
+        version: 3,
+        itemData: {
+          name: 'Intro to Pottery',
+          variations: [
+            {
+              id: 'CLASS_VAR_1',
+              itemVariationData: { sku: '', priceMoney: { amount: 4500n } },
+            },
+          ],
+        },
+      },
+      {
+        id: 'ITEM_REAL',
+        type: 'ITEM',
+        version: 1,
+        itemData: {
+          name: 'Real Product',
+          variations: [
+            {
+              id: 'VAR_REAL',
+              itemVariationData: { sku: 'R', priceMoney: { amount: 200n } },
+            },
+          ],
+        },
+      },
+    ]);
+    mocks.getItemImageUrl.mockResolvedValue('img');
+    mocks.createProduct.mockResolvedValue({ id: 'prod-real' });
+
+    await handler(makeEvent({ requestedAt: new Date(), running: false }));
+
+    // Exactly one create — for the real product, not the class item.
+    expect(mocks.createProduct).toHaveBeenCalledTimes(1);
+    expect(mocks.createProduct).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Real Product' }),
+      expect.objectContaining({ squareItemId: 'ITEM_REAL' })
+    );
+    // The class item was scanned but skipped (2 scanned, 1 created, 1 skipped).
+    expect(mocks.markCompleted).toHaveBeenCalledWith(
+      expect.stringContaining('scanned 2')
+    );
+    expect(mocks.markCompleted).toHaveBeenCalledWith(
+      expect.stringContaining('skipped 1')
     );
   });
 

--- a/libs/firebase/maple-functions/process-catalog-sync-request/src/lib/process-catalog-sync-request.ts
+++ b/libs/firebase/maple-functions/process-catalog-sync-request/src/lib/process-catalog-sync-request.ts
@@ -27,6 +27,7 @@ import { onDocumentWritten } from 'firebase-functions/v2/firestore';
 import { defineSecret, defineString } from 'firebase-functions/params';
 import {
   CatalogSyncRequestRepository,
+  ClassRepository,
   ProductRepository,
 } from '@maple/firebase/database';
 import {
@@ -86,6 +87,15 @@ async function runCatalogSync(square: Square): Promise<SyncSummary> {
     products.filter((p) => p.squareItemId).map((p) => p.squareItemId!)
   );
 
+  // Square catalog items that are actually class mirrors (pushed by
+  // syncClassToSquare). These must NOT be reflected back into the Products
+  // collection — otherwise every published class would spawn a phantom
+  // `status:'draft'` Product here. Skip them entirely (neither update nor
+  // create). Sourced from findAll() + filter to avoid a composite index.
+  const classCatalogItemIds = new Set(
+    await ClassRepository.listSquareCatalogItemIds()
+  );
+
   const squareItems = await square.catalogService.listItems();
 
   console.log(
@@ -104,6 +114,13 @@ async function runCatalogSync(square: Square): Promise<SyncSummary> {
 
   for (const catalogObject of squareItems) {
     if (catalogObject.type !== 'ITEM' || !catalogObject.id) {
+      skipped++;
+      continue;
+    }
+
+    // Class catalog items are owned by syncClassToSquare. Skip them so this
+    // worker never mirrors a class back as a phantom draft Product.
+    if (classCatalogItemIds.has(catalogObject.id)) {
       skipped++;
       continue;
     }

--- a/libs/firebase/maple-functions/sync-class-to-square/eslint.config.mjs
+++ b/libs/firebase/maple-functions/sync-class-to-square/eslint.config.mjs
@@ -1,0 +1,22 @@
+import baseConfig from '../../../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredFiles: [
+            '{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}',
+            '{projectRoot}/esbuild.config.{js,ts,mjs,mts}',
+          ],
+        },
+      ],
+    },
+    languageOptions: {
+      parser: await import('jsonc-eslint-parser'),
+    },
+  },
+];

--- a/libs/firebase/maple-functions/sync-class-to-square/project.json
+++ b/libs/firebase/maple-functions/sync-class-to-square/project.json
@@ -1,0 +1,15 @@
+{
+  "name": "firebase-maple-functions-sync-class-to-square",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/sync-class-to-square/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {
+    "test": {
+      "executor": "@nx/vitest:test",
+      "options": {
+        "config": "libs/firebase/maple-functions/sync-class-to-square/vitest.config.ts"
+      }
+    }
+  }
+}

--- a/libs/firebase/maple-functions/sync-class-to-square/src/index.ts
+++ b/libs/firebase/maple-functions/sync-class-to-square/src/index.ts
@@ -1,0 +1,1 @@
+export { syncClassToSquare } from './lib/sync-class-to-square';

--- a/libs/firebase/maple-functions/sync-class-to-square/src/lib/sync-class-to-square.spec.ts
+++ b/libs/firebase/maple-functions/sync-class-to-square/src/lib/sync-class-to-square.spec.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Class } from '@maple/ts/domain';
+
+/**
+ * Tests for sync-class-to-square.ts
+ *
+ * Covers the four lifecycle branches of the trigger:
+ *  - Published create  → creates Square catalog item + seeds inventory
+ *  - Published update  → updates name/price; resets inventory on capacity change
+ *  - Unpublished       → deletes catalog item + clears back-refs
+ *  - Deleted           → deletes catalog item if it existed
+ *
+ * Plus the Square-relevant change guard (skip writes that touch nothing
+ * material — prevents the trigger feedback loop with `updateSquareSyncIds`).
+ */
+
+const mocks = vi.hoisted(() => ({
+  classFindById: vi.fn(),
+  registrationCountByClassId: vi.fn(),
+  updateSquareSyncIds: vi.fn(),
+  clearSquareSyncIds: vi.fn(),
+  // Square service mocks
+  createClassCatalogItem: vi.fn(),
+  updateItem: vi.fn(),
+  deleteItem: vi.fn(),
+  setQuantity: vi.fn(),
+  locationId: 'mock-location',
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  ClassRepository: {
+    findById: mocks.classFindById,
+    updateSquareSyncIds: mocks.updateSquareSyncIds,
+    clearSquareSyncIds: mocks.clearSquareSyncIds,
+  },
+  RegistrationRepository: {
+    countByClassId: mocks.registrationCountByClassId,
+  },
+}));
+
+vi.mock('@maple/firebase/square', () => {
+  return {
+    Square: class MockSquare {
+      catalogService = {
+        createClassCatalogItem: mocks.createClassCatalogItem,
+        updateItem: mocks.updateItem,
+        deleteItem: mocks.deleteItem,
+      };
+      inventoryService = { setQuantity: mocks.setQuantity };
+      locationId = mocks.locationId;
+    },
+    SQUARE_SECRET_NAMES: ['SQUARE_ACCESS_TOKEN'],
+    SQUARE_STRING_NAMES: ['SQUARE_LOCATION_ID'],
+  };
+});
+
+vi.mock('firebase-functions/v2/firestore', () => ({
+  onDocumentWritten: vi.fn((_config, handler) => handler),
+}));
+
+vi.mock('firebase-functions/params', () => ({
+  defineSecret: vi.fn((name: string) => ({ name, value: () => `mock-${name}` })),
+  defineString: vi.fn((name: string) => ({ name, value: () => `mock-${name}` })),
+}));
+
+import { syncClassToSquare } from './sync-class-to-square';
+
+const handler = syncClassToSquare as unknown as (
+  event: unknown
+) => Promise<void>;
+
+function makeSnapshot(exists: boolean, data?: Record<string, unknown>): unknown {
+  return {
+    id: (data?.['id'] as string | undefined) ?? 'class-001',
+    exists,
+    data: () => (exists ? data : undefined),
+  };
+}
+
+function makeClassData(overrides: Partial<Class> = {}): Record<string, unknown> {
+  const base: Class = {
+    id: 'class-001',
+    name: 'Intro to Pottery',
+    description: 'Learn pottery basics',
+    sessions: [{ dateTime: new Date('2026-05-15T14:00:00Z') }],
+    durationMinutes: 120,
+    capacity: 10,
+    priceCents: 4500,
+    skillLevel: 'beginner',
+    status: 'published',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+  return { ...base } as unknown as Record<string, unknown>;
+}
+
+function makeEvent(beforeData: unknown, afterData: unknown) {
+  return {
+    params: { classId: 'class-001' },
+    data: {
+      before: beforeData,
+      after: afterData,
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.registrationCountByClassId.mockResolvedValue(0);
+});
+
+describe('syncClassToSquare — published create', () => {
+  it('creates the Square catalog item, stores the IDs, and seeds inventory', async () => {
+    mocks.createClassCatalogItem.mockResolvedValue({
+      squareItemId: 'SQ-ITEM-1',
+      squareVariationId: 'SQ-VAR-1',
+      squareModifierListId: 'SQ-MOD-1',
+      squareCatalogVersion: 1,
+    });
+
+    const before = makeSnapshot(false);
+    const after = makeSnapshot(true, makeClassData({ capacity: 8 }));
+
+    await handler(makeEvent(before, after));
+
+    expect(mocks.createClassCatalogItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        classId: 'class-001',
+        name: 'Intro to Pottery',
+        priceCents: 4500,
+      })
+    );
+    expect(mocks.updateSquareSyncIds).toHaveBeenCalledWith('class-001', {
+      squareCatalogItemId: 'SQ-ITEM-1',
+      squareVariationId: 'SQ-VAR-1',
+      squareModifierListId: 'SQ-MOD-1',
+      squareCatalogVersion: 1,
+    });
+    expect(mocks.setQuantity).toHaveBeenCalledWith({
+      squareVariationId: 'SQ-VAR-1',
+      locationId: 'mock-location',
+      quantity: 8,
+    });
+  });
+
+  it('seeds inventory at (capacity - existingRegistrationCount)', async () => {
+    mocks.createClassCatalogItem.mockResolvedValue({
+      squareItemId: 'I',
+      squareVariationId: 'V',
+      squareModifierListId: 'M',
+      squareCatalogVersion: 1,
+    });
+    mocks.registrationCountByClassId.mockResolvedValue(3);
+
+    const before = makeSnapshot(false);
+    const after = makeSnapshot(true, makeClassData({ capacity: 10 }));
+
+    await handler(makeEvent(before, after));
+
+    expect(mocks.setQuantity).toHaveBeenCalledWith(
+      expect.objectContaining({ quantity: 7 })
+    );
+  });
+
+  it('skips inventory seeding when remaining capacity is zero', async () => {
+    mocks.createClassCatalogItem.mockResolvedValue({
+      squareItemId: 'I',
+      squareVariationId: 'V',
+      squareModifierListId: 'M',
+      squareCatalogVersion: 1,
+    });
+    mocks.registrationCountByClassId.mockResolvedValue(10);
+
+    const before = makeSnapshot(false);
+    const after = makeSnapshot(true, makeClassData({ capacity: 10 }));
+
+    await handler(makeEvent(before, after));
+
+    expect(mocks.setQuantity).not.toHaveBeenCalled();
+  });
+});
+
+describe('syncClassToSquare — published update on existing mirror', () => {
+  it('updates name and price when changed and persists the new catalog version', async () => {
+    mocks.updateItem.mockResolvedValue({ squareCatalogVersion: 5 });
+
+    const before = makeSnapshot(
+      true,
+      makeClassData({
+        name: 'Old Name',
+        priceCents: 4000,
+        squareCatalogItemId: 'SQ-ITEM-1',
+        squareVariationId: 'SQ-VAR-1',
+        squareCatalogVersion: 4,
+      })
+    );
+    const after = makeSnapshot(
+      true,
+      makeClassData({
+        name: 'New Name',
+        priceCents: 5000,
+        squareCatalogItemId: 'SQ-ITEM-1',
+        squareVariationId: 'SQ-VAR-1',
+        squareCatalogVersion: 4,
+      })
+    );
+
+    await handler(makeEvent(before, after));
+
+    expect(mocks.updateItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        squareItemId: 'SQ-ITEM-1',
+        name: 'New Name',
+        variations: [
+          { squareVariationId: 'SQ-VAR-1', priceCents: 5000 },
+        ],
+      })
+    );
+    expect(mocks.updateSquareSyncIds).toHaveBeenCalledWith('class-001', {
+      squareCatalogVersion: 5,
+    });
+    // No catalog create when mirror already exists
+    expect(mocks.createClassCatalogItem).not.toHaveBeenCalled();
+  });
+
+  it('resets Square inventory when capacity changes', async () => {
+    mocks.registrationCountByClassId.mockResolvedValue(2);
+
+    const before = makeSnapshot(
+      true,
+      makeClassData({
+        capacity: 8,
+        squareCatalogItemId: 'I',
+        squareVariationId: 'V',
+        squareCatalogVersion: 1,
+      })
+    );
+    const after = makeSnapshot(
+      true,
+      makeClassData({
+        capacity: 12,
+        squareCatalogItemId: 'I',
+        squareVariationId: 'V',
+        squareCatalogVersion: 1,
+      })
+    );
+
+    await handler(makeEvent(before, after));
+
+    expect(mocks.setQuantity).toHaveBeenCalledWith({
+      squareVariationId: 'V',
+      locationId: 'mock-location',
+      quantity: 10, // 12 - 2
+    });
+  });
+
+  it('skips writes that change no Square-relevant field (feedback-loop guard)', async () => {
+    const data = makeClassData({
+      squareCatalogItemId: 'I',
+      squareVariationId: 'V',
+    });
+    const before = makeSnapshot(true, data);
+    const after = makeSnapshot(true, data); // identical — only updatedAt-style write
+
+    await handler(makeEvent(before, after));
+
+    expect(mocks.createClassCatalogItem).not.toHaveBeenCalled();
+    expect(mocks.updateItem).not.toHaveBeenCalled();
+    expect(mocks.setQuantity).not.toHaveBeenCalled();
+  });
+});
+
+describe('syncClassToSquare — unpublish & delete', () => {
+  it('deletes the Square catalog item and clears back-refs when class is unpublished', async () => {
+    const before = makeSnapshot(
+      true,
+      makeClassData({
+        status: 'published',
+        squareCatalogItemId: 'SQ-ITEM-1',
+        squareVariationId: 'SQ-VAR-1',
+      })
+    );
+    const after = makeSnapshot(
+      true,
+      makeClassData({
+        status: 'cancelled',
+        squareCatalogItemId: 'SQ-ITEM-1',
+        squareVariationId: 'SQ-VAR-1',
+      })
+    );
+
+    await handler(makeEvent(before, after));
+
+    expect(mocks.deleteItem).toHaveBeenCalledWith('SQ-ITEM-1');
+    expect(mocks.clearSquareSyncIds).toHaveBeenCalledWith('class-001');
+  });
+
+  it('deletes the Square catalog item when the class doc is deleted', async () => {
+    const before = makeSnapshot(
+      true,
+      makeClassData({ squareCatalogItemId: 'SQ-ITEM-1' })
+    );
+    const after = makeSnapshot(false);
+
+    await handler(makeEvent(before, after));
+
+    expect(mocks.deleteItem).toHaveBeenCalledWith('SQ-ITEM-1');
+  });
+
+  it('is a no-op when an unpublished class never had a Square mirror', async () => {
+    const before = makeSnapshot(true, makeClassData({ status: 'draft' }));
+    const after = makeSnapshot(true, makeClassData({ status: 'cancelled' }));
+
+    await handler(makeEvent(before, after));
+
+    expect(mocks.deleteItem).not.toHaveBeenCalled();
+    expect(mocks.clearSquareSyncIds).not.toHaveBeenCalled();
+  });
+});

--- a/libs/firebase/maple-functions/sync-class-to-square/src/lib/sync-class-to-square.ts
+++ b/libs/firebase/maple-functions/sync-class-to-square/src/lib/sync-class-to-square.ts
@@ -1,0 +1,273 @@
+/**
+ * Sync Class to Square Cloud Function
+ *
+ * Firestore trigger that mirrors classes to Square as catalog items so they
+ * can be rung up at in-person POS. The Square inventory quantity for the
+ * class variation tracks remaining seats — POS will refuse to ring up a
+ * sold-out class.
+ *
+ * Triggers on `classes/{classId}` writes:
+ * - Class published (create or status flip → published): create catalog
+ *   ITEM + ITEM_VARIATION + required selection MODIFIER_LIST, then seed
+ *   inventory to (capacity - currentRegistrationCount).
+ * - Class updated while still published: update name/description/price on
+ *   the existing item; reset inventory if capacity changed.
+ * - Class unpublished (published → draft/cancelled/completed) or deleted:
+ *   delete the Square catalog item and clear the back-references.
+ *
+ * Feedback-loop guard: writes triggered by `updateSquareSyncIds` /
+ * `clearSquareSyncIds` skip `updatedAt`, but the trigger fires anyway —
+ * we early-return when nothing relevant changed.
+ */
+import {
+  onDocumentWritten,
+  type Change,
+  type DocumentSnapshot,
+} from 'firebase-functions/v2/firestore';
+import { defineSecret, defineString } from 'firebase-functions/params';
+import type { Class } from '@maple/ts/domain';
+import {
+  Square,
+  SQUARE_SECRET_NAMES,
+  SQUARE_STRING_NAMES,
+} from '@maple/firebase/square';
+import {
+  ClassRepository,
+  RegistrationRepository,
+} from '@maple/firebase/database';
+
+const squareSecretParams = SQUARE_SECRET_NAMES.map((name) =>
+  defineSecret(name)
+);
+const squareStringParams = SQUARE_STRING_NAMES.map((name) =>
+  defineString(name)
+);
+
+function toDateLike(value: unknown): Date | undefined {
+  if (!value) return undefined;
+  if (value instanceof Date) return value;
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    'toDate' in value &&
+    typeof (value as { toDate: unknown }).toDate === 'function'
+  ) {
+    return (value as { toDate: () => Date }).toDate();
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    const d = new Date(value);
+    return isNaN(d.getTime()) ? undefined : d;
+  }
+  return undefined;
+}
+
+function extractClass(snapshot: DocumentSnapshot | undefined): Class | null {
+  if (!snapshot || !snapshot.exists) {
+    return null;
+  }
+  const data = snapshot.data();
+  if (!data) return null;
+
+  return {
+    id: snapshot.id,
+    ...data,
+    createdAt: toDateLike(data['createdAt']) ?? new Date(),
+    updatedAt: toDateLike(data['updatedAt']) ?? new Date(),
+  } as Class;
+}
+
+/**
+ * Did the write change anything that requires a Square sync?
+ *
+ * Without this guard the trigger feedback loops: every Square sync stamps
+ * `squareCatalogItemId`/`squareVariationId`/`squareModifierListId` back onto
+ * the class, which re-fires this trigger, which re-syncs, and so on.
+ *
+ * The Square sync IDs themselves are *not* in this list, so writes that
+ * only touch them are no-ops here.
+ */
+const SQUARE_RELEVANT_FIELDS: ReadonlyArray<keyof Class> = [
+  'name',
+  'description',
+  'priceCents',
+  'capacity',
+  'status',
+];
+
+function isSquareRelevantChange(
+  before: Class | null,
+  after: Class | null
+): boolean {
+  if (!before || !after) return true; // create or delete
+  return SQUARE_RELEVANT_FIELDS.some(
+    (field) => before[field] !== after[field]
+  );
+}
+
+export const syncClassToSquare = onDocumentWritten(
+  {
+    document: 'classes/{classId}',
+    region: 'us-east4',
+    secrets: squareSecretParams,
+  },
+  async (event) => {
+    const change: Change<DocumentSnapshot> = event.data!;
+    const before = extractClass(change.before);
+    const after = extractClass(change.after);
+
+    if (!isSquareRelevantChange(before, after)) {
+      console.log(
+        'Class write did not change Square-relevant fields, skipping sync',
+        { classId: event.params.classId }
+      );
+      return;
+    }
+
+    const secrets = Object.fromEntries(
+      squareSecretParams.map((s) => [s.name, s.value()])
+    ) as Record<(typeof SQUARE_SECRET_NAMES)[number], string>;
+    const strings = Object.fromEntries(
+      squareStringParams.map((s) => [s.name, s.value()])
+    ) as Record<(typeof SQUARE_STRING_NAMES)[number], string>;
+
+    const square = new Square(secrets, strings);
+
+    try {
+      // Case 1: class deleted — remove from Square if it was there
+      if (!after) {
+        if (before?.squareCatalogItemId) {
+          console.log('Class deleted, removing from Square', {
+            classId: event.params.classId,
+            squareItemId: before.squareCatalogItemId,
+          });
+          await square.catalogService.deleteItem(before.squareCatalogItemId);
+        }
+        return;
+      }
+
+      const becameUnpublished =
+        before?.status === 'published' && after.status !== 'published';
+
+      // Case 2: class is no longer published — tear down the Square mirror
+      if (becameUnpublished || after.status !== 'published') {
+        if (after.squareCatalogItemId) {
+          console.log(
+            'Class unpublished/non-publishable, removing Square catalog item',
+            {
+              classId: after.id,
+              squareItemId: after.squareCatalogItemId,
+              status: after.status,
+            }
+          );
+          await square.catalogService.deleteItem(after.squareCatalogItemId);
+          await ClassRepository.clearSquareSyncIds(after.id);
+        } else {
+          console.log('Class is not published and not in Square, skipping', {
+            classId: after.id,
+            status: after.status,
+          });
+        }
+        return;
+      }
+
+      // Case 3: class is published — sync (create or update)
+      const registrationCount = await RegistrationRepository.countByClassId(
+        after.id
+      );
+      const remainingCapacity = Math.max(after.capacity - registrationCount, 0);
+
+      if (!after.squareCatalogItemId || !after.squareVariationId) {
+        // No Square mirror yet — create one
+        console.log('Creating Square catalog item for published class', {
+          classId: after.id,
+          name: after.name,
+          priceCents: after.priceCents,
+          capacity: after.capacity,
+          remainingCapacity,
+        });
+
+        const created = await square.catalogService.createClassCatalogItem({
+          classId: after.id,
+          name: after.name,
+          description: after.description,
+          priceCents: after.priceCents,
+        });
+
+        await ClassRepository.updateSquareSyncIds(after.id, {
+          squareCatalogItemId: created.squareItemId,
+          squareVariationId: created.squareVariationId,
+          squareModifierListId: created.squareModifierListId,
+          squareCatalogVersion: created.squareCatalogVersion,
+        });
+
+        // Seed inventory at remainingCapacity (capacity minus existing
+        // registrations). For a brand-new class this is just `capacity`.
+        if (remainingCapacity > 0) {
+          await square.inventoryService.setQuantity({
+            squareVariationId: created.squareVariationId,
+            locationId: square.locationId,
+            quantity: remainingCapacity,
+          });
+        }
+
+        console.log('Square catalog item created', {
+          classId: after.id,
+          squareItemId: created.squareItemId,
+          squareVariationId: created.squareVariationId,
+          inventory: remainingCapacity,
+        });
+        return;
+      }
+
+      // Existing Square mirror — update name/description/price if changed,
+      // and reset inventory if capacity changed.
+      const nameChanged = before?.name !== after.name;
+      const descriptionChanged = before?.description !== after.description;
+      const priceChanged = before?.priceCents !== after.priceCents;
+      const capacityChanged = before?.capacity !== after.capacity;
+
+      if (nameChanged || descriptionChanged || priceChanged) {
+        console.log('Updating Square catalog item for class', {
+          classId: after.id,
+          nameChanged,
+          descriptionChanged,
+          priceChanged,
+        });
+        const updated = await square.catalogService.updateItem({
+          squareItemId: after.squareCatalogItemId,
+          squareCatalogVersion: after.squareCatalogVersion ?? 0,
+          name: nameChanged ? after.name : undefined,
+          description: descriptionChanged ? after.description : undefined,
+          variations: priceChanged
+            ? [
+                {
+                  squareVariationId: after.squareVariationId,
+                  priceCents: after.priceCents,
+                },
+              ]
+            : undefined,
+        });
+        await ClassRepository.updateSquareSyncIds(after.id, {
+          squareCatalogVersion: updated.squareCatalogVersion,
+        });
+      }
+
+      if (capacityChanged) {
+        console.log('Resetting Square inventory after capacity change', {
+          classId: after.id,
+          newCapacity: after.capacity,
+          remainingCapacity,
+        });
+        await square.inventoryService.setQuantity({
+          squareVariationId: after.squareVariationId,
+          locationId: square.locationId,
+          quantity: remainingCapacity,
+        });
+      }
+    } catch (error) {
+      // Don't throw — Cloud Functions retries triggers on uncaught errors,
+      // and a flapping Square API call would fan out into a tight loop.
+      console.error('Square sync error (class):', error);
+    }
+  }
+);

--- a/libs/firebase/maple-functions/sync-class-to-square/tsconfig.json
+++ b/libs/firebase/maple-functions/sync-class-to-square/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/sync-class-to-square/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/sync-class-to-square/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/sync-class-to-square/vitest.config.ts
+++ b/libs/firebase/maple-functions/sync-class-to-square/vitest.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  root: __dirname,
+  test: {
+    name: 'firebase-maple-functions-sync-class-to-square',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov', 'json-summary', 'json'],
+      reportsDirectory:
+        '../../../../coverage/libs/firebase/maple-functions/sync-class-to-square',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.spec.ts', 'src/index.ts'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@maple/ts/domain': resolve(__dirname, '../../../ts/domain/src/index.ts'),
+      '@maple/ts/firebase/api-types': resolve(
+        __dirname,
+        '../../../ts/firebase/api-types/src/index.ts'
+      ),
+      '@maple/firebase/database': resolve(
+        __dirname,
+        '../../../firebase/database/src/index.ts'
+      ),
+      '@maple/firebase/square': resolve(
+        __dirname,
+        '../../../firebase/square/src/index.ts'
+      ),
+      '@maple/firebase/functions': resolve(
+        __dirname,
+        '../../../firebase/functions/src/index.ts'
+      ),
+    },
+  },
+});

--- a/libs/firebase/square-test-mock-server/src/lib/routes/square.ts
+++ b/libs/firebase/square-test-mock-server/src/lib/routes/square.ts
@@ -316,6 +316,31 @@ export function registerSquareRoutes(server: SquareMockServer): void {
   });
 
   registerCraftClubRoutes(server);
+  registerMockControlRoutes(server);
+}
+
+/**
+ * Test-control endpoints under /_mock/*.
+ *
+ * The mock server runs in its own process, separate from the test runner, so
+ * suites need an HTTP surface to reset state and read back the requests the
+ * function process sent. Mirrors the Etsy mock's `/_mock/*` pattern. These
+ * routes are prefixed with `_mock/` to stay obviously non-Square.
+ */
+function registerMockControlRoutes(server: SquareMockServer): void {
+  // Clear recorded requests + reset in-memory catalog/inventory/payment state.
+  server.post('/_mock/reset', () => {
+    server.clearRequests();
+    resetSquareState();
+    return { status: 200, body: { ok: true } };
+  });
+
+  // Return the recorded requests as JSON so tests can assert on the actual
+  // payloads the function sent to Square. Query filtering is done client-side
+  // by the test (the handler has no access to the query string).
+  server.get('/_mock/requests', () => {
+    return { status: 200, body: { requests: server.requests } };
+  });
 }
 
 /**

--- a/libs/firebase/square/src/index.ts
+++ b/libs/firebase/square/src/index.ts
@@ -18,6 +18,8 @@ export {
   type CatalogVariationInput,
   type CreateCatalogItemInput,
   type CreateCatalogItemResult,
+  type CreateClassCatalogItemInput,
+  type CreateClassCatalogItemResult,
   type UpdateCatalogItemInput,
   type UpdateCatalogItemResult,
   type UpdateCatalogVariationInput,

--- a/libs/firebase/square/src/lib/catalog.service.spec.ts
+++ b/libs/firebase/square/src/lib/catalog.service.spec.ts
@@ -421,3 +421,136 @@ describe('CatalogService.updateItem', () => {
     expect(result.squareCatalogVersion).toBe(6);
   });
 });
+
+describe('CatalogService.createClassCatalogItem', () => {
+  let client: MockClient;
+  let service: CatalogService;
+
+  beforeEach(() => {
+    client = makeMockClient();
+    service = new CatalogService(client as unknown as SquareClient);
+  });
+
+  it('upserts a MODIFIER_LIST and ITEM (with one variation) in a single batch and returns parsed IDs', async () => {
+    client.catalog.batchUpsert.mockResolvedValue({
+      objects: [
+        { type: 'MODIFIER_LIST', id: 'SQ-MODLIST-1', version: 1n },
+        {
+          type: 'ITEM',
+          id: 'SQ-ITEM-CLASS-1',
+          version: 2n,
+          itemData: {
+            variations: [
+              {
+                type: 'ITEM_VARIATION',
+                id: 'SQ-VAR-CLASS-1',
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const result = await service.createClassCatalogItem({
+      classId: 'class-abc',
+      name: 'Sourdough Workshop',
+      description: 'Bring an apron',
+      priceCents: 4500,
+    });
+
+    // Result fields parsed correctly
+    expect(result.squareItemId).toBe('SQ-ITEM-CLASS-1');
+    expect(result.squareVariationId).toBe('SQ-VAR-CLASS-1');
+    expect(result.squareModifierListId).toBe('SQ-MODLIST-1');
+    expect(result.squareCatalogVersion).toBe(2);
+
+    // Inspect the request shape — modifier list, item, and variation
+    // must all live in one batches[0].objects so Square resolves the
+    // temp-id references between them atomically.
+    const call = client.catalog.batchUpsert.mock.calls[0][0];
+    const objects = call.batches[0].objects;
+    expect(objects).toHaveLength(2);
+
+    const modList = objects.find(
+      (o: { type: string }) => o.type === 'MODIFIER_LIST'
+    );
+    expect(modList).toBeDefined();
+    expect(modList.modifierListData.selectionType).toBe('SINGLE');
+    expect(modList.modifierListData.modifiers).toHaveLength(1);
+    expect(modList.modifierListData.modifiers[0].modifierData.name).toBe('Yes');
+
+    const item = objects.find((o: { type: string }) => o.type === 'ITEM');
+    expect(item).toBeDefined();
+    expect(item.itemData.name).toBe('Sourdough Workshop');
+    expect(item.itemData.modifierListInfo[0].modifierListId).toBe(modList.id);
+    expect(item.itemData.variations).toHaveLength(1);
+    expect(item.itemData.variations[0].itemVariationData.priceMoney.amount).toBe(
+      4500n
+    );
+    expect(item.itemData.variations[0].itemVariationData.trackInventory).toBe(
+      true
+    );
+  });
+
+  it('uses the default modifier list name when none is provided', async () => {
+    client.catalog.batchUpsert.mockResolvedValue({
+      objects: [
+        { type: 'MODIFIER_LIST', id: 'M1', version: 1n },
+        {
+          type: 'ITEM',
+          id: 'I1',
+          version: 1n,
+          itemData: {
+            variations: [{ type: 'ITEM_VARIATION', id: 'V1' }],
+          },
+        },
+      ],
+    });
+
+    await service.createClassCatalogItem({
+      classId: 'class-1',
+      name: 'X',
+      priceCents: 1000,
+    });
+
+    const call = client.catalog.batchUpsert.mock.calls[0][0];
+    const modList = call.batches[0].objects.find(
+      (o: { type: string }) => o.type === 'MODIFIER_LIST'
+    );
+    expect(modList.modifierListData.name).toBe(
+      'Added customer email (required)?'
+    );
+  });
+
+  it('throws when the response is missing the ITEM or MODIFIER_LIST', async () => {
+    // Use a plain number version here — the catalog code logs the response
+    // via JSON.stringify on the error path, which can't serialize bigints.
+    // Real Square responses come back as plain JSON before the SDK has had
+    // a chance to widen any field to BigInt.
+    client.catalog.batchUpsert.mockResolvedValue({
+      objects: [{ type: 'MODIFIER_LIST', id: 'M1', version: 1 }],
+    });
+
+    await expect(
+      service.createClassCatalogItem({
+        classId: 'class-broken',
+        name: 'Broken',
+        priceCents: 100,
+      })
+    ).rejects.toThrow(/ITEM or MODIFIER_LIST missing/);
+  });
+
+  it('surfaces Square API errors', async () => {
+    client.catalog.batchUpsert.mockResolvedValue({
+      errors: [{ code: 'BAD_REQUEST', detail: 'invalid price' }],
+    });
+
+    await expect(
+      service.createClassCatalogItem({
+        classId: 'class-bad',
+        name: 'Bad',
+        priceCents: -1,
+      })
+    ).rejects.toThrow(/invalid price/);
+  });
+});

--- a/libs/firebase/square/src/lib/catalog.service.ts
+++ b/libs/firebase/square/src/lib/catalog.service.ts
@@ -142,10 +142,168 @@ export interface UpdateCatalogItemResult {
 }
 
 /**
+ * Input for creating a class catalog item
+ */
+export interface CreateClassCatalogItemInput {
+  /** Firestore class id (used to derive a deterministic idempotency key) */
+  classId: string;
+  /** Class display name (becomes the catalog item name) */
+  name: string;
+  /** Optional class description */
+  description?: string;
+  /** Class price in cents (single-variation; classes have one price) */
+  priceCents: number;
+  /**
+   * Modifier list name shown to staff at POS. Defaults to
+   * `"Added customer email (required)?"` — required selection modifier
+   * with one Yes option whose only purpose is to force staff to acknowledge
+   * customer collection before tendering. There is no native way to *enforce*
+   * email collection at in-person POS, so this is the operational nudge.
+   */
+  modifierListName?: string;
+}
+
+/**
+ * Result of creating a class catalog item
+ */
+export interface CreateClassCatalogItemResult {
+  /** Square ITEM id */
+  squareItemId: string;
+  /** Square ITEM_VARIATION id (single variation per class) */
+  squareVariationId: string;
+  /** Square MODIFIER_LIST id attached to the item */
+  squareModifierListId: string;
+  /** Catalog version of the created ITEM (for optimistic locking) */
+  squareCatalogVersion: number;
+}
+
+/**
  * Catalog service for Square API operations
  */
 export class CatalogService {
   constructor(private readonly client: SquareClient) {}
+
+  /**
+   * Create a Square catalog ITEM, ITEM_VARIATION, and required MODIFIER_LIST
+   * for a class in a single batchUpsert. The modifier list is a single-option
+   * required selection ("Yes") so staff sees a prompt at POS — the closest
+   * thing Square offers to a per-item required field at in-person checkout
+   * (text-input modifiers don't render on the POS register; selection-only
+   * modifiers do).
+   */
+  async createClassCatalogItem(
+    input: CreateClassCatalogItemInput
+  ): Promise<CreateClassCatalogItemResult> {
+    const idempotencyKey = `class-create-${input.classId}-${Date.now()}`;
+    const itemTempId = `#class-item-${input.classId}`;
+    const variationTempId = `#class-variation-${input.classId}`;
+    const modifierListTempId = `#class-modlist-${input.classId}`;
+    const modifierTempId = `#class-mod-yes-${input.classId}`;
+    const modifierListName =
+      input.modifierListName ?? 'Added customer email (required)?';
+
+    const response = await this.client.catalog.batchUpsert({
+      idempotencyKey,
+      batches: [
+        {
+          objects: [
+            {
+              type: 'MODIFIER_LIST',
+              id: modifierListTempId,
+              modifierListData: {
+                name: modifierListName,
+                selectionType: 'SINGLE',
+                modifiers: [
+                  {
+                    type: 'MODIFIER',
+                    id: modifierTempId,
+                    modifierData: {
+                      name: 'Yes',
+                      priceMoney: { amount: 0n, currency: 'USD' },
+                    },
+                  },
+                ],
+              },
+            },
+            {
+              type: 'ITEM',
+              id: itemTempId,
+              itemData: {
+                name: input.name,
+                description: input.description,
+                modifierListInfo: [
+                  {
+                    modifierListId: modifierListTempId,
+                    enabled: true,
+                    minSelectedModifiers: 1,
+                    maxSelectedModifiers: 1,
+                  },
+                ],
+                variations: [
+                  {
+                    type: 'ITEM_VARIATION',
+                    id: variationTempId,
+                    itemVariationData: {
+                      name: 'Registration',
+                      pricingType: 'FIXED_PRICING',
+                      priceMoney: {
+                        amount: BigInt(input.priceCents),
+                        currency: 'USD',
+                      },
+                      trackInventory: true,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    if (response.errors && response.errors.length > 0) {
+      const errorMessages = response.errors
+        .map((e) => e.detail || e.code || 'Unknown error')
+        .join(', ');
+      throw new Error(`Square API error: ${errorMessages}`);
+    }
+
+    const objects = response.objects || [];
+    const itemObject = objects.find(
+      (obj: Square.CatalogObject) => obj.type === 'ITEM'
+    );
+    const modListObject = objects.find(
+      (obj: Square.CatalogObject) => obj.type === 'MODIFIER_LIST'
+    );
+
+    if (!itemObject || !modListObject) {
+      console.error(
+        'Square batchUpsert response (class):',
+        JSON.stringify(response, null, 2)
+      );
+      throw new Error(
+        'Failed to create class catalog item: ITEM or MODIFIER_LIST missing'
+      );
+    }
+
+    const variation = itemObject.itemData?.variations?.[0];
+    if (!variation?.id) {
+      console.error(
+        'Square ITEM response (class):',
+        JSON.stringify(itemObject, null, 2)
+      );
+      throw new Error(
+        'Failed to create class catalog item: variation missing in response'
+      );
+    }
+
+    return {
+      squareItemId: itemObject.id!,
+      squareVariationId: variation.id,
+      squareModifierListId: modListObject.id!,
+      squareCatalogVersion: Number(itemObject.version || 0),
+    };
+  }
 
   /**
    * Create a new catalog item with one or more variations

--- a/libs/ts/domain/src/lib/class.ts
+++ b/libs/ts/domain/src/lib/class.ts
@@ -111,6 +111,27 @@ export interface Class {
    */
   webflowSlug?: string;
   /**
+   * Square catalog ITEM id, set by `syncClassToSquare` after the first
+   * successful sync. Presence is the signal that this class is sellable
+   * on Square POS in person.
+   */
+  squareCatalogItemId?: string;
+  /**
+   * Square catalog ITEM_VARIATION id (one variation per class). Used to
+   * adjust inventory and to identify the line item on POS-originated orders.
+   */
+  squareVariationId?: string;
+  /**
+   * Square MODIFIER_LIST id for the "Added customer email (required)?" prompt
+   * attached to the class item. Forces staff to acknowledge customer
+   * collection before tendering at POS.
+   */
+  squareModifierListId?: string;
+  /**
+   * Square catalog version for optimistic locking on subsequent updates.
+   */
+  squareCatalogVersion?: number;
+  /**
    * Opt-in to the friend-referral program for this class. When set, every
    * confirmed registration auto-generates a single-use Discount and the
    * confirmation email includes a code the customer can share.
@@ -135,11 +156,19 @@ export interface ClassReferralDiscount {
 }
 
 /**
- * Input for creating a new class (no id, timestamps, or webflowItemId)
+ * Input for creating a new class. External-system IDs (Webflow, Square) are
+ * populated by their respective sync functions, never by the create caller.
  */
 export type CreateClassInput = Omit<
   Class,
-  'id' | 'createdAt' | 'updatedAt' | 'webflowItemId'
+  | 'id'
+  | 'createdAt'
+  | 'updatedAt'
+  | 'webflowItemId'
+  | 'squareCatalogItemId'
+  | 'squareVariationId'
+  | 'squareModifierListId'
+  | 'squareCatalogVersion'
 >;
 
 /**

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -484,6 +484,9 @@
       "@maple/firebase/maple-functions/sync-inventory-to-square": [
         "libs/firebase/maple-functions/sync-inventory-to-square/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/sync-class-to-square": [
+        "libs/firebase/maple-functions/sync-class-to-square/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/record-sale": [
         "libs/firebase/maple-functions/record-sale/src/index.ts"
       ],


### PR DESCRIPTION
PR A of 3 in the in-person Square POS class-registration plan. **Supersedes the stale #416** (2 months old, 114 commits behind, and written before #444 rewrote catalog sync into the async worker). PR 1 of that plan — the `Registration.source` field — already merged in #415.

## What this does
Firestore trigger `syncClassToSquare` (maple-square codebase) mirrors **published** classes into Square as catalog items so they can be rung up at in-person POS, with remaining seats tracked as Square inventory.

Lifecycle on `classes/{id}` writes:
- **Published create** → `batchUpsert` a Square `ITEM` + `ITEM_VARIATION` + a required single-option `MODIFIER_LIST` ("Added customer email (required)?"), store the IDs back on the class, seed inventory to `(capacity − currentRegistrationCount)`.
- **Published update** → update name/description/price; reset inventory if capacity changed.
- **Unpublished or deleted** → delete the Square catalog item + clear the back-refs.

The modifier list is the register-time email-collection nudge — Square can't enforce a real per-item required field at in-person POS (text-input modifiers don't render on the register; selection-only ones do). The actual missing-email safety net is server-side in PR C.

## The reason this is a fresh build, not a rebase of #416
Since #416 was written, #444 introduced `processCatalogSyncRequest`, which walks **every** Square catalog ITEM and auto-creates a `status:'draft'` Product for any it doesn't already track. Left alone, every class pushed to Square would spawn a **phantom draft Product**. This PR adds the guard:

- New `ClassRepository.listSquareCatalogItemIds()` (findAll + in-memory filter — deliberately no `.where()`, so no composite index).
- `processCatalogSyncRequest.runCatalogSync` skips any Square item whose id is a class catalog item.

## Domain + repo
- `Class` gains optional `squareCatalogItemId`, `squareVariationId`, `squareModifierListId`, `squareCatalogVersion` (excluded from `CreateClassInput`).
- `ClassRepository.updateSquareSyncIds` / `clearSquareSyncIds` — bare updates with **no `updatedAt` bump** (same trigger feedback-loop guard as `updateWebflowItemId`). The trigger's `SQUARE_RELEVANT_FIELDS` change-guard excludes the Square ID fields, so these writes don't re-fire the sync.
- `CatalogService.createClassCatalogItem` + net-new MODIFIER_LIST support.

## Verification
- [x] `firebase-maple-functions-sync-class-to-square:test` — 9 tests (4 lifecycle branches + feedback-loop guard + inventory edges)
- [x] `process-catalog-sync-request:test` — +1 phantom-product guard test (10 total)
- [x] `square` — +4 `createClassCatalogItem` tests (88 total)
- [x] `domain:test`, `firebase-database:test`, `maple-spruce:typecheck` pass
- [x] `functions-square:build` (esbuild bundle) passes
- [x] `./tools/validate-function-tsconfigs.sh` passes
- [x] `tools/check-firestore-indexes.ts` — no new composite index required
- [ ] Manual smoke (post-merge, dev): publish a test class → Square catalog item appears with the modifier list; capacity mirrors as inventory

## Out of scope (later PRs)
- **PR B** — `syncClassInventoryToSquare`: mirror registration count → Square inventory via idempotent `PHYSICAL_COUNT`.
- **PR C** — POS `order`/`payment` webhook → create a `source:'pos'` registration (dedup via the order's existing `referenceId`) + missing-email admin alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
