### PR TITLE
fix(webflow): capture real Webflow slug so public class links resolve

### DIFF
--- a/libs/firebase/database/src/lib/class.repository.spec.ts
+++ b/libs/firebase/database/src/lib/class.repository.spec.ts
@@ -636,6 +636,43 @@ describe('ClassRepository', () => {
     });
   });
 
+  // ─── updateWebflowSync ───────────────────────────────────────────
+
+  describe('updateWebflowSync', () => {
+    function stubUpdate() {
+      const mockUpdate = vi.fn().mockResolvedValue(undefined);
+      const mockDocFn = vi.fn().mockReturnValue({ update: mockUpdate });
+      const mockCollection = vi.fn().mockReturnValue({ doc: mockDocFn });
+      vi.mocked(db.collection).mockImplementation(mockCollection);
+      return { mockUpdate, mockDocFn, mockCollection };
+    }
+
+    it('writes both the item ID and slug', async () => {
+      const { mockUpdate, mockDocFn, mockCollection } = stubUpdate();
+
+      await ClassRepository.updateWebflowSync(
+        'class-1',
+        'wf-abc-123',
+        'stained-glass-tryit-class-b192d'
+      );
+
+      expect(mockCollection).toHaveBeenCalledWith('classes');
+      expect(mockDocFn).toHaveBeenCalledWith('class-1');
+      expect(mockUpdate).toHaveBeenCalledWith({
+        webflowItemId: 'wf-abc-123',
+        webflowSlug: 'stained-glass-tryit-class-b192d',
+      });
+    });
+
+    it('omits webflowSlug when empty so a good stored slug is not clobbered', async () => {
+      const { mockUpdate } = stubUpdate();
+
+      await ClassRepository.updateWebflowSync('class-1', 'wf-abc-123', '');
+
+      expect(mockUpdate).toHaveBeenCalledWith({ webflowItemId: 'wf-abc-123' });
+    });
+  });
+
   // ─── cancel ───────────────────────────────────────────────────────
 
   describe('cancel', () => {

--- a/libs/firebase/database/src/lib/class.repository.ts
+++ b/libs/firebase/database/src/lib/class.repository.ts
@@ -93,6 +93,7 @@ function docToClass(
     whatToBring: data.whatToBring,
     minimumAge: data.minimumAge,
     webflowItemId: data.webflowItemId,
+    webflowSlug: data.webflowSlug,
     referralDiscount:
       data.referralDiscount &&
       typeof data.referralDiscount.percent === 'number' &&
@@ -273,6 +274,30 @@ export const ClassRepository = {
   async updateWebflowItemId(id: string, webflowItemId: string): Promise<void> {
     const docRef = db.collection(COLLECTION).doc(id);
     await docRef.update({ webflowItemId });
+  },
+
+  /**
+   * Persist the Webflow sync identifiers (item ID and the real slug) for a
+   * class. Called after syncing to Webflow CMS. Only the provided fields are
+   * written; `webflowSlug` is skipped when empty so we never clobber a good
+   * stored slug with a blank from a response that omitted it.
+   *
+   * Uses a bare `update` (no `updatedAt`) so it doesn't re-trigger the sync
+   * feedback loop beyond the caller's own change guard.
+   */
+  async updateWebflowSync(
+    id: string,
+    webflowItemId: string,
+    webflowSlug?: string
+  ): Promise<void> {
+    const docRef = db.collection(COLLECTION).doc(id);
+    const payload: { webflowItemId: string; webflowSlug?: string } = {
+      webflowItemId,
+    };
+    if (webflowSlug) {
+      payload.webflowSlug = webflowSlug;
+    }
+    await docRef.update(payload);
   },
 
   /**

--- a/libs/firebase/maple-functions/class-catalog-feed/src/lib/class-catalog-feed.spec.ts
+++ b/libs/firebase/maple-functions/class-catalog-feed/src/lib/class-catalog-feed.spec.ts
@@ -58,10 +58,20 @@ describe('generateClassSlug', () => {
 });
 
 describe('mapClassToFeedItem', () => {
-  it('builds the public link from the class name slug', () => {
+  it('falls back to the name-derived slug when webflowSlug is absent', () => {
     const item = mapClassToFeedItem(makeClass(), 0);
     expect(item?.link).toBe(
       'https://mapleandsprucefolkarts.com/classes/stained-glass-studio-series'
+    );
+  });
+
+  it('builds the public link from the real Webflow slug when present', () => {
+    const item = mapClassToFeedItem(
+      makeClass({ webflowSlug: 'stained-glass-studio-series-b192d' }),
+      0
+    );
+    expect(item?.link).toBe(
+      'https://mapleandsprucefolkarts.com/classes/stained-glass-studio-series-b192d'
     );
   });
 

--- a/libs/firebase/maple-functions/class-catalog-feed/src/lib/class-catalog-feed.ts
+++ b/libs/firebase/maple-functions/class-catalog-feed/src/lib/class-catalog-feed.ts
@@ -71,7 +71,9 @@ export function mapClassToFeedItem(
     return null;
   }
 
-  const slug = generateClassSlug(classEntity.name);
+  // Prefer the real Webflow slug (captured during sync); fall back to the
+  // name-derived slug only for classes that haven't synced/backfilled yet.
+  const slug = classEntity.webflowSlug ?? generateClassSlug(classEntity.name);
   const spotsRemaining = Math.max(
     0,
     classEntity.capacity - registrationCount

--- a/libs/firebase/maple-functions/notify-waitlist-on-spot-open/src/lib/notify-waitlist-on-spot-open.spec.ts
+++ b/libs/firebase/maple-functions/notify-waitlist-on-spot-open/src/lib/notify-waitlist-on-spot-open.spec.ts
@@ -38,19 +38,6 @@ vi.mock('firebase-functions/v2/firestore', () => ({
   onDocumentWritten: vi.fn((_config, handler) => handler),
 }));
 
-// `getAppUrl` prefers the first https origin, so mixing in a non-https
-// localhost entry doesn't change the assertion — we keep the mock https-only
-// to satisfy sonarjs/no-clear-text-protocols on the spec file.
-vi.mock('firebase-functions/params', () => ({
-  defineString: vi.fn((name: string) => ({
-    name,
-    value: () =>
-      name === 'ALLOWED_ORIGINS'
-        ? 'https://mapleandsprucefolkarts.com'
-        : `mock-${name}`,
-  })),
-}));
-
 import {
   isSpotOpeningChange,
   notifyWaitlistOnSpotOpen,
@@ -219,11 +206,43 @@ describe('notifyWaitlistOnSpotOpen handler', () => {
     expect(firstCall.to).toBe('alice@example.com');
     expect(firstCall.template.name).toBe('class-spot-available');
     expect(firstCall.template.data.className).toBe('Try-It Stained Glass');
+    // No webflowSlug on this fixture → falls back to the name-derived slug.
     expect(firstCall.template.data.classUrl).toBe(
       'https://mapleandsprucefolkarts.com/classes/try-it-stained-glass'
     );
     expect(mocks.batchCommit).toHaveBeenCalledOnce();
     expect(mocks.waitlistClear).toHaveBeenCalledWith('class-1');
+  });
+
+  it('links to the real Webflow slug when the class has one', async () => {
+    // Webflow auto-suffixes slug collisions; the stored slug does not match
+    // the name-derived one, so the email must use the stored value verbatim.
+    mocks.classFindById.mockResolvedValue({
+      ...publishedClass,
+      webflowSlug: 'stained-glass-tryit-class-b192d',
+    });
+    mocks.waitlistFind.mockResolvedValue([
+      {
+        id: 'alice@example.com',
+        classId: 'class-1',
+        email: 'alice@example.com',
+        createdAt: new Date(),
+      },
+    ]);
+
+    await handler(
+      event(
+        snap({ status: 'confirmed', classId: 'class-1' }),
+        snap({ status: 'cancelled', classId: 'class-1' })
+      )
+    );
+
+    const firstCall = mocks.batchSet.mock.calls[0]?.[1] as {
+      template: { data: { classUrl: string } };
+    };
+    expect(firstCall.template.data.classUrl).toBe(
+      'https://mapleandsprucefolkarts.com/classes/stained-glass-tryit-class-b192d'
+    );
   });
 
   it('clears waitlist without emailing when class is unpublished or gone', async () => {

--- a/libs/firebase/maple-functions/notify-waitlist-on-spot-open/src/lib/notify-waitlist-on-spot-open.ts
+++ b/libs/firebase/maple-functions/notify-waitlist-on-spot-open/src/lib/notify-waitlist-on-spot-open.ts
@@ -18,7 +18,6 @@ import {
   type Change,
   type DocumentSnapshot,
 } from 'firebase-functions/v2/firestore';
-import { defineString } from 'firebase-functions/params';
 import {
   ClassRepository,
   ClassWaitlistRepository,
@@ -26,6 +25,14 @@ import {
 } from '@maple/firebase/database';
 import { asPublishable, getFirstSession } from '@maple/ts/domain';
 import type { RegistrationStatus } from '@maple/ts/domain';
+
+/**
+ * Public marketing site that hosts the class detail pages. The spot-available
+ * email links customers to the live class page so they can re-register — NOT
+ * the admin/business app. Mirrors `PUBLIC_SITE_BASE_URL` in
+ * `class-catalog-feed.ts`; keep them in sync.
+ */
+const PUBLIC_SITE_BASE_URL = 'https://mapleandsprucefolkarts.com';
 
 /**
  * Inlined to avoid pulling in the webflow library (and its API SDK) into
@@ -38,8 +45,6 @@ function generateClassSlug(name: string): string {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-|-$/g, '');
 }
-
-const allowedOriginsParam = defineString('ALLOWED_ORIGINS');
 
 const ACTIVE_STATUSES: ReadonlySet<RegistrationStatus> = new Set([
   'pending',
@@ -72,17 +77,6 @@ export function isSpotOpeningChange(
     ACTIVE_STATUSES.has(afterData['status'] as RegistrationStatus);
 
   return wasActive && !isActive;
-}
-
-/**
- * Pull a https origin out of ALLOWED_ORIGINS for building public class URLs.
- * Mirrors the helper used by send-agreement-request — kept inline rather
- * than shared so each function stays self-contained.
- */
-function getAppUrl(allowedOrigins: string): string {
-  const origins = allowedOrigins.split(',').map((o) => o.trim());
-  const httpsOrigin = origins.find((o) => o.startsWith('https://'));
-  return httpsOrigin ?? origins[0] ?? 'http://localhost:3000';
 }
 
 function formatSessionDate(date: Date): string {
@@ -141,9 +135,10 @@ export const notifyWaitlistOnSpotOpen = onDocumentWritten(
       return;
     }
 
-    const appUrl = getAppUrl(allowedOriginsParam.value());
-    const slug = generateClassSlug(publishable.name);
-    const classUrl = `${appUrl}/classes/${slug}`;
+    // Prefer the real Webflow slug (captured during sync); fall back to the
+    // name-derived slug only for classes that haven't synced/backfilled yet.
+    const slug = publishable.webflowSlug ?? generateClassSlug(publishable.name);
+    const classUrl = `${PUBLIC_SITE_BASE_URL}/classes/${slug}`;
     const firstSession = getFirstSession(publishable);
     const classDate = formatSessionDate(firstSession.dateTime);
 

--- a/libs/firebase/maple-functions/sync-class-to-webflow/src/lib/sync-class-to-webflow.ts
+++ b/libs/firebase/maple-functions/sync-class-to-webflow/src/lib/sync-class-to-webflow.ts
@@ -236,19 +236,27 @@ export const syncClassToWebflow = onDocumentWritten(
       console.log('Webflow sync result:', {
         success: result.success,
         webflowItemId: result.webflowItemId,
+        webflowSlug: result.webflowSlug,
         isNew: result.isNew,
         isDev,
         published: shouldPublish,
       });
 
-      // Store the Webflow item ID back in Firestore
-      // Uses bare update (no updatedAt) to prevent re-triggering sync
-      if (result.success && result.webflowItemId && publishable.webflowItemId !== result.webflowItemId) {
-        await ClassRepository.updateWebflowItemId(
+      // Store the Webflow item ID and real slug back in Firestore. Uses a bare
+      // update (no updatedAt) and only writes when something actually changed,
+      // so the resulting write doesn't re-trigger this sync indefinitely.
+      const itemIdChanged =
+        !!result.webflowItemId &&
+        publishable.webflowItemId !== result.webflowItemId;
+      const slugChanged =
+        !!result.webflowSlug && publishable.webflowSlug !== result.webflowSlug;
+      if (result.success && (itemIdChanged || slugChanged)) {
+        await ClassRepository.updateWebflowSync(
           publishable.id,
-          result.webflowItemId
+          result.webflowItemId,
+          result.webflowSlug
         );
-        console.log('Updated Firestore with Webflow item ID');
+        console.log('Updated Firestore with Webflow item ID and slug');
       }
     } catch (error) {
       console.error('Webflow sync error:', error);

--- a/libs/firebase/webflow/src/lib/class.service.spec.ts
+++ b/libs/firebase/webflow/src/lib/class.service.spec.ts
@@ -342,8 +342,10 @@ describe('ClassService', () => {
     it('creates a new Webflow item when class does not exist', async () => {
       // findByFirebaseId returns nothing
       mockClient.collections.items.listItems.mockResolvedValue({ items: [] });
+      // Webflow auto-suffixed the slug on create — capture the real value.
       mockClient.collections.items.createItem.mockResolvedValue({
         id: 'wf-new-item',
+        fieldData: { slug: 'pottery-101-9f2a1' },
       });
 
       const result = await service.syncClass({
@@ -355,6 +357,7 @@ describe('ClassService', () => {
       expect(result).toEqual({
         success: true,
         webflowItemId: 'wf-new-item',
+        webflowSlug: 'pottery-101-9f2a1',
         isNew: true,
       });
       expect(mockClient.collections.items.createItem).toHaveBeenCalledWith(
@@ -379,7 +382,10 @@ describe('ClassService', () => {
           },
         ],
       });
-      mockClient.collections.items.updateItem.mockResolvedValue({});
+      // Update response echoes the item's existing (unchanged) slug.
+      mockClient.collections.items.updateItem.mockResolvedValue({
+        fieldData: { slug: 'pottery-101-9f2a1' },
+      });
 
       const result = await service.syncClass({
         classEntity: mockClass,
@@ -393,6 +399,7 @@ describe('ClassService', () => {
       expect(result).toEqual({
         success: true,
         webflowItemId: 'wf-existing',
+        webflowSlug: 'pottery-101-9f2a1',
         isNew: false,
       });
       expect(mockClient.collections.items.updateItem).toHaveBeenCalledWith(
@@ -495,7 +502,9 @@ describe('ClassService', () => {
         id: 'wf-known',
         fieldData: { 'firebase-id': 'class-abc' },
       });
-      mockClient.collections.items.updateItem.mockResolvedValue({});
+      mockClient.collections.items.updateItem.mockResolvedValue({
+        fieldData: { slug: 'pottery-101' },
+      });
 
       const result = await service.syncClass({
         classEntity: mockClass,
@@ -506,6 +515,7 @@ describe('ClassService', () => {
       expect(result).toEqual({
         success: true,
         webflowItemId: 'wf-known',
+        webflowSlug: 'pottery-101',
         isNew: false,
       });
       expect(mockClient.collections.items.getItem).toHaveBeenCalledWith(

--- a/libs/firebase/webflow/src/lib/class.service.ts
+++ b/libs/firebase/webflow/src/lib/class.service.ts
@@ -61,6 +61,12 @@ export interface SyncClassInput {
 export interface SyncClassResult {
   success: boolean;
   webflowItemId: string;
+  /**
+   * The slug Webflow actually assigned the item (including any auto-appended
+   * collision suffix). Empty string if the API response omitted it. Persist
+   * this so public `/classes/{slug}` links resolve to the real page.
+   */
+  webflowSlug: string;
   isNew: boolean;
 }
 
@@ -69,6 +75,16 @@ export interface SyncClassResult {
  */
 interface WebflowItemWithId extends CollectionItem {
   id: string;
+}
+
+/**
+ * Pull the slug out of a Webflow item response. `fieldData.slug` is the real,
+ * Webflow-assigned slug; returns '' when the response shape lacks it so the
+ * caller can decline to overwrite a previously stored slug.
+ */
+function extractSlug(item: CollectionItem | undefined): string {
+  const fieldData = item?.fieldData as { slug?: unknown } | undefined;
+  return typeof fieldData?.slug === 'string' ? fieldData.slug : '';
 }
 
 /**
@@ -259,6 +275,7 @@ export class ClassService {
     );
 
     let webflowItemId: string;
+    let webflowSlug: string;
     let isNew: boolean;
 
     const fieldData = mapClassToFieldData(classEntity, {
@@ -271,12 +288,13 @@ export class ClassService {
     });
 
     if (existingItemId) {
-      await this.updateItem(existingItemId, fieldData);
+      webflowSlug = await this.updateItem(existingItemId, fieldData);
       webflowItemId = existingItemId;
       isNew = false;
     } else {
       const newItem = await this.createItem(fieldData);
       webflowItemId = newItem.id;
+      webflowSlug = extractSlug(newItem);
       isNew = true;
     }
 
@@ -284,7 +302,7 @@ export class ClassService {
       await this.publishItem(webflowItemId);
     }
 
-    return { success: true, webflowItemId, isNew };
+    return { success: true, webflowItemId, webflowSlug, isNew };
   }
 
   /**
@@ -427,19 +445,29 @@ export class ClassService {
     return response as WebflowItemWithId;
   }
 
+  /**
+   * Update an item's field data. Returns the item's real Webflow slug from
+   * the response (unchanged by the update — we never re-send it), or '' if the
+   * response omits it.
+   */
   private async updateItem(
     itemId: string,
     fieldData: ClassWebflowFieldData
-  ): Promise<void> {
+  ): Promise<string> {
     // Omit `slug` on update — Webflow auto-suffixes slug collisions on
     // create (e.g. `name-94fde` when `name` is taken), but on update it
     // 400s with a uniqueness error. Re-sending the deterministic slug
     // would freeze every later sync (incl. spots-remaining).
     const { slug: _slug, ...fieldDataWithoutSlug } = fieldData;
-    await this.client.collections.items.updateItem(this.collectionId, itemId, {
-      isArchived: false,
-      isDraft: false,
-      fieldData: fieldDataWithoutSlug,
-    });
+    const response = await this.client.collections.items.updateItem(
+      this.collectionId,
+      itemId,
+      {
+        isArchived: false,
+        isDraft: false,
+        fieldData: fieldDataWithoutSlug,
+      }
+    );
+    return extractSlug(response);
   }
 }

--- a/libs/ts/domain/src/lib/class.spec.ts
+++ b/libs/ts/domain/src/lib/class.spec.ts
@@ -146,6 +146,20 @@ describe('Class domain helpers', () => {
       expect(result.spotsRemaining).toBe(8); // capacity - 0
     });
 
+    it('falls back to the name-derived slug when webflowSlug is absent', () => {
+      expect(toPublicClass(baseClass).slug).toBe('introduction-to-weaving');
+    });
+
+    it('prefers the real Webflow slug over the name-derived one', () => {
+      // Webflow auto-suffixes collisions, so the stored slug is not derivable
+      // from the name — the public URL must use it verbatim.
+      const result = toPublicClass({
+        ...baseClass,
+        webflowSlug: 'introduction-to-weaving-b192d',
+      });
+      expect(result.slug).toBe('introduction-to-weaving-b192d');
+    });
+
     it('calculates spotsRemaining correctly', () => {
       expect(toPublicClass(baseClass, undefined, undefined, 0).spotsRemaining).toBe(8);
       expect(toPublicClass(baseClass, undefined, undefined, 5).spotsRemaining).toBe(3);

--- a/libs/ts/domain/src/lib/class.ts
+++ b/libs/ts/domain/src/lib/class.ts
@@ -102,6 +102,15 @@ export interface Class {
    */
   webflowItemId?: string;
   /**
+   * The real Webflow CMS slug for this class, captured from the Webflow API
+   * response during sync. Webflow auto-suffixes slug collisions (e.g.
+   * `stained-glass-tryit-class-b192d`), so the live URL is NOT derivable from
+   * `name`. Prefer this over a name-derived slug when building public
+   * `/classes/{slug}` links. Undefined until the class has synced (or been
+   * backfilled) — callers must fall back to the name-derived slug.
+   */
+  webflowSlug?: string;
+  /**
    * Opt-in to the friend-referral program for this class. When set, every
    * confirmed registration auto-generates a single-use Discount and the
    * confirmation email includes a code the customer can share.
@@ -157,8 +166,10 @@ export interface PublicClass {
   id: string;
   name: string;
   /**
-   * URL-safe slug derived from `name`. Mirrors the slug used by the Webflow
-   * CMS sync, so `/classes/{slug}` resolves to the public class detail page.
+   * URL slug for the public class detail page, so `/classes/{slug}` resolves
+   * correctly. Prefers the real Webflow-assigned slug (`Class.webflowSlug`,
+   * which includes any auto-appended collision suffix) and falls back to a
+   * name-derived slug for classes that haven't synced yet.
    */
   slug: string;
   shortDescription?: string;
@@ -270,7 +281,7 @@ export function toPublicClass(
   return {
     id: classEntity.id,
     name: classEntity.name,
-    slug: buildClassSlug(classEntity.name),
+    slug: classEntity.webflowSlug ?? buildClassSlug(classEntity.name),
     shortDescription: classEntity.shortDescription,
     description: classEntity.description,
     instructorId: classEntity.instructorId,

--- a/tools/backfill-webflow-slugs.ts
+++ b/tools/backfill-webflow-slugs.ts
@@ -1,0 +1,151 @@
+/**
+ * One-time backfill for `Class.webflowSlug`.
+ *
+ * Historically the class → Webflow sync discarded the Webflow API response
+ * except for the item ID, so the real slug (which Webflow auto-suffixes on
+ * collision, e.g. `stained-glass-tryit-class-b192d`) was never stored. Every
+ * public `/classes/{slug}` link — the waitlist "spot opened" email, the Meta/
+ * Google catalog feed, the registration widget — regenerated the slug from the
+ * class name and therefore 404'd for any class whose Webflow slug differs.
+ *
+ * The sync now captures `fieldData.slug` going forward. This script populates
+ * the field for classes that were already synced before that change, by
+ * fetching each class's live Webflow item and reading its real slug.
+ *
+ * Credentials:
+ *   - Firebase: Application Default Credentials
+ *       (gcloud auth application-default login)
+ *   - Webflow: WEBFLOW_API_TOKEN + WEBFLOW_CLASSES_COLLECTION_ID env vars.
+ *     Use the PROD Webflow token/collection when running with --prod. Values
+ *     live in Firebase Secret Manager / the Functions env for each project.
+ *
+ * Usage:
+ *   export WEBFLOW_API_TOKEN=...
+ *   export WEBFLOW_CLASSES_COLLECTION_ID=...
+ *   npx tsx tools/backfill-webflow-slugs.ts                   # dry-run, dev
+ *   npx tsx tools/backfill-webflow-slugs.ts --prod            # dry-run, prod
+ *   npx tsx tools/backfill-webflow-slugs.ts --execute         # write, dev
+ *   npx tsx tools/backfill-webflow-slugs.ts --prod --execute  # write, prod
+ */
+
+import { initializeApp } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+import { WebflowClient } from 'webflow-api';
+
+const isProd = process.argv.includes('--prod');
+const isExecute = process.argv.includes('--execute');
+const projectId = isProd ? 'maple-and-spruce' : 'maple-and-spruce-dev';
+
+const accessToken = process.env['WEBFLOW_API_TOKEN'];
+const collectionId = process.env['WEBFLOW_CLASSES_COLLECTION_ID'];
+
+if (!accessToken || !collectionId) {
+  console.error(
+    'WEBFLOW_API_TOKEN and WEBFLOW_CLASSES_COLLECTION_ID env vars are required.\n' +
+      'Grab the values for the target project from its Functions env / Secret Manager.'
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Backfill Class.webflowSlug on ${projectId} (${
+    isExecute ? 'EXECUTE' : 'DRY-RUN'
+  })`
+);
+
+const app = initializeApp({ projectId });
+const db = getFirestore(app);
+const webflow = new WebflowClient({ accessToken });
+
+interface Row {
+  id: string;
+  name: string;
+  webflowItemId: string;
+  storedSlug: string | undefined;
+  liveSlug: string | undefined;
+}
+
+async function fetchLiveSlug(itemId: string): Promise<string | undefined> {
+  try {
+    const item = await webflow.collections.items.getItem(collectionId!, itemId);
+    const fieldData = item?.fieldData as { slug?: unknown } | undefined;
+    return typeof fieldData?.slug === 'string' ? fieldData.slug : undefined;
+  } catch (error) {
+    console.warn(
+      `  ! getItem failed for ${itemId}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    return undefined;
+  }
+}
+
+async function main(): Promise<void> {
+  const snap = await db.collection('classes').get();
+
+  const candidates = snap.docs
+    .map((doc) => ({ id: doc.id, data: doc.data() }))
+    .filter((c) => typeof c.data['webflowItemId'] === 'string');
+
+  console.log(
+    `${snap.size} classes total; ${candidates.length} have a webflowItemId.`
+  );
+
+  const rows: Row[] = [];
+  for (const c of candidates) {
+    const webflowItemId = c.data['webflowItemId'] as string;
+    const liveSlug = await fetchLiveSlug(webflowItemId);
+    rows.push({
+      id: c.id,
+      name: (c.data['name'] as string) ?? '(unnamed)',
+      webflowItemId,
+      storedSlug: c.data['webflowSlug'] as string | undefined,
+      liveSlug,
+    });
+  }
+
+  // Only rows where we resolved a live slug that differs from what's stored.
+  const toUpdate = rows.filter(
+    (r) => r.liveSlug && r.liveSlug !== r.storedSlug
+  );
+  const unresolved = rows.filter((r) => !r.liveSlug);
+
+  console.log('');
+  for (const r of toUpdate) {
+    console.log(
+      `  ${r.name}\n    ${r.storedSlug ?? '(none)'} -> ${r.liveSlug}`
+    );
+  }
+  if (unresolved.length > 0) {
+    console.log(
+      `\n${unresolved.length} class(es) had no resolvable Webflow slug (deleted item or API error):`
+    );
+    for (const r of unresolved) console.log(`  - ${r.name} (${r.id})`);
+  }
+
+  console.log(
+    `\n${toUpdate.length} class(es) need a slug update; ${
+      rows.length - toUpdate.length - unresolved.length
+    } already correct.`
+  );
+
+  if (!isExecute) {
+    console.log('\nDry-run only. Re-run with --execute to write.');
+    return;
+  }
+
+  let written = 0;
+  for (const r of toUpdate) {
+    // Bare update (no updatedAt) so it does not re-trigger the Webflow sync.
+    await db.collection('classes').doc(r.id).update({ webflowSlug: r.liveSlug });
+    written++;
+  }
+  console.log(`\nUpdated ${written} class document(s).`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error('Backfill failed:', error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Problem

The waitlist **"spot opened"** email (and other surfaces) linked to the wrong URLs. Two compounding bugs:

1. **Wrong host.** The email built its base URL from `ALLOWED_ORIGINS`, whose first entry in prod is `business.mapleandsprucefolkarts.com` (the admin app) — so every class link pointed at the admin app, not the public site.
2. **Wrong slug (the deeper one).** Every public `/classes/{slug}` URL is regenerated from the class **name** via `generateClassSlug()`. But Webflow auto-suffixes slug collisions (e.g. `stained-glass-tryit-class-b192d`), so the derived slug doesn't match the live page — and the sync **discarded** the real slug from the Webflow API response, keeping only the item ID.

The slug bug affects **three** live surfaces:
- the waitlist "spot opened" email,
- the **Meta/Google catalog feed** (`class-catalog-feed.ts`) — shopping ads can land on 404s,
- the **RegistrationWidget** links on the Webflow site.

## Fix

Capture Webflow's real slug during sync, persist it, and use it everywhere.

- **Entity** — `Class` gains `webflowSlug?`; `toPublicClass` prefers it over the name-derived slug (fixes the widget for free).
- **Webflow lib** — `ClassService` reads `fieldData.slug` from the create/update response and returns it in `SyncClassResult`.
- **Repository** — `updateWebflowSync` persists item ID + slug (skips an empty slug so a good stored value is never clobbered); `docToClass` reads it.
- **Sync writeback** — persists the slug with a combined change guard so the Firestore trigger doesn't loop.
- **URL builders** — waitlist email + catalog feed use `webflowSlug ?? generated`; email host hard-coded to the public base URL (mirrors `class-catalog-feed.ts`).
- **Backfill** — `tools/backfill-webflow-slugs.ts` populates the field for already-synced classes (dry-run by default; `--execute` / `--prod`).

Going forward the slug **self-heals** on the next sync; the backfill closes the gap immediately for live classes.

## Testing

- `notify-waitlist`, `class.service`, `class` (domain), `class-catalog-feed`, `class.repository` specs — **169 passing**, including new cases proving the real Webflow slug is used and the name-derived slug remains the fallback.
- `tsc --noEmit` clean on domain / webflow / firebase-database / sync-class-to-webflow.
- Firestore index analyzer passes (no new query shapes).

## Follow-up (separate PR)

Business-portal waitlist view (list of waitlisted emails + count on the class roster page).