### PR TITLE
feat(portal): show class waitlist (list + count) on the roster page

### DIFF
--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -115,6 +115,7 @@ export { updateMusicTogetherSection } from '@maple/firebase/maple-functions/upda
 export { getMusicTogetherRoster } from '@maple/firebase/maple-functions/get-music-together-roster';
 export { getRelatedPublicClasses } from '@maple/firebase/maple-functions/get-related-public-classes';
 export { addToClassWaitlist } from '@maple/firebase/maple-functions/add-to-class-waitlist';
+export { getClassWaitlist } from '@maple/firebase/maple-functions/get-class-waitlist';
 export { notifyWaitlistOnSpotOpen } from '@maple/firebase/maple-functions/notify-waitlist-on-spot-open';
 
 // Public class catalog feed (RSS 2.0 for Meta Commerce Manager + Google Merchant Center)

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -132,6 +132,7 @@
     "../../libs/firebase/maple-functions/get-music-together-semesters/**/*.ts",
     "../../libs/firebase/maple-functions/update-music-together-semester/**/*.ts",
     "../../libs/firebase/maple-functions/get-music-together-roster/**/*.ts",
+    "../../libs/firebase/maple-functions/get-class-waitlist/**/*.ts",
     "../../libs/firebase/database/src/**/*.ts",
     "../../libs/firebase/functions/src/**/*.ts",
     "../../libs/ts/domain/src/**/*.ts",

--- a/apps/maple-spruce/src/app/(admin)/classes/[classId]/roster/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/classes/[classId]/roster/page.tsx
@@ -15,6 +15,12 @@ import {
   Select,
   MenuItem,
   Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
 } from '@mui/material';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
@@ -26,7 +32,11 @@ import {
   RegistrationList,
   RegistrationDetailDialog,
 } from '@maple/react/registrations';
-import { useRegistrations, useClasses } from '../../../../../hooks';
+import {
+  useRegistrations,
+  useClasses,
+  useClassWaitlist,
+} from '../../../../../hooks';
 import type { UseRegistrationsFilters } from '@maple/react/data';
 
 function formatDate(date: Date | string): string {
@@ -69,6 +79,8 @@ export default function ClassRosterPage() {
 
   const { registrationsState, cancelRegistration, updateRegistration } =
     useRegistrations(filters);
+
+  const { waitlistState } = useClassWaitlist(classId);
 
   const { classesState } = useClasses();
 
@@ -137,10 +149,73 @@ export default function ClassRosterPage() {
     });
   }, [confirmedRegistrations]);
 
+  const waitlistEntries = useMemo(
+    () => (waitlistState.status === 'success' ? waitlistState.data : []),
+    [waitlistState]
+  );
+
+  const handleCopyWaitlistEmails = useCallback(() => {
+    const emails = waitlistEntries
+      .map((e) => e.email)
+      .filter((email, index, arr) => arr.indexOf(email) === index) // dedupe
+      .join(', ');
+
+    navigator.clipboard.writeText(emails).then(() => {
+      setCopySuccess(true);
+    });
+  }, [waitlistEntries]);
+
   const classMap = useMemo(
     () => new Map(classes.map((c) => [c.id, c.name])),
     [classes]
   );
+
+  const renderWaitlistBody = () => {
+    if (
+      waitlistState.status === 'loading' ||
+      waitlistState.status === 'idle'
+    ) {
+      return (
+        <Skeleton variant="rectangular" height={120} sx={{ borderRadius: 2 }} />
+      );
+    }
+    if (waitlistState.status === 'error') {
+      return <Alert severity="error">{waitlistState.error}</Alert>;
+    }
+    if (waitlistEntries.length === 0) {
+      return (
+        <Paper sx={{ p: 3, textAlign: 'center' }}>
+          <Typography variant="body2" color="text.secondary">
+            No one is on the waitlist for this class.
+          </Typography>
+        </Paper>
+      );
+    }
+    return (
+      <TableContainer component={Paper}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>#</TableCell>
+              <TableCell>Email</TableCell>
+              <TableCell>Joined</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {waitlistEntries.map((entry, index) => (
+              <TableRow key={entry.id}>
+                <TableCell>{index + 1}</TableCell>
+                <TableCell>{entry.email}</TableCell>
+                <TableCell>
+                  {formatDate(entry.createdAt)} at {formatTime(entry.createdAt)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    );
+  };
 
   return (
     <>
@@ -263,6 +338,41 @@ export default function ClassRosterPage() {
         classes={classes}
         onViewDetail={handleViewDetail}
       />
+
+      {/* Waitlist */}
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mt: 4,
+          mb: 2,
+          flexWrap: 'wrap',
+          gap: 2,
+        }}
+      >
+        <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
+          <Typography variant="h6">Waitlist</Typography>
+          {waitlistState.status === 'success' && (
+            <Chip
+              label={`${waitlistEntries.length} waiting`}
+              size="small"
+              color={waitlistEntries.length > 0 ? 'primary' : 'default'}
+            />
+          )}
+        </Box>
+        <Button
+          variant="outlined"
+          startIcon={<ContentCopyIcon />}
+          onClick={handleCopyWaitlistEmails}
+          disabled={waitlistEntries.length === 0}
+          size="small"
+        >
+          Copy Emails ({waitlistEntries.length})
+        </Button>
+      </Box>
+
+      {renderWaitlistBody()}
 
       {/* Detail Dialog */}
       <RegistrationDetailDialog

--- a/apps/maple-spruce/src/hooks/index.ts
+++ b/apps/maple-spruce/src/hooks/index.ts
@@ -12,6 +12,7 @@ export {
   useClassCategories,
   useDiscounts,
   useRegistrations,
+  useClassWaitlist,
   useCalendarEvents,
   useArtistPayouts,
   useAgreementTemplates,

--- a/docs/reference/deployed-functions.md
+++ b/docs/reference/deployed-functions.md
@@ -38,6 +38,7 @@ Core CRUD operations, auth, triggers, and admin functions. No heavy third-party 
 - `getPublicClass` _(minInstances: 1 in prod / 0 in dev, concurrency: 80)_
 - `getRelatedPublicClasses` _(public; same-category siblings with future sessions + spots remaining; powers the sold-out widget's "other dates" list)_
 - `addToClassWaitlist` _(public; idempotent email signup stored under `classes/{id}/waitlist/{emailKey}`)_
+- `getClassWaitlist` _(admin; returns a class's waitlist entries ordered earliest-signup-first plus a count; powers the portal roster's Waitlist section)_
 - `notifyWaitlistOnSpotOpen` _(Firestore trigger on `registrations/{id}`; on active → inactive transition or delete, queues `class-spot-available` mail to every waitlist email then clears the subcollection)_
 - `classCatalogFeed` _(public RSS 2.0 feed at `/catalog/classes.xml`; consumed by Meta Commerce Manager + Google Merchant Center; 15-min cache)_
 

--- a/libs/firebase/maple-functions/get-class-waitlist/project.json
+++ b/libs/firebase/maple-functions/get-class-waitlist/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-get-class-waitlist",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/get-class-waitlist/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/get-class-waitlist/src/index.ts
+++ b/libs/firebase/maple-functions/get-class-waitlist/src/index.ts
@@ -1,0 +1,1 @@
+export { getClassWaitlist } from './lib/get-class-waitlist';

--- a/libs/firebase/maple-functions/get-class-waitlist/src/lib/get-class-waitlist.spec.ts
+++ b/libs/firebase/maple-functions/get-class-waitlist/src/lib/get-class-waitlist.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findByClassId: vi.fn(),
+}));
+
+// createAdminFunction wraps the handler with auth/role plumbing we don't want
+// in a unit test — stub it to return the raw handler and surface the thrown
+// HttpsError codes verbatim.
+vi.mock('@maple/firebase/functions', () => ({
+  createAdminFunction: <Req, Res>(handler: (data: Req) => Promise<Res>) =>
+    handler,
+  throwInvalidArgument: (message: string) => {
+    throw new Error(`invalid-argument: ${message}`);
+  },
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  ClassWaitlistRepository: {
+    findByClassId: mocks.findByClassId,
+  },
+}));
+
+import { getClassWaitlist } from './get-class-waitlist';
+
+const handler = getClassWaitlist as unknown as (data: {
+  classId: string;
+}) => Promise<{ entries: { email: string }[]; count: number }>;
+
+describe('getClassWaitlist', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('requires a classId', async () => {
+    await expect(handler({ classId: '' })).rejects.toThrow('invalid-argument');
+    expect(mocks.findByClassId).not.toHaveBeenCalled();
+  });
+
+  it('returns entries ordered by signup time with a count', async () => {
+    mocks.findByClassId.mockResolvedValue([
+      {
+        id: 'bob@example.com',
+        classId: 'class-1',
+        email: 'bob@example.com',
+        createdAt: new Date('2026-07-02T10:00:00Z'),
+      },
+      {
+        id: 'alice@example.com',
+        classId: 'class-1',
+        email: 'alice@example.com',
+        createdAt: new Date('2026-07-01T10:00:00Z'),
+      },
+    ]);
+
+    const result = await handler({ classId: 'class-1' });
+
+    expect(mocks.findByClassId).toHaveBeenCalledWith('class-1');
+    expect(result.count).toBe(2);
+    // Alice signed up first, so she sorts ahead of Bob.
+    expect(result.entries.map((e) => e.email)).toEqual([
+      'alice@example.com',
+      'bob@example.com',
+    ]);
+  });
+
+  it('returns an empty list and zero count when nobody is waitlisted', async () => {
+    mocks.findByClassId.mockResolvedValue([]);
+
+    const result = await handler({ classId: 'class-1' });
+
+    expect(result).toEqual({ entries: [], count: 0 });
+  });
+});

--- a/libs/firebase/maple-functions/get-class-waitlist/src/lib/get-class-waitlist.ts
+++ b/libs/firebase/maple-functions/get-class-waitlist/src/lib/get-class-waitlist.ts
@@ -1,0 +1,34 @@
+/**
+ * Get Class Waitlist Cloud Function
+ *
+ * Returns the waitlist entries for a class plus a total count. Admin-only,
+ * used by the portal class roster page. The class waitlist is an informal
+ * broadcast list (email + signup time only), so entries are returned ordered
+ * earliest-signup-first for a stable display.
+ *
+ * Deployed to us-east4 via CI/CD pipeline.
+ */
+import {
+  createAdminFunction,
+  throwInvalidArgument,
+} from '@maple/firebase/functions';
+import { ClassWaitlistRepository } from '@maple/firebase/database';
+import type {
+  GetClassWaitlistRequest,
+  GetClassWaitlistResponse,
+} from '@maple/ts/firebase/api-types';
+
+export const getClassWaitlist = createAdminFunction<
+  GetClassWaitlistRequest,
+  GetClassWaitlistResponse
+>(async (data) => {
+  if (!data.classId) throwInvalidArgument('Class ID is required');
+
+  const entries = await ClassWaitlistRepository.findByClassId(data.classId);
+
+  // Stored keyed by email with no inherent order — sort by signup time so the
+  // portal shows a stable, meaningful "who joined first" list.
+  entries.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+
+  return { entries, count: entries.length };
+});

--- a/libs/firebase/maple-functions/get-class-waitlist/tsconfig.json
+++ b/libs/firebase/maple-functions/get-class-waitlist/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/get-class-waitlist/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/get-class-waitlist/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/react/data/src/index.ts
+++ b/libs/react/data/src/index.ts
@@ -86,6 +86,7 @@ export {
   useRegistrations,
   type UseRegistrationsFilters,
 } from './lib/useRegistrations';
+export { useClassWaitlist } from './lib/useClassWaitlist';
 
 // User & role administration
 export { useUsers } from './lib/useUsers';

--- a/libs/react/data/src/lib/useClassWaitlist.ts
+++ b/libs/react/data/src/lib/useClassWaitlist.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { callDeduped } from './call-deduped';
+import type { ClassWaitlistEntry, RequestState } from '@maple/ts/domain';
+import type {
+  GetClassWaitlistRequest,
+  GetClassWaitlistResponse,
+} from '@maple/ts/firebase/api-types';
+
+/**
+ * Hook for reading a class's waitlist (admin). Returns the entries as a
+ * RequestState plus the server-reported count. No mutations — the class
+ * waitlist is cleared automatically when a spot opens.
+ *
+ * Pass `undefined`/empty `classId` to stay idle (e.g. before the route param
+ * resolves) rather than firing a doomed request.
+ */
+export function useClassWaitlist(classId?: string) {
+  const [waitlistState, setWaitlistState] = useState<
+    RequestState<ClassWaitlistEntry[]>
+  >({ status: 'idle' });
+
+  const fetchWaitlist = useCallback(async () => {
+    if (!classId) {
+      setWaitlistState({ status: 'idle' });
+      return;
+    }
+
+    setWaitlistState({ status: 'loading' });
+
+    try {
+      const result = await callDeduped<
+        GetClassWaitlistRequest,
+        GetClassWaitlistResponse
+      >('getClassWaitlist', { classId });
+      setWaitlistState({ status: 'success', data: result.data.entries });
+    } catch (error) {
+      console.error('Failed to fetch class waitlist:', error);
+      setWaitlistState({
+        status: 'error',
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to fetch class waitlist',
+      });
+    }
+  }, [classId]);
+
+  useEffect(() => {
+    fetchWaitlist();
+  }, [fetchWaitlist]);
+
+  return { waitlistState, fetchWaitlist };
+}

--- a/libs/ts/firebase/api-types/src/lib/class-waitlist.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/class-waitlist.types.ts
@@ -2,9 +2,9 @@
  * Class waitlist API request/response types
  *
  * Public endpoints used by the embedded Webflow registration widget when
- * a class is full.
+ * a class is full, plus an admin read endpoint for the portal roster.
  */
-import type { PublicClass } from '@maple/ts/domain';
+import type { ClassWaitlistEntry, PublicClass } from '@maple/ts/domain';
 
 // ============================================================================
 // Add to Class Waitlist (public — no auth)
@@ -34,4 +34,19 @@ export interface GetRelatedPublicClassesRequest {
 export interface GetRelatedPublicClassesResponse {
   /** Other published classes in the same category with future sessions and spots remaining. */
   classes: PublicClass[];
+}
+
+// ============================================================================
+// Get Class Waitlist (admin — portal roster)
+// ============================================================================
+
+export interface GetClassWaitlistRequest {
+  classId: string;
+}
+
+export interface GetClassWaitlistResponse {
+  /** Waitlist entries for the class, ordered earliest signup first. */
+  entries: ClassWaitlistEntry[];
+  /** Total number of entries (equals `entries.length`; sent explicitly for convenience). */
+  count: number;
 }

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -181,12 +181,14 @@ export type {
   UploadCategoryGalleryImageResponse,
 } from './class-category.types';
 
-// Class Waitlist + Related Classes (public widget endpoints)
+// Class Waitlist + Related Classes (public widget endpoints + admin roster read)
 export type {
   AddToClassWaitlistRequest,
   AddToClassWaitlistResponse,
   GetRelatedPublicClassesRequest,
   GetRelatedPublicClassesResponse,
+  GetClassWaitlistRequest,
+  GetClassWaitlistResponse,
 } from './class-waitlist.types';
 
 // Phase 3c: Discount types

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -311,6 +311,9 @@
       "@maple/firebase/maple-functions/get-registrations": [
         "libs/firebase/maple-functions/get-registrations/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/get-class-waitlist": [
+        "libs/firebase/maple-functions/get-class-waitlist/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/get-registration": [
         "libs/firebase/maple-functions/get-registration/src/index.ts"
       ],


### PR DESCRIPTION
## What

Adds a **Waitlist** view to the admin class roster page so you can see who's waitlisted for a class and how many.

Until now the class waitlist (email + signup time, stored under `classes/{id}/waitlist/{emailKey}`) had no admin read path — the repository methods existed but were only used by the "spot opened" notify trigger.

## Changes

Full-stack read path, mirroring the existing registrations pattern:

- **`getClassWaitlist`** admin callable (maple-core) — returns entries ordered earliest-signup-first + a `count`.
- **API types** — `GetClassWaitlistRequest` / `GetClassWaitlistResponse`.
- **`useClassWaitlist(classId)`** data hook — `RequestState` + `callDeduped`, same shape as `useRegistrations`.
- **Roster page** — a "Waitlist" section below the registration list: a count chip, a per-entry email + join-time table, and a **Copy Emails** action, with loading / empty / error states matching the roster.

## Note on the data

The class waitlist is intentionally lightweight — **email + signup time only**, no name (it's a "notify everyone when a spot opens" list, cleared after each broadcast). So the view shows emails + when they joined + a count. If you'd like names captured too, that's a follow-up on the public signup widget.

## Testing

- Unit test for the function: requires `classId`, orders by signup time, returns the count, handles empty.
- `apps/maple-spruce` typechecks clean; `api-types`, `data`, and the new function pass lint; Firestore-index analyzer passes.
- Recommend a quick visual check in a preview/local run (admin app needs the functions emulator + admin auth to exercise end-to-end).

## Related

Companion to #585 (waitlist "spot opened" email link fix).