### PR TITLE
feat: mirror class capacity to Square inventory (PR B of 3, stacked on #583)

### DIFF
--- a/apps/functions-integration-tests-class-square/project.json
+++ b/apps/functions-integration-tests-class-square/project.json
@@ -6,6 +6,7 @@
   "tags": ["type:e2e"],
   "implicitDependencies": [
     "firebase-maple-functions-sync-class-to-square",
+    "firebase-maple-functions-sync-class-inventory-to-square",
     "firebase-integration-test-utils",
     "firebase-square-test-mock-server"
   ],

--- a/apps/functions-integration-tests-class-square/src/sync-class-inventory-to-square.spec.ts
+++ b/apps/functions-integration-tests-class-square/src/sync-class-inventory-to-square.spec.ts
@@ -1,0 +1,231 @@
+/**
+ * Integration tests for the `syncClassInventoryToSquare` Firestore trigger.
+ *
+ * Exercises the REAL chain end-to-end against the Firebase emulator:
+ *
+ *   Firestore write (registrations/{id})  →  syncClassInventoryToSquare fires
+ *   in the maple-square functions emulator  →  it reads the class + recomputes
+ *   RegistrationRepository.countByClassId  →  its `new Square(...)` client
+ *   PHYSICAL_COUNTs the class variation to (capacity - count) on the Square
+ *   mock server (redirected via SQUARE_BASE_URL).
+ *
+ * To isolate THIS trigger from the sibling `syncClassToSquare` (class-write)
+ * trigger, we seed the already-synced class first, let its inventory-seeding
+ * write settle, then RESET the Square mock — so only registration-triggered
+ * inventory calls are observed.
+ *
+ * NOTE: requires the maple-square codebase to be built and loaded in the
+ * emulator, and the Square mock server running on 9997(+offset). The harness
+ * (`tools/run-integration-tests.sh class-square`) sets all of this up.
+ */
+import {
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  EMULATOR_CONFIG,
+  PUBLISHED_CLASS,
+} from '@maple/firebase/integration-test-utils';
+
+const squareMockUrl = EMULATOR_CONFIG.squareMockServerUrl;
+
+interface RecordedRequest {
+  method: string;
+  path: string;
+  body: unknown;
+}
+
+/** Wait for the async Firestore trigger + Square round-trip to complete. */
+function waitForTrigger(ms = 5000): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function resetSquareMock(): Promise<void> {
+  const res = await fetch(`${squareMockUrl}/_mock/reset`, { method: 'POST' });
+  if (!res.ok) {
+    throw new Error(`Square mock reset failed: ${res.status}`);
+  }
+}
+
+async function getSquareRequests(pathPrefix?: string): Promise<RecordedRequest[]> {
+  const res = await fetch(`${squareMockUrl}/_mock/requests`);
+  if (!res.ok) {
+    throw new Error(`Square mock requests failed: ${res.status}`);
+  }
+  const body = (await res.json()) as { requests: RecordedRequest[] };
+  const requests = body.requests ?? [];
+  return pathPrefix
+    ? requests.filter((r) => r.path.startsWith(pathPrefix))
+    : requests;
+}
+
+/** Pull `physical_count` / `physicalCount` off a change regardless of casing. */
+function dataFor(
+  obj: Record<string, unknown>,
+  snake: string,
+  camel: string
+): Record<string, unknown> | undefined {
+  return (obj[snake] ?? obj[camel]) as Record<string, unknown> | undefined;
+}
+
+/**
+ * Collect every PHYSICAL_COUNT change (catalog_object_id + quantity) found in
+ * the recorded `/v2/inventory/changes/batch-create` bodies. Tolerant of
+ * snake_case vs camelCase — Square serializes quantity as a string.
+ */
+async function getPhysicalCounts(): Promise<
+  { catalogObjectId: unknown; quantity: unknown }[]
+> {
+  const reqs = await getSquareRequests('/v2/inventory/changes/batch-create');
+  const out: { catalogObjectId: unknown; quantity: unknown }[] = [];
+  for (const req of reqs) {
+    const body = req.body as Record<string, unknown>;
+    const changes = (body['changes'] as Record<string, unknown>[]) ?? [];
+    for (const change of changes) {
+      const pc = dataFor(change, 'physical_count', 'physicalCount');
+      if (pc) {
+        out.push({
+          catalogObjectId: pc['catalog_object_id'] ?? pc['catalogObjectId'],
+          quantity: pc['quantity'],
+        });
+      }
+    }
+  }
+  return out;
+}
+
+const CLASS_ID = 'prb-class-1';
+const VARIATION_ID = 'prb-var-1';
+const CAPACITY = 10;
+
+/**
+ * A published class that already carries FIXED Square IDs, so its
+ * `squareVariationId` is deterministic and `syncClassToSquare` takes its
+ * existing-mirror update path (which preserves the variation ID) rather than
+ * creating a fresh catalog item.
+ */
+function syncedClassDoc(): Record<string, unknown> {
+  return {
+    ...PUBLISHED_CLASS,
+    id: CLASS_ID,
+    name: 'Inventory Weaving 201',
+    capacity: CAPACITY,
+    status: 'published',
+    squareCatalogItemId: 'prb-item-1',
+    squareVariationId: VARIATION_ID,
+    squareModifierListId: 'prb-modlist-1',
+    squareCatalogVersion: 1,
+  };
+}
+
+/**
+ * A registration that `countByClassId` will count (status confirmed, matching
+ * classId, numeric quantity). Full doc — `setFirestoreDoc` PATCHes without an
+ * updateMask, so it REPLACES the whole doc.
+ */
+function confirmedRegistrationDoc(
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  const now = new Date().toISOString();
+  return {
+    id: 'prb-reg-1',
+    classId: CLASS_ID,
+    customerEmail: 'weaver@test.com',
+    customerName: 'Test Weaver',
+    quantity: 2,
+    status: 'confirmed',
+    source: 'web',
+    pricePaidCents: 4770,
+    subtotalCents: 4500,
+    taxAmountCents: 270,
+    taxRatePercent: 6.0,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+/**
+ * Seed the Square-synced class, let the class-write trigger's inventory
+ * seeding settle, then reset the mock so only registration-triggered inventory
+ * calls are observed thereafter.
+ */
+async function seedSyncedClassAndSettle(): Promise<void> {
+  await setFirestoreDoc('classes', CLASS_ID, syncedClassDoc());
+  await waitForTrigger(5000);
+  await resetSquareMock();
+}
+
+describe('syncClassInventoryToSquare (emulator + Square mock)', () => {
+  beforeEach(async () => {
+    await clearFirestoreEmulator();
+    await resetSquareMock();
+  });
+
+  it('sets Square inventory to (capacity - count) when a registration is created', async () => {
+    await seedSyncedClassAndSettle();
+
+    // Registration for 2 spots on a capacity-10 class → remaining 8.
+    await setFirestoreDoc('registrations', 'prb-reg-1', confirmedRegistrationDoc());
+    await waitForTrigger(5000);
+
+    const counts = await getPhysicalCounts();
+    if (process.env['DEBUG_SQUARE_MOCK']) {
+      console.log('PHYSICAL_COUNTS', JSON.stringify(counts, null, 2));
+    }
+
+    // At least one PHYSICAL_COUNT for our variation set to 8.
+    const forVariation = counts.filter(
+      (c) => c.catalogObjectId === VARIATION_ID
+    );
+    expect(forVariation.length).toBeGreaterThanOrEqual(1);
+    expect(forVariation.map((c) => String(c.quantity))).toContain('8');
+  });
+
+  it('issues NO inventory call for a non-count-relevant registration update', async () => {
+    await seedSyncedClassAndSettle();
+
+    // Seed one confirmed registration (fires the inventory sync once).
+    await setFirestoreDoc('registrations', 'prb-reg-1', confirmedRegistrationDoc());
+    await waitForTrigger(5000);
+
+    // Discard that registration-create inventory call; only observe the update.
+    await resetSquareMock();
+
+    // Whole-doc replace: carry every field forward, change ONLY a non-count
+    // field (squarePaymentId) — classId/status/quantity stay identical.
+    await setFirestoreDoc(
+      'registrations',
+      'prb-reg-1',
+      confirmedRegistrationDoc({ squarePaymentId: 'sq-pay-abc123' })
+    );
+    await waitForTrigger(5000);
+
+    const counts = await getPhysicalCounts();
+    expect(counts).toHaveLength(0);
+  });
+
+  it('recomputes inventory to full capacity when a registration is cancelled', async () => {
+    await seedSyncedClassAndSettle();
+
+    await setFirestoreDoc('registrations', 'prb-reg-1', confirmedRegistrationDoc());
+    await waitForTrigger(5000);
+
+    // Discard the create-time inventory call; only observe the cancellation.
+    await resetSquareMock();
+
+    // Flip confirmed → cancelled (count-relevant). cancelled is excluded from
+    // countByClassId, so remaining returns to capacity (10).
+    await setFirestoreDoc(
+      'registrations',
+      'prb-reg-1',
+      confirmedRegistrationDoc({ status: 'cancelled' })
+    );
+    await waitForTrigger(5000);
+
+    const counts = await getPhysicalCounts();
+    const forVariation = counts.filter(
+      (c) => c.catalogObjectId === VARIATION_ID
+    );
+    expect(forVariation.length).toBeGreaterThanOrEqual(1);
+    expect(forVariation.map((c) => String(c.quantity))).toContain('10');
+  });
+});

--- a/apps/functions-square/src/index.ts
+++ b/apps/functions-square/src/index.ts
@@ -66,3 +66,9 @@ export { adminCancelCraftClubSubscription } from '@maple/firebase/maple-function
 // Mirrors a published class as a Square catalog item + variation + required
 // modifier list so it can be rung up on POS in person.
 export { syncClassToSquare } from '@maple/firebase/maple-functions/sync-class-to-square';
+
+// Class registration → Square inventory sync (Firestore trigger on
+// registrations/{id}). Mirrors remaining seats (capacity - count) to the
+// class's Square variation via idempotent PHYSICAL_COUNT so POS stock stays
+// accurate as web registrations happen.
+export { syncClassInventoryToSquare } from '@maple/firebase/maple-functions/sync-class-inventory-to-square';

--- a/apps/functions-square/tsconfig.app.json
+++ b/apps/functions-square/tsconfig.app.json
@@ -19,6 +19,7 @@
     "../../libs/firebase/maple-functions/import-etsy-listings/**/*.ts",
     "../../libs/firebase/maple-functions/sync-inventory-to-square/**/*.ts",
     "../../libs/firebase/maple-functions/sync-class-to-square/**/*.ts",
+    "../../libs/firebase/maple-functions/sync-class-inventory-to-square/**/*.ts",
     "../../libs/firebase/maple-functions/create-craft-club-subscription/**/*.ts",
     "../../libs/firebase/maple-functions/cancel-craft-club-subscription/**/*.ts",
     "../../libs/firebase/maple-functions/update-craft-club-payment-method/**/*.ts",

--- a/function-codebases.json
+++ b/function-codebases.json
@@ -42,6 +42,7 @@
     "firebase-maple-functions-sync-inventory-to-etsy": "maple-sync",
     "firebase-maple-functions-sync-inventory-to-square": "maple-square",
     "firebase-maple-functions-sync-class-to-square": "maple-square",
+    "firebase-maple-functions-sync-class-inventory-to-square": "maple-square",
     "firebase-maple-functions-create-craft-club-subscription": "maple-square",
     "firebase-maple-functions-create-music-together-registration": "maple-square",
     "firebase-maple-functions-charge-music-together-installments": "maple-square",

--- a/libs/firebase/maple-functions/sync-class-inventory-to-square/eslint.config.mjs
+++ b/libs/firebase/maple-functions/sync-class-inventory-to-square/eslint.config.mjs
@@ -1,0 +1,22 @@
+import baseConfig from '../../../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredFiles: [
+            '{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}',
+            '{projectRoot}/esbuild.config.{js,ts,mjs,mts}',
+          ],
+        },
+      ],
+    },
+    languageOptions: {
+      parser: await import('jsonc-eslint-parser'),
+    },
+  },
+];

--- a/libs/firebase/maple-functions/sync-class-inventory-to-square/project.json
+++ b/libs/firebase/maple-functions/sync-class-inventory-to-square/project.json
@@ -1,0 +1,15 @@
+{
+  "name": "firebase-maple-functions-sync-class-inventory-to-square",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/sync-class-inventory-to-square/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {
+    "test": {
+      "executor": "@nx/vitest:test",
+      "options": {
+        "config": "libs/firebase/maple-functions/sync-class-inventory-to-square/vitest.config.ts"
+      }
+    }
+  }
+}

--- a/libs/firebase/maple-functions/sync-class-inventory-to-square/src/index.ts
+++ b/libs/firebase/maple-functions/sync-class-inventory-to-square/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/sync-class-inventory-to-square';

--- a/libs/firebase/maple-functions/sync-class-inventory-to-square/src/lib/sync-class-inventory-to-square.spec.ts
+++ b/libs/firebase/maple-functions/sync-class-inventory-to-square/src/lib/sync-class-inventory-to-square.spec.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Tests for sync-class-inventory-to-square.ts
+ *
+ * The trigger recomputes the class registration count on any count-relevant
+ * registrations/{id} write and PHYSICAL_COUNTs the class's Square variation
+ * to (capacity - count). Covers:
+ *  - count-relevant create → sets inventory to (capacity - count)
+ *  - non-count-relevant update (only squarePaymentId/updatedAt) → no Square call
+ *  - delete (cancel) → recomputes higher remaining
+ *  - class with no squareVariationId → skip
+ *  - class not found → skip
+ *  - oversold clamp (count > capacity) → quantity clamped to 0
+ *  - Square API throws → error swallowed, no rethrow
+ */
+
+const mocks = vi.hoisted(() => ({
+  classFindById: vi.fn(),
+  registrationCountByClassId: vi.fn(),
+  setQuantity: vi.fn(),
+  locationId: 'mock-location',
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  ClassRepository: {
+    findById: mocks.classFindById,
+  },
+  RegistrationRepository: {
+    countByClassId: mocks.registrationCountByClassId,
+  },
+}));
+
+vi.mock('@maple/firebase/square', () => {
+  return {
+    Square: class MockSquare {
+      inventoryService = { setQuantity: mocks.setQuantity };
+      locationId = mocks.locationId;
+    },
+    SQUARE_SECRET_NAMES: ['SQUARE_ACCESS_TOKEN'],
+    SQUARE_STRING_NAMES: ['SQUARE_LOCATION_ID'],
+  };
+});
+
+vi.mock('firebase-functions/v2/firestore', () => ({
+  onDocumentWritten: vi.fn((_config, handler) => handler),
+}));
+
+vi.mock('firebase-functions/params', () => ({
+  defineSecret: vi.fn((name: string) => ({ name, value: () => `mock-${name}` })),
+  defineString: vi.fn((name: string) => ({ name, value: () => `mock-${name}` })),
+}));
+
+import { syncClassInventoryToSquare } from './sync-class-inventory-to-square';
+
+const handler = syncClassInventoryToSquare as unknown as (
+  event: unknown
+) => Promise<void>;
+
+function makeSnapshot(exists: boolean, data?: Record<string, unknown>): unknown {
+  return {
+    id: (data?.['id'] as string | undefined) ?? 'reg-001',
+    exists,
+    data: () => (exists ? data : undefined),
+  };
+}
+
+function makeRegistrationData(
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    classId: 'class-001',
+    status: 'confirmed',
+    quantity: 1,
+    ...overrides,
+  };
+}
+
+function makeClass(
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    id: 'class-001',
+    name: 'Intro to Pottery',
+    capacity: 10,
+    squareVariationId: 'SQ-VAR-1',
+    ...overrides,
+  };
+}
+
+function makeEvent(beforeData: unknown, afterData: unknown) {
+  return {
+    params: { registrationId: 'reg-001' },
+    data: {
+      before: beforeData,
+      after: afterData,
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.classFindById.mockResolvedValue(makeClass());
+  mocks.registrationCountByClassId.mockResolvedValue(0);
+});
+
+describe('syncClassInventoryToSquare — count-relevant create', () => {
+  it('sets Square inventory to (capacity - registrationCount)', async () => {
+    mocks.registrationCountByClassId.mockResolvedValue(3);
+
+    const before = makeSnapshot(false);
+    const after = makeSnapshot(true, makeRegistrationData());
+
+    await handler(makeEvent(before, after));
+
+    expect(mocks.classFindById).toHaveBeenCalledWith('class-001');
+    expect(mocks.setQuantity).toHaveBeenCalledWith({
+      squareVariationId: 'SQ-VAR-1',
+      locationId: 'mock-location',
+      quantity: 7, // 10 - 3
+    });
+  });
+});
+
+describe('syncClassInventoryToSquare — non-count-relevant update', () => {
+  it('skips Square when only squarePaymentId / updatedAt changed', async () => {
+    const before = makeSnapshot(
+      true,
+      makeRegistrationData({ squarePaymentId: 'PAY-1', updatedAt: 'a' })
+    );
+    const after = makeSnapshot(
+      true,
+      makeRegistrationData({ squarePaymentId: 'PAY-2', updatedAt: 'b' })
+    );
+
+    await handler(makeEvent(before, after));
+
+    expect(mocks.classFindById).not.toHaveBeenCalled();
+    expect(mocks.setQuantity).not.toHaveBeenCalled();
+  });
+});
+
+describe('syncClassInventoryToSquare — delete (cancel)', () => {
+  it('recomputes and sets a higher remaining count', async () => {
+    // After the delete only 2 active registrations remain → remaining 8.
+    mocks.registrationCountByClassId.mockResolvedValue(2);
+
+    const before = makeSnapshot(true, makeRegistrationData());
+    const after = makeSnapshot(false);
+
+    await handler(makeEvent(before, after));
+
+    // classId sourced from the `before` snapshot when after is gone.
+    expect(mocks.classFindById).toHaveBeenCalledWith('class-001');
+    expect(mocks.setQuantity).toHaveBeenCalledWith({
+      squareVariationId: 'SQ-VAR-1',
+      locationId: 'mock-location',
+      quantity: 8, // 10 - 2
+    });
+  });
+});
+
+describe('syncClassInventoryToSquare — skips', () => {
+  it('skips when the class has no squareVariationId', async () => {
+    mocks.classFindById.mockResolvedValue(
+      makeClass({ squareVariationId: undefined })
+    );
+
+    const before = makeSnapshot(false);
+    const after = makeSnapshot(true, makeRegistrationData());
+
+    await handler(makeEvent(before, after));
+
+    expect(mocks.registrationCountByClassId).not.toHaveBeenCalled();
+    expect(mocks.setQuantity).not.toHaveBeenCalled();
+  });
+
+  it('skips when the class is not found', async () => {
+    mocks.classFindById.mockResolvedValue(undefined);
+
+    const before = makeSnapshot(false);
+    const after = makeSnapshot(true, makeRegistrationData());
+
+    await handler(makeEvent(before, after));
+
+    expect(mocks.registrationCountByClassId).not.toHaveBeenCalled();
+    expect(mocks.setQuantity).not.toHaveBeenCalled();
+  });
+});
+
+describe('syncClassInventoryToSquare — oversold clamp', () => {
+  it('clamps quantity to 0 when count exceeds capacity', async () => {
+    mocks.classFindById.mockResolvedValue(makeClass({ capacity: 5 }));
+    mocks.registrationCountByClassId.mockResolvedValue(8);
+
+    const before = makeSnapshot(false);
+    const after = makeSnapshot(true, makeRegistrationData());
+
+    await handler(makeEvent(before, after));
+
+    expect(mocks.setQuantity).toHaveBeenCalledWith({
+      squareVariationId: 'SQ-VAR-1',
+      locationId: 'mock-location',
+      quantity: 0, // Math.max(5 - 8, 0)
+    });
+  });
+});
+
+describe('syncClassInventoryToSquare — Square API error', () => {
+  it('swallows Square errors and does not reject', async () => {
+    mocks.setQuantity.mockRejectedValue(new Error('Square down'));
+
+    const before = makeSnapshot(false);
+    const after = makeSnapshot(true, makeRegistrationData());
+
+    await expect(handler(makeEvent(before, after))).resolves.toBeUndefined();
+    expect(mocks.setQuantity).toHaveBeenCalled();
+  });
+});

--- a/libs/firebase/maple-functions/sync-class-inventory-to-square/src/lib/sync-class-inventory-to-square.ts
+++ b/libs/firebase/maple-functions/sync-class-inventory-to-square/src/lib/sync-class-inventory-to-square.ts
@@ -1,0 +1,135 @@
+/**
+ * Sync Class Inventory to Square Cloud Function
+ *
+ * Firestore trigger on `registrations/{registrationId}` that mirrors
+ * remaining-seat counts to Square inventory so POS staff see the right
+ * stock when ringing up a class. Firestore is the source of truth for
+ * class capacity; Square inventory is a write-through projection.
+ *
+ * Strategy: on every count-relevant write (create / delete / status or
+ * quantity change), recompute the registration count and PHYSICAL_COUNT
+ * the Square variation to `(capacity - count)`. PHYSICAL_COUNT is
+ * idempotent — preferred over delta-based ADJUSTMENT because two near-
+ * simultaneous registration writes can't double-decrement.
+ *
+ * Skips:
+ * - Writes that don't change classId/status/quantity (mirror of the
+ *   `sync-registration-count` guard — prevents trigger churn).
+ * - Classes with no `squareVariationId` (not yet synced to Square; the
+ *   `syncClassToSquare` trigger will set inventory when it runs).
+ *
+ * Note on Square's echo: setting inventory here makes Square emit an
+ * `inventory.count.updated` webhook for this catalog_object_id. The
+ * squareWebhook handler (`handleInventoryUpdate`) only matches variations
+ * tracked in ProductRepository; class variations live on the Class doc, so
+ * the echo falls through as "untracked" and is ignored. No echo guard is
+ * needed (unlike the store-product inventory path).
+ */
+import {
+  onDocumentWritten,
+  type Change,
+  type DocumentSnapshot,
+} from 'firebase-functions/v2/firestore';
+import { defineSecret, defineString } from 'firebase-functions/params';
+import {
+  Square,
+  SQUARE_SECRET_NAMES,
+  SQUARE_STRING_NAMES,
+} from '@maple/firebase/square';
+import {
+  ClassRepository,
+  RegistrationRepository,
+} from '@maple/firebase/database';
+
+const squareSecretParams = SQUARE_SECRET_NAMES.map((name) =>
+  defineSecret(name)
+);
+const squareStringParams = SQUARE_STRING_NAMES.map((name) =>
+  defineString(name)
+);
+
+function extractClassId(snapshot: DocumentSnapshot | undefined): string | null {
+  if (!snapshot || !snapshot.exists) return null;
+  const data = snapshot.data();
+  return (data?.['classId'] as string | undefined) ?? null;
+}
+
+const COUNT_RELEVANT_FIELDS = ['classId', 'status', 'quantity'] as const;
+
+function isCountRelevantChange(
+  before: DocumentSnapshot | undefined,
+  after: DocumentSnapshot | undefined
+): boolean {
+  const beforeExists = before?.exists ?? false;
+  const afterExists = after?.exists ?? false;
+  if (!beforeExists || !afterExists) return true;
+
+  const beforeData = before!.data();
+  const afterData = after!.data();
+  if (!beforeData || !afterData) return true;
+
+  return COUNT_RELEVANT_FIELDS.some(
+    (field) => beforeData[field] !== afterData[field]
+  );
+}
+
+export const syncClassInventoryToSquare = onDocumentWritten(
+  {
+    document: 'registrations/{registrationId}',
+    region: 'us-east4',
+    secrets: squareSecretParams,
+  },
+  async (event) => {
+    const change: Change<DocumentSnapshot> = event.data!;
+
+    if (!isCountRelevantChange(change.before, change.after)) {
+      return;
+    }
+
+    const classId =
+      extractClassId(change.after) ?? extractClassId(change.before);
+    if (!classId) {
+      console.log('Registration write has no classId, skipping Square inventory sync');
+      return;
+    }
+
+    const classEntity = await ClassRepository.findById(classId);
+    if (!classEntity) {
+      console.log('Class not found, skipping Square inventory sync', { classId });
+      return;
+    }
+
+    if (!classEntity.squareVariationId) {
+      return;
+    }
+
+    const registrationCount = await RegistrationRepository.countByClassId(classId);
+    const remaining = Math.max(classEntity.capacity - registrationCount, 0);
+
+    const secrets = Object.fromEntries(
+      squareSecretParams.map((s) => [s.name, s.value()])
+    ) as Record<(typeof SQUARE_SECRET_NAMES)[number], string>;
+    const strings = Object.fromEntries(
+      squareStringParams.map((s) => [s.name, s.value()])
+    ) as Record<(typeof SQUARE_STRING_NAMES)[number], string>;
+
+    const square = new Square(secrets, strings);
+
+    try {
+      console.log('Syncing class inventory to Square', {
+        classId,
+        squareVariationId: classEntity.squareVariationId,
+        capacity: classEntity.capacity,
+        registrationCount,
+        remaining,
+      });
+      await square.inventoryService.setQuantity({
+        squareVariationId: classEntity.squareVariationId,
+        locationId: square.locationId,
+        quantity: remaining,
+      });
+    } catch (error) {
+      console.error('Square inventory sync error (class):', error);
+    }
+  }
+);

--- a/libs/firebase/maple-functions/sync-class-inventory-to-square/tsconfig.json
+++ b/libs/firebase/maple-functions/sync-class-inventory-to-square/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/sync-class-inventory-to-square/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/sync-class-inventory-to-square/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/sync-class-inventory-to-square/vitest.config.ts
+++ b/libs/firebase/maple-functions/sync-class-inventory-to-square/vitest.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  root: __dirname,
+  test: {
+    name: 'firebase-maple-functions-sync-class-inventory-to-square',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov', 'json-summary', 'json'],
+      reportsDirectory:
+        '../../../../coverage/libs/firebase/maple-functions/sync-class-inventory-to-square',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.spec.ts', 'src/index.ts'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@maple/ts/domain': resolve(__dirname, '../../../ts/domain/src/index.ts'),
+      '@maple/ts/firebase/api-types': resolve(
+        __dirname,
+        '../../../ts/firebase/api-types/src/index.ts'
+      ),
+      '@maple/firebase/database': resolve(
+        __dirname,
+        '../../../firebase/database/src/index.ts'
+      ),
+      '@maple/firebase/square': resolve(
+        __dirname,
+        '../../../firebase/square/src/index.ts'
+      ),
+      '@maple/firebase/functions': resolve(
+        __dirname,
+        '../../../firebase/functions/src/index.ts'
+      ),
+    },
+  },
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -487,6 +487,9 @@
       "@maple/firebase/maple-functions/sync-class-to-square": [
         "libs/firebase/maple-functions/sync-class-to-square/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/sync-class-inventory-to-square": [
+        "libs/firebase/maple-functions/sync-class-inventory-to-square/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/record-sale": [
         "libs/firebase/maple-functions/record-sale/src/index.ts"
       ],


### PR DESCRIPTION
PR B of 3 in the in-person Square POS class-registration plan. **Stacked on #583 (PR A)** — review/merge that first; this PR's base is `feat/sync-class-catalog-to-square`, so its diff shows only the inventory-mirror changes.

## What this does
Firestore trigger `syncClassInventoryToSquare` on `registrations/{id}` (maple-square codebase). On any **count-relevant** write (create/delete, or a change to `classId`/`status`/`quantity`), it recomputes the class's registration count and PHYSICAL_COUNTs the class's Square variation to `Math.max(capacity − count, 0)`. This keeps in-person POS stock accurate as web registrations come and go.

- **Idempotent** — `PHYSICAL_COUNT` (absolute set), not delta `ADJUSTMENT`, so two near-simultaneous registration writes can't double-decrement.
- Reuses the same `COUNT_RELEVANT_FIELDS` guard as `sync-registration-count` to avoid trigger churn on unrelated writes (`squarePaymentId`, `updatedAt`, …).
- Skips classes without a `squareVariationId` (not yet synced by PR A's `syncClassToSquare` — which seeds inventory itself when it runs).

## No webhook echo guard needed (a simplification vs. the old #416)
Setting class inventory makes Square emit an `inventory.count.updated` webhook echo. The `squareWebhook` handler (`handleInventoryUpdate`) only matches variations tracked in `ProductRepository`; class variations live on the `Class` doc, so the echo already falls through as "untracked" and is ignored. The old #416 added a dedicated skip guard for this — it's dead weight on current `main`, so it's intentionally omitted.

## Tests
- **Unit** (7): count-relevant create → `(capacity−count)`; non-count-relevant update → no call; delete/cancel → recompute; no `squareVariationId` → skip; class not found → skip; oversold clamp → 0; Square throws → swallowed.
- **Integration** (real emulator + Square mock, in the `class-square` suite from PR A) — all green locally:
  - registration created (qty 2, cap 10) → Square mock receives PHYSICAL_COUNT `= 8` on the class variation
  - non-count-relevant update (adds `squarePaymentId`) → **zero** inventory calls (guard holds)
  - registration cancelled → recomputes to full capacity (`= 10`)

## Verification
- [x] unit tests, `functions-square:build`, `maple-spruce:typecheck` pass
- [x] `./tools/validate-function-tsconfigs.sh`, `tools/check-firestore-indexes.ts` (no new index) pass
- [x] `class-square` integration suite (both spec files) passes locally via `run-integration-tests.sh`

## Next
- **PR C** — POS `order`/`payment` webhook → create a `source:'pos'` registration (dedup via the order's existing `referenceId`) + missing-email admin alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
