### PR TITLE
feat(portal): add a Waitlist count column to the classes list

### DIFF
--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -116,6 +116,7 @@ export { getMusicTogetherRoster } from '@maple/firebase/maple-functions/get-musi
 export { getRelatedPublicClasses } from '@maple/firebase/maple-functions/get-related-public-classes';
 export { addToClassWaitlist } from '@maple/firebase/maple-functions/add-to-class-waitlist';
 export { getClassWaitlist } from '@maple/firebase/maple-functions/get-class-waitlist';
+export { getClassWaitlistCounts } from '@maple/firebase/maple-functions/get-class-waitlist-counts';
 export { notifyWaitlistOnSpotOpen } from '@maple/firebase/maple-functions/notify-waitlist-on-spot-open';
 
 // Public class catalog feed (RSS 2.0 for Meta Commerce Manager + Google Merchant Center)

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -133,6 +133,7 @@
     "../../libs/firebase/maple-functions/update-music-together-semester/**/*.ts",
     "../../libs/firebase/maple-functions/get-music-together-roster/**/*.ts",
     "../../libs/firebase/maple-functions/get-class-waitlist/**/*.ts",
+    "../../libs/firebase/maple-functions/get-class-waitlist-counts/**/*.ts",
     "../../libs/firebase/database/src/**/*.ts",
     "../../libs/firebase/functions/src/**/*.ts",
     "../../libs/ts/domain/src/**/*.ts",

--- a/apps/maple-spruce/src/app/(admin)/classes/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/classes/page.tsx
@@ -17,6 +17,7 @@ import {
   useInstructors,
   useClassCategories,
   useRegistrations,
+  useClassWaitlistCounts,
 } from '../../../hooks';
 
 export default function ClassesPage() {
@@ -66,6 +67,17 @@ export default function ClassesPage() {
     }
     return counts;
   }, [registrationsState]);
+
+  // Waitlist counts per class (classId → count), for the "Waitlist" column.
+  const { waitlistCountsState } = useClassWaitlistCounts();
+  const waitlistCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    if (waitlistCountsState.status !== 'success') return counts;
+    for (const [classId, count] of Object.entries(waitlistCountsState.data)) {
+      counts.set(classId, count);
+    }
+    return counts;
+  }, [waitlistCountsState]);
 
   const instructors = useMemo(
     () => (instructorsState.status === 'success' ? instructorsState.data : []),
@@ -221,6 +233,7 @@ export default function ClassesPage() {
         instructors={instructors}
         categories={categories}
         registrationCounts={registrationCounts}
+        waitlistCounts={waitlistCounts}
         onEdit={handleOpenForm}
         onDelete={handleOpenDelete}
         onDuplicate={handleDuplicate}

--- a/apps/maple-spruce/src/hooks/index.ts
+++ b/apps/maple-spruce/src/hooks/index.ts
@@ -13,6 +13,7 @@ export {
   useDiscounts,
   useRegistrations,
   useClassWaitlist,
+  useClassWaitlistCounts,
   useCalendarEvents,
   useArtistPayouts,
   useAgreementTemplates,

--- a/docs/reference/deployed-functions.md
+++ b/docs/reference/deployed-functions.md
@@ -39,6 +39,7 @@ Core CRUD operations, auth, triggers, and admin functions. No heavy third-party 
 - `getRelatedPublicClasses` _(public; same-category siblings with future sessions + spots remaining; powers the sold-out widget's "other dates" list)_
 - `addToClassWaitlist` _(public; idempotent email signup stored under `classes/{id}/waitlist/{emailKey}`)_
 - `getClassWaitlist` _(admin; returns a class's waitlist entries ordered earliest-signup-first plus a count; powers the portal roster's Waitlist section)_
+- `getClassWaitlistCounts` _(admin; `classId -> count` map for every class via a `waitlist` collection-group scan, filtered to `classes` parents; powers the classes-list Waitlist column)_
 - `notifyWaitlistOnSpotOpen` _(Firestore trigger on `registrations/{id}`; on active → inactive transition or delete, queues `class-spot-available` mail to every waitlist email then clears the subcollection)_
 - `classCatalogFeed` _(public RSS 2.0 feed at `/catalog/classes.xml`; consumed by Meta Commerce Manager + Google Merchant Center; 15-min cache)_
 

--- a/libs/firebase/database/src/lib/class-waitlist.repository.spec.ts
+++ b/libs/firebase/database/src/lib/class-waitlist.repository.spec.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   set: vi.fn(),
   get: vi.fn(),
   collectionGet: vi.fn(),
+  collectionGroupGet: vi.fn(),
   countGet: vi.fn(),
   count: vi.fn(),
   batchSet: vi.fn(),
@@ -30,6 +31,7 @@ vi.mock('./utilities/database.config', () => {
   };
   const db = {
     collection: () => collection,
+    collectionGroup: () => ({ get: mocks.collectionGroupGet }),
     batch: () => ({
       delete: mocks.batchDelete,
       set: mocks.batchSet,
@@ -152,6 +154,44 @@ describe('ClassWaitlistRepository.countByClassId', () => {
     mocks.countGet.mockResolvedValue({ data: () => ({ count: 7 }) });
     const result = await ClassWaitlistRepository.countByClassId('class-1');
     expect(result).toBe(7);
+  });
+});
+
+describe('ClassWaitlistRepository.countsByClass', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // A `waitlist` collection-group doc: `<topCollection>/<parentId>/waitlist/<id>`.
+  const groupDoc = (topCollection: string, parentId: string) => ({
+    ref: {
+      parent: {
+        // the waitlist subcollection; its parent is the class/section doc
+        parent: { id: parentId, parent: { id: topCollection } },
+      },
+    },
+  });
+
+  it('tallies per class and excludes the Music Together waitlist', async () => {
+    mocks.collectionGroupGet.mockResolvedValue({
+      docs: [
+        groupDoc('classes', 'class-1'),
+        groupDoc('classes', 'class-1'),
+        groupDoc('classes', 'class-2'),
+        // Same `waitlist` subcollection name under MT — must NOT be counted.
+        groupDoc('musicTogetherSections', 'section-9'),
+      ],
+    });
+
+    const result = await ClassWaitlistRepository.countsByClass();
+
+    expect(result).toEqual({ 'class-1': 2, 'class-2': 1 });
+    expect(result['section-9']).toBeUndefined();
+  });
+
+  it('returns an empty map when no waitlists exist', async () => {
+    mocks.collectionGroupGet.mockResolvedValue({ docs: [] });
+    expect(await ClassWaitlistRepository.countsByClass()).toEqual({});
   });
 });
 

--- a/libs/firebase/database/src/lib/class-waitlist.repository.ts
+++ b/libs/firebase/database/src/lib/class-waitlist.repository.ts
@@ -89,6 +89,30 @@ export const ClassWaitlistRepository = {
   },
 
   /**
+   * Waitlist counts for every class in one pass, as a `classId -> count` map
+   * (classes with no waitlist are simply absent). Powers the classes-list
+   * "Waitlist" column so the admin doesn't have to open each roster.
+   *
+   * Uses a `waitlist` collection-group scan. The Music Together waitlist also
+   * lives in a `waitlist` subcollection, so we must keep only entries whose
+   * grandparent is the top-level `classes` collection — otherwise MT signups
+   * would leak in under a sectionId masquerading as a classId.
+   */
+  async countsByClass(): Promise<Record<string, number>> {
+    const snapshot = await getDb().collectionGroup(SUBCOLLECTION).get();
+    const counts: Record<string, number> = {};
+    for (const doc of snapshot.docs) {
+      const parentClassDoc = doc.ref.parent.parent;
+      // parentClassDoc.parent is the top-level collection the doc belongs to.
+      if (!parentClassDoc || parentClassDoc.parent.id !== PARENT_COLLECTION) {
+        continue;
+      }
+      counts[parentClassDoc.id] = (counts[parentClassDoc.id] ?? 0) + 1;
+    }
+    return counts;
+  },
+
+  /**
    * Delete every entry for a class. Used after a broadcast notification
    * fires so we don't re-email everyone on the next cancellation.
    */

--- a/libs/firebase/maple-functions/get-class-waitlist-counts/project.json
+++ b/libs/firebase/maple-functions/get-class-waitlist-counts/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-get-class-waitlist-counts",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/get-class-waitlist-counts/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/get-class-waitlist-counts/src/index.ts
+++ b/libs/firebase/maple-functions/get-class-waitlist-counts/src/index.ts
@@ -1,0 +1,1 @@
+export { getClassWaitlistCounts } from './lib/get-class-waitlist-counts';

--- a/libs/firebase/maple-functions/get-class-waitlist-counts/src/lib/get-class-waitlist-counts.spec.ts
+++ b/libs/firebase/maple-functions/get-class-waitlist-counts/src/lib/get-class-waitlist-counts.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  countsByClass: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/functions', () => ({
+  createAdminFunction: <Req, Res>(handler: (data: Req) => Promise<Res>) =>
+    handler,
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  ClassWaitlistRepository: {
+    countsByClass: mocks.countsByClass,
+  },
+}));
+
+import { getClassWaitlistCounts } from './get-class-waitlist-counts';
+
+const handler = getClassWaitlistCounts as unknown as (
+  data: Record<string, never>
+) => Promise<{ counts: Record<string, number> }>;
+
+describe('getClassWaitlistCounts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the repository counts map verbatim', async () => {
+    mocks.countsByClass.mockResolvedValue({ 'class-1': 3, 'class-2': 1 });
+
+    const result = await handler({});
+
+    expect(mocks.countsByClass).toHaveBeenCalledOnce();
+    expect(result).toEqual({ counts: { 'class-1': 3, 'class-2': 1 } });
+  });
+
+  it('returns an empty map when no class has a waitlist', async () => {
+    mocks.countsByClass.mockResolvedValue({});
+
+    const result = await handler({});
+
+    expect(result).toEqual({ counts: {} });
+  });
+});

--- a/libs/firebase/maple-functions/get-class-waitlist-counts/src/lib/get-class-waitlist-counts.ts
+++ b/libs/firebase/maple-functions/get-class-waitlist-counts/src/lib/get-class-waitlist-counts.ts
@@ -1,0 +1,23 @@
+/**
+ * Get Class Waitlist Counts Cloud Function
+ *
+ * Returns a `classId -> waitlist count` map for every class in one call.
+ * Admin-only, used by the classes-list "Waitlist" column so the count is
+ * visible at a glance without opening each roster.
+ *
+ * Deployed to us-east4 via CI/CD pipeline.
+ */
+import { createAdminFunction } from '@maple/firebase/functions';
+import { ClassWaitlistRepository } from '@maple/firebase/database';
+import type {
+  GetClassWaitlistCountsRequest,
+  GetClassWaitlistCountsResponse,
+} from '@maple/ts/firebase/api-types';
+
+export const getClassWaitlistCounts = createAdminFunction<
+  GetClassWaitlistCountsRequest,
+  GetClassWaitlistCountsResponse
+>(async () => {
+  const counts = await ClassWaitlistRepository.countsByClass();
+  return { counts };
+});

--- a/libs/firebase/maple-functions/get-class-waitlist-counts/tsconfig.json
+++ b/libs/firebase/maple-functions/get-class-waitlist-counts/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/get-class-waitlist-counts/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/get-class-waitlist-counts/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/react/classes/src/lib/ClassTable.tsx
+++ b/libs/react/classes/src/lib/ClassTable.tsx
@@ -37,6 +37,8 @@ interface ClassTableProps {
   categories?: ClassCategory[];
   /** Map of classId → number of active (pending+confirmed) registrations. */
   registrationCounts?: Map<string, number>;
+  /** Map of classId → number of people on the class waitlist. */
+  waitlistCounts?: Map<string, number>;
   onEdit: (classItem: Class) => void;
   onDelete: (classItem: Class) => void;
   onDuplicate?: (classItem: Class) => void;
@@ -70,6 +72,7 @@ interface ClassRow {
   categoryName: string;
   filled: number;
   capacity: number;
+  waitlist: number;
   priceCents: number;
   status: Class['status'];
 }
@@ -79,6 +82,7 @@ export function ClassTable({
   instructors = [],
   categories = [],
   registrationCounts,
+  waitlistCounts,
   onEdit,
   onDelete,
   onDuplicate,
@@ -120,11 +124,12 @@ export function ClassTable({
           : '—',
         filled: registrationCounts?.get(classItem.id) ?? 0,
         capacity: classItem.capacity,
+        waitlist: waitlistCounts?.get(classItem.id) ?? 0,
         priceCents: classItem.priceCents,
         status: classItem.status,
       };
     });
-  }, [classesState, instructorMap, categoryMap, registrationCounts]);
+  }, [classesState, instructorMap, categoryMap, registrationCounts, waitlistCounts]);
 
   const columns: GridColDef<ClassRow>[] = useMemo(
     () => [
@@ -254,6 +259,24 @@ export function ClassTable({
               {filled}/{capacity}
             </Typography>
           );
+        },
+      },
+      {
+        field: 'waitlist',
+        headerName: 'Waitlist',
+        width: 100,
+        type: 'number',
+        valueGetter: (_value, row) => row.waitlist,
+        renderCell: (params: GridRenderCellParams<ClassRow>) => {
+          const { waitlist } = params.row;
+          if (waitlist === 0) {
+            return (
+              <Typography variant="body2" color="text.disabled">
+                —
+              </Typography>
+            );
+          }
+          return <Chip label={waitlist} size="small" color="primary" />;
         },
       },
       {

--- a/libs/react/data/src/index.ts
+++ b/libs/react/data/src/index.ts
@@ -87,6 +87,7 @@ export {
   type UseRegistrationsFilters,
 } from './lib/useRegistrations';
 export { useClassWaitlist } from './lib/useClassWaitlist';
+export { useClassWaitlistCounts } from './lib/useClassWaitlistCounts';
 
 // User & role administration
 export { useUsers } from './lib/useUsers';

--- a/libs/react/data/src/lib/useClassWaitlistCounts.ts
+++ b/libs/react/data/src/lib/useClassWaitlistCounts.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { callDeduped } from './call-deduped';
+import type { RequestState } from '@maple/ts/domain';
+import type {
+  GetClassWaitlistCountsRequest,
+  GetClassWaitlistCountsResponse,
+} from '@maple/ts/firebase/api-types';
+
+/**
+ * Hook for reading waitlist counts for every class in one call (admin).
+ * Returns a `classId -> count` map as a RequestState — mirrors how the
+ * classes list derives registration counts. No mutations.
+ */
+export function useClassWaitlistCounts() {
+  const [waitlistCountsState, setWaitlistCountsState] = useState<
+    RequestState<Record<string, number>>
+  >({ status: 'idle' });
+
+  const fetchWaitlistCounts = useCallback(async () => {
+    setWaitlistCountsState({ status: 'loading' });
+
+    try {
+      const result = await callDeduped<
+        GetClassWaitlistCountsRequest,
+        GetClassWaitlistCountsResponse
+      >('getClassWaitlistCounts', {});
+      setWaitlistCountsState({ status: 'success', data: result.data.counts });
+    } catch (error) {
+      console.error('Failed to fetch class waitlist counts:', error);
+      setWaitlistCountsState({
+        status: 'error',
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to fetch class waitlist counts',
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchWaitlistCounts();
+  }, [fetchWaitlistCounts]);
+
+  return { waitlistCountsState, fetchWaitlistCounts };
+}

--- a/libs/ts/firebase/api-types/src/lib/class-waitlist.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/class-waitlist.types.ts
@@ -50,3 +50,15 @@ export interface GetClassWaitlistResponse {
   /** Total number of entries (equals `entries.length`; sent explicitly for convenience). */
   count: number;
 }
+
+// ============================================================================
+// Get Class Waitlist Counts (admin — classes-list column)
+// ============================================================================
+
+/** No filters — returns waitlist counts for every class in one call. */
+export type GetClassWaitlistCountsRequest = Record<string, never>;
+
+export interface GetClassWaitlistCountsResponse {
+  /** `classId -> waitlist entry count`. Classes with no waitlist are omitted. */
+  counts: Record<string, number>;
+}

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -189,6 +189,8 @@ export type {
   GetRelatedPublicClassesResponse,
   GetClassWaitlistRequest,
   GetClassWaitlistResponse,
+  GetClassWaitlistCountsRequest,
+  GetClassWaitlistCountsResponse,
 } from './class-waitlist.types';
 
 // Phase 3c: Discount types

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -314,6 +314,9 @@
       "@maple/firebase/maple-functions/get-class-waitlist": [
         "libs/firebase/maple-functions/get-class-waitlist/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/get-class-waitlist-counts": [
+        "libs/firebase/maple-functions/get-class-waitlist-counts/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/get-registration": [
         "libs/firebase/maple-functions/get-registration/src/index.ts"
       ],


### PR DESCRIPTION
## What

Surfaces each class's **waitlist count** as a column on the main classes list, so demand is visible at a glance without drilling into each roster.

- **Zero** waitlist → muted `—`
- **>0** → a primary Chip with the count

## Changes

- **`getClassWaitlistCounts`** admin callable (maple-core) — returns a `classId → count` map for all classes in one call.
- **`ClassWaitlistRepository.countsByClass()`** — a single `waitlist` collection-group scan. ⚠️ The Music Together waitlist reuses the same `waitlist` subcollection name, so entries whose grandparent isn't the top-level `classes` collection are filtered out (otherwise MT signups would show up under a sectionId posing as a classId). Covered by a test.
- **`useClassWaitlistCounts`** hook — `RequestState<Record<string,number>>`, mirroring how the page already derives registration counts.
- **`ClassTable`** — new "Waitlist" column beside "Filled".

## Testing

- Unit tests: count tally + MT-exclusion (`countsByClass`), and the callable (map passthrough + empty).
- `api-types`, `data`, `firebase-database`, and the new function typecheck + lint clean; `apps/maple-spruce` typechecks clean.
- Firestore-index analyzer passes — a bare collection-group `get()` needs no composite index.

## Depends on / related

- Sibling of #586 (roster Waitlist section) and #585 (slug fix).
- ⚠️ **Deploy note:** the new `getClassWaitlistCounts` function only deploys if this PR's merge deploy runs to completion. #586's `getClassWaitlist` was orphaned when a back-to-back merge cancelled its deploy — let this one's "Deploy on merge" finish (and approve the prod gate) before merging anything else.