### PR TITLE
feat(music-together): section explicit controls + derived status (#581, #582)

### DIFF
--- a/apps/functions-integration-tests-music-together/src/cancel-music-together-registration.spec.ts
+++ b/apps/functions-integration-tests-music-together/src/cancel-music-together-registration.spec.ts
@@ -69,7 +69,8 @@ describe('cancelMusicTogetherRegistration', () => {
       sessions: [{ dateTime: future }],
       capacityFamilies: 8,
       priceFullCents: 25200,
-      status: 'open',
+      visible: true,
+      enrollmentActive: true,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     });
@@ -78,7 +79,8 @@ describe('cancelMusicTogetherRegistration', () => {
       sessions: [{ dateTime: pastDate }],
       capacityFamilies: 8,
       priceFullCents: 25200,
-      status: 'open',
+      visible: true,
+      enrollmentActive: true,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     });

--- a/apps/functions-integration-tests-music-together/src/create-music-together-registration.spec.ts
+++ b/apps/functions-integration-tests-music-together/src/create-music-together-registration.spec.ts
@@ -33,7 +33,8 @@ function sectionDoc(overrides: Record<string, unknown> = {}) {
       { amountCents: 13200, dueAt: week1 },
       { amountCents: 13200, dueAt: week5 },
     ],
-    status: 'open',
+    visible: true,
+    enrollmentActive: true,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     ...overrides,
@@ -68,7 +69,7 @@ describe('createMusicTogetherRegistration', () => {
     await setFirestoreDoc(
       'musicTogetherSections',
       'sec-draft',
-      sectionDoc({ status: 'draft' })
+      sectionDoc({ enrollmentActive: false })
     );
     await setFirestoreDoc(
       'musicTogetherSections',

--- a/apps/functions-integration-tests-music-together/src/music-together-admin.spec.ts
+++ b/apps/functions-integration-tests-music-together/src/music-together-admin.spec.ts
@@ -37,7 +37,8 @@ function createInput(
       { amountCents: 13200, dueAt: week1 },
       { amountCents: 13200, dueAt: week5 },
     ],
-    status: 'open',
+    visible: true,
+    enrollmentActive: true,
     ...overrides,
   };
 }
@@ -165,7 +166,8 @@ describe('getMusicTogetherRoster', () => {
       sessions: [{ dateTime: week1 }],
       capacityFamilies: 8,
       priceFullCents: 25200,
-      status: 'open',
+      visible: true,
+      enrollmentActive: true,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     });

--- a/apps/functions-integration-tests-music-together/src/public-music-together.spec.ts
+++ b/apps/functions-integration-tests-music-together/src/public-music-together.spec.ts
@@ -30,7 +30,8 @@ function sectionDoc(overrides: Record<string, unknown> = {}) {
       { amountCents: 13200, dueAt: week1 },
       { amountCents: 13200, dueAt: week5 },
     ],
-    status: 'open',
+    visible: true,
+    enrollmentActive: true,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     ...overrides,
@@ -62,7 +63,7 @@ describe('getPublicMusicTogetherSection', () => {
     await setFirestoreDoc(
       'musicTogetherSections',
       'sec-pub-draft',
-      sectionDoc({ status: 'draft' })
+      sectionDoc({ visible: false })
     );
     // two confirmed families → 6 of 8 spots remaining
     await setFirestoreDoc(
@@ -124,12 +125,12 @@ describe('addToMusicTogetherWaitlist', () => {
     await setFirestoreDoc(
       'musicTogetherSections',
       'sec-wl',
-      sectionDoc({ status: 'closed' })
+      sectionDoc({ enrollmentActive: false })
     );
     await setFirestoreDoc(
       'musicTogetherSections',
       'sec-wl-draft',
-      sectionDoc({ status: 'draft' })
+      sectionDoc({ visible: false })
     );
   });
 

--- a/apps/maple-spruce/src/app/(admin)/music-together/SectionFormDialog.stories.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/SectionFormDialog.stories.tsx
@@ -28,7 +28,8 @@ const mockSection: MusicTogetherSection = {
     { amountCents: 13200, dueAt: new Date('2030-04-02T14:00:00Z') },
     { amountCents: 13200, dueAt: new Date('2030-04-30T14:00:00Z') },
   ],
-  status: 'open',
+  visible: true,
+  enrollmentActive: true,
   location: 'Studio',
   room: 'spruce',
   createdAt: new Date('2030-01-01T00:00:00Z'),
@@ -85,7 +86,8 @@ export const CreateSubmits: Story = {
       expect(args.onSubmit).toHaveBeenCalledWith(
         expect.objectContaining({
           name: 'Fall 2026',
-          status: 'draft',
+          visible: false,
+          enrollmentActive: false,
           capacityFamilies: 8,
           priceFullCents: 25200,
           sessions: [],

--- a/apps/maple-spruce/src/app/(admin)/music-together/SectionFormDialog.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/SectionFormDialog.tsx
@@ -14,6 +14,9 @@ import {
   IconButton,
   Stack,
   Divider,
+  Switch,
+  FormControlLabel,
+  Chip,
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
@@ -21,20 +24,13 @@ import {
   MT_DEFAULT_CAPACITY_FAMILIES,
   MT_PRICE_FULL_CENTS,
   MT_DEFAULT_INSTALLMENT_CENTS,
+  mtSectionDerivedStatus,
   type MusicTogetherSection,
   type MusicTogetherSemester,
   type CreateMusicTogetherSectionInput,
-  type MusicTogetherSectionStatus,
   ROOMS,
   getRoomLabel,
 } from '@maple/ts/domain';
-
-const STATUSES: MusicTogetherSectionStatus[] = [
-  'draft',
-  'open',
-  'closed',
-  'completed',
-];
 
 /** Date <-> <input type="datetime-local"> string (local time). */
 function toLocalInput(date: Date): string {
@@ -70,7 +66,11 @@ export function SectionFormDialog({
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [semesterId, setSemesterId] = useState('');
-  const [status, setStatus] = useState<MusicTogetherSectionStatus>('draft');
+  // Explicit controls — the overall status is derived from these (see the Chip).
+  const [visible, setVisible] = useState(false);
+  const [enrollmentActive, setEnrollmentActive] = useState(false);
+  const [enrollmentOpensAt, setEnrollmentOpensAt] = useState('');
+  const [enrollmentClosesAt, setEnrollmentClosesAt] = useState('');
   const [capacity, setCapacity] = useState(String(MT_DEFAULT_CAPACITY_FAMILIES));
   const [priceFull, setPriceFull] = useState(dollars(MT_PRICE_FULL_CENTS));
   const [location, setLocation] = useState('');
@@ -93,7 +93,18 @@ export function SectionFormDialog({
       setName(section.name);
       setDescription(section.description ?? '');
       setSemesterId(section.semesterId ?? '');
-      setStatus(section.status);
+      setVisible(section.visible);
+      setEnrollmentActive(section.enrollmentActive);
+      setEnrollmentOpensAt(
+        section.enrollmentOpensAt
+          ? toLocalInput(new Date(section.enrollmentOpensAt))
+          : ''
+      );
+      setEnrollmentClosesAt(
+        section.enrollmentClosesAt
+          ? toLocalInput(new Date(section.enrollmentClosesAt))
+          : ''
+      );
       setCapacity(String(section.capacityFamilies));
       setPriceFull(dollars(section.priceFullCents));
       setLocation(section.location ?? '');
@@ -109,7 +120,10 @@ export function SectionFormDialog({
       setName('');
       setDescription('');
       setSemesterId('');
-      setStatus('draft');
+      setVisible(false);
+      setEnrollmentActive(false);
+      setEnrollmentOpensAt('');
+      setEnrollmentClosesAt('');
       setCapacity(String(MT_DEFAULT_CAPACITY_FAMILIES));
       setPriceFull(dollars(MT_PRICE_FULL_CENTS));
       setLocation('');
@@ -125,7 +139,14 @@ export function SectionFormDialog({
       const input: CreateMusicTogetherSectionInput = {
         name: name.trim(),
         description: description.trim() || undefined,
-        status,
+        visible,
+        enrollmentActive,
+        enrollmentOpensAt: enrollmentOpensAt
+          ? fromLocalInput(enrollmentOpensAt)
+          : undefined,
+        enrollmentClosesAt: enrollmentClosesAt
+          ? fromLocalInput(enrollmentClosesAt)
+          : undefined,
         semesterId: semesterId || undefined,
         capacityFamilies: parseInt(capacity, 10),
         priceFullCents: toCents(priceFull),
@@ -165,6 +186,26 @@ export function SectionFormDialog({
     );
   const removeInstallmentAt = (idx: number) =>
     setInstallments((prev) => prev.filter((_, i) => i !== idx));
+
+  // Live preview of the derived status from the current control values (no
+  // family count in the form, so this never shows 'full').
+  const derivedStatus = mtSectionDerivedStatus(
+    {
+      visible,
+      enrollmentActive,
+      enrollmentOpensAt: enrollmentOpensAt
+        ? fromLocalInput(enrollmentOpensAt)
+        : undefined,
+      enrollmentClosesAt: enrollmentClosesAt
+        ? fromLocalInput(enrollmentClosesAt)
+        : undefined,
+      capacityFamilies: parseInt(capacity, 10) || 0,
+      sessions: sessions
+        .filter((s) => s)
+        .map((s) => ({ dateTime: fromLocalInput(s) })),
+    },
+    new Date()
+  );
 
   const prefillInstallments = () => {
     const firstSession = sessions[0]
@@ -216,22 +257,62 @@ export function SectionFormDialog({
               </MenuItem>
             ))}
           </TextField>
+          <Divider />
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+            }}
+          >
+            <Typography variant="subtitle2">Visibility &amp; enrollment</Typography>
+            <Chip
+              size="small"
+              label={derivedStatus}
+              color={derivedStatus === 'open' ? 'success' : 'default'}
+            />
+          </Box>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={visible}
+                onChange={(e) => setVisible(e.target.checked)}
+                inputProps={{ 'aria-label': 'Show on calendar and site' }}
+              />
+            }
+            label="Show on calendar &amp; site (registration can still be closed)"
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                checked={enrollmentActive}
+                onChange={(e) => setEnrollmentActive(e.target.checked)}
+                inputProps={{ 'aria-label': 'Enrollment active' }}
+              />
+            }
+            label="Enrollment active (accept registrations now)"
+          />
           <Box sx={{ display: 'flex', gap: 2 }}>
             <TextField
-              label="Status"
-              select
-              value={status}
-              onChange={(e) =>
-                setStatus(e.target.value as MusicTogetherSectionStatus)
-              }
+              label="Enrollment opens (optional)"
+              type="datetime-local"
+              value={enrollmentOpensAt}
+              onChange={(e) => setEnrollmentOpensAt(e.target.value)}
+              InputLabelProps={{ shrink: true }}
+              helperText="Auto-opens at this time when active"
               sx={{ flex: 1 }}
-            >
-              {STATUSES.map((s) => (
-                <MenuItem key={s} value={s}>
-                  {s}
-                </MenuItem>
-              ))}
-            </TextField>
+            />
+            <TextField
+              label="Enrollment closes (optional)"
+              type="datetime-local"
+              value={enrollmentClosesAt}
+              onChange={(e) => setEnrollmentClosesAt(e.target.value)}
+              InputLabelProps={{ shrink: true }}
+              sx={{ flex: 1 }}
+            />
+          </Box>
+          <Divider />
+          <Box sx={{ display: 'flex', gap: 2 }}>
             <TextField
               label="Capacity (families)"
               type="number"
@@ -239,8 +320,6 @@ export function SectionFormDialog({
               onChange={(e) => setCapacity(e.target.value)}
               sx={{ flex: 1 }}
             />
-          </Box>
-          <Box sx={{ display: 'flex', gap: 2 }}>
             <TextField
               label="Full price ($)"
               value={priceFull}

--- a/apps/maple-spruce/src/app/(admin)/music-together/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/page.tsx
@@ -21,6 +21,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import GroupIcon from '@mui/icons-material/Group';
 import {
   getMusicTogetherSeasonLabel,
+  mtSectionDerivedStatus,
   type MusicTogetherSection,
   type MusicTogetherSemester,
   type CreateMusicTogetherSectionInput,
@@ -273,11 +274,20 @@ export default function MusicTogetherPage() {
                     : '—'}
                 </TableCell>
                 <TableCell>
-                  <Chip
-                    size="small"
-                    label={section.status}
-                    color={section.status === 'open' ? 'success' : 'default'}
-                  />
+                  {(() => {
+                    const derived = mtSectionDerivedStatus(
+                      section,
+                      new Date(),
+                      countsBySection[section.id]?.families
+                    );
+                    return (
+                      <Chip
+                        size="small"
+                        label={derived}
+                        color={derived === 'open' ? 'success' : 'default'}
+                      />
+                    );
+                  })()}
                 </TableCell>
                 <TableCell>{fmtDate(section.sessions?.[0]?.dateTime)}</TableCell>
                 <TableCell>{section.capacityFamilies} families</TableCell>

--- a/apps/webflow-components/src/MusicTogetherRegistrationWidget.spec.tsx
+++ b/apps/webflow-components/src/MusicTogetherRegistrationWidget.spec.tsx
@@ -31,7 +31,7 @@ function makeSection(
     ],
     capacityFamilies: 8,
     spotsRemaining: 5,
-    status: 'open',
+    enrollmentOpen: true,
     ...overrides,
   };
 }
@@ -306,5 +306,21 @@ describe('MusicTogetherRegistrationWidget', () => {
       email: 'wait@example.com',
       availability: 'weekday mornings',
     });
+  });
+
+  it('shows an "opens soon" notice instead of the form when enrollment is closed', async () => {
+    nextSection = makeSection({
+      enrollmentOpen: false,
+      enrollmentOpensAt: '2026-10-01T13:00:00.000Z',
+    });
+    renderWidget();
+
+    expect(
+      await screen.findByText(/isn't open yet/i)
+    ).toBeInTheDocument();
+    // The registration form (Register button) must not render.
+    expect(
+      screen.queryByRole('button', { name: /Register — \$/i })
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/webflow-components/src/MusicTogetherRegistrationWidget.tsx
+++ b/apps/webflow-components/src/MusicTogetherRegistrationWidget.tsx
@@ -458,7 +458,22 @@ export function MusicTogetherRegistrationWidget({
           <WaitlistPanel section={section} functions={functions} />
         )}
 
-        {section && section.spotsRemaining > 0 && (
+        {section &&
+          section.spotsRemaining > 0 &&
+          !section.enrollmentOpen && (
+            <Alert severity="info">
+              Registration for <strong>{section.name}</strong> isn&apos;t open
+              yet
+              {section.enrollmentOpensAt
+                ? ` — it opens ${formatSessionDateTime(
+                    section.enrollmentOpensAt
+                  )}.`
+                : '.'}{' '}
+              Check back soon.
+            </Alert>
+          )}
+
+        {section && section.spotsRemaining > 0 && section.enrollmentOpen && (
           <Stack spacing={3}>
             {/* Section summary */}
             <Box>

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1399,38 +1399,6 @@
       "queryScope": "COLLECTION",
       "fields": [
         {
-          "fieldPath": "status",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "firstSessionAt",
-          "order": "ASCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "musicTogetherSections",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "semesterId",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "firstSessionAt",
-          "order": "ASCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "musicTogetherSections",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "status",
-          "order": "ASCENDING"
-        },
-        {
           "fieldPath": "semesterId",
           "order": "ASCENDING"
         },

--- a/libs/firebase/database/src/lib/music-together-section.repository.ts
+++ b/libs/firebase/database/src/lib/music-together-section.repository.ts
@@ -10,7 +10,6 @@ import {
   type MusicTogetherSection,
   type MusicTogetherSession,
   type MusicTogetherInstallmentPlanItem,
-  type MusicTogetherSectionStatus,
   type CreateMusicTogetherSectionInput,
   type UpdateMusicTogetherSectionInput,
 } from '@maple/ts/domain';
@@ -58,7 +57,16 @@ function docToSection(
     capacityFamilies: data.capacityFamilies,
     priceFullCents: data.priceFullCents,
     installmentPlan: parseInstallmentPlan(data.installmentPlan),
-    status: data.status as MusicTogetherSectionStatus,
+    // Explicit controls; status is derived, never stored. Default false so any
+    // pre-existing docs (which lacked these fields) read as hidden + paused.
+    visible: data.visible ?? false,
+    enrollmentActive: data.enrollmentActive ?? false,
+    enrollmentOpensAt: data.enrollmentOpensAt
+      ? toDate(data.enrollmentOpensAt)
+      : undefined,
+    enrollmentClosesAt: data.enrollmentClosesAt
+      ? toDate(data.enrollmentClosesAt)
+      : undefined,
     location: data.location,
     room: data.room,
     semesterId: data.semesterId,
@@ -82,11 +90,19 @@ function toPersisted(
   if (input.sessions) {
     data.firstSessionAt = mtSectionFirstSessionAt({ sessions: input.sessions });
   }
+  // Optional scheduled-enrollment dates are clearable: persist `null` (not
+  // `undefined`) when absent so `update()` actually removes a previously-set
+  // date instead of leaving it stale.
+  if ('enrollmentOpensAt' in input && !input.enrollmentOpensAt) {
+    data.enrollmentOpensAt = null;
+  }
+  if ('enrollmentClosesAt' in input && !input.enrollmentClosesAt) {
+    data.enrollmentClosesAt = null;
+  }
   return data;
 }
 
 export interface MusicTogetherSectionFilters {
-  status?: MusicTogetherSectionStatus;
   /** Only sections belonging to this semester. */
   semesterId?: string;
 }
@@ -96,10 +112,6 @@ export const MusicTogetherSectionRepository = {
     filters?: MusicTogetherSectionFilters
   ): Promise<MusicTogetherSection[]> {
     let query: FirebaseFirestore.Query = getDb().collection(COLLECTION);
-
-    if (filters?.status) {
-      query = query.where('status', '==', filters.status);
-    }
 
     if (filters?.semesterId) {
       query = query.where('semesterId', '==', filters.semesterId);

--- a/libs/firebase/maple-functions/add-to-music-together-waitlist/src/lib/add-to-music-together-waitlist.spec.ts
+++ b/libs/firebase/maple-functions/add-to-music-together-waitlist/src/lib/add-to-music-together-waitlist.spec.ts
@@ -54,7 +54,7 @@ const validEntry = {
 describe('addToMusicTogetherWaitlist', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.sectionFindById.mockResolvedValue({ id: 'sec-1', status: 'closed' });
+    mocks.sectionFindById.mockResolvedValue({ id: 'sec-1', visible: true });
     mocks.waitlistAdd.mockResolvedValue({ created: true });
   });
 
@@ -72,8 +72,12 @@ describe('addToMusicTogetherWaitlist', () => {
     expect(result.added).toBe(false);
   });
 
-  it('works for an open section too (no capacity gate)', async () => {
-    mocks.sectionFindById.mockResolvedValue({ id: 'sec-1', status: 'open' });
+  it('works for a visible section regardless of enrollment (no capacity gate)', async () => {
+    mocks.sectionFindById.mockResolvedValue({
+      id: 'sec-1',
+      visible: true,
+      enrollmentActive: true,
+    });
     const result = (await run(validEntry)) as { added: boolean };
     expect(result.added).toBe(true);
   });
@@ -89,8 +93,8 @@ describe('addToMusicTogetherWaitlist', () => {
     expect(mocks.waitlistAdd).not.toHaveBeenCalled();
   });
 
-  it('rejects a draft section', async () => {
-    mocks.sectionFindById.mockResolvedValue({ id: 'sec-1', status: 'draft' });
+  it('rejects a hidden section', async () => {
+    mocks.sectionFindById.mockResolvedValue({ id: 'sec-1', visible: false });
     await expect(run(validEntry)).rejects.toThrow(/not available/i);
   });
 });

--- a/libs/firebase/maple-functions/add-to-music-together-waitlist/src/lib/add-to-music-together-waitlist.ts
+++ b/libs/firebase/maple-functions/add-to-music-together-waitlist/src/lib/add-to-music-together-waitlist.ts
@@ -7,8 +7,8 @@
  * repeat signup with the same email returns `added: false` and keeps the
  * family's place in line.
  *
- * The section must exist and not be a draft; beyond that there is no capacity
- * gate (a family may want to be waitlisted even before a section fills).
+ * The section must exist and be publicly visible; beyond that there is no
+ * capacity gate (a family may want to be waitlisted even before a section fills).
  *
  * Deployed to us-east4 via CI/CD (maple-core codebase).
  */
@@ -50,7 +50,7 @@ export const addToMusicTogetherWaitlist = Functions.endpoint
     if (!section) {
       throwNotFound('Music Together section', data.sectionId);
     }
-    if (section.status === 'draft') {
+    if (!section.visible) {
       throwInvalidArgument(
         'This section is not available for waitlist signup'
       );

--- a/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.spec.ts
+++ b/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.spec.ts
@@ -116,7 +116,8 @@ function run(data: unknown) {
 const openFullOnly = {
   id: 'sec-1',
   name: 'Spring 2026',
-  status: 'open',
+  visible: true,
+  enrollmentActive: true,
   capacityFamilies: 8,
   priceFullCents: 25200,
   installmentPlan: undefined,
@@ -248,10 +249,24 @@ describe('createMusicTogetherRegistration', () => {
     expect(mocks.createPayment).not.toHaveBeenCalled();
   });
 
-  it('rejects a section that is not open', async () => {
-    mocks.sectionFindById.mockResolvedValue({ ...openFullOnly, status: 'closed' });
+  it('rejects a section whose enrollment is paused', async () => {
+    mocks.sectionFindById.mockResolvedValue({
+      ...openFullOnly,
+      enrollmentActive: false,
+    });
     await expect(run({ ...baseFamily, paymentPlan: 'full' })).rejects.toThrow(
-      /not open/i
+      /has closed/i
+    );
+  });
+
+  it("rejects a section whose enrollment hasn't opened yet", async () => {
+    mocks.sectionFindById.mockResolvedValue({
+      ...openFullOnly,
+      enrollmentActive: true,
+      enrollmentOpensAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    });
+    await expect(run({ ...baseFamily, paymentPlan: 'full' })).rejects.toThrow(
+      /isn't open yet/i
     );
   });
 

--- a/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.ts
+++ b/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.ts
@@ -43,6 +43,7 @@ import {
 import {
   MT_CAPACITY_STATUSES,
   mtSectionOffersInstallments,
+  mtSectionEnrollmentOpen,
 } from '@maple/ts/domain';
 import { musicTogetherRegistrationValidation } from '@maple/ts/validation';
 import type {
@@ -104,8 +105,21 @@ export const createMusicTogetherRegistration = Functions.endpoint
     if (!section) {
       throwNotFound('Music Together section', data.sectionId);
     }
-    if (section.status !== 'open') {
-      throwFailedPrecondition('This section is not open for registration.');
+    // Enrollment is gated by the explicit controls (live toggle + optional
+    // schedule), evaluated now — not a stored status. Capacity is enforced
+    // transactionally below, so the window-only check is used here.
+    const now = new Date();
+    if (!mtSectionEnrollmentOpen(section, now)) {
+      if (
+        section.enrollmentActive &&
+        section.enrollmentOpensAt &&
+        now < section.enrollmentOpensAt
+      ) {
+        throwFailedPrecondition(
+          "Registration for this section isn't open yet."
+        );
+      }
+      throwFailedPrecondition('Registration for this section has closed.');
     }
 
     // 3. Resolve the charge amounts from the section's configurable plan.
@@ -129,7 +143,6 @@ export const createMusicTogetherRegistration = Functions.endpoint
     // 4. Reserve the seat inside a transaction that enforces the family cap.
     const db = getDb();
     const regRef = MusicTogetherRegistrationRepository.getDocRef();
-    const now = new Date();
     const children = data.children.map((c) => ({
       name: c.name.trim(),
       dob: new Date(c.dob),

--- a/libs/firebase/maple-functions/get-music-together-sections/src/lib/get-music-together-sections.spec.ts
+++ b/libs/firebase/maple-functions/get-music-together-sections/src/lib/get-music-together-sections.spec.ts
@@ -29,17 +29,17 @@ describe('getMusicTogetherSections', () => {
     mocks.regFindAll.mockResolvedValue([]);
   });
 
-  it('returns sections, passing the status filter through', async () => {
+  it('returns sections, passing the semester filter through', async () => {
     mocks.findAll.mockResolvedValue([{ id: 'sec-1' }]);
-    const result = await handler({ status: 'open' }, {});
-    expect(mocks.findAll).toHaveBeenCalledWith({ status: 'open' });
+    const result = await handler({ semesterId: 'sem-1' }, {});
+    expect(mocks.findAll).toHaveBeenCalledWith({ semesterId: 'sem-1' });
     expect(result.sections).toEqual([{ id: 'sec-1' }]);
   });
 
   it('works with no filter', async () => {
     mocks.findAll.mockResolvedValue([]);
     const result = await handler({}, {});
-    expect(mocks.findAll).toHaveBeenCalledWith({ status: undefined });
+    expect(mocks.findAll).toHaveBeenCalledWith({ semesterId: undefined });
     expect(result.sections).toEqual([]);
   });
 

--- a/libs/firebase/maple-functions/get-music-together-sections/src/lib/get-music-together-sections.ts
+++ b/libs/firebase/maple-functions/get-music-together-sections/src/lib/get-music-together-sections.ts
@@ -2,8 +2,9 @@
  * Get Music Together Sections Cloud Function
  *
  * Lists Music Together sections for the admin app (authenticated). Optional
- * status filter. Also returns per-section registration counts so the admin
- * table can show how full each section is without opening the roster.
+ * semester filter. Also returns per-section registration counts so the admin
+ * table can show how full each section is without opening the roster. The
+ * section's overall status is DERIVED client-side from its explicit controls.
  * Deployed to us-east4 via CI/CD (maple-core codebase).
  */
 import { createAuthenticatedFunction } from '@maple/firebase/functions';
@@ -23,7 +24,7 @@ export const getMusicTogetherSections = createAuthenticatedFunction<
   GetMusicTogetherSectionsResponse
 >(async (data) => {
   const sections = await MusicTogetherSectionRepository.findAll({
-    status: data.status,
+    semesterId: data.semesterId,
   });
 
   // Per-section registration counts in one query, grouped in memory. Count the

--- a/libs/firebase/maple-functions/get-public-music-together-section/src/lib/get-public-music-together-section.spec.ts
+++ b/libs/firebase/maple-functions/get-public-music-together-section/src/lib/get-public-music-together-section.spec.ts
@@ -34,7 +34,8 @@ const section = {
   id: 'sec-1',
   name: 'Spring 2026',
   description: 'Tuesdays 10am',
-  status: 'open',
+  visible: true,
+  enrollmentActive: true,
   capacityFamilies: 8,
   priceFullCents: 25200,
   sessions: [{ dateTime: new Date('2026-09-01T14:00:00Z') }],
@@ -89,11 +90,29 @@ describe('getPublicMusicTogetherSection', () => {
     await expect(run({ sectionId: 'nope' })).rejects.toThrow(/not found/i);
   });
 
-  it('hides draft sections', async () => {
-    mocks.findById.mockResolvedValue({ ...section, status: 'draft' });
+  it('hides sections that are not visible', async () => {
+    mocks.findById.mockResolvedValue({ ...section, visible: false });
     await expect(run({ sectionId: 'sec-1' })).rejects.toThrow(
       /not available/i
     );
     expect(mocks.countBySectionId).not.toHaveBeenCalled();
+  });
+
+  it('reports enrollmentOpen from the live controls', async () => {
+    mocks.findById.mockResolvedValue(section);
+    mocks.countBySectionId.mockResolvedValue(3);
+    const result = (await run({ sectionId: 'sec-1' })) as {
+      section: { enrollmentOpen: boolean };
+    };
+    expect(result.section.enrollmentOpen).toBe(true);
+  });
+
+  it('reports enrollmentOpen=false when enrollment is paused', async () => {
+    mocks.findById.mockResolvedValue({ ...section, enrollmentActive: false });
+    mocks.countBySectionId.mockResolvedValue(3);
+    const result = (await run({ sectionId: 'sec-1' })) as {
+      section: { enrollmentOpen: boolean };
+    };
+    expect(result.section.enrollmentOpen).toBe(false);
   });
 });

--- a/libs/firebase/maple-functions/get-public-music-together-section/src/lib/get-public-music-together-section.ts
+++ b/libs/firebase/maple-functions/get-public-music-together-section/src/lib/get-public-music-together-section.ts
@@ -11,7 +11,7 @@ import {
   MusicTogetherSectionRepository,
   MusicTogetherRegistrationRepository,
 } from '@maple/firebase/database';
-import { mtSpotsRemaining } from '@maple/ts/domain';
+import { mtSpotsRemaining, mtSectionEnrollmentOpen } from '@maple/ts/domain';
 import type {
   GetPublicMusicTogetherSectionRequest,
   GetPublicMusicTogetherSectionResponse,
@@ -38,8 +38,8 @@ export const getPublicMusicTogetherSection = Functions.endpoint
     if (!section) {
       throw new Error(`Music Together section not found: ${data.sectionId}`);
     }
-    // Draft sections are not publicly visible.
-    if (section.status === 'draft') {
+    // Only visible sections are publicly available.
+    if (!section.visible) {
       throw new Error('This section is not available');
     }
 
@@ -60,7 +60,8 @@ export const getPublicMusicTogetherSection = Functions.endpoint
       })),
       capacityFamilies: section.capacityFamilies,
       spotsRemaining: mtSpotsRemaining(section, familyCount),
-      status: section.status,
+      enrollmentOpen: mtSectionEnrollmentOpen(section, new Date(), familyCount),
+      enrollmentOpensAt: section.enrollmentOpensAt?.toISOString(),
       location: section.location,
       room: section.room,
     };

--- a/libs/firebase/maple-functions/on-music-together-section-write/src/lib/on-music-together-section-write.spec.ts
+++ b/libs/firebase/maple-functions/on-music-together-section-write/src/lib/on-music-together-section-write.spec.ts
@@ -7,7 +7,8 @@ import type { CalendarEvent } from '@maple/ts/domain';
  * Verifies that MT section create/update/delete reconciles CalendarEvents —
  * one per session, type `musictogether`, 45-minute duration — using
  * deterministic IDs of the form `mt-{sectionId}-{timestampMs}`, and that
- * events exist only while the section is live (status `open` or `closed`).
+ * events exist only while the section is `visible` (independent of whether
+ * enrollment is open).
  */
 
 const mocks = vi.hoisted(() => ({
@@ -56,7 +57,8 @@ const openSection = {
   name: 'Thursday Morning — Mixed Age (0–5)',
   description: 'Fall 2026',
   sessions: sessionDates.map((d) => ({ dateTime: ts(d) })),
-  status: 'open',
+  visible: true,
+  enrollmentActive: true,
   location: 'Spruce Room',
   room: 'spruce',
   capacityFamilies: 8,
@@ -120,29 +122,32 @@ describe('onMusicTogetherSectionWrite', () => {
     expect(mocks.delete).not.toHaveBeenCalled();
   });
 
-  it('still creates events for a closed (full) section', async () => {
+  it('still creates events for a visible section with enrollment closed', async () => {
     await handler({
       params: { sectionId: 'sec-1' },
       data: {
         before: makeSnapshot(true, openSection),
-        after: makeSnapshot(true, { ...openSection, status: 'closed' }),
+        after: makeSnapshot(true, {
+          ...openSection,
+          enrollmentActive: false,
+        }),
       },
     });
     expect(mocks.upsertWithId).toHaveBeenCalledTimes(3);
   });
 
-  it('does not create events for a draft section', async () => {
+  it('does not create events for a hidden section', async () => {
     await handler({
       params: { sectionId: 'sec-1' },
       data: {
         before: makeSnapshot(false),
-        after: makeSnapshot(true, { ...openSection, status: 'draft' }),
+        after: makeSnapshot(true, { ...openSection, visible: false }),
       },
     });
     expect(mocks.upsertWithId).not.toHaveBeenCalled();
   });
 
-  it('removes events when a section is completed', async () => {
+  it('removes events when a section becomes hidden', async () => {
     const existing = sessionDates.map((d) => makeCalendarEvent('sec-1', d));
     mocks.findAllBySourceRef.mockResolvedValue(existing);
 
@@ -150,7 +155,7 @@ describe('onMusicTogetherSectionWrite', () => {
       params: { sectionId: 'sec-1' },
       data: {
         before: makeSnapshot(true, openSection),
-        after: makeSnapshot(true, { ...openSection, status: 'completed' }),
+        after: makeSnapshot(true, { ...openSection, visible: false }),
       },
     });
 

--- a/libs/firebase/maple-functions/on-music-together-section-write/src/lib/on-music-together-section-write.ts
+++ b/libs/firebase/maple-functions/on-music-together-section-write/src/lib/on-music-together-section-write.ts
@@ -6,11 +6,11 @@
  * session — the same "one entity drives registration AND the calendar" pattern
  * as `onClassWrite` does for classes.
  *
- * - Create/Update: if the section is live (status `open` or `closed`), upserts
- *   one event per session at a stable ID and deletes events whose session no
- *   longer exists.
- * - Not live (`draft` / `completed`) or deleted: removes every CalendarEvent
- *   tied to this section.
+ * - Create/Update: if the section is `visible`, upserts one event per session
+ *   at a stable ID and deletes events whose session no longer exists.
+ * - Not visible or deleted: removes every CalendarEvent tied to this section.
+ *   (Visibility is decoupled from registration — a section can be on the
+ *   calendar while enrollment is still closed.)
  *
  * MT classes are always 45 minutes (`MT_CLASS_DURATION_MINUTES`), so sections
  * carry no per-session duration; the end time is derived here.
@@ -33,7 +33,7 @@ interface SectionData {
   name: string;
   description?: string;
   sessions: MusicTogetherSession[];
-  status: string;
+  visible: boolean;
   location?: string;
   room?: string;
 }
@@ -83,7 +83,7 @@ function extractSection(
     description:
       typeof data['description'] === 'string' ? data['description'] : undefined,
     sessions: extractSessions(data),
-    status: typeof data['status'] === 'string' ? data['status'] : 'draft',
+    visible: data['visible'] === true,
     location:
       typeof data['location'] === 'string' ? data['location'] : undefined,
     room: typeof data['room'] === 'string' ? data['room'] : undefined,
@@ -106,10 +106,6 @@ function resolveRoom(room: string | undefined): Room | null {
   return room && (ROOMS as string[]).includes(room) ? (room as Room) : null;
 }
 
-/** A section shows on the public calendar once it's live (open or closed). */
-function isLive(status: string): boolean {
-  return status === 'open' || status === 'closed';
-}
 
 export const onMusicTogetherSectionWrite = onDocumentWritten(
   {
@@ -126,8 +122,8 @@ export const onMusicTogetherSectionWrite = onDocumentWritten(
       const existingEvents =
         await CalendarEventRepository.findAllBySourceRef(sourceRef);
 
-      // Deleted, not-live, or no sessions → remove all its events.
-      if (!after || !isLive(after.status) || after.sessions.length === 0) {
+      // Deleted, not visible, or no sessions → remove all its events.
+      if (!after || !after.visible || after.sessions.length === 0) {
         await Promise.all(
           existingEvents.map((e) => CalendarEventRepository.delete(e.id))
         );

--- a/libs/firebase/maple-functions/sync-music-together-section-to-webflow/src/lib/sync-music-together-section-to-webflow.spec.ts
+++ b/libs/firebase/maple-functions/sync-music-together-section-to-webflow/src/lib/sync-music-together-section-to-webflow.spec.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  * Covers the Firestore trigger handler:
  * 1. Deleted section → removeSection
  * 2. Draft section → removeSection
- * 3. Non-draft section → enrich with family count → syncSection + writeback
+ * 3. Visible section → enrich with family count → syncSection + writeback
  * 4. Webflow errors are swallowed (no retry loops)
  */
 
@@ -81,7 +81,8 @@ const openSectionData = {
   sessions: [{ dateTime: new Date('2026-03-03T15:00:00Z') }],
   capacityFamilies: 8,
   priceFullCents: 25200,
-  status: 'open',
+  visible: true,
+  enrollmentActive: true,
 };
 
 describe('syncMusicTogetherSectionToWebflow', () => {
@@ -112,7 +113,7 @@ describe('syncMusicTogetherSectionToWebflow', () => {
     expect(mocks.syncSection).not.toHaveBeenCalled();
   });
 
-  it('removes from Webflow when the section is a draft', async () => {
+  it('removes from Webflow when the section is hidden', async () => {
     mocks.removeSection.mockResolvedValue(true);
 
     await handler({
@@ -121,7 +122,7 @@ describe('syncMusicTogetherSectionToWebflow', () => {
         before: makeSnapshot(true, 'section-001', openSectionData),
         after: makeSnapshot(true, 'section-001', {
           ...openSectionData,
-          status: 'draft',
+          visible: false,
           webflowItemId: 'wf-draft',
         }),
       },

--- a/libs/firebase/maple-functions/sync-music-together-section-to-webflow/src/lib/sync-music-together-section-to-webflow.ts
+++ b/libs/firebase/maple-functions/sync-music-together-section-to-webflow/src/lib/sync-music-together-section-to-webflow.ts
@@ -112,6 +112,8 @@ function extractSection(
     ...data,
     sessions: parseSessions(data['sessions']),
     installmentPlan: parseInstallmentPlan(data['installmentPlan']),
+    enrollmentOpensAt: toDateLike(data['enrollmentOpensAt']),
+    enrollmentClosesAt: toDateLike(data['enrollmentClosesAt']),
     createdAt: toDateLike(data['createdAt']) ?? new Date(),
     updatedAt: toDateLike(data['updatedAt']) ?? new Date(),
   } as MusicTogetherSection;
@@ -138,10 +140,10 @@ export const syncMusicTogetherSectionToWebflow = onDocumentWritten(
     console.log('Sync MT section to Webflow triggered:', {
       sectionId: event.params.sectionId,
       before: beforeSection
-        ? { name: beforeSection.name, status: beforeSection.status }
+        ? { name: beforeSection.name, visible: beforeSection.visible }
         : null,
       after: afterSection
-        ? { name: afterSection.name, status: afterSection.status }
+        ? { name: afterSection.name, visible: afterSection.visible }
         : null,
     });
 
@@ -175,10 +177,11 @@ export const syncMusicTogetherSectionToWebflow = onDocumentWritten(
         return;
       }
 
-      // Case 2: Section is a draft — not publicly visible. Remove any prior
-      // Webflow item (covers "was open, now draft" as well as create-as-draft).
-      if (afterSection.status === 'draft') {
-        console.log('MT section is draft, removing from Webflow');
+      // Case 2: Section is not visible — hidden from the public site. Remove any
+      // prior Webflow item (covers "was visible, now hidden" as well as
+      // create-as-hidden).
+      if (!afterSection.visible) {
+        console.log('MT section is hidden, removing from Webflow');
         const removed = await webflow.sectionService.removeSection(
           afterSection.id,
           shouldPublish,
@@ -192,8 +195,8 @@ export const syncMusicTogetherSectionToWebflow = onDocumentWritten(
         return;
       }
 
-      // Case 3: Section is non-draft (open/closed/completed) — enrich with the
-      // live family count and sync to Webflow.
+      // Case 3: Section is visible — enrich with the live family count and sync
+      // to Webflow (the derived status is computed in the field mapping).
       const familyCount =
         await MusicTogetherRegistrationRepository.countBySectionId(
           afterSection.id
@@ -201,7 +204,7 @@ export const syncMusicTogetherSectionToWebflow = onDocumentWritten(
 
       console.log('Syncing MT section to Webflow:', {
         name: afterSection.name,
-        status: afterSection.status,
+        visible: afterSection.visible,
         isDev,
         autoPublish: shouldPublish,
         familyCount,

--- a/libs/firebase/webflow/src/lib/mt-section.service.spec.ts
+++ b/libs/firebase/webflow/src/lib/mt-section.service.spec.ts
@@ -12,7 +12,8 @@ const baseSection: MusicTogetherSection = {
   ],
   capacityFamilies: 8,
   priceFullCents: 25200,
-  status: 'open',
+  visible: true,
+  enrollmentActive: true,
   location: 'Maple & Spruce Studio',
   room: 'Room A',
   createdAt: new Date('2026-01-01'),
@@ -45,6 +46,17 @@ describe('mapSectionToFieldData', () => {
     expect(fd['price-full-cents']).toBe(25200);
     expect(fd['capacity-families']).toBe(8);
     expect(fd['spots-remaining']).toBe(5);
+    // Derived from the controls: this fixture's sessions are in the past, so a
+    // visible section derives to 'completed'.
+    expect(fd['status']).toBe('completed');
+  });
+
+  it('derives status=open for a visible, enrolling, future-dated section', () => {
+    const future = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+    const fd = mapSectionToFieldData(
+      { ...baseSection, sessions: [{ dateTime: future }] },
+      { isDev: false, familyCount: 3 }
+    );
     expect(fd['status']).toBe('open');
   });
 

--- a/libs/firebase/webflow/src/lib/mt-section.service.ts
+++ b/libs/firebase/webflow/src/lib/mt-section.service.ts
@@ -21,6 +21,7 @@ import {
   formatSessions,
   mtSectionFirstSessionAt,
   mtSpotsRemaining,
+  mtSectionDerivedStatus,
   mtSectionOffersInstallments,
   MT_CLASS_DURATION_MINUTES,
 } from '@maple/ts/domain';
@@ -169,7 +170,11 @@ export function mapSectionToFieldData(
     'price-full-cents': section.priceFullCents,
     'capacity-families': section.capacityFamilies,
     'spots-remaining': spotsRemaining,
-    status: section.status,
+    // Derived from the section's explicit controls + live family count. Only
+    // visible sections reach Webflow, so this is one of upcoming/open/full/
+    // closed/completed. Time-based transitions (e.g. a scheduled open) refresh
+    // on the next section write.
+    status: mtSectionDerivedStatus(section, new Date(), familyCount),
     'price-display': priceDisplay,
     'spots-display': spotsDisplay,
     'date-display': dateDisplay,

--- a/libs/react/data/src/lib/useMusicTogetherSections.ts
+++ b/libs/react/data/src/lib/useMusicTogetherSections.ts
@@ -8,7 +8,6 @@ import type {
   MusicTogetherSection,
   CreateMusicTogetherSectionInput,
   UpdateMusicTogetherSectionInput,
-  MusicTogetherSectionStatus,
   RequestState,
 } from '@maple/ts/domain';
 import type {
@@ -22,7 +21,8 @@ import type {
 } from '@maple/ts/firebase/api-types';
 
 export interface UseMusicTogetherSectionsFilters {
-  status?: MusicTogetherSectionStatus;
+  /** Optionally scope to a single semester. */
+  semesterId?: string;
 }
 
 /** Hydrate ISO date strings (callable serialization) back into Dates. */
@@ -67,7 +67,7 @@ export function useMusicTogetherSections(
       const result = await callDeduped<
         GetMusicTogetherSectionsRequest,
         GetMusicTogetherSectionsResponse
-      >('getMusicTogetherSections', { status: filters?.status });
+      >('getMusicTogetherSections', { semesterId: filters?.semesterId });
       setSectionsState({
         status: 'success',
         data: result.data.sections
@@ -83,7 +83,7 @@ export function useMusicTogetherSections(
           error instanceof Error ? error.message : 'Failed to fetch sections',
       });
     }
-  }, [filters?.status]);
+  }, [filters?.semesterId]);
 
   const createSection = useCallback(
     async (

--- a/libs/ts/domain/src/lib/music-together-section.spec.ts
+++ b/libs/ts/domain/src/lib/music-together-section.spec.ts
@@ -3,6 +3,9 @@ import {
   mtSectionFirstSessionAt,
   mtSpotsRemaining,
   mtSectionHasAvailability,
+  mtSectionEnrollmentWindowActive,
+  mtSectionEnrollmentOpen,
+  mtSectionDerivedStatus,
   mtSectionOffersInstallments,
   mtInstallmentPlanTotalCents,
   MT_DEFAULT_CAPACITY_FAMILIES,
@@ -78,21 +81,128 @@ describe('mtSpotsRemaining', () => {
   });
 });
 
-describe('mtSectionHasAvailability', () => {
-  const open: Pick<MusicTogetherSection, 'capacityFamilies' | 'status'> = {
-    capacityFamilies: 8,
-    status: 'open',
-  };
+describe('mtSectionEnrollmentWindowActive', () => {
+  const now = new Date('2026-10-01T12:00:00Z');
+  const base = { enrollmentActive: true } as Pick<
+    MusicTogetherSection,
+    'enrollmentActive' | 'enrollmentOpensAt' | 'enrollmentClosesAt'
+  >;
 
-  it('is true when open and under capacity', () => {
-    expect(mtSectionHasAvailability(open, 7)).toBe(true);
+  it('is false when the live toggle is off', () => {
+    expect(
+      mtSectionEnrollmentWindowActive({ ...base, enrollmentActive: false }, now)
+    ).toBe(false);
+  });
+  it('is true when active with no schedule', () => {
+    expect(mtSectionEnrollmentWindowActive(base, now)).toBe(true);
+  });
+  it('is false before a scheduled open (auto-opens once reached)', () => {
+    const opensLater = { ...base, enrollmentOpensAt: new Date('2026-10-05T00:00:00Z') };
+    expect(mtSectionEnrollmentWindowActive(opensLater, now)).toBe(false);
+    expect(
+      mtSectionEnrollmentWindowActive(opensLater, new Date('2026-10-06T00:00:00Z'))
+    ).toBe(true);
+  });
+  it('is false at/after a scheduled close', () => {
+    const closes = { ...base, enrollmentClosesAt: new Date('2026-09-30T00:00:00Z') };
+    expect(mtSectionEnrollmentWindowActive(closes, now)).toBe(false);
+  });
+});
+
+describe('mtSectionEnrollmentOpen', () => {
+  const now = new Date('2026-10-01T12:00:00Z');
+  const active = {
+    enrollmentActive: true,
+    capacityFamilies: 8,
+  } as Pick<
+    MusicTogetherSection,
+    'enrollmentActive' | 'enrollmentOpensAt' | 'enrollmentClosesAt' | 'capacityFamilies'
+  >;
+
+  it('is true when window active and under capacity', () => {
+    expect(mtSectionEnrollmentOpen(active, now, 7)).toBe(true);
   });
   it('is false at capacity', () => {
-    expect(mtSectionHasAvailability(open, 8)).toBe(false);
+    expect(mtSectionEnrollmentOpen(active, now, 8)).toBe(false);
   });
-  it('is false when not open even with room', () => {
-    expect(mtSectionHasAvailability({ ...open, status: 'draft' }, 0)).toBe(
-      false
+  it('ignores capacity when no family count is given (window-only)', () => {
+    expect(mtSectionEnrollmentOpen(active, now)).toBe(true);
+  });
+});
+
+describe('mtSectionHasAvailability', () => {
+  const now = new Date('2026-10-01T12:00:00Z');
+  const active = {
+    enrollmentActive: true,
+    capacityFamilies: 8,
+  } as Pick<
+    MusicTogetherSection,
+    'enrollmentActive' | 'enrollmentOpensAt' | 'enrollmentClosesAt' | 'capacityFamilies'
+  >;
+
+  it('is true when enrolling and under capacity', () => {
+    expect(mtSectionHasAvailability(active, 7, now)).toBe(true);
+  });
+  it('is false at capacity', () => {
+    expect(mtSectionHasAvailability(active, 8, now)).toBe(false);
+  });
+  it('is false when enrollment is paused even with room', () => {
+    expect(
+      mtSectionHasAvailability({ ...active, enrollmentActive: false }, 0, now)
+    ).toBe(false);
+  });
+});
+
+describe('mtSectionDerivedStatus', () => {
+  const now = new Date('2026-10-01T12:00:00Z');
+  const future = { dateTime: new Date('2026-10-08T14:00:00Z') };
+  const past = { dateTime: new Date('2026-09-01T14:00:00Z') };
+  const base = {
+    visible: true,
+    enrollmentActive: false,
+    capacityFamilies: 8,
+    sessions: [future],
+  } as Pick<
+    MusicTogetherSection,
+    | 'visible'
+    | 'enrollmentActive'
+    | 'enrollmentOpensAt'
+    | 'enrollmentClosesAt'
+    | 'capacityFamilies'
+    | 'sessions'
+  >;
+
+  it('is draft when not visible', () => {
+    expect(mtSectionDerivedStatus({ ...base, visible: false }, now)).toBe('draft');
+  });
+  it('is completed when visible and every session is past', () => {
+    expect(mtSectionDerivedStatus({ ...base, sessions: [past] }, now)).toBe(
+      'completed'
     );
+  });
+  it('is open when enrolling with seats', () => {
+    expect(
+      mtSectionDerivedStatus({ ...base, enrollmentActive: true }, now, 3)
+    ).toBe('open');
+  });
+  it('is full when enrolling at capacity', () => {
+    expect(
+      mtSectionDerivedStatus({ ...base, enrollmentActive: true }, now, 8)
+    ).toBe('full');
+  });
+  it('is upcoming when visible with a future scheduled open', () => {
+    expect(
+      mtSectionDerivedStatus(
+        {
+          ...base,
+          enrollmentActive: true,
+          enrollmentOpensAt: new Date('2026-10-15T00:00:00Z'),
+        },
+        now
+      )
+    ).toBe('upcoming');
+  });
+  it('is closed when visible but enrollment is paused', () => {
+    expect(mtSectionDerivedStatus(base, now)).toBe('closed');
   });
 });

--- a/libs/ts/domain/src/lib/music-together-section.ts
+++ b/libs/ts/domain/src/lib/music-together-section.ts
@@ -54,12 +54,20 @@ export interface MusicTogetherInstallmentPlanItem {
   dueAt: Date;
 }
 
-/** Section lifecycle status. */
+/**
+ * Section status — DERIVED, never stored. Computed from the explicit controls
+ * (`visible` / `enrollmentActive` / the enrollment window) plus the current
+ * time and registered family count. See `mtSectionDerivedStatus`. We deliberately
+ * don't persist a hand-set status: admins flip explicit toggles/dates, and the
+ * overall state falls out of those.
+ */
 export type MusicTogetherSectionStatus =
-  | 'draft' // Not yet open for registration
-  | 'open' // Accepting registrations
-  | 'closed' // Registration closed (full, or term started)
-  | 'completed'; // Term finished
+  | 'draft' // Not visible — hidden from the calendar, public site, and Webflow
+  | 'upcoming' // Visible, enrollment scheduled but not open yet
+  | 'open' // Enrolling now, seats available
+  | 'full' // Enrollment window active but at capacity
+  | 'closed' // Visible, enrollment not active / window has passed
+  | 'completed'; // All sessions are in the past
 
 /**
  * Music Together section entity — one bookable term of the program.
@@ -81,7 +89,30 @@ export interface MusicTogetherSection {
    * card-on-file charges on their `dueAt`. Absent or empty ⇒ pay-in-full only.
    */
   installmentPlan?: MusicTogetherInstallmentPlanItem[];
-  status: MusicTogetherSectionStatus;
+  /**
+   * Whether the section is publicly visible — shown on the public calendar and
+   * Music Together site, and synced to Webflow. Registration can still be
+   * closed while a section is visible (see `enrollmentActive`). This is the
+   * "show it" control. Default false (hidden).
+   */
+  visible: boolean;
+  /**
+   * Live registration on/off switch, ad-platform style. When false, registration
+   * is closed regardless of the schedule below; pausing always wins. This is the
+   * "open for registration" control. Default false.
+   */
+  enrollmentActive: boolean;
+  /**
+   * Optional scheduled open — registration won't open before this instant even
+   * when `enrollmentActive` is true. Reaching it opens enrollment automatically
+   * (the gate is evaluated on each read; no cron needed).
+   */
+  enrollmentOpensAt?: Date;
+  /**
+   * Optional scheduled close — registration closes at this instant. Blank means
+   * no scheduled close (only `enrollmentActive` gates it).
+   */
+  enrollmentClosesAt?: Date;
   location?: string;
   room?: string;
   /**
@@ -142,12 +173,112 @@ export function mtSpotsRemaining(
   return Math.max(0, section.capacityFamilies - familyCount);
 }
 
-/** Whether the section can still accept another family. */
-export function mtSectionHasAvailability(
-  section: Pick<MusicTogetherSection, 'capacityFamilies' | 'status'>,
-  familyCount: number
+/**
+ * Whether the enrollment WINDOW is active (ad-platform semantics): the live
+ * toggle is on AND `now` is within `[enrollmentOpensAt, enrollmentClosesAt)`.
+ * Blank dates mean "no bound on that side". Ignores capacity — see
+ * `mtSectionEnrollmentOpen`.
+ */
+export function mtSectionEnrollmentWindowActive(
+  section: Pick<
+    MusicTogetherSection,
+    'enrollmentActive' | 'enrollmentOpensAt' | 'enrollmentClosesAt'
+  >,
+  now: Date
 ): boolean {
-  return section.status === 'open' && familyCount < section.capacityFamilies;
+  if (!section.enrollmentActive) return false;
+  if (section.enrollmentOpensAt && now < section.enrollmentOpensAt) return false;
+  if (section.enrollmentClosesAt && now >= section.enrollmentClosesAt)
+    return false;
+  return true;
+}
+
+/**
+ * Whether a family can register right now: the enrollment window is active AND
+ * (when a family count is supplied) the section is under capacity. The
+ * create-registration function still enforces capacity transactionally, so it
+ * may call this without a count for the window-only check.
+ */
+export function mtSectionEnrollmentOpen(
+  section: Pick<
+    MusicTogetherSection,
+    | 'enrollmentActive'
+    | 'enrollmentOpensAt'
+    | 'enrollmentClosesAt'
+    | 'capacityFamilies'
+  >,
+  now: Date,
+  familyCount?: number
+): boolean {
+  if (!mtSectionEnrollmentWindowActive(section, now)) return false;
+  if (familyCount !== undefined && familyCount >= section.capacityFamilies) {
+    return false;
+  }
+  return true;
+}
+
+/** Whether the section can still accept another family (window active + seat). */
+export function mtSectionHasAvailability(
+  section: Pick<
+    MusicTogetherSection,
+    | 'enrollmentActive'
+    | 'enrollmentOpensAt'
+    | 'enrollmentClosesAt'
+    | 'capacityFamilies'
+  >,
+  familyCount: number,
+  now: Date = new Date()
+): boolean {
+  return mtSectionEnrollmentOpen(section, now, familyCount);
+}
+
+/**
+ * The overall section status shown in the admin UI — DERIVED, never stored.
+ * Computed from the explicit controls + `now` + the registered family count.
+ *
+ * - `draft` — not visible (hidden everywhere)
+ * - `completed` — visible, but every session is in the past
+ * - `open` — enrollment window active, seats available
+ * - `full` — enrollment window active but at capacity
+ * - `upcoming` — visible, enrollment scheduled (opens later) but not open yet
+ * - `closed` — visible, enrollment not active / window has passed
+ */
+export function mtSectionDerivedStatus(
+  section: Pick<
+    MusicTogetherSection,
+    | 'visible'
+    | 'enrollmentActive'
+    | 'enrollmentOpensAt'
+    | 'enrollmentClosesAt'
+    | 'capacityFamilies'
+    | 'sessions'
+  >,
+  now: Date,
+  familyCount?: number
+): MusicTogetherSectionStatus {
+  if (!section.visible) return 'draft';
+
+  const sessions = section.sessions ?? [];
+  const allSessionsPast =
+    sessions.length > 0 &&
+    sessions.every((s) => s.dateTime.getTime() <= now.getTime());
+  if (allSessionsPast) return 'completed';
+
+  if (mtSectionEnrollmentWindowActive(section, now)) {
+    if (familyCount !== undefined && familyCount >= section.capacityFamilies) {
+      return 'full';
+    }
+    return 'open';
+  }
+
+  if (
+    section.enrollmentActive &&
+    section.enrollmentOpensAt &&
+    now < section.enrollmentOpensAt
+  ) {
+    return 'upcoming';
+  }
+  return 'closed';
 }
 
 /**

--- a/libs/ts/firebase/api-types/src/lib/music-together.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/music-together.types.ts
@@ -6,7 +6,6 @@
  */
 import type {
   MusicTogetherSection,
-  MusicTogetherSectionStatus,
   MusicTogetherSemester,
   MusicTogetherSemesterStatus,
   CreateMusicTogetherSemesterInput,
@@ -48,7 +47,8 @@ export interface UpdateMusicTogetherSemesterResponse {
 // ============================================================================
 
 export interface GetMusicTogetherSectionsRequest {
-  status?: MusicTogetherSectionStatus;
+  /** Optionally scope to a single semester. */
+  semesterId?: string;
 }
 
 /** Per-section registration counts (capacity statuses: pending + confirmed). */
@@ -116,7 +116,10 @@ export interface PublicMusicTogetherSection {
   installmentPlan?: { amountCents: number; dueAt: string }[];
   capacityFamilies: number;
   spotsRemaining: number;
-  status: MusicTogetherSection['status'];
+  /** Whether registration is open right now (window active + seats available). */
+  enrollmentOpen: boolean;
+  /** ISO instant registration opens, when scheduled and not yet open. */
+  enrollmentOpensAt?: string;
   location?: string;
   room?: string;
 }

--- a/libs/ts/validation/src/lib/music-together-section.validation.spec.ts
+++ b/libs/ts/validation/src/lib/music-together-section.validation.spec.ts
@@ -13,7 +13,8 @@ const valid: MusicTogetherSectionValidationInput = {
     { amountCents: 13200, dueAt: new Date('2026-09-01T14:00:00Z') },
     { amountCents: 13200, dueAt: new Date('2026-09-29T14:00:00Z') },
   ],
-  status: 'open',
+  visible: true,
+  enrollmentActive: true,
 };
 
 describe('musicTogetherSectionValidation', () => {
@@ -109,12 +110,23 @@ describe('musicTogetherSectionValidation', () => {
     ).toBe(true);
   });
 
-  it('rejects an invalid status', () => {
+  it('rejects an enrollment close date before the open date', () => {
     expect(
       musicTogetherSectionValidation({
         ...valid,
-        status: 'archived',
-      }).hasErrors('status')
+        enrollmentOpensAt: new Date('2026-10-01T00:00:00Z'),
+        enrollmentClosesAt: new Date('2026-09-01T00:00:00Z'),
+      }).hasErrors('enrollmentClosesAt')
     ).toBe(true);
+  });
+
+  it('accepts a valid enrollment window', () => {
+    expect(
+      musicTogetherSectionValidation({
+        ...valid,
+        enrollmentOpensAt: new Date('2026-09-01T00:00:00Z'),
+        enrollmentClosesAt: new Date('2026-10-01T00:00:00Z'),
+      }).hasErrors()
+    ).toBe(false);
   });
 });

--- a/libs/ts/validation/src/lib/music-together-section.validation.ts
+++ b/libs/ts/validation/src/lib/music-together-section.validation.ts
@@ -30,10 +30,12 @@ export interface MusicTogetherSectionValidationInput {
    * When present it must have 2+ rows (a single charge is just pay-in-full).
    */
   installmentPlan?: MusicTogetherInstallmentInput[];
-  status?: string;
+  /** Explicit visibility/enrollment controls (status is derived, not stored). */
+  visible?: boolean;
+  enrollmentActive?: boolean;
+  enrollmentOpensAt?: Date | string;
+  enrollmentClosesAt?: Date | string;
 }
-
-const SECTION_STATUSES = ['draft', 'open', 'closed', 'completed'];
 
 function parseDate(value: Date | string | undefined): Date | undefined {
   if (value === undefined) return undefined;
@@ -105,10 +107,28 @@ export const musicTogetherSectionValidation = staticSuite(
       }
     });
 
-    test('status', 'Status must be valid', () => {
-      if (data.status !== undefined) {
-        enforce(data.status).inside(SECTION_STATUSES);
+    test('enrollmentOpensAt', 'Enrollment open date must be valid', () => {
+      if (data.enrollmentOpensAt !== undefined) {
+        enforce(parseDate(data.enrollmentOpensAt)).isNotNullish();
       }
     });
+
+    test('enrollmentClosesAt', 'Enrollment close date must be valid', () => {
+      if (data.enrollmentClosesAt !== undefined) {
+        enforce(parseDate(data.enrollmentClosesAt)).isNotNullish();
+      }
+    });
+
+    test(
+      'enrollmentClosesAt',
+      'Enrollment must close after it opens',
+      () => {
+        const opens = parseDate(data.enrollmentOpensAt);
+        const closes = parseDate(data.enrollmentClosesAt);
+        if (opens && closes) {
+          enforce(closes.getTime()).greaterThan(opens.getTime());
+        }
+      }
+    );
   }
 );


### PR DESCRIPTION
## What & why

Realizes the design David asked for: **stop storing a hand-set section `status`; offer explicit controls that read as actions, and derive the overall status.** This unblocks the Music Together instructor's request — put winter/spring (and hidden "overflow") sections on the calendar independently of whether registration is open, and flip them on with clear toggles (ad-platform model: a live on/off switch plus optional start/end dates).

Closes #581 and #582. (The #584 duplicate-section action is a separate follow-up.)

## The model

Section `status` (`draft/open/closed/completed`) is **removed as a stored field**. New explicit controls:

| Control | Meaning |
|---|---|
| `visible` | Show on the public calendar + site (registration can still be closed) — the "show it" button |
| `enrollmentActive` | Live registration on/off; pausing always wins — the "open registration" button / release-early override |
| `enrollmentOpensAt?` | Optional scheduled open; auto-opens on read once reached (no cron) |
| `enrollmentClosesAt?` | Optional scheduled close |

`status` is now **derived** (`mtSectionDerivedStatus` → draft · upcoming · open · full · closed · completed) from those + now + the family count, shown read-only in the admin UI.

## Consumers rewired (all keyed off `section.status` before)

- **onMusicTogetherSectionWrite** — calendar events gate on `visible` (not open/closed)
- **getPublicMusicTogetherSection** — hides `!visible`; projects `enrollmentOpen` + `enrollmentOpensAt` so the widget can disable the Register button
- **createMusicTogetherRegistration** — gate is the derived enrollment window (distinct "isn't open yet" vs "has closed"); capacity still enforced transactionally
- **addToMusicTogetherWaitlist** — gates on `visible`
- **syncMusicTogetherSectionToWebflow** — hides `!visible`; sends the derived status to the CMS
- **Admin SectionFormDialog** — status dropdown → `visible`/`enrollmentActive` switches + enrollment-window pickers + a read-only derived-status chip; list chip is derived
- **getMusicTogetherSections** — `status` filter → optional `semesterId` filter
- **Repository** — reads new fields with `?? false` defaults (existing prod docs read as hidden + paused — safe, non-destructive); drops the status query filter; removes two now-orphan Firestore indexes

Semester status is intentionally **untouched** (separate lifecycle) — flagged as a possible follow-up.

## Verification

- Unit: `npx vitest run` → **2149 passed** (incl. a derived-status truth table + updated gates/fixtures)
- Typecheck: `tsc --noEmit` on the maple-spruce app → **clean, exit 0**; changed libs clean (no errors in touched files)
- Firestore index analyzer: **green**; orphan `status`-based section indexes removed; JSON valid
- Integration-test fixtures updated to the new controls

## Note for reviewers

The Webflow "MT Sections" CMS `status` field now receives the derived values (`upcoming`/`full` in addition to the prior set). The field is free-form in code; I'll confirm the CMS field accepts those before this affects the public site (MT public pages are still being built, so it's low-risk to adjust now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)