### PR TITLE
feat(music-together): duplicate a section into a hidden draft (#584)

### DIFF
--- a/apps/functions-integration-tests-music-together/src/music-together-admin.spec.ts
+++ b/apps/functions-integration-tests-music-together/src/music-together-admin.spec.ts
@@ -18,6 +18,8 @@ import type {
   CreateMusicTogetherSectionResponse,
   GetMusicTogetherSectionsResponse,
   UpdateMusicTogetherSectionResponse,
+  DuplicateMusicTogetherSectionRequest,
+  DuplicateMusicTogetherSectionResponse,
   GetMusicTogetherRosterRequest,
   GetMusicTogetherRosterResponse,
 } from '@maple/ts/firebase/api-types';
@@ -106,6 +108,47 @@ describe('MT section admin CRUD', () => {
     });
     expect(updated.status).toBe(200);
     expect(updated.data?.section.name).toBe('Renamed Section');
+  });
+
+  it('duplicates a section (admin) into a hidden, paused copy', async () => {
+    const dup = await callFunction<
+      DuplicateMusicTogetherSectionRequest,
+      DuplicateMusicTogetherSectionResponse
+    >({
+      functionName: 'duplicateMusicTogetherSection',
+      data: { sourceSectionId: createdId },
+      idToken: admin.idToken,
+    });
+
+    expect(dup.status).toBe(200);
+    const copy = dup.data!.section;
+    expect(copy.id).not.toBe(createdId);
+    expect(copy.name).toBe('Renamed Section (Copy)');
+    // Hidden + paused so the overflow copy stays secret until released.
+    expect(copy.visible).toBe(false);
+    expect(copy.enrollmentActive).toBe(false);
+    // Sessions are copied (unlike duplicate-class).
+    expect(copy.sessions).toHaveLength(1);
+
+    // It shows up in the admin list as its own section.
+    const list = await callFunction<
+      Record<string, never>,
+      GetMusicTogetherSectionsResponse
+    >({
+      functionName: 'getMusicTogetherSections',
+      data: {},
+      idToken: admin.idToken,
+    });
+    expect(list.data?.sections.some((s) => s.id === copy.id)).toBe(true);
+  });
+
+  it('rejects duplicate for a non-admin', async () => {
+    const result = await callFunction<DuplicateMusicTogetherSectionRequest>({
+      functionName: 'duplicateMusicTogetherSection',
+      data: { sourceSectionId: createdId },
+      idToken: nonAdmin.idToken,
+    });
+    expect(result.status).not.toBe(200);
   });
 
   it('rejects create for a non-admin', async () => {

--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -112,6 +112,7 @@ export { updateMusicTogetherSemester } from '@maple/firebase/maple-functions/upd
 export { getMusicTogetherSections } from '@maple/firebase/maple-functions/get-music-together-sections';
 export { createMusicTogetherSection } from '@maple/firebase/maple-functions/create-music-together-section';
 export { updateMusicTogetherSection } from '@maple/firebase/maple-functions/update-music-together-section';
+export { duplicateMusicTogetherSection } from '@maple/firebase/maple-functions/duplicate-music-together-section';
 export { getMusicTogetherRoster } from '@maple/firebase/maple-functions/get-music-together-roster';
 export { getRelatedPublicClasses } from '@maple/firebase/maple-functions/get-related-public-classes';
 export { addToClassWaitlist } from '@maple/firebase/maple-functions/add-to-class-waitlist';

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -134,6 +134,7 @@
     "../../libs/firebase/maple-functions/get-music-together-roster/**/*.ts",
     "../../libs/firebase/maple-functions/get-class-waitlist/**/*.ts",
     "../../libs/firebase/maple-functions/get-class-waitlist-counts/**/*.ts",
+    "../../libs/firebase/maple-functions/duplicate-music-together-section/**/*.ts",
     "../../libs/firebase/database/src/**/*.ts",
     "../../libs/firebase/functions/src/**/*.ts",
     "../../libs/ts/domain/src/**/*.ts",

--- a/apps/maple-spruce/src/app/(admin)/music-together/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/page.tsx
@@ -19,6 +19,7 @@ import {
 import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
 import GroupIcon from '@mui/icons-material/Group';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import {
   getMusicTogetherSeasonLabel,
   mtSectionDerivedStatus,
@@ -48,8 +49,32 @@ const fmtDay = (d?: Date) =>
 const fmtPrice = (cents: number) => `$${(cents / 100).toFixed(0)}`;
 
 export default function MusicTogetherPage() {
-  const { sectionsState, countsBySection, createSection, updateSection } =
-    useMusicTogetherSections();
+  const {
+    sectionsState,
+    countsBySection,
+    createSection,
+    updateSection,
+    duplicateSection,
+  } = useMusicTogetherSections();
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [duplicatingId, setDuplicatingId] = useState<string | null>(null);
+
+  const handleDuplicate = useCallback(
+    async (sectionId: string) => {
+      setActionError(null);
+      setDuplicatingId(sectionId);
+      try {
+        await duplicateSection(sectionId);
+      } catch (e) {
+        setActionError(
+          e instanceof Error ? e.message : 'Failed to duplicate section'
+        );
+      } finally {
+        setDuplicatingId(null);
+      }
+    },
+    [duplicateSection]
+  );
   const { semestersState, createSemester, updateSemester } =
     useMusicTogetherSemesters();
 
@@ -236,6 +261,12 @@ export default function MusicTogetherPage() {
         </Button>
       </Box>
 
+      {actionError && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setActionError(null)}>
+          {actionError}
+        </Alert>
+      )}
+
       {sectionsState.status === 'loading' && (
         <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
           <CircularProgress />
@@ -323,6 +354,17 @@ export default function MusicTogetherPage() {
                     >
                       <GroupIcon />
                     </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Duplicate (hidden copy)">
+                    <span>
+                      <IconButton
+                        aria-label={`Duplicate ${section.name}`}
+                        disabled={duplicatingId === section.id}
+                        onClick={() => handleDuplicate(section.id)}
+                      >
+                        <ContentCopyIcon />
+                      </IconButton>
+                    </span>
                   </Tooltip>
                   <Tooltip title="Edit">
                     <IconButton

--- a/docs/reference/deployed-functions.md
+++ b/docs/reference/deployed-functions.md
@@ -59,7 +59,7 @@ Core CRUD operations, auth, triggers, and admin functions. No heavy third-party 
 ### Calendar Triggers
 - `onClassWrite` — Firestore trigger: auto-generates CalendarEvents from published classes
 - `onLessonWrite` — Firestore trigger: auto-generates a private (`public: false`) Spruce Room CalendarEvent per scheduled lesson; removes it on cancel/delete
-- `onMusicTogetherSectionWrite` — Firestore trigger: auto-generates a public `musictogether` CalendarEvent per session of a live (`open`/`closed`) MT section; reconciles on edit and removes on draft/completed/delete
+- `onMusicTogetherSectionWrite` — Firestore trigger: auto-generates a public `musictogether` CalendarEvent per session of a `visible` MT section; reconciles on edit and removes when the section is hidden or deleted
 
 ### Room Availability (#467)
 - `getRoomSchedule` — admin-only: busy windows for a room over a time range (powers the dashboard "Spruce Room" widget and booking conflict checks)
@@ -167,7 +167,7 @@ Webflow CMS synchronization. Isolates `webflow-api`.
 
 - `syncArtistToWebflow` — Firestore trigger: syncs artist data to Webflow CMS
 - `syncClassToWebflow` — Firestore trigger: syncs class data to Webflow CMS
-- `syncMusicTogetherSectionToWebflow` — Firestore trigger: syncs Music Together section data to Webflow CMS (non-draft sections; enriches spots-remaining from live family count)
+- `syncMusicTogetherSectionToWebflow` — Firestore trigger: syncs Music Together section data to Webflow CMS (`visible` sections; enriches spots-remaining from live family count; sends the derived section status)
 - `syncMusicTogetherSemesterToWebflow` — Firestore trigger: syncs Music Together semester (term) data to Webflow CMS (all statuses incl. `planned`; only removed on delete)
 - `syncRegistrationCount` — Firestore trigger: re-syncs class to Webflow when registrations change (spots remaining)
 

--- a/libs/firebase/maple-functions/duplicate-music-together-section/project.json
+++ b/libs/firebase/maple-functions/duplicate-music-together-section/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-duplicate-music-together-section",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/duplicate-music-together-section/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/duplicate-music-together-section/src/index.ts
+++ b/libs/firebase/maple-functions/duplicate-music-together-section/src/index.ts
@@ -1,0 +1,1 @@
+export { duplicateMusicTogetherSection } from './lib/duplicate-music-together-section';

--- a/libs/firebase/maple-functions/duplicate-music-together-section/src/lib/duplicate-music-together-section.spec.ts
+++ b/libs/firebase/maple-functions/duplicate-music-together-section/src/lib/duplicate-music-together-section.spec.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { HttpsError } from 'firebase-functions/v2/https';
+import type {
+  MusicTogetherSection,
+  CreateMusicTogetherSectionInput,
+} from '@maple/ts/domain';
+
+const mocks = vi.hoisted(() => ({
+  findById: vi.fn(),
+  create: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/functions', async () => {
+  const actual =
+    await vi.importActual<typeof import('@maple/firebase/functions')>(
+      '@maple/firebase/functions'
+    );
+  return {
+    ...actual,
+    createAdminFunction: <TReq, TRes>(
+      handler: (data: TReq, ctx: unknown) => Promise<TRes>
+    ) => handler,
+  };
+});
+
+vi.mock('@maple/firebase/database', () => ({
+  MusicTogetherSectionRepository: {
+    findById: mocks.findById,
+    create: mocks.create,
+  },
+}));
+
+import { duplicateMusicTogetherSection } from './duplicate-music-together-section';
+
+type Handler = (
+  data: { sourceSectionId: string },
+  ctx?: unknown
+) => Promise<{ section: MusicTogetherSection }>;
+const handler = duplicateMusicTogetherSection as unknown as Handler;
+
+const source: MusicTogetherSection = {
+  id: 'sec-source',
+  name: 'Thursday 10:00 — Mixed Age',
+  description: 'Fall 2026 term.',
+  sessions: [
+    { dateTime: new Date('2026-09-10T14:00:00Z') },
+    { dateTime: new Date('2026-09-17T14:00:00Z') },
+  ],
+  capacityFamilies: 8,
+  priceFullCents: 25200,
+  installmentPlan: [
+    { amountCents: 13200, dueAt: new Date('2026-09-10T14:00:00Z') },
+    { amountCents: 13200, dueAt: new Date('2026-10-08T14:00:00Z') },
+  ],
+  visible: true,
+  enrollmentActive: true,
+  enrollmentOpensAt: new Date('2026-08-01T00:00:00Z'),
+  enrollmentClosesAt: new Date('2026-09-09T00:00:00Z'),
+  location: 'Maple & Spruce Studio',
+  room: 'spruce',
+  semesterId: 'sem-fall-2026',
+  webflowItemId: 'webflow-original-id',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-04-01T00:00:00Z'),
+};
+
+describe('duplicateMusicTogetherSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects a missing sourceSectionId', async () => {
+    await expect(handler({ sourceSectionId: '' })).rejects.toThrow(HttpsError);
+    expect(mocks.findById).not.toHaveBeenCalled();
+  });
+
+  it('throws not-found when the source section does not exist', async () => {
+    mocks.findById.mockResolvedValue(undefined);
+    await expect(handler({ sourceSectionId: 'nope' })).rejects.toThrow(
+      HttpsError
+    );
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+
+  it('clones into a hidden, paused draft with sessions copied', async () => {
+    mocks.findById.mockResolvedValue(source);
+    mocks.create.mockImplementation(
+      async (input: CreateMusicTogetherSectionInput) => ({
+        ...input,
+        id: 'sec-copy',
+        createdAt: new Date('2026-04-28T00:00:00Z'),
+        updatedAt: new Date('2026-04-28T00:00:00Z'),
+      })
+    );
+
+    const result = await handler({ sourceSectionId: 'sec-source' });
+
+    expect(mocks.create).toHaveBeenCalledTimes(1);
+    const created = mocks.create.mock
+      .calls[0][0] as CreateMusicTogetherSectionInput;
+
+    // Suffixed name + hidden/paused, dates cleared.
+    expect(created.name).toBe('Thursday 10:00 — Mixed Age (Copy)');
+    expect(created.visible).toBe(false);
+    expect(created.enrollmentActive).toBe(false);
+    expect(created.enrollmentOpensAt).toBeUndefined();
+    expect(created.enrollmentClosesAt).toBeUndefined();
+
+    // Sessions ARE copied (unlike duplicate-class) — deep-copied, not aliased.
+    expect(created.sessions).toEqual(source.sessions);
+    expect(created.sessions).not.toBe(source.sessions);
+
+    // Configuration carried over.
+    expect(created.description).toBe(source.description);
+    expect(created.capacityFamilies).toBe(source.capacityFamilies);
+    expect(created.priceFullCents).toBe(source.priceFullCents);
+    expect(created.installmentPlan).toEqual(source.installmentPlan);
+    expect(created.installmentPlan).not.toBe(source.installmentPlan);
+    expect(created.location).toBe(source.location);
+    expect(created.room).toBe(source.room);
+    expect(created.semesterId).toBe(source.semesterId);
+
+    // webflowItemId must not carry over (fresh sync creates a new item).
+    expect(
+      (created as unknown as Record<string, unknown>)['webflowItemId']
+    ).toBeUndefined();
+
+    expect(result.section.id).toBe('sec-copy');
+    expect(result.section.name).toBe('Thursday 10:00 — Mixed Age (Copy)');
+  });
+
+  it('handles a source section with no installment plan', async () => {
+    mocks.findById.mockResolvedValue({ ...source, installmentPlan: undefined });
+    mocks.create.mockImplementation(
+      async (input: CreateMusicTogetherSectionInput) => ({
+        ...input,
+        id: 'sec-copy',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+    );
+
+    await handler({ sourceSectionId: 'sec-source' });
+
+    const created = mocks.create.mock
+      .calls[0][0] as CreateMusicTogetherSectionInput;
+    expect(created.installmentPlan).toBeUndefined();
+  });
+});

--- a/libs/firebase/maple-functions/duplicate-music-together-section/src/lib/duplicate-music-together-section.ts
+++ b/libs/firebase/maple-functions/duplicate-music-together-section/src/lib/duplicate-music-together-section.ts
@@ -1,0 +1,72 @@
+/**
+ * Duplicate Music Together Section Cloud Function (admin)
+ *
+ * Clones an existing section into a new HIDDEN, enrollment-paused draft so an
+ * admin can pre-build overflow / "reach-goal" sections (e.g. an extra 11:15
+ * Thursday class) and keep them completely secret until they're actually
+ * needed — then release each one with the `visible` + `enrollmentActive`
+ * toggles.
+ *
+ * Behaviour:
+ * - Copied: description, sessions (the weekly pattern — the admin usually just
+ *   edits the time), capacityFamilies, priceFullCents, installmentPlan,
+ *   location, room, semesterId.
+ * - `name` gets a " (Copy)" suffix so the duplicate is easy to spot.
+ * - `visible` and `enrollmentActive` are forced to `false`, and the enrollment
+ *   window (`enrollmentOpensAt` / `enrollmentClosesAt`) is cleared, so the copy
+ *   is invisible everywhere and accepts no registrations until released.
+ * - `webflowItemId` is omitted, so the next sync creates a fresh Webflow item
+ *   rather than overwriting the source's.
+ *
+ * Unlike duplicate-class (which clears sessions), MT sections keep the source's
+ * sessions: overflow sections mirror an existing class and differ only by time,
+ * so pre-filling the schedule is the point.
+ */
+import {
+  createAdminFunction,
+  throwInvalidArgument,
+  throwNotFound,
+} from '@maple/firebase/functions';
+import { MusicTogetherSectionRepository } from '@maple/firebase/database';
+import type { CreateMusicTogetherSectionInput } from '@maple/ts/domain';
+import type {
+  DuplicateMusicTogetherSectionRequest,
+  DuplicateMusicTogetherSectionResponse,
+} from '@maple/ts/firebase/api-types';
+
+export const duplicateMusicTogetherSection = createAdminFunction<
+  DuplicateMusicTogetherSectionRequest,
+  DuplicateMusicTogetherSectionResponse
+>(async (data) => {
+  if (!data.sourceSectionId) {
+    throwInvalidArgument('Source section ID is required');
+  }
+
+  const source = await MusicTogetherSectionRepository.findById(
+    data.sourceSectionId
+  );
+  if (!source) {
+    throwNotFound('Music Together section', data.sourceSectionId);
+  }
+
+  const input: CreateMusicTogetherSectionInput = {
+    name: `${source.name} (Copy)`,
+    description: source.description,
+    sessions: source.sessions.map((s) => ({ dateTime: new Date(s.dateTime) })),
+    capacityFamilies: source.capacityFamilies,
+    priceFullCents: source.priceFullCents,
+    installmentPlan: source.installmentPlan
+      ? source.installmentPlan.map((i) => ({ ...i }))
+      : undefined,
+    // Reach-goal copy: hidden + paused until explicitly released.
+    visible: false,
+    enrollmentActive: false,
+    location: source.location,
+    room: source.room,
+    semesterId: source.semesterId,
+  };
+
+  const created = await MusicTogetherSectionRepository.create(input);
+
+  return { section: created };
+});

--- a/libs/firebase/maple-functions/duplicate-music-together-section/tsconfig.json
+++ b/libs/firebase/maple-functions/duplicate-music-together-section/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/duplicate-music-together-section/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/duplicate-music-together-section/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/react/data/src/lib/useMusicTogetherSections.ts
+++ b/libs/react/data/src/lib/useMusicTogetherSections.ts
@@ -18,6 +18,8 @@ import type {
   CreateMusicTogetherSectionResponse,
   UpdateMusicTogetherSectionRequest,
   UpdateMusicTogetherSectionResponse,
+  DuplicateMusicTogetherSectionRequest,
+  DuplicateMusicTogetherSectionResponse,
 } from '@maple/ts/firebase/api-types';
 
 export interface UseMusicTogetherSectionsFilters {
@@ -135,6 +137,29 @@ export function useMusicTogetherSections(
     []
   );
 
+  const duplicateSection = useCallback(
+    async (sourceSectionId: string): Promise<MusicTogetherSection> => {
+      const functions = getMapleFunctions();
+      const duplicate = httpsCallable<
+        DuplicateMusicTogetherSectionRequest,
+        DuplicateMusicTogetherSectionResponse
+      >(functions, 'duplicateMusicTogetherSection');
+      const result = await duplicate({ sourceSectionId });
+      const section = hydrateSection(result.data.section);
+      setSectionsState((prev) => {
+        if (prev.status !== 'success') return prev;
+        return {
+          ...prev,
+          data: [...prev.data, section].sort(
+            (a, b) => firstSessionMs(a) - firstSessionMs(b)
+          ),
+        };
+      });
+      return section;
+    },
+    []
+  );
+
   useEffect(() => {
     fetchSections();
   }, [fetchSections]);
@@ -145,5 +170,6 @@ export function useMusicTogetherSections(
     fetchSections,
     createSection,
     updateSection,
+    duplicateSection,
   };
 }

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -429,6 +429,8 @@ export type {
   CreateMusicTogetherSectionResponse,
   UpdateMusicTogetherSectionRequest,
   UpdateMusicTogetherSectionResponse,
+  DuplicateMusicTogetherSectionRequest,
+  DuplicateMusicTogetherSectionResponse,
   GetMusicTogetherRosterRequest,
   GetMusicTogetherRosterResponse,
   MusicTogetherRosterEntry,

--- a/libs/ts/firebase/api-types/src/lib/music-together.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/music-together.types.ts
@@ -77,6 +77,16 @@ export interface UpdateMusicTogetherSectionResponse {
   section: MusicTogetherSection;
 }
 
+export interface DuplicateMusicTogetherSectionRequest {
+  /** ID of the source section to copy. */
+  sourceSectionId: string;
+}
+
+export interface DuplicateMusicTogetherSectionResponse {
+  /** The new section: hidden + enrollment-paused, name suffixed, sessions copied. */
+  section: MusicTogetherSection;
+}
+
 // ============================================================================
 // Roster (admin — enrolled families + payment/charge status)
 // ============================================================================

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -359,6 +359,9 @@
       "@maple/firebase/maple-functions/update-music-together-section": [
         "libs/firebase/maple-functions/update-music-together-section/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/duplicate-music-together-section": [
+        "libs/firebase/maple-functions/duplicate-music-together-section/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/get-music-together-roster": [
         "libs/firebase/maple-functions/get-music-together-roster/src/index.ts"
       ],


### PR DESCRIPTION
## What & why

Adds the **Duplicate** admin action for Music Together sections — the last piece of Stephanie's overflow-sections workflow. She can pre-build "reach-goal" sections (e.g. an extra 11:15 Thursday/Saturday class), keep them **totally secret**, then release each one later with the `visible` + `enrollmentActive` toggles from #590.

Closes #584.

## How it works

- **New Cloud Function** `duplicateMusicTogetherSection` (admin-only, maple-core), modeled on `duplicateClass` — with one deliberate difference: it **copies the sessions** instead of clearing them. Overflow sections mirror an existing class and differ only by time, so pre-filling the schedule (admin just edits the time) is the whole point.
- The copy is created **hidden + enrollment-paused**: `visible: false`, `enrollmentActive: false`, enrollment dates cleared, name suffixed `" (Copy)"`, `webflowItemId` dropped so the next sync makes a fresh Webflow item. It stays invisible everywhere until explicitly released.
- Carried over: description, sessions, capacity, price, installment plan, location, room, semester.

## Surfaces

- `useMusicTogetherSections.duplicateSection()` + optimistic list insert
- Admin sections table: a **Duplicate** (copy) icon button per row, with an error surface
- `DuplicateMusicTogetherSection{Request,Response}` api-types

## Verification

- Unit: new `duplicate-music-together-section.spec.ts` (4 tests — hidden/paused copy, sessions deep-copied, no webflowItemId, no-plan case); full MT unit filter **209 passing**
- Integration: added duplicate cases to the MT admin suite (admin duplicate → hidden/paused copy in the list; non-admin rejected)
- `tsc --noEmit` on the maple-spruce app + api-types → **exit 0**
- `./tools/validate-function-tsconfigs.sh` → all checks pass (tsconfig include + codebase mapping added)

## Also

Corrected two stale `deployed-functions.md` descriptions that #590 left on the old status-based model (now `visible`-based).

🤖 Generated with [Claude Code](https://claude.com/claude-code)