### PR TITLE
feat(music-together): word installment-summary as "installments" not "payments" (#596)

### DIFF
--- a/libs/firebase/webflow/src/lib/mt-section.service.spec.ts
+++ b/libs/firebase/webflow/src/lib/mt-section.service.spec.ts
@@ -183,7 +183,7 @@ describe('mapSectionToFieldData', () => {
     expect(fd).not.toHaveProperty('installment-summary');
   });
 
-  it('summarizes equal installments as "N payments of $X"', () => {
+  it('summarizes equal installments as "N installments of $X"', () => {
     const fd = mapSectionToFieldData(
       {
         ...baseSection,
@@ -194,7 +194,7 @@ describe('mapSectionToFieldData', () => {
       },
       prodOptions
     );
-    expect(fd['installment-summary']).toBe('or 2 payments of $132');
+    expect(fd['installment-summary']).toBe('or 2 installments of $132');
   });
 
   it('summarizes unequal installments by total', () => {
@@ -208,7 +208,7 @@ describe('mapSectionToFieldData', () => {
       },
       prodOptions
     );
-    expect(fd['installment-summary']).toBe('or 2 payments totaling $252');
+    expect(fd['installment-summary']).toBe('or 2 installments totaling $252');
   });
 });
 

--- a/libs/firebase/webflow/src/lib/mt-section.service.ts
+++ b/libs/firebase/webflow/src/lib/mt-section.service.ts
@@ -211,8 +211,8 @@ export function mapSectionToFieldData(
     );
     const total = plan.reduce((sum, item) => sum + item.amountCents, 0);
     fieldData['installment-summary'] = allEqual
-      ? `or ${plan.length} payments of ${formatDollars(plan[0].amountCents)}`
-      : `or ${plan.length} payments totaling ${formatDollars(total)}`;
+      ? `or ${plan.length} installments of ${formatDollars(plan[0].amountCents)}`
+      : `or ${plan.length} installments totaling ${formatDollars(total)}`;
   }
 
   return fieldData;


### PR DESCRIPTION
## What

Backend wording half of #596. The `installment-summary` Webflow CMS field built in `mapSectionToFieldData` (`libs/firebase/webflow/src/lib/mt-section.service.ts`) said **"payments"** — e.g. `"or 2 payments of $132"` — but Stephanie's requested phrasing, and the copy already visible on the MT landing page, says **"installments"**.

Changed wording only:
- equal plans → `"or 2 installments of $132"`
- unequal plans → `"or N installments totaling $X"`

Amounts and logic are untouched. Updated the matching `.spec.ts` assertions. This is the only place that formats the MT "installment-summary" string (verified by grep).

## Not in this PR (done separately)

The visible change on the section listing card also requires the **Webflow listing-card binding** for #596 (bind `installment-summary` next to `price-display` on the MT Sections card + detail header). That is a Webflow Designer/Data-API change handled separately.

## Verification

- `npx vitest run libs/firebase/webflow/src/lib/mt-section.service.spec.ts` → **27 passed**
- `npx tsc --noEmit -p libs/firebase/webflow/tsconfig.lib.json` → clean (exit 0)
- Lint: the only errors on this project are pre-existing `@nx/enforce-module-boundaries` errors on unchanged import lines; the string-only diff introduces none.

Related: Music Together epic #508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>