### PR TITLE
feat(music-together): semester status → derived from dates

### DIFF
--- a/apps/functions-integration-tests-music-together/src/music-together-semester.spec.ts
+++ b/apps/functions-integration-tests-music-together/src/music-together-semester.spec.ts
@@ -28,7 +28,6 @@ function createInput(
     season: 'fall',
     year: 2026,
     weeks: 10,
-    status: 'planned',
     ...overrides,
   };
 }
@@ -88,15 +87,15 @@ describe('MT semester admin CRUD', () => {
 
   it('updates a semester (admin)', async () => {
     const updated = await callFunction<
-      { id: string; status: string },
+      { id: string; notes: string },
       UpdateMusicTogetherSemesterResponse
     >({
       functionName: 'updateMusicTogetherSemester',
-      data: { id: createdId, status: 'enrolling' },
+      data: { id: createdId, notes: 'Enrollment opens mid-August.' },
       idToken: admin.idToken,
     });
     expect(updated.status).toBe(200);
-    expect(updated.data?.semester.status).toBe('enrolling');
+    expect(updated.data?.semester.notes).toBe('Enrollment opens mid-August.');
   });
 
   it('rejects create for a non-admin', async () => {

--- a/apps/maple-spruce/src/app/(admin)/music-together/SemesterFormDialog.stories.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/SemesterFormDialog.stories.tsx
@@ -33,7 +33,6 @@ const mockSemester: MusicTogetherSemester = {
     new Date('2027-03-04T00:00:00'),
   ],
   enrollmentOpensAt: new Date('2026-11-12T00:00:00'),
-  status: 'enrolling',
   notes: 'Two snow makeup days built in.',
   createdAt: new Date('2026-01-01T00:00:00Z'),
   updatedAt: new Date('2026-01-01T00:00:00Z'),
@@ -86,7 +85,6 @@ export const CreateSubmits: Story = {
         expect.objectContaining({
           name: 'Fall 2026',
           season: 'fall',
-          status: 'planned',
           weeks: 10,
         })
       )
@@ -193,10 +191,6 @@ export const FillsAllFields: Story = {
     });
     await userEvent.type(canvas.getByLabelText('Notes'), 'Spring term.');
 
-    // Change the Status select.
-    await userEvent.click(canvas.getByRole('combobox', { name: /status/i }));
-    await userEvent.click(canvas.getByRole('option', { name: 'enrolling' }));
-
     await userEvent.click(canvas.getByRole('button', { name: /save/i }));
 
     await waitFor(() =>
@@ -205,7 +199,6 @@ export const FillsAllFields: Story = {
           name: 'Spring 2027',
           year: 2027,
           weeks: 10,
-          status: 'enrolling',
           notes: 'Spring term.',
         })
       )

--- a/apps/maple-spruce/src/app/(admin)/music-together/SemesterFormDialog.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/SemesterFormDialog.tsx
@@ -14,6 +14,7 @@ import {
   IconButton,
   Stack,
   Divider,
+  Chip,
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
@@ -21,18 +22,11 @@ import {
   MT_SEASONS,
   MT_SEASON_DEFAULT_WEEKS,
   getMusicTogetherSeasonLabel,
+  mtSemesterDerivedStatus,
   type MusicTogetherSemester,
   type MusicTogetherSeason,
   type CreateMusicTogetherSemesterInput,
-  type MusicTogetherSemesterStatus,
 } from '@maple/ts/domain';
-
-const STATUSES: MusicTogetherSemesterStatus[] = [
-  'planned',
-  'enrolling',
-  'active',
-  'completed',
-];
 
 /** Date <-> <input type="date"> string (local, day granularity). */
 function toDateInput(date?: Date): string {
@@ -70,7 +64,6 @@ export function SemesterFormDialog({
   const [name, setName] = useState('');
   const [season, setSeason] = useState<MusicTogetherSeason>('fall');
   const [year, setYear] = useState(String(new Date().getFullYear()));
-  const [status, setStatus] = useState<MusicTogetherSemesterStatus>('planned');
   const [weeks, setWeeks] = useState(String(MT_SEASON_DEFAULT_WEEKS.fall));
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
@@ -88,7 +81,6 @@ export function SemesterFormDialog({
       setName(semester.name);
       setSeason(semester.season);
       setYear(String(semester.year));
-      setStatus(semester.status);
       setWeeks(semester.weeks != null ? String(semester.weeks) : '');
       setStartDate(toDateInput(semester.startDate));
       setEndDate(toDateInput(semester.endDate));
@@ -106,7 +98,6 @@ export function SemesterFormDialog({
       setName('');
       setSeason('fall');
       setYear(String(new Date().getFullYear()));
-      setStatus('planned');
       setWeeks(String(MT_SEASON_DEFAULT_WEEKS.fall));
       setStartDate('');
       setEndDate('');
@@ -147,7 +138,6 @@ export function SemesterFormDialog({
         name: name.trim(),
         season,
         year: parseInt(year, 10),
-        status,
         weeks: weeks ? parseInt(weeks, 10) : undefined,
         startDate: startDate ? fromDateInput(startDate) : undefined,
         endDate: endDate ? fromDateInput(endDate) : undefined,
@@ -163,6 +153,18 @@ export function SemesterFormDialog({
       setError(e instanceof Error ? e.message : 'Failed to save semester');
     }
   };
+
+  // Live preview of the derived status from the current date controls.
+  const derivedStatus = mtSemesterDerivedStatus(
+    {
+      startDate: startDate ? fromDateInput(startDate) : undefined,
+      endDate: endDate ? fromDateInput(endDate) : undefined,
+      enrollmentOpensAt: enrollmentOpensAt
+        ? fromDateInput(enrollmentOpensAt)
+        : undefined,
+    },
+    new Date()
+  );
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
@@ -202,22 +204,7 @@ export function SemesterFormDialog({
               sx={{ flex: 1 }}
             />
           </Box>
-          <Box sx={{ display: 'flex', gap: 2 }}>
-            <TextField
-              label="Status"
-              select
-              value={status}
-              onChange={(e) =>
-                setStatus(e.target.value as MusicTogetherSemesterStatus)
-              }
-              sx={{ flex: 1 }}
-            >
-              {STATUSES.map((s) => (
-                <MenuItem key={s} value={s}>
-                  {s}
-                </MenuItem>
-              ))}
-            </TextField>
+          <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
             <TextField
               label="Weeks"
               type="number"
@@ -225,6 +212,18 @@ export function SemesterFormDialog({
               onChange={(e) => setWeeks(e.target.value)}
               sx={{ flex: 1 }}
             />
+            <Box
+              sx={{ flex: 1, display: 'flex', alignItems: 'center', gap: 1 }}
+            >
+              <Typography variant="body2" color="text.secondary">
+                Status
+              </Typography>
+              <Chip
+                size="small"
+                label={derivedStatus}
+                color={derivedStatus === 'enrolling' ? 'success' : 'default'}
+              />
+            </Box>
           </Box>
           <Box sx={{ display: 'flex', gap: 2 }}>
             <TextField

--- a/apps/maple-spruce/src/app/(admin)/music-together/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/page.tsx
@@ -23,6 +23,7 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import {
   getMusicTogetherSeasonLabel,
   mtSectionDerivedStatus,
+  mtSemesterDerivedStatus,
   type MusicTogetherSection,
   type MusicTogetherSemester,
   type CreateMusicTogetherSectionInput,
@@ -206,11 +207,16 @@ export default function MusicTogetherPage() {
                   {getMusicTogetherSeasonLabel(sem.season)} {sem.year}
                 </TableCell>
                 <TableCell>
-                  <Chip
-                    size="small"
-                    label={sem.status}
-                    color={sem.status === 'enrolling' ? 'success' : 'default'}
-                  />
+                  {(() => {
+                    const derived = mtSemesterDerivedStatus(sem, new Date());
+                    return (
+                      <Chip
+                        size="small"
+                        label={derived}
+                        color={derived === 'enrolling' ? 'success' : 'default'}
+                      />
+                    );
+                  })()}
                 </TableCell>
                 <TableCell>
                   {sem.startDate || sem.endDate

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1409,20 +1409,6 @@
       ]
     },
     {
-      "collectionGroup": "musicTogetherSemesters",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "status",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "sortValue",
-          "order": "ASCENDING"
-        }
-      ]
-    },
-    {
       "collectionGroup": "musicTogetherRegistrations",
       "queryScope": "COLLECTION",
       "fields": [

--- a/libs/firebase/database/src/index.ts
+++ b/libs/firebase/database/src/index.ts
@@ -94,10 +94,7 @@ export {
 } from './lib/craft-club-token.repository';
 
 // Music Together (separate-business early-childhood music program)
-export {
-  MusicTogetherSemesterRepository,
-  type MusicTogetherSemesterFilters,
-} from './lib/music-together-semester.repository';
+export { MusicTogetherSemesterRepository } from './lib/music-together-semester.repository';
 export {
   MusicTogetherSectionRepository,
   type MusicTogetherSectionFilters,

--- a/libs/firebase/database/src/lib/music-together-semester.repository.spec.ts
+++ b/libs/firebase/database/src/lib/music-together-semester.repository.spec.ts
@@ -45,7 +45,6 @@ function semData(overrides: Record<string, unknown> = {}) {
     ],
     weatherMakeupDates: [ts('2027-02-25T00:00:00.000Z')],
     enrollmentOpensAt: ts('2026-11-12T00:00:00.000Z'),
-    status: 'enrolling',
     notes: 'Two snow makeup days built in.',
     createdAt: ts('2026-01-01T00:00:00.000Z'),
     updatedAt: ts('2026-01-01T00:00:00.000Z'),
@@ -77,20 +76,6 @@ describe('MusicTogetherSemesterRepository', () => {
       expect(result[0].breaks?.[0].label).toBe('Holiday break');
       expect(result[0].startDate).toBeInstanceOf(Date);
       expect(result[0].weatherMakeupDates?.[0]).toBeInstanceOf(Date);
-    });
-
-    it('applies the status filter when provided', async () => {
-      const get = vi.fn().mockResolvedValue({ docs: [fakeDoc('s1', semData())] });
-      const orderBy = vi.fn().mockReturnValue({ get });
-      const where = vi.fn().mockReturnValue({ orderBy });
-      mocks.collection.mockReturnValue({ where });
-
-      const result = await MusicTogetherSemesterRepository.findAll({
-        status: 'enrolling',
-      });
-
-      expect(where).toHaveBeenCalledWith('status', '==', 'enrolling');
-      expect(result).toHaveLength(1);
     });
 
     it('drops non-existent docs', async () => {
@@ -156,7 +141,6 @@ describe('MusicTogetherSemesterRepository', () => {
         name: 'Winter 2026–2027',
         season: 'winter',
         year: 2026,
-        status: 'enrolling',
       });
 
       const written = set.mock.calls[0][0] as Record<string, unknown>;
@@ -179,7 +163,6 @@ describe('MusicTogetherSemesterRepository', () => {
           name: 'X',
           season: 'fall',
           year: 2026,
-          status: 'planned',
         })
       ).rejects.toThrow(/not found after create/);
     });
@@ -190,20 +173,20 @@ describe('MusicTogetherSemesterRepository', () => {
       const update = vi.fn().mockResolvedValue(undefined);
       const get = vi
         .fn()
-        .mockResolvedValue(fakeDoc('s1', semData({ status: 'active' })));
+        .mockResolvedValue(fakeDoc('s1', semData({ name: 'Renamed' })));
       mocks.collection.mockReturnValue({
         doc: vi.fn().mockReturnValue({ update, get }),
       });
 
       const result = await MusicTogetherSemesterRepository.update({
         id: 's1',
-        status: 'active',
+        name: 'Renamed',
       });
 
       expect(update).toHaveBeenCalled();
       const patch = update.mock.calls[0][0] as Record<string, unknown>;
       expect(patch.updatedAt).toBeInstanceOf(Date);
-      expect(result.status).toBe('active');
+      expect(result.name).toBe('Renamed');
     });
   });
 

--- a/libs/firebase/database/src/lib/music-together-semester.repository.ts
+++ b/libs/firebase/database/src/lib/music-together-semester.repository.ts
@@ -10,7 +10,6 @@ import {
   mtSemesterSortValue,
   type MusicTogetherSemester,
   type MusicTogetherSemesterBreak,
-  type MusicTogetherSemesterStatus,
   type MusicTogetherSeason,
   type CreateMusicTogetherSemesterInput,
   type UpdateMusicTogetherSemesterInput,
@@ -60,7 +59,6 @@ function docToSemester(
     enrollmentOpensAt: data.enrollmentOpensAt
       ? toDate(data.enrollmentOpensAt)
       : undefined,
-    status: data.status as MusicTogetherSemesterStatus,
     notes: data.notes,
     webflowItemId: data.webflowItemId,
     createdAt: toDate(data.createdAt),
@@ -90,21 +88,11 @@ function toPersisted(
   return data;
 }
 
-export interface MusicTogetherSemesterFilters {
-  status?: MusicTogetherSemesterStatus;
-}
-
 export const MusicTogetherSemesterRepository = {
-  async findAll(
-    filters?: MusicTogetherSemesterFilters
-  ): Promise<MusicTogetherSemester[]> {
-    let query: FirebaseFirestore.Query = getDb().collection(COLLECTION);
-
-    if (filters?.status) {
-      query = query.where('status', '==', filters.status);
-    }
-
-    query = query.orderBy('sortValue', 'asc');
+  async findAll(): Promise<MusicTogetherSemester[]> {
+    const query = getDb()
+      .collection(COLLECTION)
+      .orderBy('sortValue', 'asc');
 
     const snapshot = await query.get();
     return snapshot.docs

--- a/libs/firebase/maple-functions/create-music-together-semester/src/lib/create-music-together-semester.spec.ts
+++ b/libs/firebase/maple-functions/create-music-together-semester/src/lib/create-music-together-semester.spec.ts
@@ -27,7 +27,7 @@ describe('createMusicTogetherSemester', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('creates a semester and returns it', async () => {
-    const input = { name: 'Fall 2026', season: 'fall', year: 2026, status: 'planned' };
+    const input = { name: 'Fall 2026', season: 'fall', year: 2026 };
     mocks.create.mockResolvedValue({ id: 'sem-1', ...input });
 
     const result = (await mocks.capturedHandler!(input)) as {

--- a/libs/firebase/maple-functions/get-music-together-semesters/src/lib/get-music-together-semesters.spec.ts
+++ b/libs/firebase/maple-functions/get-music-together-semesters/src/lib/get-music-together-semesters.spec.ts
@@ -19,17 +19,16 @@ const handler = getMusicTogetherSemesters as unknown as (
 describe('getMusicTogetherSemesters', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('returns semesters, passing the status filter through', async () => {
+  it('returns all semesters (no filter)', async () => {
     mocks.findAll.mockResolvedValue([{ id: 'sem-1' }]);
-    const result = await handler({ status: 'enrolling' }, {});
-    expect(mocks.findAll).toHaveBeenCalledWith({ status: 'enrolling' });
+    const result = await handler({}, {});
+    expect(mocks.findAll).toHaveBeenCalledWith();
     expect(result.semesters).toEqual([{ id: 'sem-1' }]);
   });
 
-  it('works with no filter', async () => {
+  it('works when there are no semesters', async () => {
     mocks.findAll.mockResolvedValue([]);
     const result = await handler({}, {});
-    expect(mocks.findAll).toHaveBeenCalledWith({ status: undefined });
     expect(result.semesters).toEqual([]);
   });
 });

--- a/libs/firebase/maple-functions/get-music-together-semesters/src/lib/get-music-together-semesters.ts
+++ b/libs/firebase/maple-functions/get-music-together-semesters/src/lib/get-music-together-semesters.ts
@@ -2,8 +2,9 @@
  * Get Music Together Semesters Cloud Function
  *
  * Lists Music Together semesters (terms of the program year) for the admin
- * app (authenticated). Optional status filter; returned in chronological
- * program-year order. Deployed to us-east4 via CI/CD (maple-core codebase).
+ * app (authenticated), in chronological program-year order. The overall status
+ * is DERIVED client-side from each term's dates. Deployed to us-east4 via CI/CD
+ * (maple-core codebase).
  */
 import { createAuthenticatedFunction } from '@maple/firebase/functions';
 import { MusicTogetherSemesterRepository } from '@maple/firebase/database';
@@ -15,9 +16,7 @@ import type {
 export const getMusicTogetherSemesters = createAuthenticatedFunction<
   GetMusicTogetherSemestersRequest,
   GetMusicTogetherSemestersResponse
->(async (data) => {
-  const semesters = await MusicTogetherSemesterRepository.findAll({
-    status: data.status,
-  });
+>(async () => {
+  const semesters = await MusicTogetherSemesterRepository.findAll();
   return { semesters };
 });

--- a/libs/firebase/maple-functions/sync-music-together-semester-to-webflow/src/lib/sync-music-together-semester-to-webflow.spec.ts
+++ b/libs/firebase/maple-functions/sync-music-together-semester-to-webflow/src/lib/sync-music-together-semester-to-webflow.spec.ts
@@ -78,8 +78,8 @@ const enrollingSemesterData = {
   year: 2026,
   startDate: new Date('2026-09-10T14:00:00Z'),
   endDate: new Date('2026-11-12T14:00:00Z'),
+  enrollmentOpensAt: new Date('2026-07-01T14:00:00Z'),
   weeks: 10,
-  status: 'enrolling',
 };
 
 describe('syncMusicTogetherSemesterToWebflow', () => {
@@ -150,17 +150,19 @@ describe('syncMusicTogetherSemesterToWebflow', () => {
         before: makeSnapshot(false),
         after: makeSnapshot(true, 'semester-001', {
           ...enrollingSemesterData,
-          status: 'planned',
+          enrollmentOpensAt: undefined,
           startDate: undefined,
           endDate: undefined,
         }),
       },
     });
 
+    // Semesters are never hidden — a term with no dates (derives 'planned')
+    // still syncs to Webflow.
     expect(mocks.removeSemester).not.toHaveBeenCalled();
     expect(mocks.syncSemester).toHaveBeenCalledWith(
       expect.objectContaining({
-        semester: expect.objectContaining({ status: 'planned' }),
+        semester: expect.objectContaining({ name: 'Fall 2026' }),
       })
     );
   });

--- a/libs/firebase/maple-functions/sync-music-together-semester-to-webflow/src/lib/sync-music-together-semester-to-webflow.ts
+++ b/libs/firebase/maple-functions/sync-music-together-semester-to-webflow/src/lib/sync-music-together-semester-to-webflow.ts
@@ -138,12 +138,8 @@ export const syncMusicTogetherSemesterToWebflow = onDocumentWritten(
 
     console.log('Sync MT semester to Webflow triggered:', {
       semesterId: event.params.semesterId,
-      before: beforeSemester
-        ? { name: beforeSemester.name, status: beforeSemester.status }
-        : null,
-      after: afterSemester
-        ? { name: afterSemester.name, status: afterSemester.status }
-        : null,
+      before: beforeSemester ? { name: beforeSemester.name } : null,
+      after: afterSemester ? { name: afterSemester.name } : null,
     });
 
     const secrets = Object.fromEntries(
@@ -180,7 +176,6 @@ export const syncMusicTogetherSemesterToWebflow = onDocumentWritten(
       // status (planned/enrolling/active/completed all show publicly).
       console.log('Syncing MT semester to Webflow:', {
         name: afterSemester.name,
-        status: afterSemester.status,
         isDev,
         autoPublish: shouldPublish,
       });

--- a/libs/firebase/webflow/src/lib/mt-semester.service.spec.ts
+++ b/libs/firebase/webflow/src/lib/mt-semester.service.spec.ts
@@ -11,7 +11,6 @@ const baseSemester: MusicTogetherSemester = {
   endDate: new Date('2026-11-12T14:00:00Z'),
   weeks: 10,
   enrollmentOpensAt: new Date('2026-08-01T12:00:00Z'),
-  status: 'enrolling',
   notes: 'Exact dates confirmed by summer.',
   breaks: [
     {
@@ -43,12 +42,22 @@ describe('mapSemesterToFieldData', () => {
     );
   });
 
-  it('maps season, season-label, year, and status', () => {
+  it('maps season, season-label, year, and derived status', () => {
     const fd = mapSemesterToFieldData(baseSemester, prodOptions);
     expect(fd['season']).toBe('fall');
     expect(fd['season-label']).toBe('Fall');
     expect(fd['year']).toBe(2026);
-    expect(fd['status']).toBe('enrolling');
+    // Status is DERIVED from the term's dates at sync time: registration open
+    // (yesterday) and the term hasn't started (next month) → 'enrolling'.
+    const enrolling = {
+      ...baseSemester,
+      enrollmentOpensAt: new Date(Date.now() - 86_400_000),
+      startDate: new Date(Date.now() + 30 * 86_400_000),
+      endDate: new Date(Date.now() + 90 * 86_400_000),
+    };
+    expect(mapSemesterToFieldData(enrolling, prodOptions)['status']).toBe(
+      'enrolling'
+    );
   });
 
   it('sets start-date and end-date to ISO strings', () => {

--- a/libs/firebase/webflow/src/lib/mt-semester.service.ts
+++ b/libs/firebase/webflow/src/lib/mt-semester.service.ts
@@ -28,6 +28,7 @@ import type {
 import {
   getMusicTogetherSeasonLabel,
   mtSemesterSortValue,
+  mtSemesterDerivedStatus,
 } from '@maple/ts/domain';
 import { generateSlug } from './artist.service';
 
@@ -153,7 +154,8 @@ export function mapSemesterToFieldData(
     season: semester.season,
     'season-label': getMusicTogetherSeasonLabel(semester.season),
     year: semester.year,
-    status: semester.status,
+    // Derived from the term's dates (enrollmentOpensAt/start/end) at sync time.
+    status: mtSemesterDerivedStatus(semester, new Date()),
     'sort-value': mtSemesterSortValue(semester),
     'date-range-display': formatDateRangeDisplay(
       semester.startDate,

--- a/libs/react/data/src/index.ts
+++ b/libs/react/data/src/index.ts
@@ -12,10 +12,7 @@ export {
   useMusicTogetherSections,
   type UseMusicTogetherSectionsFilters,
 } from './lib/useMusicTogetherSections';
-export {
-  useMusicTogetherSemesters,
-  type UseMusicTogetherSemestersFilters,
-} from './lib/useMusicTogetherSemesters';
+export { useMusicTogetherSemesters } from './lib/useMusicTogetherSemesters';
 export { useMusicTogetherRoster } from './lib/useMusicTogetherRoster';
 export { useClassCategories } from './lib/useClassCategories';
 

--- a/libs/react/data/src/lib/useMusicTogetherSemesters.ts
+++ b/libs/react/data/src/lib/useMusicTogetherSemesters.ts
@@ -9,7 +9,6 @@ import {
   type MusicTogetherSemester,
   type CreateMusicTogetherSemesterInput,
   type UpdateMusicTogetherSemesterInput,
-  type MusicTogetherSemesterStatus,
   type RequestState,
 } from '@maple/ts/domain';
 import type {
@@ -20,10 +19,6 @@ import type {
   UpdateMusicTogetherSemesterRequest,
   UpdateMusicTogetherSemesterResponse,
 } from '@maple/ts/firebase/api-types';
-
-export interface UseMusicTogetherSemestersFilters {
-  status?: MusicTogetherSemesterStatus;
-}
 
 /** Hydrate ISO date strings (callable serialization) back into Dates. */
 function hydrateSemester(
@@ -54,9 +49,7 @@ function bySortValue(a: MusicTogetherSemester, b: MusicTogetherSemester): number
 /**
  * Hook for managing Music Together semester CRUD in the admin app.
  */
-export function useMusicTogetherSemesters(
-  filters?: UseMusicTogetherSemestersFilters
-) {
+export function useMusicTogetherSemesters() {
   const [semestersState, setSemestersState] = useState<
     RequestState<MusicTogetherSemester[]>
   >({ status: 'idle' });
@@ -67,7 +60,7 @@ export function useMusicTogetherSemesters(
       const result = await callDeduped<
         GetMusicTogetherSemestersRequest,
         GetMusicTogetherSemestersResponse
-      >('getMusicTogetherSemesters', { status: filters?.status });
+      >('getMusicTogetherSemesters', {});
       setSemestersState({
         status: 'success',
         data: result.data.semesters.map(hydrateSemester).sort(bySortValue),
@@ -80,7 +73,7 @@ export function useMusicTogetherSemesters(
           error instanceof Error ? error.message : 'Failed to fetch semesters',
       });
     }
-  }, [filters?.status]);
+  }, []);
 
   const createSemester = useCallback(
     async (

--- a/libs/ts/domain/src/lib/music-together-semester.spec.ts
+++ b/libs/ts/domain/src/lib/music-together-semester.spec.ts
@@ -5,6 +5,7 @@ import {
   getMusicTogetherSeasonLabel,
   mtSemesterSortValue,
   mtSemesterIsEnrolling,
+  mtSemesterDerivedStatus,
   type MusicTogetherSemester,
 } from './music-together-semester';
 
@@ -16,7 +17,6 @@ function semester(
     name: 'Fall 2026',
     season: 'fall',
     year: 2026,
-    status: 'planned',
     createdAt: new Date(),
     updatedAt: new Date(),
     ...overrides,
@@ -66,9 +66,70 @@ describe('music-together-semester', () => {
     });
   });
 
-  it('reports enrolling status', () => {
-    expect(mtSemesterIsEnrolling(semester({ status: 'enrolling' }))).toBe(true);
-    expect(mtSemesterIsEnrolling(semester({ status: 'planned' }))).toBe(false);
-    expect(mtSemesterIsEnrolling(semester({ status: 'active' }))).toBe(false);
+  describe('mtSemesterDerivedStatus', () => {
+    const now = new Date('2026-08-01T12:00:00Z');
+
+    it('is planned before registration opens (or no dates set)', () => {
+      expect(mtSemesterDerivedStatus(semester(), now)).toBe('planned');
+      expect(
+        mtSemesterDerivedStatus(
+          semester({ enrollmentOpensAt: new Date('2026-08-15T00:00:00Z') }),
+          now
+        )
+      ).toBe('planned');
+    });
+
+    it('is enrolling once registration opens, before the term starts', () => {
+      expect(
+        mtSemesterDerivedStatus(
+          semester({
+            enrollmentOpensAt: new Date('2026-07-01T00:00:00Z'),
+            startDate: new Date('2026-09-10T00:00:00Z'),
+            endDate: new Date('2026-11-14T00:00:00Z'),
+          }),
+          now
+        )
+      ).toBe('enrolling');
+    });
+
+    it('is active once the term has started', () => {
+      expect(
+        mtSemesterDerivedStatus(
+          semester({
+            enrollmentOpensAt: new Date('2026-07-01T00:00:00Z'),
+            startDate: new Date('2026-07-20T00:00:00Z'),
+            endDate: new Date('2026-11-14T00:00:00Z'),
+          }),
+          now
+        )
+      ).toBe('active');
+    });
+
+    it('is completed after the end date', () => {
+      expect(
+        mtSemesterDerivedStatus(
+          semester({
+            startDate: new Date('2026-01-10T00:00:00Z'),
+            endDate: new Date('2026-03-14T00:00:00Z'),
+          }),
+          now
+        )
+      ).toBe('completed');
+    });
+  });
+
+  it('reports enrolling status (derived from dates)', () => {
+    expect(
+      mtSemesterIsEnrolling(
+        semester({
+          enrollmentOpensAt: new Date('2026-07-01T00:00:00Z'),
+          startDate: new Date('2026-09-10T00:00:00Z'),
+        }),
+        new Date('2026-08-01T12:00:00Z')
+      )
+    ).toBe(true);
+    expect(
+      mtSemesterIsEnrolling(semester(), new Date('2026-08-01T12:00:00Z'))
+    ).toBe(false);
   });
 });

--- a/libs/ts/domain/src/lib/music-together-semester.ts
+++ b/libs/ts/domain/src/lib/music-together-semester.ts
@@ -30,10 +30,14 @@ export const MT_SEASON_DEFAULT_WEEKS: Record<MusicTogetherSeason, number> = {
   summer: 6,
 };
 
-/** Semester lifecycle. `planned` terms may have no sections yet. */
+/**
+ * Semester lifecycle — DERIVED from the term's dates, never stored. Admins set
+ * the explicit date controls (`enrollmentOpensAt`, `startDate`, `endDate`) and
+ * the overall status falls out of them via `mtSemesterDerivedStatus`.
+ */
 export type MusicTogetherSemesterStatus =
   | 'planned' // On the calendar, not yet open for registration
-  | 'enrolling' // Sections open for registration
+  | 'enrolling' // Registration window open, term not started
   | 'active' // Term in progress
   | 'completed'; // Term finished
 
@@ -63,9 +67,8 @@ export interface MusicTogetherSemester {
   breaks?: MusicTogetherSemesterBreak[];
   /** Built-in weather makeup dates (e.g. the two snow days held in Winter). */
   weatherMakeupDates?: Date[];
-  /** When re-registration opens for this term. */
+  /** When registration opens for this term. Drives the `enrolling` status. */
   enrollmentOpensAt?: Date;
-  status: MusicTogetherSemesterStatus;
   /** Free-text note, e.g. "exact dates confirmed by spring 2027" (Summer). */
   notes?: string;
   /** Webflow CMS item ID, once synced to the public site. */
@@ -115,9 +118,41 @@ export function mtSemesterSortValue(
   return semester.year * 12 + seasonIndex;
 }
 
-/** Whether a semester is accepting registrations right now. */
+/**
+ * The overall semester status — DERIVED, never stored. Computed from the term's
+ * date controls + `now`:
+ *
+ * - `completed` — the end date has passed
+ * - `active` — the start date has passed (term in progress)
+ * - `enrolling` — registration has opened (`enrollmentOpensAt` reached) but the
+ *   term hasn't started
+ * - `planned` — none of the above (on the calendar, registration not open yet)
+ *
+ * Ordering matters: later phases win, so a term reads `active` once it starts
+ * even if `enrollmentOpensAt` is also in the past.
+ */
+export function mtSemesterDerivedStatus(
+  semester: Pick<
+    MusicTogetherSemester,
+    'startDate' | 'endDate' | 'enrollmentOpensAt'
+  >,
+  now: Date
+): MusicTogetherSemesterStatus {
+  if (semester.endDate && now >= semester.endDate) return 'completed';
+  if (semester.startDate && now >= semester.startDate) return 'active';
+  if (semester.enrollmentOpensAt && now >= semester.enrollmentOpensAt) {
+    return 'enrolling';
+  }
+  return 'planned';
+}
+
+/** Whether a semester is in its registration window right now (derived). */
 export function mtSemesterIsEnrolling(
-  semester: Pick<MusicTogetherSemester, 'status'>
+  semester: Pick<
+    MusicTogetherSemester,
+    'startDate' | 'endDate' | 'enrollmentOpensAt'
+  >,
+  now: Date = new Date()
 ): boolean {
-  return semester.status === 'enrolling';
+  return mtSemesterDerivedStatus(semester, now) === 'enrolling';
 }

--- a/libs/ts/firebase/api-types/src/lib/music-together.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/music-together.types.ts
@@ -7,7 +7,6 @@
 import type {
   MusicTogetherSection,
   MusicTogetherSemester,
-  MusicTogetherSemesterStatus,
   CreateMusicTogetherSemesterInput,
   UpdateMusicTogetherSemesterInput,
   MusicTogetherRegistration,
@@ -20,9 +19,8 @@ import type {
 // Semester admin CRUD (authenticated read; admin writes)
 // ============================================================================
 
-export interface GetMusicTogetherSemestersRequest {
-  status?: MusicTogetherSemesterStatus;
-}
+// No filters — semesters are returned in full (status is derived client-side).
+export type GetMusicTogetherSemestersRequest = Record<string, never>;
 
 export interface GetMusicTogetherSemestersResponse {
   semesters: MusicTogetherSemester[];

--- a/libs/ts/validation/src/lib/music-together-semester.validation.spec.ts
+++ b/libs/ts/validation/src/lib/music-together-semester.validation.spec.ts
@@ -11,7 +11,6 @@ function valid(
     name: 'Fall 2026',
     season: 'fall',
     year: 2026,
-    status: 'planned',
     ...overrides,
   };
 }
@@ -70,11 +69,6 @@ describe('musicTogetherSemesterValidation', () => {
       valid({ breaks: [{ label: 'Holiday', startDate: '2026-12-18', endDate: '2027-01-06' }] })
     );
     expect(ok.hasErrors('breaks')).toBe(false);
-  });
-
-  it('rejects an invalid status', () => {
-    const result = musicTogetherSemesterValidation(valid({ status: 'archived' }));
-    expect(result.hasErrors('status')).toBe(true);
   });
 
   it('supports partial (single-field) validation for updates', () => {

--- a/libs/ts/validation/src/lib/music-together-semester.validation.ts
+++ b/libs/ts/validation/src/lib/music-together-semester.validation.ts
@@ -25,12 +25,10 @@ export interface MusicTogetherSemesterValidationInput {
   breaks?: MusicTogetherSemesterBreakInput[];
   weatherMakeupDates?: (Date | string)[];
   enrollmentOpensAt?: Date | string;
-  status?: string;
   notes?: string;
 }
 
 const SEASONS = ['fall', 'winter', 'spring', 'summer'];
-const SEMESTER_STATUSES = ['planned', 'enrolling', 'active', 'completed'];
 
 function parseDate(value: Date | string | undefined): Date | undefined {
   if (value === undefined) return undefined;
@@ -98,12 +96,6 @@ export const musicTogetherSemesterValidation = staticSuite(
     test('weatherMakeupDates', 'Each weather makeup date must be valid', () => {
       for (const d of data.weatherMakeupDates ?? []) {
         enforce(parseDate(d)).isNotNullish();
-      }
-    });
-
-    test('status', 'Status must be valid', () => {
-      if (data.status !== undefined) {
-        enforce(data.status).inside(SEMESTER_STATUSES);
       }
     });
   }


### PR DESCRIPTION
## What & why

Applies the explicit-controls / derived-status philosophy (from #590 for sections) to **semesters**. The hand-set `status` dropdown (`planned/enrolling/active/completed`) is removed; status is now **derived from the term's date controls the form already collects**:

| Condition | Derived status |
|---|---|
| `endDate` passed | `completed` |
| `startDate` passed | `active` |
| `enrollmentOpensAt` reached | `enrolling` |
| otherwise | `planned` |

## Why it's low-risk (lower than sections)

- **No new fields** — the dates already exist as the explicit controls.
- **Same four status values** — so the Webflow "MT Semesters" CMS field needs no change.
- **Nothing functionally gates on semester status** — it's display-only (Webflow label + admin chip); `mtSemesterIsEnrolling` had no consumers but its own spec. So this is purely a "stop hand-setting, start deriving" change.

## Changes

- **domain**: `mtSemesterDerivedStatus(semester, now)`; `mtSemesterIsEnrolling` reimplemented as derived; `status` removed from `MusicTogetherSemester`
- **validation**: drop the status test + `SEMESTER_STATUSES`
- **repository**: `docToSemester` drops status; `findAll` drops the status filter; removed the now-orphan `status + sortValue` Firestore index
- **api-types**: `GetMusicTogetherSemestersRequest` no longer takes a status filter
- **webflow sync**: sends the derived status
- **admin**: `SemesterFormDialog` status dropdown → read-only derived-status chip; page list chip derived; hook drops the status filter
- specs / fixtures / stories updated

## One behavior change

To show **"enrolling," you set the "Re-enrollment opens" date** (already a form field) instead of picking it from a dropdown — the date is the explicit control.

## Verification

- Unit: full suite **2187 passing** (incl. a semester derived-status truth table)
- Typecheck: `tsc --noEmit` on the maple-spruce app + api-types + webflow → **clean, exit 0**
- Firestore index analyzer: **green**; orphan semester index removed; JSON valid

## Migration (post-merge)

Existing semesters were hand-set. Fall 2026 is `enrolling` with **no** `enrollmentOpensAt`, so it would now derive `planned`. `tools/backfill-mt-semester-status.ts` (untracked, `--prod --apply`) sets the minimal date (its `createdAt`) so each term keeps its old status. I'll run the dry-run and share it before applying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)