### PR TITLE
feat(music-together): admin partial/full cancel-refund parity with classes (#562)

### DIFF
--- a/apps/functions-integration-tests-music-together/src/cancel-music-together-registration.spec.ts
+++ b/apps/functions-integration-tests-music-together/src/cancel-music-together-registration.spec.ts
@@ -173,4 +173,129 @@ describe('cancelMusicTogetherRegistration', () => {
     });
     expect(result.status).not.toBe(200);
   });
+
+  it('admin partial refund: refunds the chosen amount, cancels scheduled charges', async () => {
+    await setFirestoreDoc(
+      'musicTogetherRegistrations',
+      'reg-partial',
+      reg({ email: 'partial@test.com' })
+    );
+    await setFirestoreDoc('musicTogetherScheduledCharges', 'chg-partial', {
+      registrationId: 'reg-partial',
+      sectionId: 'sec-future',
+      installmentNumber: 2,
+      amountCents: 12000,
+      dueAt: future,
+      status: 'scheduled',
+      idempotencyKey: 'mt-charge-partial',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const result = await callFunction<
+      CancelMusicTogetherRegistrationRequest,
+      CancelMusicTogetherRegistrationResponse
+    >({
+      functionName: 'cancelMusicTogetherRegistration',
+      data: { registrationId: 'reg-partial', refundCents: 5000 },
+      idToken: admin.idToken,
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data?.status).toBe('refunded');
+    expect(result.data?.refundCents).toBe(5000);
+    expect(String(result.data?.refundId)).toMatch(/^mock-refund-/);
+    expect(result.data?.cancelledChargeCount).toBe(1);
+
+    const charge = await getFirestoreDoc(
+      'musicTogetherScheduledCharges',
+      'chg-partial'
+    );
+    expect(charge?.status).toBe('cancelled');
+    const updated = await getFirestoreDoc(
+      'musicTogetherRegistrations',
+      'reg-partial'
+    );
+    expect(updated?.status).toBe('refunded');
+  });
+
+  it('admin full refund overrides the $25 policy fee', async () => {
+    await setFirestoreDoc(
+      'musicTogetherRegistrations',
+      'reg-full',
+      reg({ email: 'full@test.com' })
+    );
+
+    const result = await callFunction<
+      CancelMusicTogetherRegistrationRequest,
+      CancelMusicTogetherRegistrationResponse
+    >({
+      functionName: 'cancelMusicTogetherRegistration',
+      data: { registrationId: 'reg-full', refundCents: 13200 },
+      idToken: admin.idToken,
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data?.status).toBe('refunded');
+    expect(result.data?.refundCents).toBe(13200);
+  });
+
+  it('installment-aware: a partial refund spans a paid installment payment', async () => {
+    // Registration payment (13200) + a paid installment 2 (12000) captured.
+    await setFirestoreDoc(
+      'musicTogetherRegistrations',
+      'reg-span',
+      reg({ email: 'span@test.com' })
+    );
+    await setFirestoreDoc('musicTogetherScheduledCharges', 'chg-span-paid', {
+      registrationId: 'reg-span',
+      sectionId: 'sec-future',
+      installmentNumber: 2,
+      amountCents: 12000,
+      dueAt: pastDate,
+      status: 'paid',
+      squarePaymentId: 'mock-payment-installment2',
+      idempotencyKey: 'mt-charge-span',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const result = await callFunction<
+      CancelMusicTogetherRegistrationRequest,
+      CancelMusicTogetherRegistrationResponse
+    >({
+      functionName: 'cancelMusicTogetherRegistration',
+      // 20000 = 13200 (reg payment) + 6800 (installment 2)
+      data: { registrationId: 'reg-span', refundCents: 20000 },
+      idToken: admin.idToken,
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data?.status).toBe('refunded');
+    expect(result.data?.refundCents).toBe(20000);
+    // Two refunds issued — one per captured payment.
+    expect(result.data?.refundIds).toHaveLength(2);
+  });
+
+  it('rejects an over-refund above the captured amount (no state change)', async () => {
+    await setFirestoreDoc(
+      'musicTogetherRegistrations',
+      'reg-over',
+      reg({ email: 'over@test.com' })
+    );
+
+    const result = await callFunction<CancelMusicTogetherRegistrationRequest>({
+      functionName: 'cancelMusicTogetherRegistration',
+      data: { registrationId: 'reg-over', refundCents: 13201 },
+      idToken: admin.idToken,
+    });
+
+    expect(result.status).not.toBe(200);
+    // Registration is untouched — still confirmed.
+    const untouched = await getFirestoreDoc(
+      'musicTogetherRegistrations',
+      'reg-over'
+    );
+    expect(untouched?.status).toBe('confirmed');
+  });
 });

--- a/apps/maple-spruce/src/app/(admin)/music-together/RosterDialog.stories.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/RosterDialog.stories.tsx
@@ -23,6 +23,7 @@ function reg(
     paymentPlan: 'installments',
     policiesAcceptedAt: new Date('2030-01-01T00:00:00Z'),
     pricePaidCents: 13200,
+    squarePaymentId: 'pay-1',
     status: 'confirmed',
     createdAt: new Date('2030-01-01T00:00:00Z'),
     updatedAt: new Date('2030-01-01T00:00:00Z'),
@@ -177,6 +178,96 @@ export const RostersAndDownloadsCsv: Story = {
 
     await userEvent.click(canvas.getByRole('button', { name: /close/i }));
     await expect(args.onClose).toHaveBeenCalled();
+  },
+};
+
+/**
+ * Drives the admin cancel/refund flow: open the confirm dialog for a family,
+ * override the prefilled policy amount with a partial refund, confirm, and
+ * assert the callback fires with the chosen cents. The amount field prefills
+ * with the policy refund (paid − $25 fee) since the mock section is pre-class.
+ */
+export const CancelsWithPartialRefund: Story = {
+  args: {
+    rosterState: { status: 'success', data: withFamilies },
+    onCancelRegistration: fn(async () => ({
+      registrationId: 'reg-1',
+      status: 'refunded' as const,
+      refundCents: 5000,
+      refundId: 'ref-1',
+      cancelledChargeCount: 1,
+    })),
+  },
+  play: async ({ args }) => {
+    const canvas = body();
+    await waitFor(() =>
+      expect(canvas.getByRole('dialog')).toBeInTheDocument()
+    );
+
+    // Open the cancel dialog for the first family.
+    await userEvent.click(
+      canvas.getByRole('button', {
+        name: /cancel registration for Jamie Rivera/i,
+      })
+    );
+
+    // The amount field prefills with the policy refund ($132.00 − $25 fee).
+    const amount = (await waitFor(() =>
+      canvas.getByLabelText(/refund amount/i)
+    )) as HTMLInputElement;
+    await expect(amount).toHaveValue(107);
+
+    // Override with a partial refund of $50.00.
+    await userEvent.clear(amount);
+    await userEvent.type(amount, '50');
+
+    await userEvent.click(
+      canvas.getByRole('button', { name: /confirm cancel/i })
+    );
+
+    await waitFor(() =>
+      expect(args.onCancelRegistration).toHaveBeenCalledWith('reg-1', 5000)
+    );
+  },
+};
+
+/**
+ * The refund field rejects an amount above what was captured, disabling the
+ * confirm button so an over-refund can't be submitted.
+ */
+export const RejectsOverRefund: Story = {
+  args: {
+    rosterState: { status: 'success', data: withFamilies },
+    onCancelRegistration: fn(async () => ({
+      registrationId: 'reg-1',
+      status: 'refunded' as const,
+      refundCents: 0,
+      cancelledChargeCount: 0,
+    })),
+  },
+  play: async ({ args }) => {
+    const canvas = body();
+    await waitFor(() =>
+      expect(canvas.getByRole('dialog')).toBeInTheDocument()
+    );
+
+    await userEvent.click(
+      canvas.getByRole('button', {
+        name: /cancel registration for Jamie Rivera/i,
+      })
+    );
+    const amount = (await waitFor(() =>
+      canvas.getByLabelText(/refund amount/i)
+    )) as HTMLInputElement;
+
+    // $200 exceeds the $132 captured on this registration.
+    await userEvent.clear(amount);
+    await userEvent.type(amount, '200');
+
+    // The confirm button is disabled, so the over-refund can't be submitted.
+    const confirm = canvas.getByRole('button', { name: /confirm cancel/i });
+    await expect(confirm).toBeDisabled();
+    await expect(args.onCancelRegistration).not.toHaveBeenCalled();
   },
 };
 

--- a/apps/maple-spruce/src/app/(admin)/music-together/RosterDialog.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/RosterDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -17,21 +17,38 @@ import {
   Box,
   CircularProgress,
   Alert,
+  TextField,
 } from '@mui/material';
 import DownloadIcon from '@mui/icons-material/Download';
 import {
   buildMusicTogetherLicenseeCsv,
   buildMusicTogetherInternalRosterCsv,
   mtFormatDob,
+  mtRefundCents,
+  mtSectionFirstSessionAt,
   type RequestState,
+  type MusicTogetherSection,
 } from '@maple/ts/domain';
-import type { GetMusicTogetherRosterResponse } from '@maple/ts/firebase/api-types';
+import type {
+  GetMusicTogetherRosterResponse,
+  MusicTogetherRosterEntry,
+  CancelMusicTogetherRegistrationResponse,
+} from '@maple/ts/firebase/api-types';
 
 interface Props {
   open: boolean;
   onClose: () => void;
   sectionName: string;
   rosterState: RequestState<GetMusicTogetherRosterResponse>;
+  /**
+   * Cancel a family's registration with an optional refund amount (cents).
+   * Omit the amount to apply the program's policy refund. When not provided,
+   * the roster is read-only (no cancel action rendered).
+   */
+  onCancelRegistration?: (
+    registrationId: string,
+    refundCents?: number
+  ) => Promise<CancelMusicTogetherRegistrationResponse>;
 }
 
 function downloadCsv(filename: string, csv: string) {
@@ -46,17 +63,121 @@ function downloadCsv(filename: string, csv: string) {
   URL.revokeObjectURL(url);
 }
 
-export function RosterDialog({ open, onClose, sectionName, rosterState }: Props) {
+const fmtCents = (cents: number) => `$${(cents / 100).toFixed(2)}`;
+
+/** Chip color for a roster row's status (past-due takes precedence). */
+function statusChipColor(
+  status: string,
+  pastDue: boolean
+): 'error' | 'success' | 'info' | 'default' {
+  if (pastDue) return 'error';
+  if (status === 'confirmed') return 'success';
+  if (status === 'refunded') return 'info';
+  if (status === 'cancelled') return 'error';
+  return 'default';
+}
+
+/** Total amount captured for a registration: reg-time charge + paid installments. */
+function capturedCents(entry: MusicTogetherRosterEntry): number {
+  const reg = entry.registration;
+  const base = reg.squarePaymentId ? reg.pricePaidCents : 0;
+  const paid = (entry.charges ?? [])
+    .filter((c) => c.status === 'paid' && !!c.squarePaymentId)
+    .reduce((sum, c) => sum + c.amountCents, 0);
+  return base + paid;
+}
+
+export function RosterDialog({
+  open,
+  onClose,
+  sectionName,
+  rosterState,
+  onCancelRegistration,
+}: Props) {
+  const section: MusicTogetherSection | undefined =
+    rosterState.status === 'success' ? rosterState.data.section : undefined;
   const entries =
     rosterState.status === 'success' ? rosterState.data.entries : [];
 
   const confirmed = useMemo(
-    () =>
-      entries.filter((e) => e.registration.status === 'confirmed'),
+    () => entries.filter((e) => e.registration.status === 'confirmed'),
     [entries]
   );
 
   const safeName = sectionName.replace(/[^a-z0-9]+/gi, '-').toLowerCase();
+
+  // ── Cancel / refund flow ─────────────────────────────────────────────
+  const [cancelTarget, setCancelTarget] =
+    useState<MusicTogetherRosterEntry | null>(null);
+  const [refundDollars, setRefundDollars] = useState('');
+  const [isCancelling, setIsCancelling] = useState(false);
+  const [cancelError, setCancelError] = useState<string | null>(null);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+
+  const targetCaptured = cancelTarget ? capturedCents(cancelTarget) : 0;
+  const targetPolicyCents = cancelTarget
+    ? Math.min(
+        mtRefundCents(
+          cancelTarget.registration.pricePaidCents,
+          section ? mtSectionFirstSessionAt(section) : undefined,
+          new Date()
+        ),
+        targetCaptured
+      )
+    : 0;
+
+  const openCancel = (entry: MusicTogetherRosterEntry) => {
+    setCancelTarget(entry);
+    setCancelError(null);
+    // Prefill with the policy default; admin can override to any amount.
+    const policy = Math.min(
+      mtRefundCents(
+        entry.registration.pricePaidCents,
+        section ? mtSectionFirstSessionAt(section) : undefined,
+        new Date()
+      ),
+      capturedCents(entry)
+    );
+    setRefundDollars((policy / 100).toFixed(2));
+  };
+
+  const closeCancel = () => {
+    setCancelTarget(null);
+    setRefundDollars('');
+    setCancelError(null);
+    setIsCancelling(false);
+  };
+
+  const refundCentsValue = Math.round(parseFloat(refundDollars) * 100);
+  const refundInvalid =
+    refundDollars.trim() === '' ||
+    Number.isNaN(refundCentsValue) ||
+    refundCentsValue < 0 ||
+    refundCentsValue > targetCaptured;
+
+  const handleConfirmCancel = async () => {
+    if (!cancelTarget || !onCancelRegistration || refundInvalid) return;
+    setIsCancelling(true);
+    setCancelError(null);
+    try {
+      const result = await onCancelRegistration(
+        cancelTarget.registration.id,
+        refundCentsValue
+      );
+      setActionMessage(
+        result.refundCents > 0
+          ? `Registration cancelled; ${fmtCents(result.refundCents)} refunded.`
+          : 'Registration cancelled (no refund).'
+      );
+      closeCancel();
+    } catch (error) {
+      setCancelError(
+        error instanceof Error ? error.message : 'Failed to cancel'
+      );
+    } finally {
+      setIsCancelling(false);
+    }
+  };
 
   // Licensee report → shared with Music Together Worldwide: adult contact only.
   const handleDownloadLicensee = () => {
@@ -78,6 +199,15 @@ export function RosterDialog({ open, onClose, sectionName, rosterState }: Props)
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
       <DialogTitle>Roster — {sectionName}</DialogTitle>
       <DialogContent>
+        {actionMessage && (
+          <Alert
+            severity="success"
+            sx={{ mb: 2 }}
+            onClose={() => setActionMessage(null)}
+          >
+            {actionMessage}
+          </Alert>
+        )}
         {rosterState.status === 'loading' && (
           <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
             <CircularProgress />
@@ -100,53 +230,69 @@ export function RosterDialog({ open, onClose, sectionName, rosterState }: Props)
                 <TableCell>Accommodations / notes</TableCell>
                 <TableCell>Plan</TableCell>
                 <TableCell>Status</TableCell>
+                {onCancelRegistration && (
+                  <TableCell align="right">Actions</TableCell>
+                )}
               </TableRow>
             </TableHead>
             <TableBody>
-              {entries.map((entry) => (
-                <TableRow key={entry.registration.id}>
-                  <TableCell>{entry.registration.parentNames.join(', ')}</TableCell>
-                  <TableCell>
-                    {entry.registration.children
-                      .map((c) => `${c.name} (${mtFormatDob(new Date(c.dob))})`)
-                      .join(', ')}
-                  </TableCell>
-                  <TableCell sx={{ maxWidth: 240, whiteSpace: 'pre-wrap' }}>
-                    {[
-                      entry.registration.accommodations
-                        ? `Accommodations: ${entry.registration.accommodations}`
-                        : null,
-                      entry.registration.notes
-                        ? `Notes: ${entry.registration.notes}`
-                        : null,
-                    ]
-                      .filter(Boolean)
-                      .join('\n') || (
-                      <Typography variant="body2" color="text.disabled">
-                        —
-                      </Typography>
+              {entries.map((entry) => {
+                const status = entry.registration.status;
+                const canCancel =
+                  status === 'confirmed' || status === 'pending';
+                return (
+                  <TableRow key={entry.registration.id}>
+                    <TableCell>
+                      {entry.registration.parentNames.join(', ')}
+                    </TableCell>
+                    <TableCell>
+                      {entry.registration.children
+                        .map(
+                          (c) => `${c.name} (${mtFormatDob(new Date(c.dob))})`
+                        )
+                        .join(', ')}
+                    </TableCell>
+                    <TableCell sx={{ maxWidth: 240, whiteSpace: 'pre-wrap' }}>
+                      {[
+                        entry.registration.accommodations
+                          ? `Accommodations: ${entry.registration.accommodations}`
+                          : null,
+                        entry.registration.notes
+                          ? `Notes: ${entry.registration.notes}`
+                          : null,
+                      ]
+                        .filter(Boolean)
+                        .join('\n') || (
+                        <Typography variant="body2" color="text.disabled">
+                          —
+                        </Typography>
+                      )}
+                    </TableCell>
+                    <TableCell>{entry.registration.paymentPlan}</TableCell>
+                    <TableCell>
+                      <Chip
+                        size="small"
+                        label={entry.pastDue ? 'Past due' : status}
+                        color={statusChipColor(status, entry.pastDue)}
+                      />
+                    </TableCell>
+                    {onCancelRegistration && (
+                      <TableCell align="right">
+                        {canCancel && (
+                          <Button
+                            size="small"
+                            color="error"
+                            onClick={() => openCancel(entry)}
+                            aria-label={`Cancel registration for ${entry.registration.parentNames.join(', ')}`}
+                          >
+                            Cancel / refund
+                          </Button>
+                        )}
+                      </TableCell>
                     )}
-                  </TableCell>
-                  <TableCell>{entry.registration.paymentPlan}</TableCell>
-                  <TableCell>
-                    <Chip
-                      size="small"
-                      label={
-                        entry.pastDue
-                          ? 'Past due'
-                          : entry.registration.status
-                      }
-                      color={
-                        entry.pastDue
-                          ? 'error'
-                          : entry.registration.status === 'confirmed'
-                            ? 'success'
-                            : 'default'
-                      }
-                    />
-                  </TableCell>
-                </TableRow>
-              ))}
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
         )}
@@ -168,6 +314,64 @@ export function RosterDialog({ open, onClose, sectionName, rosterState }: Props)
         </Button>
         <Button onClick={onClose}>Close</Button>
       </DialogActions>
+
+      {/* Cancel / refund confirmation */}
+      <Dialog open={!!cancelTarget} onClose={closeCancel} maxWidth="xs" fullWidth>
+        <DialogTitle>Cancel registration</DialogTitle>
+        <DialogContent>
+          {cancelTarget && (
+            <Box
+              sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}
+            >
+              {cancelError && (
+                <Alert severity="error" onClose={() => setCancelError(null)}>
+                  {cancelError}
+                </Alert>
+              )}
+              <Typography variant="body2">
+                Cancel{' '}
+                <strong>
+                  {cancelTarget.registration.parentNames.join(', ')}
+                </strong>
+                ? Any scheduled installment charges will be cancelled so they
+                never run.
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Captured: {fmtCents(targetCaptured)} · Policy refund:{' '}
+                {fmtCents(targetPolicyCents)}
+              </Typography>
+              <TextField
+                label="Refund amount ($)"
+                value={refundDollars}
+                onChange={(e) => setRefundDollars(e.target.value)}
+                type="number"
+                size="small"
+                inputProps={{ min: 0, max: targetCaptured / 100, step: 0.01 }}
+                error={refundInvalid}
+                helperText={
+                  refundInvalid
+                    ? `Enter an amount between $0.00 and ${fmtCents(targetCaptured)}`
+                    : `Max ${fmtCents(targetCaptured)}. Enter $0.00 to cancel with no refund.`
+                }
+                fullWidth
+              />
+            </Box>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeCancel} disabled={isCancelling}>
+            Back
+          </Button>
+          <Button
+            color="error"
+            variant="contained"
+            onClick={handleConfirmCancel}
+            disabled={isCancelling || refundInvalid}
+          >
+            {isCancelling ? 'Cancelling…' : 'Confirm cancel'}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Dialog>
   );
 }

--- a/apps/maple-spruce/src/app/(admin)/music-together/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/page.tsx
@@ -93,7 +93,9 @@ export default function MusicTogetherPage() {
   const [rosterSection, setRosterSection] = useState<
     MusicTogetherSection | undefined
   >();
-  const { rosterState } = useMusicTogetherRoster(rosterSection?.id);
+  const { rosterState, cancelRegistration } = useMusicTogetherRoster(
+    rosterSection?.id
+  );
 
   const semesters = useMemo(
     () => (semestersState.status === 'success' ? semestersState.data : []),
@@ -412,6 +414,7 @@ export default function MusicTogetherPage() {
         onClose={() => setRosterSection(undefined)}
         sectionName={rosterSection?.name ?? ''}
         rosterState={rosterState}
+        onCancelRegistration={cancelRegistration}
       />
     </>
   );

--- a/libs/firebase/maple-functions/cancel-music-together-registration/src/lib/cancel-music-together-registration.spec.ts
+++ b/libs/firebase/maple-functions/cancel-music-together-registration/src/lib/cancel-music-together-registration.spec.ts
@@ -179,4 +179,145 @@ describe('cancelMusicTogetherRegistration', () => {
   it('requires a registration id', async () => {
     await expect(run({})).rejects.toThrow(/required/i);
   });
+
+  it('admin partial refund: refunds the chosen amount against the reg payment', async () => {
+    mocks.sectionFindById.mockResolvedValue(futureSection);
+
+    const result = (await run({
+      registrationId: 'reg-1',
+      refundCents: 5000,
+    })) as { status: string; refundCents: number; cancelledChargeCount: number };
+
+    expect(mocks.refundPayment).toHaveBeenCalledTimes(1);
+    expect(mocks.refundPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paymentId: 'pay-1',
+        amountCents: 5000,
+        idempotencyKey: 'mtrefund-reg-1', // stable
+      })
+    );
+    // Section policy is NOT consulted when an explicit amount is given.
+    expect(mocks.sectionFindById).not.toHaveBeenCalled();
+    expect(result.status).toBe('refunded');
+    expect(result.refundCents).toBe(5000);
+    expect(result.cancelledChargeCount).toBe(1);
+  });
+
+  it('admin full refund overrides the $25 policy fee', async () => {
+    mocks.sectionFindById.mockResolvedValue(futureSection);
+
+    const result = (await run({
+      registrationId: 'reg-1',
+      refundCents: 13200,
+    })) as { refundCents: number };
+
+    expect(mocks.refundPayment).toHaveBeenCalledWith(
+      expect.objectContaining({ paymentId: 'pay-1', amountCents: 13200 })
+    );
+    expect(result.refundCents).toBe(13200);
+  });
+
+  it('admin refund of 0 cancels without a Square refund', async () => {
+    const result = (await run({
+      registrationId: 'reg-1',
+      refundCents: 0,
+    })) as { status: string; refundCents: number };
+
+    expect(mocks.refundPayment).not.toHaveBeenCalled();
+    expect(result.status).toBe('cancelled');
+    expect(result.refundCents).toBe(0);
+  });
+
+  it('rejects an over-refund above the captured amount (before any Square call)', async () => {
+    await expect(
+      run({ registrationId: 'reg-1', refundCents: 13201 })
+    ).rejects.toThrow(/exceeds/i);
+    expect(mocks.refundPayment).not.toHaveBeenCalled();
+    expect(mocks.regUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a negative / non-integer refund amount', async () => {
+    await expect(
+      run({ registrationId: 'reg-1', refundCents: -1 })
+    ).rejects.toThrow(/whole number|non-negative/i);
+    await expect(
+      run({ registrationId: 'reg-1', refundCents: 12.5 })
+    ).rejects.toThrow(/whole number|non-negative/i);
+    expect(mocks.refundPayment).not.toHaveBeenCalled();
+  });
+
+  it('installment-aware: a partial refund spans a paid installment payment', async () => {
+    // Reg payment 13200 (installment 1) + a paid installment 2 of 12000.
+    mocks.chargesByReg.mockResolvedValue([
+      {
+        id: 'chg-2',
+        status: 'paid',
+        squarePaymentId: 'pay-2',
+        amountCents: 12000,
+        installmentNumber: 2,
+      },
+    ]);
+    mocks.refundPayment.mockImplementation(async (input: { paymentId: string }) => ({
+      refundId: `ref-${input.paymentId}`,
+    }));
+
+    const result = (await run({
+      registrationId: 'reg-1',
+      refundCents: 20000, // 13200 from reg payment + 6800 from installment 2
+    })) as { refundCents: number; refundId?: string; refundIds?: string[] };
+
+    expect(mocks.refundPayment).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        paymentId: 'pay-1',
+        amountCents: 13200,
+        idempotencyKey: 'mtrefund-reg-1',
+      })
+    );
+    expect(mocks.refundPayment).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        paymentId: 'pay-2',
+        amountCents: 6800,
+        idempotencyKey: 'mtrefund-reg-1-pay-2', // stable, per-payment
+      })
+    );
+    expect(result.refundCents).toBe(20000);
+    expect(result.refundId).toBe('ref-pay-1');
+    expect(result.refundIds).toEqual(['ref-pay-1', 'ref-pay-2']);
+  });
+
+  it('installment-aware: over-refund rejected against total captured (reg + paid installment)', async () => {
+    mocks.chargesByReg.mockResolvedValue([
+      {
+        id: 'chg-2',
+        status: 'paid',
+        squarePaymentId: 'pay-2',
+        amountCents: 12000,
+        installmentNumber: 2,
+      },
+    ]);
+    // Total captured = 25200; 25201 must be rejected.
+    await expect(
+      run({ registrationId: 'reg-1', refundCents: 25201 })
+    ).rejects.toThrow(/exceeds/i);
+    expect(mocks.refundPayment).not.toHaveBeenCalled();
+  });
+
+  it('policy default clamps to captured when the reg has no payment on file', async () => {
+    mocks.sectionFindById.mockResolvedValue(futureSection);
+    mocks.regFindById.mockResolvedValue({
+      ...installmentReg,
+      squarePaymentId: undefined,
+    });
+
+    const result = (await run({ registrationId: 'reg-1' })) as {
+      status: string;
+      refundCents: number;
+    };
+
+    expect(mocks.refundPayment).not.toHaveBeenCalled();
+    expect(result.status).toBe('cancelled');
+    expect(result.refundCents).toBe(0);
+  });
 });

--- a/libs/firebase/maple-functions/cancel-music-together-registration/src/lib/cancel-music-together-registration.ts
+++ b/libs/firebase/maple-functions/cancel-music-together-registration/src/lib/cancel-music-together-registration.ts
@@ -1,14 +1,24 @@
 /**
  * Cancel Music Together Registration Cloud Function (admin, MT Square account)
  *
- * Admin-only cancellation from the roster. Applies the program's refund policy
- * and — critically — flips the family's scheduled installment charges to
+ * Admin-only cancellation from the roster. Issues a Square refund — the
+ * program's policy amount by default, or an admin-chosen partial/full amount —
+ * and, critically, flips the family's scheduled installment charges to
  * `cancelled` so the Week-5 auto-charge job never runs them (the cancel-guard
  * layer of the overcharge-safety model).
  *
- * Refund policy:
- *   - BEFORE the first class → amount paid at registration minus the $25 fee.
- *   - ON/AFTER the first class → non-refundable.
+ * Refund amount:
+ *   - `refundCents` omitted → program policy: amount paid at registration minus
+ *     the $25 fee before the first class; non-refundable on/after. This is also
+ *     the amount a customer self-service cancellation would use.
+ *   - `refundCents` provided → that exact amount (admin discretion), validated
+ *     to be an integer in [0, total captured] BEFORE any Square write.
+ *
+ * "Total captured" is the registration-time charge plus any installments
+ * already paid. A partial/full refund is allocated greedily across those
+ * captured payments (Square refunds are per-payment), so a refund can span the
+ * registration charge and a paid installment. Not-yet-charged scheduled charges
+ * are never "refunded" — they are cancelled so they never run.
  *
  * Refund routes to MT's separate Square account (MT_SQUARE_KEYS).
  * Deployed to us-east4 via CI/CD (maple-square codebase).
@@ -31,7 +41,13 @@ import {
   MusicTogetherSectionRepository,
   MusicTogetherScheduledChargeRepository,
 } from '@maple/firebase/database';
-import { mtRefundCents, mtSectionFirstSessionAt } from '@maple/ts/domain';
+import {
+  mtRefundCents,
+  mtSectionFirstSessionAt,
+  mtTotalCapturedCents,
+  mtAllocateRefund,
+  type MtCapturedPayment,
+} from '@maple/ts/domain';
 import type {
   CancelMusicTogetherRegistrationRequest,
   CancelMusicTogetherRegistrationResponse,
@@ -64,39 +80,97 @@ export const cancelMusicTogetherRegistration = Functions.endpoint
       );
     }
 
-    // Determine the refund from the program policy (section first-class date).
-    const section = await MusicTogetherSectionRepository.findById(
-      registration.sectionId
-    );
-    const firstClassAt = section
-      ? mtSectionFirstSessionAt(section)
-      : undefined;
-    const refundCents = mtRefundCents(
-      registration.pricePaidCents,
-      firstClassAt,
-      new Date()
-    );
-
-    // Issue the refund (if any) against the registration-time payment.
-    let refundId: string | undefined;
-    if (refundCents > 0 && registration.squarePaymentId) {
-      const square = new Square(secrets, strings, MT_SQUARE_KEYS);
-      const refund = await square.paymentsService.refundPayment({
-        paymentId: registration.squarePaymentId,
-        amountCents: refundCents,
-        // Stable key — a retried cancel returns the original refund.
-        idempotencyKey: `mtrefund-${data.registrationId}`,
-        reason: 'Music Together registration cancelled',
-      });
-      refundId = refund.refundId;
-    }
-
-    // Cancel any still-scheduled future charges so the auto-charge job skips
-    // them. Already-paid/failed charges are left as-is for the record.
+    // All charges for this registration — needed both to compute what's been
+    // captured (paid installments are refundable) and, later, to cancel the
+    // still-scheduled ones (the cancel-guard).
     const charges =
       await MusicTogetherScheduledChargeRepository.findByRegistrationId(
         data.registrationId
       );
+
+    // Captured payments a refund can draw against, in order: the
+    // registration-time charge first, then paid installments by installment
+    // number. Refunds allocate greedily across these.
+    const paidCharges = charges
+      .filter((c) => c.status === 'paid' && !!c.squarePaymentId)
+      .sort((a, b) => a.installmentNumber - b.installmentNumber);
+    const capturedPayments: MtCapturedPayment[] = [];
+    if (registration.squarePaymentId) {
+      capturedPayments.push({
+        squarePaymentId: registration.squarePaymentId,
+        amountCents: registration.pricePaidCents,
+      });
+    }
+    for (const charge of paidCharges) {
+      capturedPayments.push({
+        squarePaymentId: charge.squarePaymentId as string,
+        amountCents: charge.amountCents,
+      });
+    }
+    const totalCaptured = mtTotalCapturedCents(capturedPayments);
+
+    // Resolve the refund amount. Validate BEFORE any Square write so an invalid
+    // amount never reaches the payments API.
+    let requestedRefundCents: number;
+    if (data.refundCents === undefined) {
+      // Policy default (also the customer self-service amount).
+      const section = await MusicTogetherSectionRepository.findById(
+        registration.sectionId
+      );
+      const firstClassAt = section
+        ? mtSectionFirstSessionAt(section)
+        : undefined;
+      // Policy is based on the registration-time charge; clamp to what's
+      // actually captured for safety.
+      requestedRefundCents = Math.min(
+        mtRefundCents(registration.pricePaidCents, firstClassAt, new Date()),
+        totalCaptured
+      );
+    } else {
+      if (!Number.isInteger(data.refundCents) || data.refundCents < 0) {
+        throwInvalidArgument(
+          'Refund amount must be a non-negative whole number of cents'
+        );
+      }
+      if (data.refundCents > totalCaptured) {
+        throwInvalidArgument(
+          `Refund amount (${data.refundCents}¢) exceeds the amount captured (${totalCaptured}¢)`
+        );
+      }
+      requestedRefundCents = data.refundCents;
+    }
+
+    // Issue the refund(s), allocated across the captured payments.
+    const allocations = mtAllocateRefund(
+      capturedPayments,
+      requestedRefundCents
+    );
+    const refundIds: string[] = [];
+    let refundedCents = 0;
+    if (allocations.length > 0) {
+      const square = new Square(secrets, strings, MT_SQUARE_KEYS);
+      for (const allocation of allocations) {
+        // Stable idempotency key so a retried cancel returns the original
+        // refund instead of refunding again. Keyed by payment: the
+        // registration charge keeps the historical `mtrefund-<regId>` key;
+        // installment payments get a per-payment key.
+        const idempotencyKey =
+          allocation.squarePaymentId === registration.squarePaymentId
+            ? `mtrefund-${data.registrationId}`
+            : `mtrefund-${data.registrationId}-${allocation.squarePaymentId}`;
+        const refund = await square.paymentsService.refundPayment({
+          paymentId: allocation.squarePaymentId,
+          amountCents: allocation.amountCents,
+          idempotencyKey,
+          reason: 'Music Together registration cancelled',
+        });
+        refundIds.push(refund.refundId);
+        refundedCents += allocation.amountCents;
+      }
+    }
+
+    // Cancel any still-scheduled future charges so the auto-charge job skips
+    // them. Already-paid/failed charges are left as-is for the record.
     let cancelledChargeCount = 0;
     for (const charge of charges) {
       if (charge.status === 'scheduled') {
@@ -109,7 +183,7 @@ export const cancelMusicTogetherRegistration = Functions.endpoint
       }
     }
 
-    const status = refundId ? 'refunded' : 'cancelled';
+    const status = refundIds.length > 0 ? 'refunded' : 'cancelled';
     await MusicTogetherRegistrationRepository.update({
       id: data.registrationId,
       status,
@@ -118,8 +192,9 @@ export const cancelMusicTogetherRegistration = Functions.endpoint
     return {
       registrationId: data.registrationId,
       status,
-      refundCents: refundId ? refundCents : 0,
-      refundId,
+      refundCents: refundedCents,
+      refundId: refundIds[0],
+      refundIds: refundIds.length > 0 ? refundIds : undefined,
       cancelledChargeCount,
     };
   });

--- a/libs/react/data/src/lib/useMusicTogetherRoster.ts
+++ b/libs/react/data/src/lib/useMusicTogetherRoster.ts
@@ -1,12 +1,16 @@
 'use client';
 
 import { useState, useCallback, useEffect } from 'react';
+import { httpsCallable } from 'firebase/functions';
+import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
 import { callDeduped } from './call-deduped';
 import type { RequestState } from '@maple/ts/domain';
 import type {
   GetMusicTogetherRosterRequest,
   GetMusicTogetherRosterResponse,
   MusicTogetherRosterEntry,
+  CancelMusicTogetherRegistrationRequest,
+  CancelMusicTogetherRegistrationResponse,
 } from '@maple/ts/firebase/api-types';
 
 /** Hydrate ISO date strings in a roster entry back into Dates. */
@@ -70,5 +74,31 @@ export function useMusicTogetherRoster(sectionId: string | undefined) {
     fetchRoster();
   }, [fetchRoster]);
 
-  return { rosterState, fetchRoster };
+  /**
+   * Cancel a family's registration with an optional refund. Omit `refundCents`
+   * to apply the program's policy refund (paid − $25 before the first class;
+   * $0 after); pass an explicit amount for a partial/full refund. Reloads the
+   * roster on success so the updated status shows.
+   */
+  const cancelRegistration = useCallback(
+    async (
+      registrationId: string,
+      refundCents?: number
+    ): Promise<CancelMusicTogetherRegistrationResponse> => {
+      const functions = getMapleFunctions();
+      const cancel = httpsCallable<
+        CancelMusicTogetherRegistrationRequest,
+        CancelMusicTogetherRegistrationResponse
+      >(functions, 'cancelMusicTogetherRegistration');
+      const result = await cancel({
+        registrationId,
+        ...(refundCents !== undefined ? { refundCents } : {}),
+      });
+      await fetchRoster();
+      return result.data;
+    },
+    [fetchRoster]
+  );
+
+  return { rosterState, fetchRoster, cancelRegistration };
 }

--- a/libs/ts/domain/src/lib/music-together-registration.spec.ts
+++ b/libs/ts/domain/src/lib/music-together-registration.spec.ts
@@ -3,6 +3,8 @@ import {
   isMtRegistrationConfirmed,
   mtRegistrationHasScheduledCharges,
   mtRefundCents,
+  mtTotalCapturedCents,
+  mtAllocateRefund,
   MT_CANCELLATION_FEE_CENTS,
   MT_CAPACITY_STATUSES,
 } from './music-together-registration';
@@ -45,6 +47,63 @@ describe('mtRefundCents', () => {
 
   it('treats a section with no first class as pre-class (refundable)', () => {
     expect(mtRefundCents(25200, undefined, new Date())).toBe(25200 - fee);
+  });
+});
+
+describe('mtTotalCapturedCents', () => {
+  it('sums captured payment amounts', () => {
+    expect(
+      mtTotalCapturedCents([
+        { squarePaymentId: 'p1', amountCents: 13200 },
+        { squarePaymentId: 'p2', amountCents: 12000 },
+      ])
+    ).toBe(25200);
+  });
+
+  it('is 0 for no payments and ignores negative amounts', () => {
+    expect(mtTotalCapturedCents([])).toBe(0);
+    expect(
+      mtTotalCapturedCents([{ squarePaymentId: 'p1', amountCents: -5 }])
+    ).toBe(0);
+  });
+});
+
+describe('mtAllocateRefund', () => {
+  const payments = [
+    { squarePaymentId: 'reg', amountCents: 13200 },
+    { squarePaymentId: 'inst2', amountCents: 12000 },
+  ];
+
+  it('draws a partial refund from the first payment only', () => {
+    expect(mtAllocateRefund(payments, 5000)).toEqual([
+      { squarePaymentId: 'reg', amountCents: 5000 },
+    ]);
+  });
+
+  it('spans payments once the first is drained', () => {
+    expect(mtAllocateRefund(payments, 20000)).toEqual([
+      { squarePaymentId: 'reg', amountCents: 13200 },
+      { squarePaymentId: 'inst2', amountCents: 6800 },
+    ]);
+  });
+
+  it('a full refund allocates every payment to capacity', () => {
+    expect(mtAllocateRefund(payments, 25200)).toEqual([
+      { squarePaymentId: 'reg', amountCents: 13200 },
+      { squarePaymentId: 'inst2', amountCents: 12000 },
+    ]);
+  });
+
+  it('clamps a request above total captured to the captured total', () => {
+    expect(mtAllocateRefund(payments, 99999)).toEqual([
+      { squarePaymentId: 'reg', amountCents: 13200 },
+      { squarePaymentId: 'inst2', amountCents: 12000 },
+    ]);
+  });
+
+  it('allocates nothing for a zero or negative request', () => {
+    expect(mtAllocateRefund(payments, 0)).toEqual([]);
+    expect(mtAllocateRefund(payments, -100)).toEqual([]);
   });
 });
 

--- a/libs/ts/domain/src/lib/music-together-registration.ts
+++ b/libs/ts/domain/src/lib/music-together-registration.ts
@@ -165,3 +165,58 @@ export function mtRefundCents(
   }
   return Math.max(0, pricePaidCents - MT_CANCELLATION_FEE_CENTS);
 }
+
+/**
+ * One captured Square payment that a refund can draw against — the
+ * registration-time charge, or a paid installment. `amountCents` is the amount
+ * captured on that payment (the ceiling for refunding it).
+ */
+export interface MtCapturedPayment {
+  squarePaymentId: string;
+  amountCents: number;
+}
+
+/** Sum of a set of captured payments — the maximum a refund may total. */
+export function mtTotalCapturedCents(payments: MtCapturedPayment[]): number {
+  return payments.reduce((sum, p) => sum + Math.max(0, p.amountCents), 0);
+}
+
+/** One payment's share of a refund (only payments with a non-zero share). */
+export interface MtRefundAllocation {
+  squarePaymentId: string;
+  amountCents: number;
+}
+
+/**
+ * Split a requested refund across captured payments, greedily and in order:
+ * drain the first payment up to its captured amount, then the next, until the
+ * requested amount is satisfied. Square refunds are per-payment, so an
+ * arbitrary partial refund on an installment registration may span more than
+ * one payment (registration charge + a paid installment).
+ *
+ * `amountCents` is clamped to the total captured, so the returned allocations
+ * always sum to `min(amountCents, totalCaptured)`. Payments that receive
+ * nothing are omitted. A non-positive request yields no allocations.
+ */
+export function mtAllocateRefund(
+  payments: MtCapturedPayment[],
+  amountCents: number
+): MtRefundAllocation[] {
+  let remaining = Math.min(
+    Math.max(0, Math.floor(amountCents)),
+    mtTotalCapturedCents(payments)
+  );
+  const allocations: MtRefundAllocation[] = [];
+  for (const payment of payments) {
+    if (remaining <= 0) break;
+    const capacity = Math.max(0, payment.amountCents);
+    if (capacity <= 0) continue;
+    const take = Math.min(capacity, remaining);
+    allocations.push({
+      squarePaymentId: payment.squarePaymentId,
+      amountCents: take,
+    });
+    remaining -= take;
+  }
+  return allocations;
+}

--- a/libs/ts/firebase/api-types/src/lib/music-together.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/music-together.types.ts
@@ -228,6 +228,16 @@ export interface MusicTogetherInstallmentChargeResult {
 
 export interface CancelMusicTogetherRegistrationRequest {
   registrationId: string;
+  /**
+   * Explicit refund amount in cents (admin discretion — full or partial). When
+   * omitted, the program's policy refund is applied (amount paid − the $25 fee
+   * before the first class; $0 on/after). Must be an integer between 0 and the
+   * total amount captured for the registration (registration-time charge plus
+   * any installments already paid); a value above that is rejected. The
+   * policy-default path (omit this field) is what a customer self-service
+   * cancellation uses.
+   */
+  refundCents?: number;
 }
 
 export interface CancelMusicTogetherRegistrationResponse {
@@ -235,7 +245,14 @@ export interface CancelMusicTogetherRegistrationResponse {
   status: 'cancelled' | 'refunded';
   /** Amount refunded in cents (0 when non-refundable / nothing to refund). */
   refundCents: number;
+  /** First Square refund id (the registration-time charge, when refunded). */
   refundId?: string;
+  /**
+   * All Square refund ids issued. A partial/full refund on an installment
+   * registration can span more than one payment (registration charge + a paid
+   * installment), so there may be more than one.
+   */
+  refundIds?: string[];
   /** How many scheduled future charges were cancelled. */
   cancelledChargeCount: number;
 }


### PR DESCRIPTION
Closes #562. Part of the Music Together epic #508.

## What

Brings Music Together cancel/refund to parity with the M&S **classes** admin cancel/refund, extending it to support **partial or full** refunds at admin discretion.

Today `cancelMusicTogetherRegistration` was fixed-policy (paid − $25 before the first class, nothing after) and backend-only. This PR:

- **Admin discretion**: request now accepts an optional `refundCents`. Omit it → the program policy applies (also the amount a customer self-service cancellation would use). Provide it → that exact amount, validated to be an integer in `[0, total captured]` **before any Square write**.
- **Installment-aware**: "total captured" = the registration-time charge + any installments already **paid**. A refund is allocated greedily across those captured payments (Square refunds are per-payment), so a partial/full refund can span the registration charge and a paid installment. Not-yet-charged scheduled charges are **cancelled, never refunded** — preserving the overcharge-safety cancel-guard (`scheduled → cancelled`).
- **Idempotency**: stable keys per payment — the registration charge keeps the historical `mtrefund-<regId>`; installment payments get `mtrefund-<regId>-<paymentId>`. A retried cancel never double-refunds. Refunds route to MT's Square account (`MT_SQUARE_KEYS`).
- **Admin UI**: `RosterDialog` gains a per-family **Cancel / refund** action opening a confirm dialog with a partial-amount field, prefilled to the policy refund and clamped to the captured total. The roster reloads on success.

## Policy decisions (please review)

- **The $25 fee is now the policy default only** (applied when `refundCents` is omitted). Admins can override to **any** amount 0–captured, including a full refund that waives the fee. Flagged per the issue's "decide whether the $25 fee remains the self-service default while admins can override."
- **Customer self-service is intentionally deferred.** M&S classes have **no** customer-facing (non-admin) cancel to mirror — the only class cancel is the admin `cancelRegistration`. A true MT customer flow needs a session/token model (like craft-club's magic links) that doesn't exist for MT yet. This PR ships the admin flow (the concrete class parity) and leaves the policy-default path ready to back a future customer entrypoint.

## API changes (additive)

- `CancelMusicTogetherRegistrationRequest.refundCents?: number`
- `CancelMusicTogetherRegistrationResponse.refundIds?: string[]` (a refund may span >1 payment; `refundId` remains the first)
- New domain helpers: `mtCapturedPayments`-style `MtCapturedPayment`, `mtTotalCapturedCents`, `mtAllocateRefund`

## Verification

- **Unit** (domain + function, `vi.mock` Square/repos): allocation/captured helpers; full refund, partial refund, over-refund rejected (before any Square call), negative/non-integer rejected, installment-aware span with stable per-payment keys, policy-clamp, auth/status guards. **28 passed.**
- **Integration** (`./tools/run-integration-tests.sh music-together`, emulators + Square mock `/v2/refunds`): admin partial refund, full refund overriding the fee, installment-aware refund spanning a paid installment (2 refund ids), over-refund rejected with no state change, scheduled charges flip to `cancelled`. **44 passed.**
- **Storybook** play stories: drives the refund dialog through a partial refund (asserts callback cents) and asserts an over-refund disables confirm. **8 passed.**
- Typecheck (maple-spruce) + ESLint clean (0 errors); Firestore index analyzer clean (no new queries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)