### PR TITLE
feat(music-together): per-family auto-updating calendar subscription feed (#591)

### DIFF
--- a/apps/functions-calendar/src/index.ts
+++ b/apps/functions-calendar/src/index.ts
@@ -19,4 +19,5 @@ export { calendarHoursFeed } from '@maple/firebase/maple-functions/calendar-hour
 export { calendarAllFeed } from '@maple/firebase/maple-functions/calendar-all-feed';
 export { calendarAdhocProxy } from '@maple/firebase/maple-functions/calendar-adhoc-proxy';
 export { calendarMusicTogetherFeed } from '@maple/firebase/maple-functions/calendar-music-together-feed';
+export { calendarFamilyMusicTogetherFeed } from '@maple/firebase/maple-functions/calendar-family-music-together-feed';
 export { calendarPrivateFeed } from '@maple/firebase/maple-functions/calendar-private-feed';

--- a/apps/functions-calendar/tsconfig.app.json
+++ b/apps/functions-calendar/tsconfig.app.json
@@ -13,6 +13,7 @@
     "../../libs/firebase/maple-functions/calendar-all-feed/**/*.ts",
     "../../libs/firebase/maple-functions/calendar-adhoc-proxy/**/*.ts",
     "../../libs/firebase/maple-functions/calendar-music-together-feed/**/*.ts",
+    "../../libs/firebase/maple-functions/calendar-family-music-together-feed/**/*.ts",
     "../../libs/firebase/maple-functions/calendar-private-feed/**/*.ts",
     "../../libs/firebase/database/src/**/*.ts",
     "../../libs/firebase/functions/src/**/*.ts",

--- a/apps/functions-integration-tests-music-together/src/family-calendar-feed.spec.ts
+++ b/apps/functions-integration-tests-music-together/src/family-calendar-feed.spec.ts
@@ -1,0 +1,229 @@
+/**
+ * Integration tests for the per-family Music Together calendar feed.
+ *
+ * Runs `calendarFamilyMusicTogetherFeed` in the Firebase emulator. Proves the
+ * token-scoped ICS feed returns exactly the family's confirmed-section sessions
+ * (and updates when a new session appears), and that an unknown token yields an
+ * empty but valid calendar (no enumeration).
+ *
+ * Also asserts the create-registration flow now stamps a per-family
+ * `calendarToken` and drops a `webcal://` subscribe link into the confirmation
+ * email.
+ */
+import {
+  clearAuthEmulator,
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  getFirestoreDoc,
+  listFirestoreDocs,
+  callFunction,
+  getFunctionUrl,
+} from '@maple/firebase/integration-test-utils';
+import type {
+  CreateMusicTogetherRegistrationRequest,
+  CreateMusicTogetherRegistrationResponse,
+} from '@maple/ts/firebase/api-types';
+
+const FAMILY_TOKEN = 'famtok-integration-abc123';
+
+async function fetchFeed(
+  token: string
+): Promise<{ status: number; body: string }> {
+  const url = `${getFunctionUrl('calendarFamilyMusicTogetherFeed')}?token=${encodeURIComponent(token)}`;
+  const res = await fetch(url, { method: 'GET' });
+  return { status: res.status, body: await res.text() };
+}
+
+function calendarEventDoc(
+  sectionId: string,
+  title: string,
+  startIso: string
+): Record<string, unknown> {
+  const start = new Date(startIso);
+  return {
+    title,
+    description: 'Music Together session',
+    startDateTime: start,
+    endDateTime: new Date(start.getTime() + 45 * 60 * 1000),
+    recurrenceRule: null,
+    location: 'Spruce Room',
+    type: 'musictogether',
+    public: true,
+    room: 'spruce',
+    sourceRef: `musicTogetherSections/${sectionId}`,
+    createdBy: 'system',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+describe('calendarFamilyMusicTogetherFeed', () => {
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+
+    // Two sections. The family is confirmed in A only.
+    await setFirestoreDoc('musicTogetherSections', 'fam-sec-a', {
+      name: 'Family Section A',
+      sessions: [{ dateTime: new Date('2030-09-10T14:00:00Z') }],
+      status: 'open',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    await setFirestoreDoc('musicTogetherSections', 'fam-sec-b', {
+      name: 'Family Section B',
+      sessions: [{ dateTime: new Date('2030-09-11T14:00:00Z') }],
+      status: 'open',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    // Live calendar events (as onMusicTogetherSectionWrite would produce).
+    await setFirestoreDoc(
+      'calendarEvents',
+      'fam-evt-a1',
+      calendarEventDoc('fam-sec-a', 'Family Class A — Session 1', '2030-09-10T14:00:00Z')
+    );
+    await setFirestoreDoc(
+      'calendarEvents',
+      'fam-evt-b1',
+      calendarEventDoc('fam-sec-b', 'Family Class B — Session 1', '2030-09-11T14:00:00Z')
+    );
+
+    // The family: confirmed in A, and a pending (unpaid) reservation in B with
+    // the SAME token — B must NOT appear in the feed.
+    await setFirestoreDoc('musicTogetherRegistrations', 'fam-reg-a', {
+      sectionId: 'fam-sec-a',
+      parentNames: ['Casey Family'],
+      children: [{ name: 'Kid', dob: new Date('2023-01-01') }],
+      email: 'casey@test.com',
+      phone: '304-555-0001',
+      address: 'somewhere',
+      paymentPlan: 'full',
+      policiesAcceptedAt: new Date(),
+      pricePaidCents: 25200,
+      status: 'confirmed',
+      calendarToken: FAMILY_TOKEN,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    await setFirestoreDoc('musicTogetherRegistrations', 'fam-reg-b', {
+      sectionId: 'fam-sec-b',
+      parentNames: ['Casey Family'],
+      children: [{ name: 'Kid', dob: new Date('2023-01-01') }],
+      email: 'casey@test.com',
+      phone: '304-555-0001',
+      address: 'somewhere',
+      paymentPlan: 'full',
+      policiesAcceptedAt: new Date(),
+      pricePaidCents: 25200,
+      status: 'pending',
+      calendarToken: FAMILY_TOKEN,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  it("returns exactly the family's confirmed-section sessions", async () => {
+    const { status, body } = await fetchFeed(FAMILY_TOKEN);
+
+    expect(status).toBe(200);
+    expect(body).toContain('BEGIN:VCALENDAR');
+    expect(body).toContain('Family Class A — Session 1');
+    // The pending section B must be excluded.
+    expect(body).not.toContain('Family Class B');
+  });
+
+  it('reflects a newly added session (feed auto-updates)', async () => {
+    await setFirestoreDoc(
+      'calendarEvents',
+      'fam-evt-a2',
+      calendarEventDoc('fam-sec-a', 'Family Class A — Session 2', '2030-09-17T14:00:00Z')
+    );
+
+    const { body } = await fetchFeed(FAMILY_TOKEN);
+    expect(body).toContain('Family Class A — Session 1');
+    expect(body).toContain('Family Class A — Session 2');
+  });
+
+  it('returns an empty but valid calendar for an unknown token', async () => {
+    const { status, body } = await fetchFeed('does-not-exist-token');
+    expect(status).toBe(200);
+    expect(body).toContain('BEGIN:VCALENDAR');
+    expect(body).not.toContain('BEGIN:VEVENT');
+  });
+
+  it('400s when no token is supplied', async () => {
+    const res = await fetch(
+      getFunctionUrl('calendarFamilyMusicTogetherFeed'),
+      { method: 'GET' }
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('registration stamps a calendar token and emails a webcal subscribe link', async () => {
+    await setFirestoreDoc('musicTogetherSections', 'fam-sec-reg', {
+      name: 'Registerable Section',
+      sessions: [{ dateTime: new Date('2030-10-01T14:00:00Z') }],
+      capacityFamilies: 8,
+      priceFullCents: 25200,
+      visible: true,
+      enrollmentActive: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const result = await callFunction<
+      CreateMusicTogetherRegistrationRequest,
+      CreateMusicTogetherRegistrationResponse
+    >({
+      functionName: 'createMusicTogetherRegistration',
+      data: {
+        sectionId: 'fam-sec-reg',
+        adultFirstName: 'Robin',
+        adultLastName: 'Lark',
+        parentNames: ['Robin Lark'],
+        children: [{ name: 'Wren', dob: '2023-04-01' }],
+        email: 'robin@test.com',
+        phone: '304-555-2222',
+        address: '1 Music Ln, Morgantown, WV',
+        paymentPlan: 'full',
+        policiesAccepted: true,
+        privacyConsent: true,
+        paymentNonce: 'cnon:card-nonce-ok',
+      },
+    });
+
+    expect(result.status).toBe(200);
+    const reg = await getFirestoreDoc(
+      'musicTogetherRegistrations',
+      result.data!.registrationId
+    );
+    const token = (reg as { calendarToken?: string }).calendarToken;
+    expect(typeof token).toBe('string');
+    expect(token && token.length).toBeGreaterThan(20);
+
+    const mail = await listFirestoreDocs('mail');
+    const robinMail = mail.find(
+      (m) => (m.data as { to?: string }).to === 'robin@test.com'
+    );
+    expect(robinMail).toBeDefined();
+    const subscribeUrl = (
+      robinMail!.data as {
+        template?: { data?: { calendarSubscribeUrl?: string } };
+      }
+    ).template?.data?.calendarSubscribeUrl;
+    expect(subscribeUrl).toBe(
+      `webcal://maple-and-spruce-dev.web.app/calendar/family/${token}.ics`
+    );
+
+    // The freshly-registered family's feed now serves their session.
+    const { body } = await fetchFeed(token!);
+    expect(body).toContain('BEGIN:VCALENDAR');
+  });
+});

--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -198,6 +198,12 @@ export {
   triggerClassReminders,
 } from '@maple/firebase/maple-functions/send-class-reminders';
 
+// Music Together scheduled functions
+export {
+  sendMusicTogetherReminders,
+  triggerMusicTogetherReminders,
+} from '@maple/firebase/maple-functions/send-music-together-reminders';
+
 // Etsy template functions (read/write Firestore only — no Etsy API dep)
 export { getEtsyTemplates } from '@maple/firebase/maple-functions/get-etsy-templates';
 export { saveEtsyCategoryTemplate } from '@maple/firebase/maple-functions/save-etsy-category-template';

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -111,6 +111,7 @@
     "../../libs/firebase/maple-functions/get-required-agreements-for-class/**/*.ts",
     "../../libs/firebase/maple-functions/expire-agreement-requests/**/*.ts",
     "../../libs/firebase/maple-functions/send-class-reminders/**/*.ts",
+    "../../libs/firebase/maple-functions/send-music-together-reminders/**/*.ts",
     "../../libs/firebase/maple-functions/list-users/**/*.ts",
     "../../libs/firebase/maple-functions/grant-admin-role/**/*.ts",
     "../../libs/firebase/maple-functions/revoke-admin-role/**/*.ts",

--- a/firebase.json
+++ b/firebase.json
@@ -56,6 +56,7 @@
         { "source": "/calendar/all.ics", "function": "calendarAllFeed" },
         { "source": "/calendar/adhoc.ics", "function": "calendarAdhocProxy" },
         { "source": "/calendar/musictogether.ics", "function": "calendarMusicTogetherFeed" },
+        { "source": "/calendar/family/*.ics", "function": "calendarFamilyMusicTogetherFeed" },
         { "source": "/calendar/private.ics", "function": "calendarPrivateFeed" },
         { "source": "/calendar/embed", "function": "calendarEmbed" },
         { "source": "/catalog/classes.xml", "function": "classCatalogFeed" }

--- a/function-codebases.json
+++ b/function-codebases.json
@@ -13,6 +13,7 @@
     "firebase-maple-functions-calendar-all-feed": "maple-calendar",
     "firebase-maple-functions-calendar-adhoc-proxy": "maple-calendar",
     "firebase-maple-functions-calendar-music-together-feed": "maple-calendar",
+    "firebase-maple-functions-calendar-family-music-together-feed": "maple-calendar",
     "firebase-maple-functions-calendar-private-feed": "maple-calendar",
     "firebase-maple-functions-create-product": "maple-square",
     "firebase-maple-functions-update-product": "maple-square",

--- a/libs/firebase/database/src/lib/music-together-registration.repository.ts
+++ b/libs/firebase/database/src/lib/music-together-registration.repository.ts
@@ -67,9 +67,21 @@ function docToRegistration(
     confirmationSentAt: data.confirmationSentAt
       ? toDate(data.confirmationSentAt)
       : undefined,
+    calendarToken: data.calendarToken ?? undefined,
+    reminderSentForSessions: parseReminderMap(data.reminderSentForSessions),
     createdAt: toDate(data.createdAt),
     updatedAt: toDate(data.updatedAt),
   };
+}
+
+function parseReminderMap(raw: unknown): Record<string, Date> | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const out: Record<string, Date> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (value === undefined || value === null) continue;
+    out[key] = toDate(value);
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 export interface MusicTogetherRegistrationFilters {
@@ -160,6 +172,58 @@ export const MusicTogetherRegistrationRepository = {
 
   async delete(id: string): Promise<void> {
     await getDb().collection(COLLECTION).doc(id).delete();
+  },
+
+  /**
+   * All registrations sharing a family calendar token. Single-field filter
+   * (auto-indexed) — the per-family calendar feed resolves the token to the
+   * family's sections. Unknown tokens simply return an empty list.
+   */
+  async findByCalendarToken(
+    token: string
+  ): Promise<MusicTogetherRegistration[]> {
+    const snapshot = await getDb()
+      .collection(COLLECTION)
+      .where('calendarToken', '==', token)
+      .get();
+    return snapshot.docs
+      .map((doc) => docToRegistration(doc))
+      .filter((r): r is MusicTogetherRegistration => r !== undefined);
+  },
+
+  /**
+   * The existing family calendar token for an email, if any prior registration
+   * has one. Lets a returning family reuse a single subscribe link across
+   * sections instead of minting a new token per registration.
+   */
+  async findCalendarTokenByEmail(email: string): Promise<string | undefined> {
+    const snapshot = await getDb()
+      .collection(COLLECTION)
+      .where('email', '==', email)
+      .get();
+    for (const doc of snapshot.docs) {
+      const token = doc.data().calendarToken;
+      if (typeof token === 'string' && token.length > 0) return token;
+    }
+    return undefined;
+  },
+
+  /**
+   * Mark a day-of reminder as sent for one session (keyed by the session's ISO
+   * `dateTime`), making the reminder job idempotent across reruns.
+   */
+  async markReminderSentForSession(
+    id: string,
+    sessionIso: string,
+    at: Date = new Date()
+  ): Promise<void> {
+    await getDb()
+      .collection(COLLECTION)
+      .doc(id)
+      .update({
+        [`reminderSentForSessions.${sessionIso}`]: at,
+        updatedAt: new Date(),
+      });
   },
 
   /** Collection reference (for transactions / the Week-5 charge query). */

--- a/libs/firebase/functions/src/lib/family-calendar.utility.spec.ts
+++ b/libs/firebase/functions/src/lib/family-calendar.utility.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import {
+  generateFamilyCalendarToken,
+  apiHostingHost,
+  familyCalendarFeedUrl,
+  familyCalendarSubscribeUrl,
+  FAMILY_CALENDAR_FEED_PATH_PREFIX,
+} from './family-calendar.utility';
+
+describe('family-calendar.utility', () => {
+  const original = process.env['GCLOUD_PROJECT'];
+
+  beforeEach(() => {
+    delete process.env['FIREBASE_CONFIG'];
+  });
+  afterEach(() => {
+    if (original === undefined) delete process.env['GCLOUD_PROJECT'];
+    else process.env['GCLOUD_PROJECT'] = original;
+  });
+
+  describe('generateFamilyCalendarToken', () => {
+    it('produces a long, URL-safe, unpredictable hex token', () => {
+      const a = generateFamilyCalendarToken();
+      const b = generateFamilyCalendarToken();
+      expect(a).toMatch(/^[0-9a-f]{48}$/); // 24 bytes hex
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('host + URL builders', () => {
+    it('uses the prod host on the prod project', () => {
+      process.env['GCLOUD_PROJECT'] = 'maple-and-spruce';
+      expect(apiHostingHost()).toBe('maple-and-spruce-api.web.app');
+      expect(familyCalendarSubscribeUrl('tok123')).toBe(
+        'webcal://maple-and-spruce-api.web.app/calendar/family/tok123.ics'
+      );
+      expect(familyCalendarFeedUrl('tok123')).toBe(
+        'https://maple-and-spruce-api.web.app/calendar/family/tok123.ics'
+      );
+    });
+
+    it('uses the dev host on the dev project', () => {
+      process.env['GCLOUD_PROJECT'] = 'maple-and-spruce-dev';
+      expect(apiHostingHost()).toBe('maple-and-spruce-dev.web.app');
+      expect(familyCalendarSubscribeUrl('tok')).toBe(
+        'webcal://maple-and-spruce-dev.web.app/calendar/family/tok.ics'
+      );
+    });
+
+    it('exposes the feed path prefix that firebase.json rewrites', () => {
+      expect(FAMILY_CALENDAR_FEED_PATH_PREFIX).toBe('/calendar/family/');
+    });
+  });
+});

--- a/libs/firebase/functions/src/lib/family-calendar.utility.ts
+++ b/libs/firebase/functions/src/lib/family-calendar.utility.ts
@@ -1,0 +1,62 @@
+/**
+ * Per-family calendar subscription helpers.
+ *
+ * A family's Music Together calendar is exposed as a token-scoped ICS feed at
+ * `/calendar/family/<token>.ics` (see `calendarFamilyMusicTogetherFeed`). The
+ * token is an unguessable capability — anyone holding the URL can read the
+ * family's enrolled sessions, and nothing else. It is generated on the family's
+ * first registration and reused across their later registrations so one
+ * subscribe link tracks all of their sections.
+ */
+import { randomBytes } from 'node:crypto';
+
+import { FirebaseProject, FIREBASE_PROJECTS } from './environment.utility';
+
+/**
+ * Path prefix (under the `api` hosting target) that serves per-family feeds.
+ * The matching rewrite lives in `firebase.json` (`/calendar/family/*.ics`).
+ */
+export const FAMILY_CALENDAR_FEED_PATH_PREFIX = '/calendar/family/';
+
+/**
+ * Generate an unguessable per-family calendar token.
+ *
+ * 24 random bytes → 192 bits of entropy, hex-encoded (URL-safe, no escaping
+ * needed). The token IS the capability, so it must never be enumerable or
+ * derivable from family data.
+ */
+export function generateFamilyCalendarToken(): string {
+  return randomBytes(24).toString('hex');
+}
+
+/**
+ * The public host for the `api` hosting target in the current project.
+ *
+ * - prod (`maple-and-spruce`)     → `maple-and-spruce-api.web.app`
+ * - dev  (`maple-and-spruce-dev`) → `maple-and-spruce-dev.web.app`
+ */
+export function apiHostingHost(): string {
+  return FirebaseProject.projectId === FIREBASE_PROJECTS.prod
+    ? 'maple-and-spruce-api.web.app'
+    : 'maple-and-spruce-dev.web.app';
+}
+
+/**
+ * The `https://` feed URL for a family token (what a browser or ICS client
+ * fetches).
+ */
+export function familyCalendarFeedUrl(token: string): string {
+  return `https://${apiHostingHost()}${FAMILY_CALENDAR_FEED_PATH_PREFIX}${token}.ics`;
+}
+
+/**
+ * The `webcal://` subscribe URL for a family token.
+ *
+ * `webcal://` is the de-facto scheme calendar clients (Apple Calendar, Google
+ * Calendar, Outlook) recognize as "subscribe to this feed and keep it in sync"
+ * rather than "download a one-off snapshot". It is otherwise identical to the
+ * https URL.
+ */
+export function familyCalendarSubscribeUrl(token: string): string {
+  return `webcal://${apiHostingHost()}${FAMILY_CALENDAR_FEED_PATH_PREFIX}${token}.ics`;
+}

--- a/libs/firebase/functions/src/lib/index.ts
+++ b/libs/firebase/functions/src/lib/index.ts
@@ -62,3 +62,12 @@ export {
 
 // Email utilities
 export { isE2ETestEmail } from './email.utility';
+
+// Per-family calendar subscription utilities
+export {
+  FAMILY_CALENDAR_FEED_PATH_PREFIX,
+  generateFamilyCalendarToken,
+  apiHostingHost,
+  familyCalendarFeedUrl,
+  familyCalendarSubscribeUrl,
+} from './family-calendar.utility';

--- a/libs/firebase/maple-functions/calendar-family-music-together-feed/project.json
+++ b/libs/firebase/maple-functions/calendar-family-music-together-feed/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-calendar-family-music-together-feed",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/calendar-family-music-together-feed/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/calendar-family-music-together-feed/src/index.ts
+++ b/libs/firebase/maple-functions/calendar-family-music-together-feed/src/index.ts
@@ -1,0 +1,1 @@
+export { calendarFamilyMusicTogetherFeed } from './lib/calendar-family-music-together-feed';

--- a/libs/firebase/maple-functions/calendar-family-music-together-feed/src/lib/calendar-family-music-together-feed.spec.ts
+++ b/libs/firebase/maple-functions/calendar-family-music-together-feed/src/lib/calendar-family-music-together-feed.spec.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findByCalendarToken: vi.fn(),
+  findAllBySourceRef: vi.fn(),
+  generateIcsFeed: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  CalendarEventRepository: { findAllBySourceRef: mocks.findAllBySourceRef },
+  MusicTogetherRegistrationRepository: {
+    findByCalendarToken: mocks.findByCalendarToken,
+  },
+}));
+
+vi.mock('@maple/ts/calendar', () => ({
+  generateIcsFeed: mocks.generateIcsFeed,
+  ICS_FEED_HEADERS: { 'Content-Type': 'text/calendar; charset=utf-8' },
+}));
+
+vi.mock('firebase-functions/v2/https', () => ({
+  onRequest: vi.fn((_config, handler) => handler),
+}));
+
+import {
+  calendarFamilyMusicTogetherFeed,
+  extractFamilyToken,
+} from './calendar-family-music-together-feed';
+
+const handler = calendarFamilyMusicTogetherFeed as unknown as (
+  req: unknown,
+  res: unknown
+) => Promise<void>;
+
+function makeRes() {
+  return {
+    statusCode: 0,
+    body: undefined as unknown,
+    headers: {} as Record<string, string>,
+    setHeader(k: string, v: string) {
+      this.headers[k] = v;
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    send(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+describe('extractFamilyToken', () => {
+  it('reads the token from an .ics path', () => {
+    expect(
+      extractFamilyToken({ path: '/calendar/family/abc123.ics' })
+    ).toBe('abc123');
+  });
+
+  it('reads the token from a query param', () => {
+    expect(extractFamilyToken({ path: '/', query: { token: 'q-tok' } })).toBe(
+      'q-tok'
+    );
+  });
+
+  it('ignores a trailing query string on the path', () => {
+    expect(
+      extractFamilyToken({ url: '/calendar/family/tok.ics?foo=1' })
+    ).toBe('tok');
+  });
+
+  it('returns undefined when no token is present', () => {
+    expect(extractFamilyToken({ path: '/calendar/family/' })).toBeUndefined();
+  });
+});
+
+describe('calendarFamilyMusicTogetherFeed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('serves only the confirmed-section events for the token', async () => {
+    mocks.findByCalendarToken.mockResolvedValue([
+      { sectionId: 'sec-a', status: 'confirmed' },
+      { sectionId: 'sec-b', status: 'confirmed' },
+      { sectionId: 'sec-c', status: 'cancelled' }, // excluded
+      { sectionId: 'sec-a', status: 'confirmed' }, // duplicate section
+    ]);
+    mocks.findAllBySourceRef.mockImplementation((sourceRef: string) =>
+      Promise.resolve([{ id: `${sourceRef}-evt` }])
+    );
+    mocks.generateIcsFeed.mockReturnValue('BEGIN:VCALENDAR');
+    const res = makeRes();
+
+    await handler({ method: 'GET', path: '/calendar/family/fam-tok.ics' }, res);
+
+    expect(mocks.findByCalendarToken).toHaveBeenCalledWith('fam-tok');
+    // Only the two unique confirmed sections are queried.
+    expect(mocks.findAllBySourceRef).toHaveBeenCalledTimes(2);
+    expect(mocks.findAllBySourceRef).toHaveBeenCalledWith(
+      'musicTogetherSections/sec-a'
+    );
+    expect(mocks.findAllBySourceRef).toHaveBeenCalledWith(
+      'musicTogetherSections/sec-b'
+    );
+    expect(mocks.generateIcsFeed).toHaveBeenCalledWith(
+      [
+        { id: 'musicTogetherSections/sec-a-evt' },
+        { id: 'musicTogetherSections/sec-b-evt' },
+      ],
+      'Your Music Together Classes'
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('BEGIN:VCALENDAR');
+    expect(res.headers['Content-Type']).toBe('text/calendar; charset=utf-8');
+  });
+
+  it('returns an empty (valid) feed for an unknown token — no enumeration', async () => {
+    mocks.findByCalendarToken.mockResolvedValue([]);
+    mocks.generateIcsFeed.mockReturnValue('BEGIN:VCALENDAR\r\nEND:VCALENDAR');
+    const res = makeRes();
+
+    await handler(
+      { method: 'GET', path: '/calendar/family/nope.ics' },
+      res
+    );
+
+    expect(mocks.findAllBySourceRef).not.toHaveBeenCalled();
+    expect(mocks.generateIcsFeed).toHaveBeenCalledWith(
+      [],
+      'Your Music Together Classes'
+    );
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('short-circuits an OPTIONS preflight', async () => {
+    const res = makeRes();
+    await handler({ method: 'OPTIONS' }, res);
+    expect(res.statusCode).toBe(204);
+    expect(mocks.findByCalendarToken).not.toHaveBeenCalled();
+  });
+
+  it('400s when the token is missing', async () => {
+    const res = makeRes();
+    await handler({ method: 'GET', path: '/calendar/family/' }, res);
+    expect(res.statusCode).toBe(400);
+    expect(mocks.findByCalendarToken).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when a repository throws', async () => {
+    mocks.findByCalendarToken.mockRejectedValue(new Error('boom'));
+    const res = makeRes();
+    await handler({ method: 'GET', path: '/calendar/family/x.ics' }, res);
+    expect(res.statusCode).toBe(500);
+  });
+});

--- a/libs/firebase/maple-functions/calendar-family-music-together-feed/src/lib/calendar-family-music-together-feed.ts
+++ b/libs/firebase/maple-functions/calendar-family-music-together-feed/src/lib/calendar-family-music-together-feed.ts
@@ -1,0 +1,114 @@
+/**
+ * Per-Family Music Together ICS Feed
+ *
+ * HTTP endpoint serving a token-scoped ICS feed of ONE family's enrolled Music
+ * Together sessions. Unlike the program-wide `calendarMusicTogetherFeed` (all
+ * MT events), this feed is keyed by an unguessable per-family capability token
+ * carried in the URL path: `/calendar/family/<token>.ics`.
+ *
+ * The token is the capability — anyone with the URL can read that family's
+ * enrolled sessions and nothing else, so the endpoint is public (no auth) but
+ * unenumerable. An unknown token yields an empty (valid) calendar rather than a
+ * 404, so callers can't probe which tokens exist.
+ *
+ * The feed auto-updates: it reads live `CalendarEvent`s (kept in sync with each
+ * section by `onMusicTogetherSectionWrite`) for every section the family is
+ * confirmed in, so registering, cancelling, or a class-time change is reflected
+ * within the 5-minute feed TTL.
+ *
+ * Subscribe via: webcal://…/calendar/family/<token>.ics
+ */
+import { onRequest } from 'firebase-functions/v2/https';
+import {
+  CalendarEventRepository,
+  MusicTogetherRegistrationRepository,
+} from '@maple/firebase/database';
+import { generateIcsFeed, ICS_FEED_HEADERS } from '@maple/ts/calendar';
+import type { CalendarEvent } from '@maple/ts/domain';
+
+const FEED_NAME = 'Your Music Together Classes';
+
+/**
+ * Extract the family token from the request. Prefers the `.ics` path segment
+ * (how Firebase Hosting forwards `/calendar/family/<token>.ics`), and falls
+ * back to a `?token=` query param so the function is drivable when hit
+ * directly (integration tests, the emulator).
+ */
+export function extractFamilyToken(request: {
+  path?: string;
+  url?: string;
+  query?: Record<string, unknown>;
+}): string | undefined {
+  const queryToken = request.query?.['token'];
+  if (typeof queryToken === 'string' && queryToken.length > 0) {
+    return queryToken;
+  }
+  // Strip any query/hash, take the last path segment, drop a trailing `.ics`.
+  let path = request.path || request.url || '';
+  const queryIdx = path.indexOf('?');
+  if (queryIdx !== -1) path = path.slice(0, queryIdx);
+  const hashIdx = path.indexOf('#');
+  if (hashIdx !== -1) path = path.slice(0, hashIdx);
+  const lastSegment = path.slice(path.lastIndexOf('/') + 1);
+  if (!lastSegment.endsWith('.ics')) return undefined;
+  const token = lastSegment.slice(0, -'.ics'.length);
+  return token.length > 0 ? token : undefined;
+}
+
+/**
+ * Gather every CalendarEvent for the sections a token's family is confirmed in.
+ */
+async function collectFamilyEvents(token: string): Promise<CalendarEvent[]> {
+  const registrations =
+    await MusicTogetherRegistrationRepository.findByCalendarToken(token);
+  const sectionIds = Array.from(
+    new Set(
+      registrations
+        .filter((reg) => reg.status === 'confirmed')
+        .map((reg) => reg.sectionId)
+    )
+  );
+  if (sectionIds.length === 0) return [];
+
+  const perSection = await Promise.all(
+    sectionIds.map((sectionId) =>
+      CalendarEventRepository.findAllBySourceRef(
+        `musicTogetherSections/${sectionId}`
+      )
+    )
+  );
+  return perSection.flat();
+}
+
+export const calendarFamilyMusicTogetherFeed = onRequest(
+  // No minInstances — the 5-minute CDN cache from ICS_FEED_HEADERS absorbs
+  // cold starts, and each family polls at most every few minutes.
+  { region: 'us-east4', cors: true, concurrency: 80 },
+  async (request, response) => {
+    if (request.method === 'OPTIONS') {
+      response.status(204).send('');
+      return;
+    }
+
+    const token = extractFamilyToken(request);
+    if (!token) {
+      response.status(400).json({ error: 'Missing family calendar token' });
+      return;
+    }
+
+    try {
+      const events = await collectFamilyEvents(token);
+      // Unknown token or no confirmed sections → an empty but valid calendar,
+      // so the endpoint never reveals whether a token exists.
+      const ics = generateIcsFeed(events, FEED_NAME);
+
+      Object.entries(ICS_FEED_HEADERS).forEach(([key, value]) => {
+        response.setHeader(key, value);
+      });
+      response.status(200).send(ics);
+    } catch (error) {
+      console.error('Error generating family Music Together feed:', error);
+      response.status(500).json({ error: 'Failed to generate feed' });
+    }
+  }
+);

--- a/libs/firebase/maple-functions/calendar-family-music-together-feed/tsconfig.json
+++ b/libs/firebase/maple-functions/calendar-family-music-together-feed/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/calendar-family-music-together-feed/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/calendar-family-music-together-feed/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.spec.ts
+++ b/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.spec.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   txSet: vi.fn(),
   regUpdate: vi.fn(),
   mailAdd: vi.fn(),
+  findCalendarTokenByEmail: vi.fn(),
 }));
 
 vi.mock('@maple/firebase/functions', () => {
@@ -46,6 +47,9 @@ vi.mock('@maple/firebase/functions', () => {
     throwFailedPrecondition: (m: string) => {
       throw new HttpsError('failed-precondition', m);
     },
+    generateFamilyCalendarToken: () => 'fam-token-test',
+    familyCalendarSubscribeUrl: (token: string) =>
+      `webcal://maple-and-spruce-dev.web.app/calendar/family/${token}.ics`,
   };
 });
 
@@ -94,7 +98,10 @@ vi.mock('@maple/firebase/database', () => {
   return {
     getDb: () => db,
     MusicTogetherSectionRepository: { findById: mocks.sectionFindById },
-    MusicTogetherRegistrationRepository: { getDocRef: () => regRef },
+    MusicTogetherRegistrationRepository: {
+      getDocRef: () => regRef,
+      findCalendarTokenByEmail: mocks.findCalendarTokenByEmail,
+    },
     MusicTogetherScheduledChargeRepository: { create: mocks.chargeCreate },
   };
 });

--- a/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.ts
+++ b/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.ts
@@ -26,6 +26,8 @@ import {
   throwNotFound,
   throwFailedPrecondition,
   throwValidationError,
+  generateFamilyCalendarToken,
+  familyCalendarSubscribeUrl,
 } from '@maple/firebase/functions';
 import {
   Square,
@@ -140,6 +142,14 @@ export const createMusicTogetherRegistration = Functions.endpoint
 
     const square = new Square(secrets, strings, MT_SQUARE_KEYS);
 
+    // Per-family calendar subscription token: reuse the family's existing token
+    // (matched by email) so one subscribe link tracks all their sections; mint
+    // a fresh unguessable one for a brand-new family.
+    const calendarToken =
+      (await MusicTogetherRegistrationRepository.findCalendarTokenByEmail(
+        data.email
+      )) ?? generateFamilyCalendarToken();
+
     // 4. Reserve the seat inside a transaction that enforces the family cap.
     const db = getDb();
     const regRef = MusicTogetherRegistrationRepository.getDocRef();
@@ -179,6 +189,7 @@ export const createMusicTogetherRegistration = Functions.endpoint
         scheduledChargeCount: scheduledItems.length,
         status: 'pending',
         notes: data.notes || null,
+        calendarToken,
         createdAt: now,
         updatedAt: now,
       });
@@ -330,6 +341,9 @@ export const createMusicTogetherRegistration = Functions.endpoint
               : '',
             cardLast4: cardLast4 ?? '',
             receiptUrl: squareReceiptUrl ?? '',
+            // Auto-updating per-family calendar subscription (webcal://). Stays
+            // current as the family registers/cancels or class times change.
+            calendarSubscribeUrl: familyCalendarSubscribeUrl(calendarToken),
           },
         },
       });

--- a/libs/firebase/maple-functions/send-music-together-reminders/project.json
+++ b/libs/firebase/maple-functions/send-music-together-reminders/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-send-music-together-reminders",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/send-music-together-reminders/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/send-music-together-reminders/src/index.ts
+++ b/libs/firebase/maple-functions/send-music-together-reminders/src/index.ts
@@ -1,0 +1,6 @@
+export {
+  sendMusicTogetherReminders,
+  triggerMusicTogetherReminders,
+  runSendMusicTogetherReminders,
+  type SendMusicTogetherRemindersResult,
+} from './lib/send-music-together-reminders';

--- a/libs/firebase/maple-functions/send-music-together-reminders/src/lib/send-music-together-reminders.spec.ts
+++ b/libs/firebase/maple-functions/send-music-together-reminders/src/lib/send-music-together-reminders.spec.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findAll: vi.fn(),
+  findBySectionId: vi.fn(),
+  markReminderSentForSession: vi.fn(),
+  mailAdd: vi.fn(),
+}));
+
+vi.mock('firebase-admin', () => {
+  const admin = {
+    apps: [{}], // non-empty → initializeApp not called
+    initializeApp: vi.fn(),
+    firestore: () => ({ collection: () => ({ add: mocks.mailAdd }) }),
+  };
+  return { default: admin, ...admin };
+});
+
+vi.mock('firebase-functions/v2/scheduler', () => ({
+  onSchedule: vi.fn((_config, handler) => handler),
+}));
+
+vi.mock('@maple/firebase/functions', () => ({
+  Functions: {
+    endpoint: { requiringRole: () => ({ handle: (fn: unknown) => fn }) },
+  },
+  Role: { Admin: 'admin' },
+  isE2ETestEmail: (email: string) => email.endsWith('.test'),
+  familyCalendarSubscribeUrl: (token: string) =>
+    `webcal://host/calendar/family/${token}.ics`,
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  MusicTogetherSectionRepository: { findAll: mocks.findAll },
+  MusicTogetherRegistrationRepository: {
+    findBySectionId: mocks.findBySectionId,
+    markReminderSentForSession: mocks.markReminderSentForSession,
+  },
+}));
+
+import { runSendMusicTogetherReminders } from './send-music-together-reminders';
+
+// 2026-07-15: session at 10am ET, "now" the same morning → session is in
+// today's ET window.
+const NOW = new Date('2026-07-15T15:00:00Z');
+const SESSION_AT = new Date('2026-07-15T14:00:00Z');
+const SESSION_ISO = SESSION_AT.toISOString();
+
+function section(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'sec-1',
+    name: 'Tuesdays 10am — Mixed Age',
+    sessions: [{ dateTime: SESSION_AT }],
+    visible: true,
+    location: 'Spruce Room',
+    ...overrides,
+  };
+}
+
+function reg(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'reg-1',
+    status: 'confirmed',
+    parentNames: ['Jamie'],
+    email: 'jamie@example.com',
+    calendarToken: 'fam-token',
+    reminderSentForSessions: undefined,
+    ...overrides,
+  };
+}
+
+describe('runSendMusicTogetherReminders', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('queues one reminder per confirmed family with the subscribe link', async () => {
+    mocks.findAll.mockResolvedValue([section()]);
+    mocks.findBySectionId.mockResolvedValue([reg()]);
+
+    const result = await runSendMusicTogetherReminders(NOW);
+
+    expect(result.mailQueued).toBe(1);
+    expect(result.sectionsWithSessionToday).toBe(1);
+    expect(mocks.mailAdd).toHaveBeenCalledTimes(1);
+    const mail = mocks.mailAdd.mock.calls[0][0];
+    expect(mail.to).toBe('jamie@example.com');
+    expect(mail.template.name).toBe('music-together-reminder');
+    expect(mail.template.data.sectionName).toBe('Tuesdays 10am — Mixed Age');
+    expect(mail.template.data.calendarSubscribeUrl).toBe(
+      'webcal://host/calendar/family/fam-token.ics'
+    );
+    expect(mocks.markReminderSentForSession).toHaveBeenCalledWith(
+      'reg-1',
+      SESSION_ISO,
+      NOW
+    );
+  });
+
+  it('is idempotent — skips a family already reminded for the session', async () => {
+    mocks.findAll.mockResolvedValue([section()]);
+    mocks.findBySectionId.mockResolvedValue([
+      reg({ reminderSentForSessions: { [SESSION_ISO]: new Date() } }),
+    ]);
+
+    const result = await runSendMusicTogetherReminders(NOW);
+
+    expect(result.mailQueued).toBe(0);
+    expect(result.skippedAlreadySent).toBe(1);
+    expect(mocks.mailAdd).not.toHaveBeenCalled();
+  });
+
+  it('skips non-confirmed registrations', async () => {
+    mocks.findAll.mockResolvedValue([section()]);
+    mocks.findBySectionId.mockResolvedValue([reg({ status: 'pending' })]);
+
+    const result = await runSendMusicTogetherReminders(NOW);
+
+    expect(result.mailQueued).toBe(0);
+    expect(result.skippedNotConfirmed).toBe(1);
+  });
+
+  it('skips E2E test emails without marking them sent', async () => {
+    mocks.findAll.mockResolvedValue([section()]);
+    mocks.findBySectionId.mockResolvedValue([
+      reg({ email: 'someone@example.test' }),
+    ]);
+
+    const result = await runSendMusicTogetherReminders(NOW);
+
+    expect(result.mailQueued).toBe(0);
+    expect(mocks.mailAdd).not.toHaveBeenCalled();
+    expect(mocks.markReminderSentForSession).not.toHaveBeenCalled();
+  });
+
+  it('ignores hidden (draft) sections and sections with no session today', async () => {
+    mocks.findAll.mockResolvedValue([
+      section({ id: 'draft', visible: false }),
+      section({
+        id: 'other-day',
+        sessions: [{ dateTime: new Date('2026-07-20T14:00:00Z') }],
+      }),
+    ]);
+
+    const result = await runSendMusicTogetherReminders(NOW);
+
+    expect(result.sectionsWithSessionToday).toBe(0);
+    expect(result.mailQueued).toBe(0);
+    expect(mocks.findBySectionId).not.toHaveBeenCalled();
+  });
+
+  it('omits the subscribe link when the family has no token', async () => {
+    mocks.findAll.mockResolvedValue([section()]);
+    mocks.findBySectionId.mockResolvedValue([
+      reg({ calendarToken: undefined }),
+    ]);
+
+    await runSendMusicTogetherReminders(NOW);
+
+    const mail = mocks.mailAdd.mock.calls[0][0];
+    expect(mail.template.data.calendarSubscribeUrl).toBeUndefined();
+  });
+});

--- a/libs/firebase/maple-functions/send-music-together-reminders/src/lib/send-music-together-reminders.ts
+++ b/libs/firebase/maple-functions/send-music-together-reminders/src/lib/send-music-together-reminders.ts
@@ -1,0 +1,280 @@
+/**
+ * Send Music Together Reminders
+ *
+ * Day-of reminder emails for enrolled Music Together families, mirroring
+ * `sendClassReminders` (which only covers the regular class program — MT
+ * sections are a separate entity and were previously getting no reminder).
+ *
+ * Two exports share the same logic:
+ *   - `sendMusicTogetherReminders` — scheduled, daily 08:00 America/New_York.
+ *   - `triggerMusicTogetherReminders` — admin-only HTTPS callable running the
+ *     same logic on demand. Useful for manual catch-up, and (importantly) gives
+ *     integration tests a way to drive it — the emulator doesn't expose
+ *     `onSchedule` triggers over HTTP.
+ *
+ * Per run:
+ *   1. Compute today's window in America/New_York.
+ *   2. Find every publicly-visible section with a session inside the window.
+ *   3. For each, email every confirmed family once per session — keyed by the
+ *      session's ISO `dateTime` in `reminderSentForSessions` so a second run on
+ *      the same day is a no-op (run-twice idempotent).
+ *
+ * Each reminder carries the family's auto-updating calendar subscribe link
+ * (webcal://) so recipients can subscribe once and stop asking "when is my
+ * class again?".
+ *
+ * Emails are queued via the firestore-send-email extension (`mail` collection),
+ * rendered from the `music-together-reminder` Handlebars template (seeded by
+ * `tools/seed-email-templates.ts`).
+ *
+ * Deployed to us-east4 via CI/CD (maple-core codebase).
+ */
+import admin from 'firebase-admin';
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+import {
+  Functions,
+  Role,
+  isE2ETestEmail,
+  familyCalendarSubscribeUrl,
+} from '@maple/firebase/functions';
+import {
+  MusicTogetherSectionRepository,
+  MusicTogetherRegistrationRepository,
+} from '@maple/firebase/database';
+import type {
+  MusicTogetherSection,
+  MusicTogetherSession,
+  MusicTogetherRegistration,
+} from '@maple/ts/domain';
+
+const TIMEZONE = 'America/New_York';
+
+/** Default MT class location; sections may override via `location`. */
+const DEFAULT_MT_LOCATION = '688 Beulah Rd, Morgantown, WV 26508';
+
+export interface SendMusicTogetherRemindersResult {
+  /** Reminder emails queued in the `mail` collection. */
+  mailQueued: number;
+  /** Skipped: family already reminded for this session. */
+  skippedAlreadySent: number;
+  /** Skipped: registration not in `confirmed` status. */
+  skippedNotConfirmed: number;
+  /** Live sections that had a session inside today's window. */
+  sectionsWithSessionToday: number;
+}
+
+function getTimezoneOffsetMinutes(at: Date, timeZone: string): number {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+  const parts = dtf.formatToParts(at);
+  const map: Record<string, string> = {};
+  for (const p of parts) {
+    if (p.type !== 'literal') map[p.type] = p.value;
+  }
+  const hour = map['hour'] === '24' ? '00' : map['hour'];
+  const tzMs = Date.UTC(
+    Number(map['year']),
+    Number(map['month']) - 1,
+    Number(map['day']),
+    Number(hour),
+    Number(map['minute']),
+    Number(map['second'])
+  );
+  return Math.round((tzMs - at.getTime()) / 60_000);
+}
+
+function getTodayWindow(now: Date): { start: Date; end: Date } {
+  const ymd = new Intl.DateTimeFormat('en-CA', {
+    timeZone: TIMEZONE,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(now);
+  const tzOffsetMinutes = getTimezoneOffsetMinutes(now, TIMEZONE);
+  const [yStr, mStr, dStr] = ymd.split('-');
+  const startUtcMs =
+    Date.UTC(Number(yStr), Number(mStr) - 1, Number(dStr), 0, 0, 0, 0) -
+    tzOffsetMinutes * 60_000;
+  return {
+    start: new Date(startUtcMs),
+    end: new Date(startUtcMs + 24 * 60 * 60 * 1000 - 1),
+  };
+}
+
+function formatSessionDate(d: Date): string {
+  return d.toLocaleDateString('en-US', {
+    timeZone: TIMEZONE,
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+function formatSessionTime(d: Date): string {
+  return d.toLocaleTimeString('en-US', {
+    timeZone: TIMEZONE,
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+/** The earliest session of a section that falls inside today's window. */
+function findSessionToday(
+  section: MusicTogetherSection,
+  start: Date,
+  end: Date
+): MusicTogetherSession | undefined {
+  return [...section.sessions]
+    .sort((a, b) => a.dateTime.getTime() - b.dateTime.getTime())
+    .find((s) => s.dateTime >= start && s.dateTime <= end);
+}
+
+function hasReminderForSession(
+  reg: MusicTogetherRegistration,
+  sessionIso: string
+): boolean {
+  return Boolean(reg.reminderSentForSessions?.[sessionIso]);
+}
+
+type ReminderOutcome = 'queued' | 'alreadySent' | 'notConfirmed' | 'skippedTest';
+
+/**
+ * Decide + send the reminder for one family/session. Extracted so the run loop
+ * stays flat (and testable) — returns what happened so the caller can tally.
+ */
+async function sendReminderForRegistration(
+  db: FirebaseFirestore.Firestore,
+  section: MusicTogetherSection,
+  session: MusicTogetherSession,
+  reg: MusicTogetherRegistration,
+  now: Date
+): Promise<ReminderOutcome> {
+  const sessionIso = session.dateTime.toISOString();
+  if (reg.status !== 'confirmed') return 'notConfirmed';
+  if (hasReminderForSession(reg, sessionIso)) return 'alreadySent';
+  if (isE2ETestEmail(reg.email)) {
+    console.log(
+      `[sendMusicTogetherReminders] Skipping E2E test registration ${reg.id} (${reg.email})`
+    );
+    return 'skippedTest';
+  }
+
+  const data: Record<string, string> = {
+    parentName: reg.parentNames[0] ?? '',
+    sectionName: section.name,
+    classDate: formatSessionDate(session.dateTime),
+    classStartTime: formatSessionTime(session.dateTime),
+    classLocation: section.location || DEFAULT_MT_LOCATION,
+  };
+  if (reg.calendarToken) {
+    data['calendarSubscribeUrl'] = familyCalendarSubscribeUrl(reg.calendarToken);
+  }
+
+  await db.collection('mail').add({
+    to: reg.email,
+    template: { name: 'music-together-reminder', data },
+  });
+  await MusicTogetherRegistrationRepository.markReminderSentForSession(
+    reg.id,
+    sessionIso,
+    now
+  );
+  return 'queued';
+}
+
+/**
+ * Core business logic — shared by the scheduled function and the admin
+ * callable so tests can drive it without Cloud Scheduler.
+ */
+export async function runSendMusicTogetherReminders(
+  now: Date = new Date()
+): Promise<SendMusicTogetherRemindersResult> {
+  if (admin.apps.length === 0) {
+    admin.initializeApp();
+  }
+
+  const { start, end } = getTodayWindow(now);
+
+  // Small data set (a handful of live sections) — pull all and filter in
+  // memory, since `sessions` is an array we can't range-query directly. Only
+  // publicly-visible sections get reminders; hidden drafts are skipped. A
+  // session inside today's window already means the term is running, so we
+  // don't gate on the (derived) enrollment status.
+  const sections = await MusicTogetherSectionRepository.findAll();
+  const todaySections = sections
+    .filter((s) => s.visible)
+    .map((section) => ({ section, session: findSessionToday(section, start, end) }))
+    .filter(
+      (
+        entry
+      ): entry is { section: MusicTogetherSection; session: MusicTogetherSession } =>
+        entry.session !== undefined
+    );
+
+  const result: SendMusicTogetherRemindersResult = {
+    mailQueued: 0,
+    skippedAlreadySent: 0,
+    skippedNotConfirmed: 0,
+    sectionsWithSessionToday: todaySections.length,
+  };
+
+  if (todaySections.length === 0) {
+    console.log(
+      `[sendMusicTogetherReminders] No live sections with a session on ${start.toISOString()} (ET window). Nothing to do.`
+    );
+    return result;
+  }
+
+  const db = admin.firestore();
+
+  for (const { section, session } of todaySections) {
+    const registrations =
+      await MusicTogetherRegistrationRepository.findBySectionId(section.id);
+
+    for (const reg of registrations) {
+      const outcome = await sendReminderForRegistration(
+        db,
+        section,
+        session,
+        reg,
+        now
+      );
+      if (outcome === 'queued') result.mailQueued += 1;
+      else if (outcome === 'alreadySent') result.skippedAlreadySent += 1;
+      else if (outcome === 'notConfirmed') result.skippedNotConfirmed += 1;
+    }
+  }
+
+  console.log(
+    `[sendMusicTogetherReminders] Queued ${result.mailQueued} reminder(s); skipped ${result.skippedAlreadySent} already-sent, ${result.skippedNotConfirmed} not-confirmed; covered ${todaySections.length} section(s).`
+  );
+
+  return result;
+}
+
+/** Scheduled trigger — daily at 08:00 America/New_York. */
+export const sendMusicTogetherReminders = onSchedule(
+  {
+    schedule: '0 8 * * *',
+    timeZone: TIMEZONE,
+    region: 'us-east4',
+  },
+  async () => {
+    await runSendMusicTogetherReminders(new Date());
+  }
+);
+
+/** Admin-callable manual trigger — same logic on demand (and drives tests). */
+export const triggerMusicTogetherReminders = Functions.endpoint
+  .requiringRole(Role.Admin)
+  .handle<Record<string, never>, SendMusicTogetherRemindersResult>(async () => {
+    return runSendMusicTogetherReminders(new Date());
+  });

--- a/libs/firebase/maple-functions/send-music-together-reminders/tsconfig.json
+++ b/libs/firebase/maple-functions/send-music-together-reminders/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [{ "path": "./tsconfig.lib.json" }]
+}

--- a/libs/firebase/maple-functions/send-music-together-reminders/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/send-music-together-reminders/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/ts/domain/src/lib/music-together-registration.ts
+++ b/libs/ts/domain/src/lib/music-together-registration.ts
@@ -96,6 +96,20 @@ export interface MusicTogetherRegistration {
   status: MusicTogetherRegistrationStatus;
   notes?: string;
   confirmationSentAt?: Date;
+  /**
+   * Unguessable per-family capability token for the auto-updating calendar
+   * subscription feed (`/calendar/family/<token>.ics`). Generated on the
+   * family's first registration and reused (by email) across their later
+   * registrations, so a single subscribe link tracks all their sections.
+   * Optional for backward compatibility with pre-feature registrations.
+   */
+  calendarToken?: string;
+  /**
+   * Per-session reminder bookkeeping. Keys are a session's ISO `dateTime`;
+   * presence means a day-of reminder email was already queued for that
+   * session, making `sendMusicTogetherReminders` idempotent across reruns.
+   */
+  reminderSentForSessions?: Record<string, Date>;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/tools/seed-email-templates.ts
+++ b/tools/seed-email-templates.ts
@@ -676,7 +676,7 @@ const craftClubCancelledHtml = `<!DOCTYPE html>
 // Sent when a family registers for a Music Together section. Transactional.
 // Routes payment to MT's Square account. Data: parentName, sectionName,
 // amountChargedLabel, isInstallments, secondInstallmentLabel,
-// secondInstallmentDate, cardLast4, receiptUrl.
+// secondInstallmentDate, cardLast4, receiptUrl, calendarSubscribeUrl.
 // ---------------------------------------------------------------------------
 
 const musicTogetherConfirmationSubject =
@@ -731,6 +731,18 @@ const musicTogetherConfirmationHtml = `<!DOCTYPE html>
         Music Together songbook and materials will be mailed to the address you
         provided.</p>
     </div>
+
+    {{#if calendarSubscribeUrl}}
+    <div class="highlight-box">
+      <strong style="color: #4A3728;">Add your classes to your calendar</strong><br>
+      <p>Subscribe once and your calendar stays up to date with your family's
+        class schedule — no need to add each session by hand, and any changes
+        sync automatically.</p>
+      <p><a href="{{calendarSubscribeUrl}}" style="color: #6B7B5E; font-weight: bold;">Subscribe to your class calendar</a></p>
+      <p style="font-size: 12px; color: #999;">Works with Apple Calendar, Google
+        Calendar, and Outlook. Keep this link private — it's unique to your family.</p>
+    </div>
+    {{/if}}
 
     <p>Questions? Reach out at
       <a href="mailto:musictogether@mapleandsprucefolkarts.com" style="color: #6B7B5E;">musictogether@mapleandsprucefolkarts.com</a>
@@ -799,6 +811,73 @@ const musicTogetherInstallmentFailedHtml = `<!DOCTYPE html>
 </html>`;
 
 // ---------------------------------------------------------------------------
+// Template: music-together-reminder
+//
+// Day-of reminder email sent by `sendMusicTogetherReminders` (scheduled, 8am
+// ET) to every confirmed family whose section meets that day. Transactional
+// (relationship message), so no unsubscribe link. Carries the family's
+// auto-updating calendar subscribe link. Data: parentName, sectionName,
+// classDate, classStartTime, classLocation, calendarSubscribeUrl.
+// ---------------------------------------------------------------------------
+
+const musicTogetherReminderSubject =
+  'Reminder: {{sectionName}} is today';
+
+const musicTogetherReminderHtml = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Music Together reminder</title>
+<style>${styles}</style>
+</head>
+<body>
+<div class="wrapper">
+  <div class="header">
+    <h1>Music Together with Maple &amp; Spruce</h1>
+  </div>
+  <div class="content">
+    <h2>See you today!</h2>
+    <p>{{#if parentName}}Hi {{parentName}},{{else}}Hello,{{/if}}</p>
+    <p>Just a friendly reminder that your <strong>{{sectionName}}</strong> Music
+      Together class is today. We can't wait to make music with you!</p>
+
+    <table class="detail-table">
+      <tr>
+        <td class="label">When</td>
+        <td>{{classStartTime}}, {{classDate}}</td>
+      </tr>
+      <tr>
+        <td class="label">Where</td>
+        <td>{{classLocation}}</td>
+      </tr>
+    </table>
+
+    {{#if calendarSubscribeUrl}}
+    <div class="highlight-box">
+      <strong style="color: #4A3728;">Keep your calendar in sync</strong><br>
+      <p>Subscribe once and your family's Music Together schedule stays up to
+        date automatically.</p>
+      <p><a href="{{calendarSubscribeUrl}}" style="color: #6B7B5E; font-weight: bold;">Subscribe to your class calendar</a></p>
+      <p style="font-size: 12px; color: #999;">Keep this link private — it's unique to your family.</p>
+    </div>
+    {{/if}}
+
+    <p>Questions? Reply to this email, reach out at
+      <a href="mailto:musictogether@mapleandsprucefolkarts.com" style="color: #6B7B5E;">musictogether@mapleandsprucefolkarts.com</a>,
+      or call <a href="tel:+13043144506" style="color: #6B7B5E;">304-314-4506</a>.</p>
+  </div>
+  <div class="footer">
+    <strong style="color: #4A3728;">Music Together with Maple &amp; Spruce</strong><br>
+    Morgantown, WV<br>
+    <a href="mailto:musictogether@mapleandsprucefolkarts.com">musictogether@mapleandsprucefolkarts.com</a> | <a href="tel:+13043144506">304-314-4506</a><br>
+    <span style="font-size: 12px; color: #999;">Music Together with Maple &amp; Spruce LLC is licensed by Music Together Worldwide. Music Together is a registered trademark.</span>
+  </div>
+</div>
+</body>
+</html>`;
+
+// ---------------------------------------------------------------------------
 // Seed to Firestore
 // ---------------------------------------------------------------------------
 
@@ -851,6 +930,10 @@ const templates: Record<string, EmailTemplate> = {
   'music-together-installment-failed': {
     subject: musicTogetherInstallmentFailedSubject,
     html: musicTogetherInstallmentFailedHtml,
+  },
+  'music-together-reminder': {
+    subject: musicTogetherReminderSubject,
+    html: musicTogetherReminderHtml,
   },
 };
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -410,6 +410,9 @@
       "@maple/firebase/maple-functions/calendar-music-together-feed": [
         "libs/firebase/maple-functions/calendar-music-together-feed/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/calendar-family-music-together-feed": [
+        "libs/firebase/maple-functions/calendar-family-music-together-feed/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/calendar-private-feed": [
         "libs/firebase/maple-functions/calendar-private-feed/src/index.ts"
       ],
@@ -519,6 +522,9 @@
       ],
       "@maple/firebase/maple-functions/send-class-reminders": [
         "libs/firebase/maple-functions/send-class-reminders/src/index.ts"
+      ],
+      "@maple/firebase/maple-functions/send-music-together-reminders": [
+        "libs/firebase/maple-functions/send-music-together-reminders/src/index.ts"
       ],
       "@maple/firebase/integration-test-utils": [
         "libs/firebase/integration-test-utils/src/index.ts"


### PR DESCRIPTION
Closes #591.

From Stephanie's feedback: families want a single link that stays current with **their** enrolled Music Together classes, dropped into confirmation + reminder emails — subscribe once, calendar tracks any changes.

## What
- **Token-scoped per-family ICS feed** `calendarFamilyMusicTogetherFeed` at `/calendar/family/<token>.ics` (maple-calendar codebase, mirrors the existing `calendar-*-feed` fns). Resolves the token → the family's **confirmed** sections → their live `CalendarEvent`s (kept in sync by `onMusicTogetherSectionWrite`), so it **auto-updates** within the 5-minute feed TTL as they register/cancel or class times change. Reuses `generateIcsFeed` from `@maple/ts/calendar`.
- **Per-family capability token** `calendarToken` on `MusicTogetherRegistration` — `randomBytes(24)` hex (192 bits), minted on the family's **first** registration and **reused by email** across later registrations so one subscribe link covers all their sections. The token *is* the capability: unguessable and non-enumerable. An unknown token returns an **empty-but-valid** calendar, so the endpoint never reveals which tokens exist.
- **`webcal://` subscribe link** added to the **MT confirmation email** (`music-together-confirmation`).
- **`sendMusicTogetherReminders`** (scheduled, 8am ET) + **`triggerMusicTogetherReminders`** (admin callable) — day-of reminders for **visible** sections meeting today, each carrying the family's subscribe link. Idempotent per session via `reminderSentForSessions`. MT families previously received **no** reminders (the class reminder job only covers the regular class program). New `music-together-reminder` template.

## Token design
`webcal://<host>/calendar/family/<token>.ics` where `<host>` is `maple-and-spruce-api.web.app` (prod) / `maple-and-spruce-dev.web.app` (dev), derived from `FirebaseProject`. Helpers live in `@maple/firebase/functions` (`family-calendar.utility.ts`). Token stored on the registration; the feed queries `where('calendarToken','==',token)` (single-field, auto-indexed — **no new composite index**, analyzer green).

## Rewrite
Added `{ "source": "/calendar/family/*.ics", "function": "calendarFamilyMusicTogetherFeed" }` under the `api` hosting target. **Note:** new `/calendar/*.ics` rewrites only resolve once `hosting:api` deploys — CI's `deploy_hosting_api` job handles that on merge (see PR #565 history).

## Emails now carrying the link
- MT registration **confirmation** email.
- MT day-of **reminder** email (new).

## Verification
- **Unit** — 19 new (feed handler + token extraction, token/URL util incl. prod/dev host, reminder logic incl. idempotency/visibility/E2E-skip); existing MT specs updated + green (201 passed).
- **Integration** (`./tools/run-integration-tests.sh music-together`, real emulators + Square mock) — **45 passed**, incl. the new `family-calendar-feed.spec.ts`: a family sees exactly their confirmed sessions (pending section excluded), the feed reflects a newly-added session, unknown token → empty calendar, missing token → 400, and registration stamps a token + emails the `webcal://` link.
- **Guardrails** — `check-firestore-indexes.ts`, `validate-function-tsconfigs.sh`, typecheck (core/calendar/square), eslint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)