### PR TITLE
feat(music-together): self-service card-on-file update for installment families (#561)

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -66,3 +66,7 @@ CRAFT_CLUB_PLAN_VARIATION_ID=RPD5VJVAAQ2CIETBSFPFMP2J
 
 # Craft Club self-service manage page (Webflow); magic-link emails point here.
 CRAFT_CLUB_MANAGE_URL=https://mapleandsprucefolkarts.com/craft-club-manage
+
+# Music Together self-service payment-method page (Webflow); update-card magic
+# links point here. The page reads ?token= to open the manage session.
+MUSIC_TOGETHER_MANAGE_URL=https://mapleandsprucefolkarts.com/music-together/manage-payment

--- a/.env.prod
+++ b/.env.prod
@@ -67,3 +67,7 @@ CRAFT_CLUB_PLAN_VARIATION_ID=C63X5O7RONKQVBAUV5WSCK3B
 
 # Craft Club self-service manage page (Webflow); magic-link emails point here.
 CRAFT_CLUB_MANAGE_URL=https://mapleandsprucefolkarts.com/craft-club-manage
+
+# Music Together self-service payment-method page (Webflow); update-card magic
+# links point here. The page reads ?token= to open the manage session.
+MUSIC_TOGETHER_MANAGE_URL=https://mapleandsprucefolkarts.com/music-together/manage-payment

--- a/apps/functions-integration-tests-music-together/src/update-music-together-payment-method.spec.ts
+++ b/apps/functions-integration-tests-music-together/src/update-music-together-payment-method.spec.ts
@@ -1,0 +1,246 @@
+/**
+ * Integration tests for the self-service card-on-file update flow, end-to-end
+ * against the Firebase emulator + Square mock server:
+ *
+ *   seed installment registration (old card) + a due scheduled charge
+ *     → startMusicTogetherManageSession(access token)  → session token
+ *     → updateMusicTogetherPaymentMethod(session, new nonce)
+ *         → MT Square mock vaults a NEW card + DISABLES the old one
+ *         → registration.squareCardId repointed to the new card (customer kept)
+ *     → triggerMusicTogetherInstallments (admin) charges the now-due installment
+ *         → the payment targets the NEW card, proving the retarget is real.
+ *
+ * Requires the maple-core + maple-square codebases built into the emulator and
+ * the Square mock server on 9997(+offset). The harness
+ * (`tools/run-integration-tests.sh music-together`) sets this up.
+ */
+import { createHash } from 'crypto';
+import {
+  createTestUser,
+  clearAuthEmulator,
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  getFirestoreDoc,
+  callFunction,
+  EMULATOR_CONFIG,
+  ADMIN_USER,
+} from '@maple/firebase/integration-test-utils';
+import type { TestUser } from '@maple/firebase/integration-test-utils';
+import type {
+  StartMusicTogetherManageSessionRequest,
+  StartMusicTogetherManageSessionResponse,
+  UpdateMusicTogetherPaymentMethodRequest,
+  UpdateMusicTogetherPaymentMethodResponse,
+  ChargeMusicTogetherInstallmentsRequest,
+  MusicTogetherInstallmentChargeResult,
+} from '@maple/ts/firebase/api-types';
+
+const squareMockUrl = EMULATOR_CONFIG.squareMockServerUrl;
+
+interface RecordedRequest {
+  method: string;
+  path: string;
+  body: unknown;
+}
+
+async function resetSquareMock(): Promise<void> {
+  const res = await fetch(`${squareMockUrl}/_mock/reset`, { method: 'POST' });
+  if (!res.ok) throw new Error(`Square mock reset failed: ${res.status}`);
+}
+
+async function getSquareRequests(
+  pathPrefix?: string
+): Promise<RecordedRequest[]> {
+  const res = await fetch(`${squareMockUrl}/_mock/requests`);
+  if (!res.ok) throw new Error(`Square mock requests failed: ${res.status}`);
+  const body = (await res.json()) as { requests: RecordedRequest[] };
+  const requests = body.requests ?? [];
+  return pathPrefix
+    ? requests.filter((r) => r.path.startsWith(pathPrefix))
+    : requests;
+}
+
+function hashToken(raw: string): string {
+  return createHash('sha256').update(raw).digest('hex');
+}
+
+const RAW_ACCESS_TOKEN = 'raw-access-token-abc123';
+const OLD_CARD_ID = 'ccof:old-card';
+const past = new Date(Date.now() - 86_400_000);
+const future = new Date(Date.now() + 30 * 60 * 1000);
+
+let sessionToken = '';
+
+describe('updateMusicTogetherPaymentMethod — end-to-end card replacement', () => {
+  let admin: TestUser;
+
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+
+    admin = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
+    await setFirestoreDoc('admins', admin.uid, {
+      userId: admin.uid,
+      email: admin.email,
+    });
+
+    await setFirestoreDoc('musicTogetherSections', 'sec-1', {
+      name: 'Fall Babies',
+      status: 'open',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    await setFirestoreDoc('musicTogetherRegistrations', 'reg-upd', {
+      sectionId: 'sec-1',
+      parentNames: ['Ada Lovelace'],
+      adultFirstName: 'Ada',
+      adultLastName: 'Lovelace',
+      children: [{ name: 'Sky', dob: new Date('2023-04-01') }],
+      email: 'update-card@test.com',
+      phone: '304-555-1212',
+      address: 'somewhere',
+      paymentPlan: 'installments',
+      policiesAcceptedAt: new Date(),
+      cardOnFileAuthAt: new Date(),
+      pricePaidCents: 9500,
+      squareCustomerId: 'cust-old',
+      squareCardId: OLD_CARD_ID,
+      status: 'confirmed',
+      scheduledChargeCount: 1,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    // A due installment so we can prove the charge job targets the new card.
+    await setFirestoreDoc('musicTogetherScheduledCharges', 'chg-upd', {
+      registrationId: 'reg-upd',
+      sectionId: 'sec-1',
+      installmentNumber: 2,
+      amountCents: 9500,
+      dueAt: past,
+      status: 'scheduled',
+      idempotencyKey: 'mt-charge-updtest',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    // Seed the emailed magic-link access token (only its hash is stored).
+    await setFirestoreDoc('musicTogetherAccessTokens', 'tok-1', {
+      tokenHash: hashToken(RAW_ACCESS_TOKEN),
+      registrationId: 'reg-upd',
+      expiresAt: future,
+      usedAt: null,
+      createdAt: new Date(),
+    });
+
+    await resetSquareMock();
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  it('exchanges the magic-link token for a session + manage view', async () => {
+    const result = await callFunction<
+      StartMusicTogetherManageSessionRequest,
+      StartMusicTogetherManageSessionResponse
+    >({
+      functionName: 'startMusicTogetherManageSession',
+      data: { token: RAW_ACCESS_TOKEN },
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data?.sessionToken).toBeTruthy();
+    expect(result.data?.registration.registrationId).toBe('reg-upd');
+    expect(result.data?.registration.sectionName).toBe('Fall Babies');
+    expect(result.data?.registration.nextInstallment?.amountLabel).toBe(
+      '$95.00'
+    );
+    sessionToken = result.data!.sessionToken;
+  });
+
+  it('rejects reusing the now-consumed magic-link token', async () => {
+    const result = await callFunction<
+      StartMusicTogetherManageSessionRequest,
+      StartMusicTogetherManageSessionResponse
+    >({
+      functionName: 'startMusicTogetherManageSession',
+      data: { token: RAW_ACCESS_TOKEN },
+    });
+    expect(result.status).not.toBe(200);
+  });
+
+  it('vaults a new card, repoints the registration, and disables the old card', async () => {
+    const result = await callFunction<
+      UpdateMusicTogetherPaymentMethodRequest,
+      UpdateMusicTogetherPaymentMethodResponse
+    >({
+      functionName: 'updateMusicTogetherPaymentMethod',
+      data: { sessionToken, paymentNonce: 'cnon:new-card' },
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data?.cardLast4).toBe('1111');
+
+    // Registration repointed to a NEW card; customer id preserved.
+    const reg = await getFirestoreDoc('musicTogetherRegistrations', 'reg-upd');
+    expect(reg?.squareCardId).not.toBe(OLD_CARD_ID);
+    expect(String(reg?.squareCardId)).toMatch(/^ccof:mock-card-/);
+    expect(reg?.squareCustomerId).toBe('cust-old');
+
+    // MT Square mock saw a card create AND a disable of the old card. The card
+    // id contains a colon; the SDK may URL-encode it, so match tolerantly.
+    const cardReqs = await getSquareRequests('/v2/cards');
+    expect(cardReqs.some((r) => r.path === '/v2/cards')).toBe(true);
+    const oldCardEncoded = encodeURIComponent(OLD_CARD_ID);
+    expect(
+      cardReqs.some(
+        (r) =>
+          /\/disable$/.test(r.path) &&
+          (r.path.includes(OLD_CARD_ID) || r.path.includes(oldCardEncoded))
+      )
+    ).toBe(true);
+  });
+
+  it('rejects an unknown session token', async () => {
+    const result = await callFunction<
+      UpdateMusicTogetherPaymentMethodRequest,
+      UpdateMusicTogetherPaymentMethodResponse
+    >({
+      functionName: 'updateMusicTogetherPaymentMethod',
+      data: { sessionToken: 'not-a-real-session', paymentNonce: 'cnon:x' },
+    });
+    expect(result.status).not.toBe(200);
+  });
+
+  it('charges the DUE installment against the NEW card (retarget is real)', async () => {
+    const reg = await getFirestoreDoc('musicTogetherRegistrations', 'reg-upd');
+    const newCardId = String(reg?.squareCardId);
+
+    const result = await callFunction<
+      ChargeMusicTogetherInstallmentsRequest,
+      MusicTogetherInstallmentChargeResult
+    >({
+      functionName: 'triggerMusicTogetherInstallments',
+      data: {},
+      idToken: admin.idToken,
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data?.charged).toBe(1);
+
+    // The last payment the charge job sent used the new card as its source.
+    const payments = await getSquareRequests('/v2/payments');
+    const lastPayment = payments[payments.length - 1];
+    const body = lastPayment.body as Record<string, unknown>;
+    expect(body['source_id'] ?? body['sourceId']).toBe(newCardId);
+
+    const charge = await getFirestoreDoc(
+      'musicTogetherScheduledCharges',
+      'chg-upd'
+    );
+    expect(charge?.status).toBe('paid');
+  });
+});

--- a/apps/functions-square/src/index.ts
+++ b/apps/functions-square/src/index.ts
@@ -56,6 +56,9 @@ export { createCraftClubSubscription } from '@maple/firebase/maple-functions/cre
 export { createMusicTogetherRegistration } from '@maple/firebase/maple-functions/create-music-together-registration';
 export { cancelMusicTogetherRegistration } from '@maple/firebase/maple-functions/cancel-music-together-registration';
 
+// Music Together self-service card-on-file update (MT's separate Square account)
+export { updateMusicTogetherPaymentMethod } from '@maple/firebase/maple-functions/update-music-together-payment-method';
+
 // Music Together Week-5 auto-charge job (scheduled + admin-callable trigger)
 export {
   chargeMusicTogetherInstallments,

--- a/apps/functions-square/tsconfig.app.json
+++ b/apps/functions-square/tsconfig.app.json
@@ -30,6 +30,7 @@
     "../../libs/firebase/maple-functions/create-music-together-registration/**/*.ts",
     "../../libs/firebase/maple-functions/charge-music-together-installments/**/*.ts",
     "../../libs/firebase/maple-functions/cancel-music-together-registration/**/*.ts",
+    "../../libs/firebase/maple-functions/update-music-together-payment-method/**/*.ts",
     "../../libs/firebase/database/src/**/*.ts",
     "../../libs/firebase/functions/src/**/*.ts",
     "../../libs/firebase/square/src/**/*.ts",

--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -241,3 +241,8 @@ export { requestCraftClubAccess } from '@maple/firebase/maple-functions/request-
 export { requestCraftClubManageLink } from '@maple/firebase/maple-functions/request-craft-club-manage-link';
 export { startCraftClubSession } from '@maple/firebase/maple-functions/start-craft-club-session';
 export { getCraftClubSubscription } from '@maple/firebase/maple-functions/get-craft-club-subscription';
+
+// Music Together — self-service card-on-file management magic-link + session
+// (no Square dep; the card update itself lives in the maple-square codebase).
+export { requestMusicTogetherManageLink } from '@maple/firebase/maple-functions/request-music-together-manage-link';
+export { startMusicTogetherManageSession } from '@maple/firebase/maple-functions/start-music-together-manage-session';

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -125,6 +125,8 @@
     "../../libs/firebase/maple-functions/start-craft-club-session/**/*.ts",
     "../../libs/firebase/maple-functions/get-craft-club-subscription/**/*.ts",
     "../../libs/firebase/maple-functions/get-public-music-together-section/**/*.ts",
+    "../../libs/firebase/maple-functions/request-music-together-manage-link/**/*.ts",
+    "../../libs/firebase/maple-functions/start-music-together-manage-session/**/*.ts",
     "../../libs/firebase/maple-functions/add-to-music-together-waitlist/**/*.ts",
     "../../libs/firebase/maple-functions/create-music-together-section/**/*.ts",
     "../../libs/firebase/maple-functions/get-music-together-sections/**/*.ts",

--- a/apps/webflow-components/src/MusicTogetherManageWidget.spec.tsx
+++ b/apps/webflow-components/src/MusicTogetherManageWidget.spec.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useEffect } from 'react';
+
+const calls: Record<string, unknown> = {};
+
+const sessionRegistration = {
+  registrationId: 'reg-1',
+  sectionName: 'Fall Babies',
+  parentName: 'Ada',
+  nextInstallment: {
+    amountCents: 9500,
+    amountLabel: '$95.00',
+    dueAt: '2026-09-15T13:00:00.000Z',
+    dueLabel: 'September 15, 2026',
+    status: 'scheduled',
+  },
+};
+
+vi.mock('./firebase-init', () => ({
+  getWidgetFunctions: () => ({ __mock: true }),
+}));
+
+vi.mock('firebase/functions', () => ({
+  httpsCallable: (_fns: unknown, name: string) => (payload: unknown) => {
+    calls[name] = payload;
+    switch (name) {
+      case 'startMusicTogetherManageSession':
+        return Promise.resolve({
+          data: { sessionToken: 'sess-1', registration: sessionRegistration },
+        });
+      case 'requestMusicTogetherManageLink':
+        return Promise.resolve({ data: { ok: true } });
+      case 'updateMusicTogetherPaymentMethod':
+        return Promise.resolve({
+          data: { registration: sessionRegistration, cardLast4: '4242' },
+        });
+      default:
+        return Promise.resolve({ data: {} });
+    }
+  },
+}));
+
+vi.mock('@maple/react/registrations', () => ({
+  SquareCardForm: ({
+    onReady,
+    onTokenizeRef,
+    afterCardContent,
+  }: {
+    onReady?: () => void;
+    onTokenizeRef: (fn: () => Promise<string>) => void;
+    afterCardContent?: React.ReactNode;
+  }) => {
+    useEffect(() => {
+      onTokenizeRef(async () => 'cnon:new-card');
+      onReady?.();
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return <div data-testid="mock-card-form">{afterCardContent}</div>;
+  },
+}));
+
+import { MusicTogetherManageWidget } from './MusicTogetherManageWidget';
+
+function renderWidget(token?: string) {
+  return render(
+    <MusicTogetherManageWidget
+      squareAppId="sandbox-app"
+      squareLocationId="LOC1"
+      env="dev"
+      token={token}
+    />
+  );
+}
+
+describe('MusicTogetherManageWidget', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(calls)) delete calls[k];
+  });
+  afterEach(() => cleanup());
+
+  it('without a token, emails an update link', async () => {
+    const user = userEvent.setup();
+    renderWidget(undefined);
+
+    await user.type(screen.getByLabelText(/Email/i), 'family@e.com');
+    await user.click(screen.getByRole('button', { name: /Email me a link/i }));
+
+    expect(await screen.findByText(/on its way/i)).toBeInTheDocument();
+    expect(calls['requestMusicTogetherManageLink']).toMatchObject({
+      email: 'family@e.com',
+    });
+  });
+
+  it('with a token, exchanges it and updates the card on file', async () => {
+    const user = userEvent.setup();
+    renderWidget('magic-token');
+
+    // Context about which installment the new card will cover.
+    expect(await screen.findByText(/Fall Babies/)).toBeInTheDocument();
+    expect(calls['startMusicTogetherManageSession']).toMatchObject({
+      token: 'magic-token',
+    });
+
+    const saveBtn = await screen.findByRole('button', {
+      name: /Save new card/i,
+    });
+    await waitFor(() => expect(saveBtn).toBeEnabled());
+    await user.click(saveBtn);
+
+    await waitFor(() =>
+      expect(calls['updateMusicTogetherPaymentMethod']).toMatchObject({
+        sessionToken: 'sess-1',
+        paymentNonce: 'cnon:new-card',
+      })
+    );
+    expect(await screen.findByText(/card was updated/i)).toBeInTheDocument();
+    expect(screen.getByText(/ending 4242/i)).toBeInTheDocument();
+  });
+});

--- a/apps/webflow-components/src/MusicTogetherManageWidget.tsx
+++ b/apps/webflow-components/src/MusicTogetherManageWidget.tsx
@@ -1,0 +1,258 @@
+/**
+ * Music Together Manage Widget — self-service payment-method update.
+ *
+ * For installment families: replace the card on file that will be charged for
+ * the Week-5 second installment. Two modes, decided by a `?token=` magic-link
+ * param:
+ *   • no token → email form → requestMusicTogetherManageLink (we email a link)
+ *   • token    → startMusicTogetherManageSession → enter a new card → save
+ *
+ * The magic-link token is exchanged once on mount for a short-lived session
+ * token, held in memory and passed on the update call. No customer auth.
+ *
+ * NOTE: SquareCardForm is intentionally rendered WITHOUT an `env` prop — the
+ * Square SDK environment follows the App ID prefix (MT's Square account), so
+ * we can pair prod data with a sandbox App ID for testing.
+ */
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
+import {
+  Box,
+  Typography,
+  CircularProgress,
+  Alert,
+  Button,
+  TextField,
+  Stack,
+  Divider,
+  ThemeProvider,
+} from '@mui/material';
+import { httpsCallable } from 'firebase/functions';
+import { theme } from '@maple/react/theme';
+import { SquareCardForm } from '@maple/react/registrations';
+import type {
+  RequestMusicTogetherManageLinkRequest,
+  RequestMusicTogetherManageLinkResponse,
+  StartMusicTogetherManageSessionRequest,
+  StartMusicTogetherManageSessionResponse,
+  UpdateMusicTogetherPaymentMethodRequest,
+  UpdateMusicTogetherPaymentMethodResponse,
+  MusicTogetherManageView,
+} from '@maple/ts/firebase/api-types';
+import { getWidgetFunctions } from './firebase-init';
+
+type Mode = 'request' | 'loading' | 'manage' | 'linkSent' | 'done' | 'error';
+
+export interface MusicTogetherManageWidgetProps {
+  /** MT Square App ID — its prefix selects the Square SDK environment. */
+  squareAppId: string;
+  /** MT Square location ID (must match squareAppId's environment). */
+  squareLocationId: string;
+  /** Firebase env for the callable functions ('dev' | 'prod'). */
+  env: string;
+  /** Override the magic-link token (defaults to reading `?token=` from the URL). */
+  token?: string;
+}
+
+function tokenFromUrl(): string | null {
+  if (typeof window === 'undefined') return null;
+  return new URLSearchParams(window.location.search).get('token');
+}
+
+export function MusicTogetherManageWidget({
+  squareAppId,
+  squareLocationId,
+  env,
+  token,
+}: MusicTogetherManageWidgetProps) {
+  const functions = useMemo(() => getWidgetFunctions(env), [env]);
+  const magicToken = useMemo(() => token ?? tokenFromUrl(), [token]);
+
+  const [mode, setMode] = useState<Mode>(magicToken ? 'loading' : 'request');
+  const [error, setError] = useState<string | null>(null);
+  const [registration, setRegistration] =
+    useState<MusicTogetherManageView | null>(null);
+  const [newCardLast4, setNewCardLast4] = useState<string | null>(null);
+  const sessionTokenRef = useRef<string | null>(null);
+
+  // Request-link form
+  const [email, setEmail] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  // Save-card sub-flow
+  const [cardReady, setCardReady] = useState(false);
+  const tokenizeRef = useRef<(() => Promise<string>) | null>(null);
+
+  // Exchange the magic-link token for a session on mount.
+  useEffect(() => {
+    if (!magicToken) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const call = httpsCallable<
+          StartMusicTogetherManageSessionRequest,
+          StartMusicTogetherManageSessionResponse
+        >(functions, 'startMusicTogetherManageSession');
+        const res = await call({ token: magicToken });
+        if (cancelled) return;
+        sessionTokenRef.current = res.data.sessionToken;
+        setRegistration(res.data.registration);
+        setMode('manage');
+      } catch (err) {
+        if (cancelled) return;
+        setError(
+          err instanceof Error
+            ? err.message
+            : 'This link is invalid or has expired.'
+        );
+        setMode('error');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [functions, magicToken]);
+
+  const handleRequestLink = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      setError(null);
+      setBusy(true);
+      try {
+        const call = httpsCallable<
+          RequestMusicTogetherManageLinkRequest,
+          RequestMusicTogetherManageLinkResponse
+        >(functions, 'requestMusicTogetherManageLink');
+        await call({ email: email.trim() });
+        setMode('linkSent');
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Something went wrong.');
+      } finally {
+        setBusy(false);
+      }
+    },
+    [functions, email]
+  );
+
+  const handleSaveCard = useCallback(async () => {
+    if (!sessionTokenRef.current || !tokenizeRef.current) return;
+    setError(null);
+    setBusy(true);
+    try {
+      const nonce = await tokenizeRef.current();
+      const call = httpsCallable<
+        UpdateMusicTogetherPaymentMethodRequest,
+        UpdateMusicTogetherPaymentMethodResponse
+      >(functions, 'updateMusicTogetherPaymentMethod');
+      const res = await call({
+        sessionToken: sessionTokenRef.current,
+        paymentNonce: nonce,
+      });
+      setRegistration(res.data.registration);
+      setNewCardLast4(res.data.cardLast4 ?? null);
+      setMode('done');
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Could not update your payment method.'
+      );
+    } finally {
+      setBusy(false);
+    }
+  }, [functions]);
+
+  return (
+    <ThemeProvider theme={theme}>
+      <Box sx={{ maxWidth: 480, mx: 'auto' }}>
+        <Typography variant="h5" component="h2" gutterBottom>
+          Update your Music Together payment method
+        </Typography>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        {/* No token → ask for the email to send a link */}
+        {mode === 'request' && (
+          <Box component="form" onSubmit={handleRequestLink}>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              Enter the email you registered with and we&apos;ll send you a
+              secure link to update the card on file for your installment plan.
+            </Typography>
+            <Stack spacing={2}>
+              <TextField
+                label="Email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                fullWidth
+                autoFocus
+              />
+              <Button type="submit" variant="contained" disabled={busy}>
+                {busy ? 'Sending…' : 'Email me a link'}
+              </Button>
+            </Stack>
+          </Box>
+        )}
+
+        {mode === 'linkSent' && (
+          <Alert severity="success">
+            If that email has an installment registration, a secure link is on
+            its way. Check your inbox (and spam) — the link expires in 30
+            minutes.
+          </Alert>
+        )}
+
+        {mode === 'loading' && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress />
+          </Box>
+        )}
+
+        {/* Token exchanged → enter a new card */}
+        {mode === 'manage' && registration && (
+          <Stack spacing={2}>
+            <Alert severity="info">
+              {registration.sectionName}
+              {registration.nextInstallment
+                ? ` — your next installment of ${registration.nextInstallment.amountLabel} on ${registration.nextInstallment.dueLabel} will use the new card.`
+                : ' — enter a new card below to keep on file.'}
+            </Alert>
+            <Divider />
+            <Typography variant="subtitle2">New payment method</Typography>
+            <SquareCardForm
+              applicationId={squareAppId}
+              locationId={squareLocationId}
+              totalCents={registration.nextInstallment?.amountCents ?? 0}
+              onReady={() => setCardReady(true)}
+              onTokenizeRef={(fn) => {
+                tokenizeRef.current = fn;
+              }}
+              afterCardContent={
+                <Button
+                  variant="contained"
+                  onClick={handleSaveCard}
+                  disabled={busy || !cardReady}
+                >
+                  {busy ? 'Saving…' : 'Save new card'}
+                </Button>
+              }
+            />
+          </Stack>
+        )}
+
+        {mode === 'done' && registration && (
+          <Alert severity="success">
+            Your card was updated{newCardLast4 ? ` (ending ${newCardLast4})` : ''}.
+            {registration.nextInstallment
+              ? ` Your ${registration.nextInstallment.amountLabel} installment on ${registration.nextInstallment.dueLabel} will use it.`
+              : ''}
+          </Alert>
+        )}
+      </Box>
+    </ThemeProvider>
+  );
+}

--- a/apps/webflow-components/src/music-together-manage.webflow.tsx
+++ b/apps/webflow-components/src/music-together-manage.webflow.tsx
@@ -1,0 +1,34 @@
+/**
+ * Webflow Code Component: Music Together Manage Payment
+ *
+ * Wraps the MusicTogetherManageWidget for the Webflow Designer. Place on the
+ * public "update my payment method" page that the magic-link emails point to.
+ * The widget reads the `?token=` query param itself; without one it shows the
+ * email form to request a fresh link.
+ */
+import { declareComponent } from '@webflow/react';
+import { props } from '@webflow/data-types';
+import { emotionShadowDomDecorator } from '@webflow/emotion-utils';
+import { MusicTogetherManageWidget } from './MusicTogetherManageWidget';
+
+export default declareComponent(MusicTogetherManageWidget, {
+  name: 'Music Together Manage Payment',
+  description:
+    "Self-service Music Together card-on-file update. Reads a ?token= magic link to let an installment family enter a new card for the Week-5 charge; otherwise emails a fresh link.",
+  decorators: [emotionShadowDomDecorator],
+  props: {
+    squareAppId: props.Text({
+      name: 'Square App ID (Music Together)',
+      defaultValue: '',
+    }),
+    squareLocationId: props.Text({
+      name: 'Square Location ID (Music Together)',
+      defaultValue: '',
+    }),
+    env: props.Variant({
+      name: 'Environment',
+      options: ['dev', 'prod'],
+      defaultValue: 'prod',
+    }),
+  },
+});

--- a/docs/reference/deployed-functions.md
+++ b/docs/reference/deployed-functions.md
@@ -110,6 +110,8 @@ Core CRUD operations, auth, triggers, and admin functions. No heavy third-party 
 - `requestCraftClubManageLink` _(public)_ — emails a single-use magic link to manage a membership; uniform response (no enumeration)
 - `startCraftClubSession` _(public)_ — exchanges a magic-link token (single-use) for a short-lived session token
 - `getCraftClubSubscription` _(public, session-gated)_ — returns the member's customer-safe subscription view
+- `requestMusicTogetherManageLink` _(public)_ — emails a single-use magic link to update the card on file for an installment registration; uniform response (no enumeration)
+- `startMusicTogetherManageSession` _(public)_ — exchanges an MT magic-link token (single-use) for a short-lived session token + a customer-safe manage view (section + next installment)
 - _Subscribe + self-service Square mutations live in the `maple-square` codebase; subscription webhooks land in a later phase._
 
 ---
@@ -154,6 +156,7 @@ Square SDK integration for payments, catalog management, and sync conflict resol
 - `createCraftClubSubscription` _(public)_ — re-checks the approval gate server-side, then upserts the Square customer, stores the card on file from the Web Payments nonce, enrolls it in the $30/mo subscription plan, and mirrors the result onto the member record
 - `cancelCraftClubSubscription` _(public, session-gated)_ — cancels the Square subscription at period end, marks the member cancelled, and emails a confirmation
 - `updateCraftClubPaymentMethod` _(public, session-gated)_ — files a new card from a Web Payments nonce and points the subscription at it
+- `updateMusicTogetherPaymentMethod` _(public, session-gated, MT Square account)_ — vaults a new card on file for an installment registration, repoints `registration.squareCardId` at it (retargets pending Week-5 scheduled charges), and disables the old card
 - `adminPauseCraftClubSubscription` / `adminResumeCraftClubSubscription` / `adminCancelCraftClubSubscription` _(admin-only)_ — Square pause/resume/cancel + mirror member status (cancel also emails)
 - `createCraftClubSubscription` also emails a welcome on success.
 

--- a/function-codebases.json
+++ b/function-codebases.json
@@ -49,6 +49,7 @@
     "firebase-maple-functions-create-music-together-registration": "maple-square",
     "firebase-maple-functions-charge-music-together-installments": "maple-square",
     "firebase-maple-functions-cancel-music-together-registration": "maple-square",
+    "firebase-maple-functions-update-music-together-payment-method": "maple-square",
     "firebase-maple-functions-cancel-craft-club-subscription": "maple-square",
     "firebase-maple-functions-update-craft-club-payment-method": "maple-square",
     "firebase-maple-functions-admin-pause-craft-club-subscription": "maple-square",

--- a/libs/firebase/database/src/index.ts
+++ b/libs/firebase/database/src/index.ts
@@ -111,6 +111,11 @@ export {
   MusicTogetherWaitlistRepository,
   mtWaitlistEmailKey,
 } from './lib/music-together-waitlist.repository';
+export {
+  MusicTogetherTokenRepository,
+  MUSIC_TOGETHER_ACCESS_TOKEN_TTL_MS,
+  MUSIC_TOGETHER_SESSION_TTL_MS,
+} from './lib/music-together-token.repository';
 
 // Phase 5: Etsy
 export {

--- a/libs/firebase/database/src/lib/music-together-token.repository.ts
+++ b/libs/firebase/database/src/lib/music-together-token.repository.ts
@@ -1,0 +1,119 @@
+/**
+ * Music Together Token Repository
+ *
+ * Two short-lived token collections powering self-service payment-method
+ * management for installment families without customer auth. Mirrors the Craft
+ * Club token model, but scoped to a *registration* (the card on file lives on
+ * the registration) rather than a member.
+ *
+ * - `musicTogetherAccessTokens` — single-use magic-link tokens emailed to a
+ *   family (~30 min). Exchanged once for a session.
+ * - `musicTogetherManageSessions` — session tokens issued after a magic link is
+ *   consumed (~1 h), bound to a registration. The manage widget holds the raw
+ *   session token and passes it on every management call.
+ *
+ * Tokens are sensitive (they authorize replacing the card that will be charged
+ * for the Week-5 installment), so only a **sha256 hash** is stored — the raw
+ * token lives only in the emailed URL / the widget's memory. Lookups hash the
+ * presented token and match on the hash.
+ */
+import { createHash, randomBytes } from 'crypto';
+import { db, toDate } from './utilities/database.config';
+
+const ACCESS_TOKENS = 'musicTogetherAccessTokens';
+const SESSIONS = 'musicTogetherManageSessions';
+
+/** Magic-link tokens are valid for 30 minutes. */
+export const MUSIC_TOGETHER_ACCESS_TOKEN_TTL_MS = 30 * 60 * 1000;
+/** Sessions are valid for 1 hour. */
+export const MUSIC_TOGETHER_SESSION_TTL_MS = 60 * 60 * 1000;
+
+function hashToken(raw: string): string {
+  return createHash('sha256').update(raw).digest('hex');
+}
+
+export const MusicTogetherTokenRepository = {
+  /**
+   * Create a single-use magic-link token for a registration. Returns the RAW
+   * token (only its hash is persisted) — embed it in the emailed URL.
+   */
+  async createAccessToken(
+    registrationId: string,
+    now: Date = new Date()
+  ): Promise<string> {
+    const rawToken = randomBytes(32).toString('hex');
+    await db.collection(ACCESS_TOKENS).add({
+      tokenHash: hashToken(rawToken),
+      registrationId,
+      expiresAt: new Date(now.getTime() + MUSIC_TOGETHER_ACCESS_TOKEN_TTL_MS),
+      usedAt: null,
+      createdAt: now,
+    });
+    return rawToken;
+  },
+
+  /**
+   * Validate and consume a magic-link token. Returns the associated
+   * registration id, or undefined if the token is unknown, already used, or
+   * expired. Marks the token used so it cannot be replayed.
+   */
+  async consumeAccessToken(
+    rawToken: string,
+    now: Date = new Date()
+  ): Promise<string | undefined> {
+    if (!rawToken) return undefined;
+    const snapshot = await db
+      .collection(ACCESS_TOKENS)
+      .where('tokenHash', '==', hashToken(rawToken))
+      .limit(1)
+      .get();
+    if (snapshot.empty) return undefined;
+
+    const doc = snapshot.docs[0];
+    const data = doc.data();
+    if (data.usedAt) return undefined;
+    if (toDate(data.expiresAt).getTime() < now.getTime()) return undefined;
+
+    await doc.ref.update({ usedAt: now });
+    return data.registrationId as string;
+  },
+
+  /**
+   * Issue a session token bound to a registration. Returns the RAW session
+   * token (only its hash is persisted).
+   */
+  async createSession(
+    registrationId: string,
+    now: Date = new Date()
+  ): Promise<string> {
+    const rawToken = randomBytes(32).toString('hex');
+    await db.collection(SESSIONS).add({
+      tokenHash: hashToken(rawToken),
+      registrationId,
+      expiresAt: new Date(now.getTime() + MUSIC_TOGETHER_SESSION_TTL_MS),
+      createdAt: now,
+    });
+    return rawToken;
+  },
+
+  /**
+   * Resolve a session token to its registration id, or undefined if the token
+   * is unknown or expired.
+   */
+  async resolveSession(
+    rawToken: string,
+    now: Date = new Date()
+  ): Promise<string | undefined> {
+    if (!rawToken) return undefined;
+    const snapshot = await db
+      .collection(SESSIONS)
+      .where('tokenHash', '==', hashToken(rawToken))
+      .limit(1)
+      .get();
+    if (snapshot.empty) return undefined;
+
+    const data = snapshot.docs[0].data();
+    if (toDate(data.expiresAt).getTime() < now.getTime()) return undefined;
+    return data.registrationId as string;
+  },
+};

--- a/libs/firebase/maple-functions/request-music-together-manage-link/project.json
+++ b/libs/firebase/maple-functions/request-music-together-manage-link/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-request-music-together-manage-link",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/request-music-together-manage-link/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/request-music-together-manage-link/src/index.ts
+++ b/libs/firebase/maple-functions/request-music-together-manage-link/src/index.ts
@@ -1,0 +1,1 @@
+export { requestMusicTogetherManageLink } from './lib/request-music-together-manage-link';

--- a/libs/firebase/maple-functions/request-music-together-manage-link/src/lib/request-music-together-manage-link.spec.ts
+++ b/libs/firebase/maple-functions/request-music-together-manage-link/src/lib/request-music-together-manage-link.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  capturedHandler: null as
+    | ((d: unknown, c: unknown, s: unknown, st: unknown) => Promise<unknown>)
+    | null,
+  findAll: vi.fn(),
+  createAccessToken: vi.fn(),
+  mailAdd: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/functions', () => {
+  const endpoint = {
+    usingStrings: vi.fn(() => endpoint),
+    handle: vi.fn((h: typeof mocks.capturedHandler) => {
+      mocks.capturedHandler = h;
+      return 'mock-function';
+    }),
+  };
+  return {
+    Functions: { endpoint },
+    throwInvalidArgument: (m: string) => {
+      throw new Error(m);
+    },
+  };
+});
+
+vi.mock('@maple/firebase/database', () => ({
+  MusicTogetherRegistrationRepository: { findAll: mocks.findAll },
+  MusicTogetherTokenRepository: { createAccessToken: mocks.createAccessToken },
+  getDb: () => ({ collection: () => ({ add: mocks.mailAdd }) }),
+}));
+
+import './request-music-together-manage-link';
+
+const STRINGS = {
+  MUSIC_TOGETHER_MANAGE_URL: 'https://site.example/mt-manage',
+};
+const run = (data: unknown) => mocks.capturedHandler!(data, {}, {}, STRINGS);
+
+const EMAIL = 'family@example.com';
+
+const manageable = {
+  id: 'reg-1',
+  email: EMAIL,
+  paymentPlan: 'installments',
+  status: 'confirmed',
+  squareCustomerId: 'cust-1',
+  squareCardId: 'card-1',
+};
+
+describe('requestMusicTogetherManageLink', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('emails a magic link scoped to the registration when manageable', async () => {
+    mocks.findAll.mockResolvedValue([manageable]);
+    mocks.createAccessToken.mockResolvedValue('rawtok123');
+
+    const result = (await run({ email: EMAIL })) as {
+      ok: boolean;
+    };
+
+    expect(result.ok).toBe(true);
+    expect(mocks.createAccessToken).toHaveBeenCalledWith('reg-1');
+    expect(mocks.mailAdd).toHaveBeenCalledTimes(1);
+    const mailDoc = mocks.mailAdd.mock.calls[0][0];
+    expect(mailDoc.to).toBe(EMAIL);
+    expect(mailDoc.template.name).toBe('music-together-manage-link');
+    expect(mailDoc.template.data.manageUrl).toContain('token=rawtok123');
+  });
+
+  it('picks the most recent manageable registration (findAll is newest-first)', async () => {
+    mocks.findAll.mockResolvedValue([
+      { ...manageable, id: 'reg-new' },
+      { ...manageable, id: 'reg-old' },
+    ]);
+    mocks.createAccessToken.mockResolvedValue('tok');
+
+    await run({ email: EMAIL });
+
+    expect(mocks.createAccessToken).toHaveBeenCalledWith('reg-new');
+  });
+
+  it('does not email pay-in-full or cancelled registrations (no enumeration)', async () => {
+    mocks.findAll.mockResolvedValue([
+      { ...manageable, paymentPlan: 'full' },
+      { ...manageable, status: 'cancelled' },
+    ]);
+
+    const result = (await run({ email: EMAIL })) as {
+      ok: boolean;
+    };
+
+    expect(result.ok).toBe(true);
+    expect(mocks.createAccessToken).not.toHaveBeenCalled();
+    expect(mocks.mailAdd).not.toHaveBeenCalled();
+  });
+
+  it('returns ok without emailing when nothing matches the email', async () => {
+    mocks.findAll.mockResolvedValue([]);
+
+    const result = (await run({ email: 'stranger@example.com' })) as {
+      ok: boolean;
+    };
+
+    expect(result.ok).toBe(true);
+    expect(mocks.mailAdd).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a lowercased email lookup', async () => {
+    mocks.findAll
+      .mockResolvedValueOnce([]) // exact (mixed-case) miss
+      .mockResolvedValueOnce([manageable]); // lowercased hit
+    mocks.createAccessToken.mockResolvedValue('tok');
+
+    await run({ email: 'Family@Example.com' });
+
+    expect(mocks.findAll).toHaveBeenNthCalledWith(1, {
+      email: 'Family@Example.com',
+    });
+    expect(mocks.findAll).toHaveBeenNthCalledWith(2, {
+      email: EMAIL,
+    });
+    expect(mocks.mailAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a missing email', async () => {
+    await expect(run({})).rejects.toThrow(/Email is required/);
+  });
+});

--- a/libs/firebase/maple-functions/request-music-together-manage-link/src/lib/request-music-together-manage-link.ts
+++ b/libs/firebase/maple-functions/request-music-together-manage-link/src/lib/request-music-together-manage-link.ts
@@ -1,0 +1,88 @@
+/**
+ * Request Music Together Manage Link Cloud Function (public)
+ *
+ * Emails a family a single-use magic link to update the card on file behind
+ * their installment registration — so the Week-5 second charge hits the right
+ * card. The response is uniform whether or not the email has a manageable
+ * registration (no enumeration): only when a chargeable installment
+ * registration exists do we mint a token and queue the email.
+ *
+ * The token is scoped to a specific registration (the card lives on the
+ * registration). When a family has more than one installment registration we
+ * pick the most recent — that is the one whose installment is still ahead.
+ *
+ * Deployed to us-east4 via CI/CD (maple-core codebase).
+ */
+import { Functions, throwInvalidArgument } from '@maple/firebase/functions';
+import {
+  MusicTogetherRegistrationRepository,
+  MusicTogetherTokenRepository,
+  getDb,
+} from '@maple/firebase/database';
+import type { MusicTogetherRegistration } from '@maple/ts/domain';
+import type {
+  RequestMusicTogetherManageLinkRequest,
+  RequestMusicTogetherManageLinkResponse,
+} from '@maple/ts/firebase/api-types';
+
+/**
+ * A registration is manageable when it is a confirmed installment plan with a
+ * vaulted card on file (customer + card ids). Pay-in-full registrations have
+ * nothing on file, and cancelled/refunded ones are never charged again.
+ */
+function isManageable(reg: MusicTogetherRegistration): boolean {
+  return (
+    reg.paymentPlan === 'installments' &&
+    reg.status === 'confirmed' &&
+    !!reg.squareCustomerId &&
+    !!reg.squareCardId
+  );
+}
+
+export const requestMusicTogetherManageLink = Functions.endpoint
+  .usingStrings('MUSIC_TOGETHER_MANAGE_URL')
+  .handle<
+    RequestMusicTogetherManageLinkRequest,
+    RequestMusicTogetherManageLinkResponse
+  >(async (data, _context, _secrets, strings) => {
+    if (!data.email) throwInvalidArgument('Email is required');
+
+    const email = data.email.trim();
+    // Registrations store the email as entered; match case-insensitively by
+    // trying the exact value then a lowercased fallback.
+    let candidates = await MusicTogetherRegistrationRepository.findAll({
+      email,
+    });
+    if (candidates.length === 0 && email !== email.toLowerCase()) {
+      candidates = await MusicTogetherRegistrationRepository.findAll({
+        email: email.toLowerCase(),
+      });
+    }
+
+    // findAll returns newest-first; take the most recent manageable one.
+    const registration = candidates.find(isManageable);
+
+    if (registration) {
+      const rawToken = await MusicTogetherTokenRepository.createAccessToken(
+        registration.id
+      );
+      const base = strings.MUSIC_TOGETHER_MANAGE_URL;
+      const separator = base.includes('?') ? '&' : '?';
+      const manageUrl = `${base}${separator}token=${rawToken}`;
+
+      // Template `music-together-manage-link` is seeded via
+      // tools/seed-email-templates.ts.
+      await getDb()
+        .collection('mail')
+        .add({
+          to: registration.email,
+          template: {
+            name: 'music-together-manage-link',
+            data: { manageUrl },
+          },
+        });
+    }
+
+    // Always uniform — do not reveal whether the email is enrolled.
+    return { ok: true };
+  });

--- a/libs/firebase/maple-functions/request-music-together-manage-link/tsconfig.json
+++ b/libs/firebase/maple-functions/request-music-together-manage-link/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/request-music-together-manage-link/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/request-music-together-manage-link/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/start-music-together-manage-session/project.json
+++ b/libs/firebase/maple-functions/start-music-together-manage-session/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-start-music-together-manage-session",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/start-music-together-manage-session/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/start-music-together-manage-session/src/index.ts
+++ b/libs/firebase/maple-functions/start-music-together-manage-session/src/index.ts
@@ -1,0 +1,1 @@
+export { startMusicTogetherManageSession } from './lib/start-music-together-manage-session';

--- a/libs/firebase/maple-functions/start-music-together-manage-session/src/lib/manage-view.ts
+++ b/libs/firebase/maple-functions/start-music-together-manage-session/src/lib/manage-view.ts
@@ -1,0 +1,50 @@
+/**
+ * Build the customer-safe manage-page view for an installment registration.
+ *
+ * Pure assembly (no I/O) from an already-loaded registration, its section, and
+ * its scheduled charges. Shared shape between `startMusicTogetherManageSession`
+ * and `updateMusicTogetherPaymentMethod`. Duplicated in both function libs to
+ * keep Nx library boundaries clean (it depends on the api-types view shape,
+ * which the domain layer cannot import).
+ */
+import {
+  mtNextActionableCharge,
+  type MusicTogetherRegistration,
+  type MusicTogetherSection,
+  type MusicTogetherScheduledCharge,
+} from '@maple/ts/domain';
+import type { MusicTogetherManageView } from '@maple/ts/firebase/api-types';
+
+const fmtMoney = (cents: number): string => `$${(cents / 100).toFixed(2)}`;
+
+const fmtDate = (d: Date): string =>
+  d.toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'America/New_York',
+  });
+
+export function buildMusicTogetherManageView(
+  registration: MusicTogetherRegistration,
+  section: MusicTogetherSection | undefined,
+  charges: MusicTogetherScheduledCharge[]
+): MusicTogetherManageView {
+  const next = mtNextActionableCharge(charges);
+  return {
+    registrationId: registration.id,
+    sectionName: section?.name ?? 'Music Together',
+    parentName:
+      registration.parentNames[0] ??
+      `${registration.adultFirstName} ${registration.adultLastName}`.trim(),
+    nextInstallment: next
+      ? {
+          amountCents: next.amountCents,
+          amountLabel: fmtMoney(next.amountCents),
+          dueAt: next.dueAt.toISOString(),
+          dueLabel: fmtDate(next.dueAt),
+          status: next.status,
+        }
+      : undefined,
+  };
+}

--- a/libs/firebase/maple-functions/start-music-together-manage-session/src/lib/start-music-together-manage-session.spec.ts
+++ b/libs/firebase/maple-functions/start-music-together-manage-session/src/lib/start-music-together-manage-session.spec.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  consumeAccessToken: vi.fn(),
+  createSession: vi.fn(),
+  findRegistrationById: vi.fn(),
+  findSectionById: vi.fn(),
+  findByRegistrationId: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/functions', () => ({
+  createPublicFunction: <TReq, TRes>(handler: (d: TReq) => Promise<TRes>) =>
+    handler,
+  throwInvalidArgument: (m: string) => {
+    throw new Error(m);
+  },
+  throwFailedPrecondition: (m: string) => {
+    throw new Error(m);
+  },
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  MusicTogetherTokenRepository: {
+    consumeAccessToken: mocks.consumeAccessToken,
+    createSession: mocks.createSession,
+  },
+  MusicTogetherRegistrationRepository: {
+    findById: mocks.findRegistrationById,
+  },
+  MusicTogetherSectionRepository: { findById: mocks.findSectionById },
+  MusicTogetherScheduledChargeRepository: {
+    findByRegistrationId: mocks.findByRegistrationId,
+  },
+}));
+
+import { startMusicTogetherManageSession } from './start-music-together-manage-session';
+
+type Handler = (data: unknown) => Promise<{
+  sessionToken: string;
+  registration: Record<string, unknown>;
+}>;
+const handler = startMusicTogetherManageSession as unknown as Handler;
+
+const registration = {
+  id: 'reg-1',
+  sectionId: 'sec-1',
+  parentNames: ['Ada Lovelace'],
+  adultFirstName: 'Ada',
+  adultLastName: 'Lovelace',
+  email: 'ada@e.com',
+  paymentPlan: 'installments',
+  status: 'confirmed',
+  squareCustomerId: 'cust-secret',
+  squareCardId: 'card-secret',
+};
+
+describe('startMusicTogetherManageSession', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('exchanges a valid token for a session and a customer-safe view', async () => {
+    mocks.consumeAccessToken.mockResolvedValue('reg-1');
+    mocks.findRegistrationById.mockResolvedValue(registration);
+    mocks.findSectionById.mockResolvedValue({ id: 'sec-1', name: 'Fall Babies' });
+    mocks.findByRegistrationId.mockResolvedValue([
+      {
+        id: 'c2',
+        amountCents: 9500,
+        dueAt: new Date('2026-09-15T13:00:00Z'),
+        status: 'scheduled',
+      },
+    ]);
+    mocks.createSession.mockResolvedValue('session-token-xyz');
+
+    const result = await handler({ token: 'magic' });
+
+    expect(mocks.createSession).toHaveBeenCalledWith('reg-1');
+    expect(result.sessionToken).toBe('session-token-xyz');
+    expect(result.registration).toMatchObject({
+      registrationId: 'reg-1',
+      sectionName: 'Fall Babies',
+      parentName: 'Ada Lovelace',
+    });
+    expect(
+      (result.registration.nextInstallment as Record<string, unknown>)
+        .amountLabel
+    ).toBe('$95.00');
+    // Public view must NOT leak Square identifiers.
+    expect(result.registration).not.toHaveProperty('squareCardId');
+    expect(result.registration).not.toHaveProperty('squareCustomerId');
+  });
+
+  it('rejects a missing token', async () => {
+    await expect(handler({})).rejects.toThrow(/Token is required/);
+  });
+
+  it('rejects an invalid or expired token', async () => {
+    mocks.consumeAccessToken.mockResolvedValue(undefined);
+    await expect(handler({ token: 'bad' })).rejects.toThrow(
+      /invalid or has expired/
+    );
+    expect(mocks.createSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the registration is cancelled', async () => {
+    mocks.consumeAccessToken.mockResolvedValue('reg-1');
+    mocks.findRegistrationById.mockResolvedValue({
+      ...registration,
+      status: 'cancelled',
+    });
+    await expect(handler({ token: 'magic' })).rejects.toThrow(
+      /can no longer be managed/i
+    );
+    expect(mocks.createSession).not.toHaveBeenCalled();
+  });
+});

--- a/libs/firebase/maple-functions/start-music-together-manage-session/src/lib/start-music-together-manage-session.ts
+++ b/libs/firebase/maple-functions/start-music-together-manage-session/src/lib/start-music-together-manage-session.ts
@@ -1,0 +1,68 @@
+/**
+ * Start Music Together Manage Session Cloud Function (public)
+ *
+ * Exchanges a single-use magic-link token for a short-lived session. The access
+ * token is consumed (marked used) so the link cannot be replayed; the returned
+ * session token authorizes the subsequent card-update call. Also returns a
+ * customer-safe snapshot (section + next installment) so the manage page can
+ * show which charge the new card will cover.
+ *
+ * Deployed to us-east4 via CI/CD (maple-core codebase).
+ */
+import {
+  createPublicFunction,
+  throwInvalidArgument,
+  throwFailedPrecondition,
+} from '@maple/firebase/functions';
+import {
+  MusicTogetherRegistrationRepository,
+  MusicTogetherSectionRepository,
+  MusicTogetherScheduledChargeRepository,
+  MusicTogetherTokenRepository,
+} from '@maple/firebase/database';
+import { buildMusicTogetherManageView } from './manage-view';
+import type {
+  StartMusicTogetherManageSessionRequest,
+  StartMusicTogetherManageSessionResponse,
+} from '@maple/ts/firebase/api-types';
+
+export const startMusicTogetherManageSession = createPublicFunction<
+  StartMusicTogetherManageSessionRequest,
+  StartMusicTogetherManageSessionResponse
+>(async (data) => {
+  if (!data.token) throwInvalidArgument('Token is required');
+
+  const registrationId =
+    await MusicTogetherTokenRepository.consumeAccessToken(data.token);
+  if (!registrationId) {
+    throwFailedPrecondition(
+      'This link is invalid or has expired. Please request a new one.'
+    );
+  }
+
+  const registration =
+    await MusicTogetherRegistrationRepository.findById(registrationId);
+  if (
+    !registration ||
+    registration.status === 'cancelled' ||
+    registration.status === 'refunded'
+  ) {
+    throwFailedPrecondition('This registration can no longer be managed.');
+  }
+
+  const [section, charges] = await Promise.all([
+    MusicTogetherSectionRepository.findById(registration.sectionId),
+    MusicTogetherScheduledChargeRepository.findByRegistrationId(
+      registration.id
+    ),
+  ]);
+
+  const sessionToken = await MusicTogetherTokenRepository.createSession(
+    registration.id
+  );
+
+  return {
+    sessionToken,
+    registration: buildMusicTogetherManageView(registration, section, charges),
+  };
+});

--- a/libs/firebase/maple-functions/start-music-together-manage-session/tsconfig.json
+++ b/libs/firebase/maple-functions/start-music-together-manage-session/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/start-music-together-manage-session/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/start-music-together-manage-session/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/update-music-together-payment-method/project.json
+++ b/libs/firebase/maple-functions/update-music-together-payment-method/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-update-music-together-payment-method",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/update-music-together-payment-method/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/update-music-together-payment-method/src/index.ts
+++ b/libs/firebase/maple-functions/update-music-together-payment-method/src/index.ts
@@ -1,0 +1,1 @@
+export { updateMusicTogetherPaymentMethod } from './lib/update-music-together-payment-method';

--- a/libs/firebase/maple-functions/update-music-together-payment-method/src/lib/manage-view.ts
+++ b/libs/firebase/maple-functions/update-music-together-payment-method/src/lib/manage-view.ts
@@ -1,0 +1,50 @@
+/**
+ * Build the customer-safe manage-page view for an installment registration.
+ *
+ * Pure assembly (no I/O) from an already-loaded registration, its section, and
+ * its scheduled charges. Shared shape between `startMusicTogetherManageSession`
+ * and `updateMusicTogetherPaymentMethod`. Duplicated in both function libs to
+ * keep Nx library boundaries clean (it depends on the api-types view shape,
+ * which the domain layer cannot import).
+ */
+import {
+  mtNextActionableCharge,
+  type MusicTogetherRegistration,
+  type MusicTogetherSection,
+  type MusicTogetherScheduledCharge,
+} from '@maple/ts/domain';
+import type { MusicTogetherManageView } from '@maple/ts/firebase/api-types';
+
+const fmtMoney = (cents: number): string => `$${(cents / 100).toFixed(2)}`;
+
+const fmtDate = (d: Date): string =>
+  d.toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'America/New_York',
+  });
+
+export function buildMusicTogetherManageView(
+  registration: MusicTogetherRegistration,
+  section: MusicTogetherSection | undefined,
+  charges: MusicTogetherScheduledCharge[]
+): MusicTogetherManageView {
+  const next = mtNextActionableCharge(charges);
+  return {
+    registrationId: registration.id,
+    sectionName: section?.name ?? 'Music Together',
+    parentName:
+      registration.parentNames[0] ??
+      `${registration.adultFirstName} ${registration.adultLastName}`.trim(),
+    nextInstallment: next
+      ? {
+          amountCents: next.amountCents,
+          amountLabel: fmtMoney(next.amountCents),
+          dueAt: next.dueAt.toISOString(),
+          dueLabel: fmtDate(next.dueAt),
+          status: next.status,
+        }
+      : undefined,
+  };
+}

--- a/libs/firebase/maple-functions/update-music-together-payment-method/src/lib/update-music-together-payment-method.spec.ts
+++ b/libs/firebase/maple-functions/update-music-together-payment-method/src/lib/update-music-together-payment-method.spec.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  capturedHandler: null as
+    | ((d: unknown, c: unknown, s: unknown, st: unknown) => Promise<unknown>)
+    | null,
+  resolveSession: vi.fn(),
+  findRegistrationById: vi.fn(),
+  updateRegistration: vi.fn(),
+  findSectionById: vi.fn(),
+  findByRegistrationId: vi.fn(),
+  createCardOnFile: vi.fn(),
+  disableCard: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/functions', () => {
+  class HttpsError extends Error {
+    constructor(public code: string, m: string) {
+      super(m);
+    }
+  }
+  const endpoint = {
+    usingSecrets: vi.fn(() => endpoint),
+    usingStrings: vi.fn(() => endpoint),
+    handle: vi.fn((h: typeof mocks.capturedHandler) => {
+      mocks.capturedHandler = h;
+      return 'mock';
+    }),
+  };
+  return {
+    Functions: { endpoint },
+    throwInvalidArgument: (m: string) => {
+      throw new HttpsError('invalid-argument', m);
+    },
+    throwFailedPrecondition: (m: string) => {
+      throw new HttpsError('failed-precondition', m);
+    },
+  };
+});
+
+vi.mock('@maple/firebase/square', () => ({
+  MT_SQUARE_SECRET_NAMES: ['MT_SQUARE_ACCESS_TOKEN'],
+  MT_SQUARE_STRING_NAMES: ['MT_SQUARE_ENV', 'MT_SQUARE_LOCATION_ID'],
+  MT_SQUARE_KEYS: {
+    accessToken: 'MT_SQUARE_ACCESS_TOKEN',
+    env: 'MT_SQUARE_ENV',
+    locationId: 'MT_SQUARE_LOCATION_ID',
+  },
+  Square: class {
+    cardsService = {
+      createCardOnFile: mocks.createCardOnFile,
+      disableCard: mocks.disableCard,
+    };
+  },
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  MusicTogetherTokenRepository: { resolveSession: mocks.resolveSession },
+  MusicTogetherRegistrationRepository: {
+    findById: mocks.findRegistrationById,
+    update: mocks.updateRegistration,
+  },
+  MusicTogetherSectionRepository: { findById: mocks.findSectionById },
+  MusicTogetherScheduledChargeRepository: {
+    findByRegistrationId: mocks.findByRegistrationId,
+  },
+}));
+
+import './update-music-together-payment-method';
+
+const SECRETS = { MT_SQUARE_ACCESS_TOKEN: 't' };
+const STRINGS = { MT_SQUARE_ENV: 'LOCAL', MT_SQUARE_LOCATION_ID: 'L' };
+const run = (data: unknown) =>
+  mocks.capturedHandler!(data, {}, SECRETS, STRINGS);
+
+const installmentReg = {
+  id: 'reg-1',
+  sectionId: 'sec-1',
+  parentNames: ['Ada Lovelace'],
+  adultFirstName: 'Ada',
+  adultLastName: 'Lovelace',
+  email: 'ada@e.com',
+  paymentPlan: 'installments',
+  status: 'confirmed',
+  squareCustomerId: 'cust-1',
+  squareCardId: 'card-old',
+};
+
+describe('updateMusicTogetherPaymentMethod', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('vaults a new card, repoints the registration, and disables the old card', async () => {
+    mocks.resolveSession.mockResolvedValue('reg-1');
+    mocks.findRegistrationById.mockResolvedValue(installmentReg);
+    mocks.createCardOnFile.mockResolvedValue({
+      cardId: 'card-new',
+      last4: '4242',
+    });
+    mocks.updateRegistration.mockResolvedValue({
+      ...installmentReg,
+      squareCardId: 'card-new',
+    });
+    mocks.findSectionById.mockResolvedValue({ id: 'sec-1', name: 'Fall Babies' });
+    mocks.findByRegistrationId.mockResolvedValue([
+      {
+        id: 'c2',
+        amountCents: 9500,
+        dueAt: new Date('2026-09-15T13:00:00Z'),
+        status: 'scheduled',
+      },
+    ]);
+
+    const result = (await run({
+      sessionToken: 'sess',
+      paymentNonce: 'cnon:new',
+    })) as { cardLast4?: string; registration: { nextInstallment?: unknown } };
+
+    expect(mocks.createCardOnFile).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceId: 'cnon:new', customerId: 'cust-1' })
+    );
+    // Registration repointed BEFORE the old card is disabled.
+    expect(mocks.updateRegistration).toHaveBeenCalledWith({
+      id: 'reg-1',
+      squareCardId: 'card-new',
+    });
+    const updateOrder =
+      mocks.updateRegistration.mock.invocationCallOrder[0];
+    const disableOrder = mocks.disableCard.mock.invocationCallOrder[0];
+    expect(updateOrder).toBeLessThan(disableOrder);
+    expect(mocks.disableCard).toHaveBeenCalledWith('card-old');
+    expect(result.cardLast4).toBe('4242');
+    expect(result.registration.nextInstallment).toMatchObject({
+      amountLabel: '$95.00',
+    });
+  });
+
+  it('still succeeds when disabling the old card fails (best-effort)', async () => {
+    mocks.resolveSession.mockResolvedValue('reg-1');
+    mocks.findRegistrationById.mockResolvedValue(installmentReg);
+    mocks.createCardOnFile.mockResolvedValue({
+      cardId: 'card-new',
+      last4: '4242',
+    });
+    mocks.updateRegistration.mockResolvedValue({
+      ...installmentReg,
+      squareCardId: 'card-new',
+    });
+    mocks.disableCard.mockRejectedValue(new Error('Square down'));
+    mocks.findSectionById.mockResolvedValue({ id: 'sec-1', name: 'Fall Babies' });
+    mocks.findByRegistrationId.mockResolvedValue([]);
+
+    const result = (await run({
+      sessionToken: 'sess',
+      paymentNonce: 'cnon:new',
+    })) as { cardLast4?: string };
+
+    expect(result.cardLast4).toBe('4242');
+    expect(mocks.updateRegistration).toHaveBeenCalled();
+  });
+
+  it('rejects a missing nonce before any Square call', async () => {
+    await expect(run({ sessionToken: 'sess' })).rejects.toThrow(
+      /Payment information is required/
+    );
+    expect(mocks.resolveSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects an expired session before any Square call', async () => {
+    mocks.resolveSession.mockResolvedValue(undefined);
+    await expect(
+      run({ sessionToken: 'bad', paymentNonce: 'cnon:new' })
+    ).rejects.toThrow(/session has expired/);
+    expect(mocks.createCardOnFile).not.toHaveBeenCalled();
+  });
+
+  it('rejects a pay-in-full registration (nothing on file)', async () => {
+    mocks.resolveSession.mockResolvedValue('reg-1');
+    mocks.findRegistrationById.mockResolvedValue({
+      ...installmentReg,
+      paymentPlan: 'full',
+    });
+    await expect(
+      run({ sessionToken: 'sess', paymentNonce: 'cnon:new' })
+    ).rejects.toThrow(/no card on file/i);
+    expect(mocks.createCardOnFile).not.toHaveBeenCalled();
+  });
+
+  it('rejects a cancelled registration', async () => {
+    mocks.resolveSession.mockResolvedValue('reg-1');
+    mocks.findRegistrationById.mockResolvedValue({
+      ...installmentReg,
+      status: 'cancelled',
+    });
+    await expect(
+      run({ sessionToken: 'sess', paymentNonce: 'cnon:new' })
+    ).rejects.toThrow(/can no longer be managed/i);
+    expect(mocks.createCardOnFile).not.toHaveBeenCalled();
+  });
+});

--- a/libs/firebase/maple-functions/update-music-together-payment-method/src/lib/update-music-together-payment-method.ts
+++ b/libs/firebase/maple-functions/update-music-together-payment-method/src/lib/update-music-together-payment-method.ts
@@ -1,0 +1,125 @@
+/**
+ * Update Music Together Payment Method Cloud Function (public, session-gated, MT Square)
+ *
+ * Self-service card change for an installment family. Vaults a new card on file
+ * from a Web Payments nonce on MT's SEPARATE Square account (MT_SQUARE_KEYS),
+ * points the registration's `squareCardId` at it, and disables the old card so
+ * it can never be charged again.
+ *
+ * Overcharge safety is preserved: the Week-5 charge job reads
+ * `registration.squareCardId` / `squareCustomerId` fresh at charge time, so
+ * repointing the registration automatically retargets every still-pending
+ * scheduled charge to the new card. The customer id is unchanged (same Square
+ * customer), so scheduled charges stay valid. We never touch a charge that is
+ * already `paid`/`charging`.
+ *
+ * Deployed to us-east4 via CI/CD (maple-square codebase).
+ */
+import {
+  Functions,
+  throwInvalidArgument,
+  throwFailedPrecondition,
+} from '@maple/firebase/functions';
+import {
+  Square,
+  MT_SQUARE_SECRET_NAMES,
+  MT_SQUARE_STRING_NAMES,
+  MT_SQUARE_KEYS,
+} from '@maple/firebase/square';
+import {
+  MusicTogetherRegistrationRepository,
+  MusicTogetherSectionRepository,
+  MusicTogetherScheduledChargeRepository,
+  MusicTogetherTokenRepository,
+} from '@maple/firebase/database';
+import { buildMusicTogetherManageView } from './manage-view';
+import type {
+  UpdateMusicTogetherPaymentMethodRequest,
+  UpdateMusicTogetherPaymentMethodResponse,
+} from '@maple/ts/firebase/api-types';
+
+export const updateMusicTogetherPaymentMethod = Functions.endpoint
+  .usingSecrets(...MT_SQUARE_SECRET_NAMES)
+  .usingStrings(...MT_SQUARE_STRING_NAMES)
+  .handle<
+    UpdateMusicTogetherPaymentMethodRequest,
+    UpdateMusicTogetherPaymentMethodResponse
+  >(async (data, _context, secrets, strings) => {
+    if (!data.paymentNonce) {
+      throwInvalidArgument('Payment information is required');
+    }
+
+    const registrationId = await MusicTogetherTokenRepository.resolveSession(
+      data.sessionToken
+    );
+    if (!registrationId) {
+      throwFailedPrecondition(
+        'Your session has expired. Please request a new link.'
+      );
+    }
+
+    const registration =
+      await MusicTogetherRegistrationRepository.findById(registrationId);
+    if (!registration) {
+      throwFailedPrecondition('Registration not found.');
+    }
+    if (
+      registration.status === 'cancelled' ||
+      registration.status === 'refunded'
+    ) {
+      throwFailedPrecondition('This registration can no longer be managed.');
+    }
+    if (registration.paymentPlan !== 'installments') {
+      throwFailedPrecondition(
+        'This registration has no card on file to update.'
+      );
+    }
+    if (!registration.squareCustomerId) {
+      throwFailedPrecondition('No card on file to update.');
+    }
+
+    const square = new Square(secrets, strings, MT_SQUARE_KEYS);
+
+    // Vault the new card under the SAME Square customer. The nonce is
+    // single-use, so include it in the idempotency key to de-dupe retries.
+    const card = await square.cardsService.createCardOnFile({
+      sourceId: data.paymentNonce,
+      customerId: registration.squareCustomerId,
+      cardholderName: registration.parentNames[0],
+      idempotencyKey: `mtcard-update-${registration.id}-${data.paymentNonce.slice(-8)}`,
+    });
+
+    const previousCardId = registration.squareCardId;
+
+    // Repoint the registration at the new card FIRST so any concurrent charge
+    // job picks up the new card; only then disable the old one.
+    const updated = await MusicTogetherRegistrationRepository.update({
+      id: registration.id,
+      squareCardId: card.cardId,
+    });
+
+    // Best-effort: detach the old card so it can never be charged again. A
+    // failure here must not fail the request — the new card is already vaulted
+    // and live, and a lingering disabled-but-not card is harmless.
+    if (previousCardId && previousCardId !== card.cardId) {
+      try {
+        await square.cardsService.disableCard(previousCardId);
+      } catch (err) {
+        console.warn(
+          `[updateMusicTogetherPaymentMethod] failed to disable old card ${previousCardId} for registration ${registration.id}: ${
+            err instanceof Error ? err.message : 'unknown error'
+          }`
+        );
+      }
+    }
+
+    const [section, charges] = await Promise.all([
+      MusicTogetherSectionRepository.findById(updated.sectionId),
+      MusicTogetherScheduledChargeRepository.findByRegistrationId(updated.id),
+    ]);
+
+    return {
+      registration: buildMusicTogetherManageView(updated, section, charges),
+      cardLast4: card.last4,
+    };
+  });

--- a/libs/firebase/maple-functions/update-music-together-payment-method/tsconfig.json
+++ b/libs/firebase/maple-functions/update-music-together-payment-method/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/update-music-together-payment-method/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/update-music-together-payment-method/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/square-test-mock-server/src/lib/routes/square.ts
+++ b/libs/firebase/square-test-mock-server/src/lib/routes/square.ts
@@ -463,6 +463,18 @@ function registerCraftClubRoutes(server: SquareMockServer): void {
     return { status: 200, body: { card } };
   });
 
+  // Disable a card on file (used when a customer replaces the card behind a
+  // card-on-file agreement — the old card is detached).
+  server.post('/v2/cards/:cardId/disable', (req) => {
+    const card = {
+      id: req.params['cardId'],
+      card_brand: 'VISA',
+      last_4: '1111',
+      enabled: false,
+    };
+    return { status: 200, body: { card } };
+  });
+
   // Create subscription
   server.post('/v2/subscriptions', (req) => {
     const body = req.body as Record<string, unknown>;

--- a/libs/firebase/square/src/lib/cards.service.ts
+++ b/libs/firebase/square/src/lib/cards.service.ts
@@ -58,6 +58,18 @@ export class CardsService {
       cardBrand: card.cardBrand as string | undefined,
     };
   }
+
+  /**
+   * Disable a card on file so it can never be charged again. Used when a
+   * customer replaces the card behind a card-on-file agreement — the old card
+   * is detached so only the new one remains chargeable. Disabling an already
+   * disabled (or unknown) card is a no-op on Square's side; we surface errors
+   * so callers can decide whether to treat them as fatal.
+   */
+  async disableCard(cardId: string): Promise<void> {
+    const response = await this.client.cards.disable({ cardId });
+    throwIfErrors(response.errors, 'disable card');
+  }
 }
 
 function throwIfErrors(

--- a/libs/ts/domain/src/lib/music-together-scheduled-charge.ts
+++ b/libs/ts/domain/src/lib/music-together-scheduled-charge.ts
@@ -102,3 +102,18 @@ export function mtHasFailedCharge(
 ): boolean {
   return charges.some((c) => c.status === 'failed');
 }
+
+/**
+ * The soonest charge a customer could still act on by updating their card —
+ * one that is `scheduled` (upcoming) or `failed` (needs a new card). Returns
+ * the earliest such charge by due date, or undefined when nothing is
+ * actionable (all paid/cancelled). Drives the "your $X charge on DATE will use
+ * the new card" context on the self-service manage page.
+ */
+export function mtNextActionableCharge(
+  charges: MusicTogetherScheduledCharge[]
+): MusicTogetherScheduledCharge | undefined {
+  return charges
+    .filter((c) => c.status === 'scheduled' || c.status === 'failed')
+    .sort((a, b) => a.dueAt.getTime() - b.dueAt.getTime())[0];
+}

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -447,4 +447,12 @@ export type {
   CancelMusicTogetherRegistrationResponse,
   AddToMusicTogetherWaitlistRequest,
   AddToMusicTogetherWaitlistResponse,
+  RequestMusicTogetherManageLinkRequest,
+  RequestMusicTogetherManageLinkResponse,
+  MusicTogetherManageInstallment,
+  MusicTogetherManageView,
+  StartMusicTogetherManageSessionRequest,
+  StartMusicTogetherManageSessionResponse,
+  UpdateMusicTogetherPaymentMethodRequest,
+  UpdateMusicTogetherPaymentMethodResponse,
 } from './music-together.types';

--- a/libs/ts/firebase/api-types/src/lib/music-together.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/music-together.types.ts
@@ -11,6 +11,7 @@ import type {
   UpdateMusicTogetherSemesterInput,
   MusicTogetherRegistration,
   MusicTogetherScheduledCharge,
+  MusicTogetherChargeStatus,
   CreateMusicTogetherSectionInput,
   UpdateMusicTogetherSectionInput,
 } from '@maple/ts/domain';
@@ -270,4 +271,74 @@ export interface AddToMusicTogetherWaitlistRequest {
 export interface AddToMusicTogetherWaitlistResponse {
   /** False when the email was already on the list (idempotent no-op). */
   added: boolean;
+}
+
+// ============================================================================
+// Self-service payment-method management (installment families — magic link)
+// ============================================================================
+
+/**
+ * Request a magic-link email to update the card on file for an installment
+ * registration (so the Week-5 charge hits the right card).
+ */
+export interface RequestMusicTogetherManageLinkRequest {
+  email: string;
+}
+
+export interface RequestMusicTogetherManageLinkResponse {
+  /**
+   * Always true — the response is deliberately uniform whether or not the email
+   * has a manageable installment registration, to avoid leaking who is
+   * enrolled.
+   */
+  ok: true;
+}
+
+/** The next upcoming/failed installment, shown for context on the manage page. */
+export interface MusicTogetherManageInstallment {
+  amountCents: number;
+  /** Presentation-ready amount, e.g. "$95.00". */
+  amountLabel: string;
+  /** ISO date string of when the charge is due. */
+  dueAt: string;
+  /** Presentation-ready due date, e.g. "September 15, 2026". */
+  dueLabel: string;
+  status: MusicTogetherChargeStatus;
+}
+
+/** Customer-safe snapshot of a registration for the manage page. */
+export interface MusicTogetherManageView {
+  registrationId: string;
+  sectionName: string;
+  /** Enrolling adult's name, for a friendly greeting. */
+  parentName: string;
+  /**
+   * The soonest installment still awaiting payment (scheduled or failed), when
+   * one exists — lets the page say which charge the new card will cover.
+   */
+  nextInstallment?: MusicTogetherManageInstallment;
+}
+
+/** Exchange a single-use magic-link token for a session. */
+export interface StartMusicTogetherManageSessionRequest {
+  token: string;
+}
+
+export interface StartMusicTogetherManageSessionResponse {
+  /** Short-lived session token; pass on every subsequent management call. */
+  sessionToken: string;
+  registration: MusicTogetherManageView;
+}
+
+/** Replace the card on file behind an installment registration. */
+export interface UpdateMusicTogetherPaymentMethodRequest {
+  sessionToken: string;
+  /** New nonce from the Square Web Payments SDK card tokenization. */
+  paymentNonce: string;
+}
+
+export interface UpdateMusicTogetherPaymentMethodResponse {
+  registration: MusicTogetherManageView;
+  /** Last 4 digits of the new card on file, for display. */
+  cardLast4?: string;
 }

--- a/tools/seed-email-templates.ts
+++ b/tools/seed-email-templates.ts
@@ -878,6 +878,64 @@ const musicTogetherReminderHtml = `<!DOCTYPE html>
 </html>`;
 
 // ---------------------------------------------------------------------------
+// Template: music-together-manage-link
+//
+// Magic link emailed when an installment family asks to update the card on file
+// for their Week-5 second charge. Carries a single-use token (~30 min) that
+// lands them on the manage-payment page. Transactional.
+// ---------------------------------------------------------------------------
+
+const musicTogetherManageLinkSubject =
+  'Update your Music Together payment method';
+
+const musicTogetherManageLinkHtml = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Update your Music Together payment method</title>
+<style>${styles}</style>
+</head>
+<body>
+<div class="wrapper">
+  <div class="header">
+    <h1>Maple &amp; Spruce Folk Arts</h1>
+  </div>
+  <div class="content">
+    <h2>Update your payment method</h2>
+    <p>You asked to update the card on file for your Music Together
+      installment plan. Use the secure link below to enter a new card — it will
+      be charged for your remaining installment.</p>
+
+    <div class="highlight-box">
+      <strong style="color: #4A3728;">Your secure link</strong><br>
+      <p style="text-align: center; margin: 16px 0;">
+        <a href="{{manageUrl}}" style="display: inline-block; background-color: #6B7B5E; color: #ffffff; padding: 12px 32px; text-decoration: none; border-radius: 4px; font-weight: bold;">Update my card</a>
+      </p>
+    </div>
+
+    <p style="font-size: 14px; color: #999;">
+      This link expires in 30 minutes and can be used once. If you didn't
+      request it, you can safely ignore this email. If the button doesn't work,
+      copy and paste this URL into your browser:<br>
+      <a href="{{manageUrl}}" style="color: #6B7B5E; word-break: break-all;">{{manageUrl}}</a>
+    </p>
+
+    <p>Questions? Reach out at
+      <a href="mailto:katie@mapleandsprucefolkarts.com" style="color: #6B7B5E;">katie@mapleandsprucefolkarts.com</a>
+      or call <a href="tel:+13043144506" style="color: #6B7B5E;">304-314-4506</a>.</p>
+  </div>
+  <div class="footer">
+    <strong style="color: #4A3728;">Maple &amp; Spruce Folk Arts</strong><br>
+    Morgantown, WV<br>
+    <a href="mailto:katie@mapleandsprucefolkarts.com">katie@mapleandsprucefolkarts.com</a> | <a href="tel:+13043144506">304-314-4506</a><br>
+    <a href="https://mapleandsprucefolkarts.com">mapleandsprucefolkarts.com</a>
+  </div>
+</div>
+</body>
+</html>`;
+
+// ---------------------------------------------------------------------------
 // Seed to Firestore
 // ---------------------------------------------------------------------------
 
@@ -934,6 +992,10 @@ const templates: Record<string, EmailTemplate> = {
   'music-together-reminder': {
     subject: musicTogetherReminderSubject,
     html: musicTogetherReminderHtml,
+  },
+  'music-together-manage-link': {
+    subject: musicTogetherManageLinkSubject,
+    html: musicTogetherManageLinkHtml,
   },
 };
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -41,6 +41,15 @@
       "@maple/firebase/maple-functions/update-craft-club-payment-method": [
         "libs/firebase/maple-functions/update-craft-club-payment-method/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/request-music-together-manage-link": [
+        "libs/firebase/maple-functions/request-music-together-manage-link/src/index.ts"
+      ],
+      "@maple/firebase/maple-functions/start-music-together-manage-session": [
+        "libs/firebase/maple-functions/start-music-together-manage-session/src/index.ts"
+      ],
+      "@maple/firebase/maple-functions/update-music-together-payment-method": [
+        "libs/firebase/maple-functions/update-music-together-payment-method/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/check-craft-club-eligibility": [
         "libs/firebase/maple-functions/check-craft-club-eligibility/src/index.ts"
       ],


### PR DESCRIPTION
Closes #561. Part of the Music Together epic #508.

## Problem
Installment families vault a card in MT's separate Square account so `chargeMusicTogetherInstallments` can auto-charge the Week-5 balance. There was **no way for a customer to update that card** if it changed or expired — the scheduled charge just failed (`music-together-installment-failed` email) and resolution was manual.

## What this adds
A customer-facing "update payment method" flow, mirroring the **Craft Club manage-link pattern** but scoped to a **registration** (the card lives on the registration), routed through **MT's** Square account (`MT_SQUARE_KEYS`).

Three Cloud Functions:
- **`requestMusicTogetherManageLink`** _(public, maple-core)_ — emails a single-use, 30-min magic link. Uniform response whether or not the email is enrolled (no enumeration). Picks the most recent confirmed installment registration with a card on file.
- **`startMusicTogetherManageSession`** _(public, maple-core)_ — consumes the token (single-use), issues a 1-hour session token, and returns a customer-safe view (section name + next installment amount/date).
- **`updateMusicTogetherPaymentMethod`** _(public, session-gated, maple-square)_ — vaults a new card on MT's Square account from a fresh Web Payments nonce, repoints `registration.squareCardId` at it, and disables the old card (best-effort).

### Overcharge-safety preserved
The Week-5 charge job reads `squareCardId` / `squareCustomerId` from the registration **at charge time**, so repointing the registration automatically retargets every still-pending scheduled charge to the new card. The Square customer id is unchanged, and no charge that is already `paid`/`charging` is touched.

### Also included
- `MusicTogetherTokenRepository` — hashed (sha256) access + session tokens, raw token only in the emailed URL / widget memory.
- `CardsService.disableCard` — detaches the old card via the Square Cards API.
- `MusicTogetherManageWidget` + `music-together-manage.webflow.tsx` — the manage page (reads `?token=`; without one, shows the email form). `SquareCardForm` rendered **without** `env` — the SDK environment follows the App ID prefix.
- `music-together-manage-link` email template (seeded).
- `MUSIC_TOGETHER_MANAGE_URL` param in `.env.dev` / `.env.prod`.

## UX
The manage page opens from a `?token=` magic link, shows which installment the new card will cover ("your $95.00 charge on September 15, 2026 will use the new card"), takes a new card via the Square Web Payments SDK, and confirms with the new card's last 4.

## Verification
- **Unit** (`vi.mock` Square/repos): 15 cases across the 3 functions + the widget, incl. failure paths — missing nonce, expired/unknown session, pay-in-full (nothing on file), cancelled registration, and best-effort old-card disable failure.
- **Integration** (`./tools/run-integration-tests.sh music-together`, emulator + Square mock): full chain — magic link → session → card replace → old card disabled → the charge job charges the **NEW** card (`source_id` asserted). **All 45 music-together integration tests pass.**
- **Interaction**: `MusicTogetherManageWidget.spec.tsx` drives request-link and token → save-card flows headlessly.
- Firestore index analyzer clean (`email + createdAt` already declared); typecheck + eslint clean; `validate-function-tsconfigs.sh` passes.

Note: `music-together.types.ts` and the api-types barrel are touched additively (parallel MT PRs also edit them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)