### PR TITLE
feat(music-together): per-child sibling discount (50% off 2nd & 3rd child)

### DIFF
--- a/apps/functions-integration-tests-music-together/src/create-music-together-registration.spec.ts
+++ b/apps/functions-integration-tests-music-together/src/create-music-together-registration.spec.ts
@@ -157,6 +157,65 @@ describe('createMusicTogetherRegistration', () => {
     expect(String(charges[0].idempotencyKey)).toMatch(/^mt-charge-/);
   });
 
+  it('full pay: charges the sibling-discounted total for a 2-child family', async () => {
+    const result = await callFunction<
+      CreateMusicTogetherRegistrationRequest,
+      CreateMusicTogetherRegistrationResponse
+    >({
+      functionName: 'createMusicTogetherRegistration',
+      data: family({
+        email: 'twokids@test.com',
+        children: [
+          { name: 'Sky', dob: '2023-04-01' },
+          { name: 'River', dob: '2024-05-02' },
+        ],
+      }),
+    });
+
+    expect(result.status).toBe(200);
+    // $252 base × 1.5 (first child full, 50% off the 2nd) = $378.
+    expect(result.data?.amountChargedCents).toBe(37800);
+    expect(result.data?.scheduledChargeCount).toBe(0);
+
+    const reg = await getFirestoreDoc(
+      'musicTogetherRegistrations',
+      result.data!.registrationId
+    );
+    expect(reg?.pricePaidCents).toBe(37800);
+  });
+
+  it('installments: discounts installment 1 AND the scheduled charge for a 3-child family', async () => {
+    const result = await callFunction<
+      CreateMusicTogetherRegistrationRequest,
+      CreateMusicTogetherRegistrationResponse
+    >({
+      functionName: 'createMusicTogetherRegistration',
+      data: family({
+        email: 'threekids@test.com',
+        paymentPlan: 'installments',
+        cardOnFileAuth: true,
+        children: [
+          { name: 'Sky', dob: '2023-04-01' },
+          { name: 'River', dob: '2024-05-02' },
+          { name: 'Wren', dob: '2025-06-03' },
+        ],
+      }),
+    });
+
+    expect(result.status).toBe(200);
+    // $132 base × 2.0 (first child full, 50% off the 2nd & 3rd) = $264 each.
+    expect(result.data?.amountChargedCents).toBe(26400); // installment 1
+    expect(result.data?.scheduledChargeCount).toBe(1);
+
+    const charges = (await listFirestoreDocs('musicTogetherScheduledCharges'))
+      .map((c) => c.data as Record<string, unknown>)
+      .filter((c) => c.registrationId === result.data!.registrationId);
+    expect(charges).toHaveLength(1);
+    // The scheduled Week-5 charge is discounted too.
+    expect(charges[0].amountCents).toBe(26400);
+    expect(charges[0].status).toBe('scheduled');
+  });
+
   it('rejects a section that is not open', async () => {
     const result = await callFunction<CreateMusicTogetherRegistrationRequest>({
       functionName: 'createMusicTogetherRegistration',

--- a/apps/webflow-components/src/MusicTogetherRegistrationWidget.spec.tsx
+++ b/apps/webflow-components/src/MusicTogetherRegistrationWidget.spec.tsx
@@ -278,6 +278,81 @@ describe('MusicTogetherRegistrationWidget', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('updates the family total with the sibling discount as children are added', async () => {
+    const user = userEvent.setup({ delay: null });
+    renderWidget();
+    await screen.findByText(/Register — Thursday Morning/i);
+
+    // Complete the first child's row → one-child price on both plans.
+    setField(/Child's first name/i, 'Sky');
+    setField(/Date of birth/i, '2023-04-01');
+    expect(
+      await screen.findByRole('radio', { name: /Pay in full — \$252\.00/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('radio', { name: /\$132\.00 now, \$132\.00 on/i })
+    ).toBeInTheDocument();
+
+    // Add a 2nd child and complete the row → 2-child price ($378 / $198).
+    await user.click(
+      screen.getByRole('button', { name: /Add another child/i })
+    );
+    let names = screen.getAllByLabelText(/Child's first name/i);
+    let dobs = screen.getAllByLabelText(/Date of birth/i);
+    fireEvent.change(names[1], { target: { value: 'River' } });
+    fireEvent.change(dobs[1], { target: { value: '2024-05-02' } });
+
+    expect(
+      await screen.findByRole('radio', { name: /Pay in full — \$378\.00/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('radio', { name: /\$198\.00 now, \$198\.00 on/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/first child full\s*price, 50% off each additional child/i)
+    ).toBeInTheDocument();
+
+    // Add a 3rd child and complete the row → 3-child price ($504 / $264).
+    await user.click(
+      screen.getByRole('button', { name: /Add another child/i })
+    );
+    names = screen.getAllByLabelText(/Child's first name/i);
+    dobs = screen.getAllByLabelText(/Date of birth/i);
+    fireEvent.change(names[2], { target: { value: 'Wren' } });
+    fireEvent.change(dobs[2], { target: { value: '2025-06-03' } });
+
+    expect(
+      await screen.findByRole('radio', { name: /Pay in full — \$504\.00/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('radio', { name: /\$264\.00 now, \$264\.00 on/i })
+    ).toBeInTheDocument();
+  });
+
+  it('reflects the discounted multi-child total on the pay button', async () => {
+    const user = userEvent.setup({ delay: null });
+    renderWidget();
+    await screen.findByText(/Register — Thursday Morning/i);
+
+    fillFamily();
+    // Add a second child so the family is priced for two ($378 total).
+    await user.click(
+      screen.getByRole('button', { name: /Add another child/i })
+    );
+    const names = screen.getAllByLabelText(/Child's first name/i);
+    const dobs = screen.getAllByLabelText(/Date of birth/i);
+    fireEvent.change(names[1], { target: { value: 'River' } });
+    fireEvent.change(dobs[1], { target: { value: '2024-05-02' } });
+    await acceptConsents(user);
+
+    // The pay button and the "today" line both show the discounted 2-child total.
+    const registerBtn = await screen.findByRole('button', {
+      name: /Register — \$378\.00/i,
+    });
+    await waitFor(() => expect(registerBtn).toBeEnabled());
+    expect(screen.getByText(/Payment — \$378\.00 today/i)).toBeInTheDocument();
+  });
+
   it('shows the waitlist when the section is full', async () => {
     nextSection = makeSection({ spotsRemaining: 0 });
     const user = userEvent.setup({ delay: null });

--- a/apps/webflow-components/src/MusicTogetherRegistrationWidget.tsx
+++ b/apps/webflow-components/src/MusicTogetherRegistrationWidget.tsx
@@ -38,7 +38,10 @@ import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { httpsCallable } from 'firebase/functions';
 import { theme, fonts } from '@maple/react/theme';
 import { SquareCardForm } from '@maple/react/registrations';
-import { MT_MAX_CHILDREN } from '@maple/ts/domain';
+import {
+  MT_MAX_CHILDREN,
+  computeMusicTogetherFamilyPrice,
+} from '@maple/ts/domain';
 import type {
   GetPublicMusicTogetherSectionRequest,
   GetPublicMusicTogetherSectionResponse,
@@ -306,18 +309,7 @@ export function MusicTogetherRegistrationWidget({
   const section = state.status === 'ready' ? state.section : null;
 
   // Two-installment plan is offered only when the section defines 2+ installments.
-  const installments = section?.installmentPlan ?? [];
-  const offersInstallments = installments.length >= 2;
-  const firstInstallment = installments[0];
-  const secondInstallment = installments[1];
-
-  // Amount charged at registration: full price, or the first installment.
-  const amountNowCents =
-    section == null
-      ? 0
-      : paymentPlan === 'installments' && firstInstallment
-        ? firstInstallment.amountCents
-        : section.priceFullCents;
+  const offersInstallments = (section?.installmentPlan?.length ?? 0) >= 2;
 
   // Trimmed / cleaned form values
   const adultFullName = `${adultFirstName.trim()} ${adultLastName.trim()}`.trim();
@@ -328,6 +320,34 @@ export function MusicTogetherRegistrationWidget({
     .map((c) => ({ name: c.name.trim(), dob: c.dob }))
     .filter((c) => c.name && c.dob);
   const emailValid = EMAIL_RE.test(email.trim());
+
+  // Per-child sibling pricing: first child full price, 50% off the 2nd & 3rd.
+  // Price the children the family will actually submit (`cleanChildren`), so
+  // the displayed total always matches what the server will charge. Clamp to
+  // 1..MT_MAX_CHILDREN so a baseline (one-child) price shows before any child
+  // row is complete.
+  const pricedChildCount = Math.min(
+    Math.max(cleanChildren.length, 1),
+    MT_MAX_CHILDREN
+  );
+  const familyPrice = useMemo(
+    () =>
+      section
+        ? computeMusicTogetherFamilyPrice(section, pricedChildCount)
+        : null,
+    [section, pricedChildCount]
+  );
+  const firstInstallment = familyPrice?.installments[0];
+  const secondInstallment = familyPrice?.installments[1];
+
+  // Amount charged at registration: discounted full price, or the discounted
+  // first installment.
+  const amountNowCents =
+    familyPrice == null
+      ? 0
+      : paymentPlan === 'installments' && firstInstallment
+        ? firstInstallment.amountCents
+        : familyPrice.fullCents;
 
   const formValid =
     adultFirstName.trim().length > 0 &&
@@ -652,6 +672,16 @@ export function MusicTogetherRegistrationWidget({
                 {/* Payment plan */}
                 <FormControl>
                   <FormLabel sx={{ mb: 1 }}>Tuition</FormLabel>
+                  {pricedChildCount > 1 && (
+                    <Typography
+                      variant="body2"
+                      color="text.secondary"
+                      sx={{ mb: 1 }}
+                    >
+                      Tuition for {pricedChildCount} children: first child full
+                      price, 50% off each additional child.
+                    </Typography>
+                  )}
                   <RadioGroup
                     value={paymentPlan}
                     onChange={(e) => setPaymentPlan(e.target.value as PaymentPlan)}
@@ -659,7 +689,9 @@ export function MusicTogetherRegistrationWidget({
                     <FormControlLabel
                       value="full"
                       control={<Radio />}
-                      label={`Pay in full — ${formatMoney(section.priceFullCents)}`}
+                      label={`Pay in full — ${formatMoney(
+                        familyPrice?.fullCents ?? section.priceFullCents
+                      )}`}
                     />
                     {offersInstallments && firstInstallment && secondInstallment && (
                       <FormControlLabel

--- a/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.spec.ts
+++ b/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.spec.ts
@@ -231,6 +231,77 @@ describe('createMusicTogetherRegistration', () => {
     expect(result.cardLast4).toBe('4242');
   });
 
+  it('full pay: applies the sibling discount for 2 children ($378)', async () => {
+    mocks.sectionFindById.mockResolvedValue(openFullOnly);
+
+    const result = (await run({
+      ...baseFamily,
+      children: [
+        { name: 'Sky', dob: '2023-04-01' },
+        { name: 'River', dob: '2024-05-02' },
+      ],
+      paymentPlan: 'full',
+    })) as { amountChargedCents: number };
+
+    expect(mocks.createPayment).toHaveBeenCalledWith(
+      expect.objectContaining({ amountCents: 37800 })
+    );
+    expect(result.amountChargedCents).toBe(37800);
+    expect(mocks.txSet).toHaveBeenCalledWith(
+      regRef,
+      expect.objectContaining({ pricePaidCents: 37800 })
+    );
+  });
+
+  it('full pay: applies the sibling discount for 3 children ($504)', async () => {
+    mocks.sectionFindById.mockResolvedValue(openFullOnly);
+
+    const result = (await run({
+      ...baseFamily,
+      children: [
+        { name: 'Sky', dob: '2023-04-01' },
+        { name: 'River', dob: '2024-05-02' },
+        { name: 'Wren', dob: '2025-06-03' },
+      ],
+      paymentPlan: 'full',
+    })) as { amountChargedCents: number };
+
+    expect(mocks.createPayment).toHaveBeenCalledWith(
+      expect.objectContaining({ amountCents: 50400 })
+    );
+    expect(result.amountChargedCents).toBe(50400);
+  });
+
+  it('installments: discounts installment 1 AND the scheduled charge for 3 children', async () => {
+    mocks.sectionFindById.mockResolvedValue(openWithInstallments);
+
+    const result = (await run({
+      ...baseFamily,
+      children: [
+        { name: 'Sky', dob: '2023-04-01' },
+        { name: 'River', dob: '2024-05-02' },
+        { name: 'Wren', dob: '2025-06-03' },
+      ],
+      paymentPlan: 'installments',
+      cardOnFileAuth: true,
+    })) as { amountChargedCents: number; scheduledChargeCount: number };
+
+    // Installment 1 charged now at the discounted $264.
+    expect(mocks.createPayment).toHaveBeenCalledWith(
+      expect.objectContaining({ amountCents: 26400 })
+    );
+    // The scheduled Week-5 charge is discounted too.
+    expect(mocks.chargeCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        installmentNumber: 2,
+        amountCents: 26400,
+        status: 'scheduled',
+      })
+    );
+    expect(result.amountChargedCents).toBe(26400);
+    expect(result.scheduledChargeCount).toBe(1);
+  });
+
   it('rejects when the section is full — no payment taken', async () => {
     mocks.sectionFindById.mockResolvedValue(openFullOnly);
     mocks.txGetSize = 8; // at capacity

--- a/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.ts
+++ b/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.ts
@@ -42,8 +42,10 @@ import {
 } from '@maple/firebase/database';
 import {
   MT_CAPACITY_STATUSES,
+  MT_MAX_CHILDREN,
   mtSectionOffersInstallments,
   mtSectionEnrollmentOpen,
+  computeMusicTogetherFamilyPrice,
 } from '@maple/ts/domain';
 import { musicTogetherRegistrationValidation } from '@maple/ts/validation';
 import type {
@@ -122,21 +124,35 @@ export const createMusicTogetherRegistration = Functions.endpoint
       throwFailedPrecondition('Registration for this section has closed.');
     }
 
-    // 3. Resolve the charge amounts from the section's configurable plan.
+    // 3. Resolve the charge amounts from the section's configurable plan,
+    //    applying the per-child sibling discount. This is AUTHORITATIVE — the
+    //    client never sends an amount; we recompute the family total here from
+    //    the section's base prices so a tampered client can't underpay.
     const offersInstallments = mtSectionOffersInstallments(section);
     if (data.paymentPlan === 'installments' && !offersInstallments) {
       throwFailedPrecondition(
         'This section does not offer an installment plan.'
       );
     }
+    const numChildren = data.children?.length ?? 0;
+    if (numChildren < 1 || numChildren > MT_MAX_CHILDREN) {
+      throwInvalidArgument(
+        `A family can enroll between 1 and ${MT_MAX_CHILDREN} children.`
+      );
+    }
     const plan = section.installmentPlan ?? [];
+    // First child full price, 50% off the 2nd & 3rd — applied identically to
+    // the pay-in-full total and to EACH installment (incl. the scheduled ones).
+    const familyPrice = computeMusicTogetherFamilyPrice(section, numChildren);
     const firstChargeCents =
       data.paymentPlan === 'installments'
-        ? plan[0].amountCents
-        : section.priceFullCents;
-    // Installments 2..N become scheduled card-on-file charges.
+        ? familyPrice.installments[0].amountCents
+        : familyPrice.fullCents;
+    // Installments 2..N become scheduled card-on-file charges (discounted too).
     const scheduledItems =
-      data.paymentPlan === 'installments' ? plan.slice(1) : [];
+      data.paymentPlan === 'installments'
+        ? familyPrice.installments.slice(1)
+        : [];
 
     const square = new Square(secrets, strings, MT_SQUARE_KEYS);
 

--- a/libs/ts/domain/src/index.ts
+++ b/libs/ts/domain/src/index.ts
@@ -50,6 +50,7 @@ export * from './lib/craft-club-member';
 export * from './lib/music-together-semester';
 export * from './lib/music-together-section';
 export * from './lib/music-together-registration';
+export * from './lib/music-together-pricing';
 export * from './lib/music-together-scheduled-charge';
 export * from './lib/music-together-waitlist';
 export * from './lib/music-together-licensee';

--- a/libs/ts/domain/src/lib/music-together-pricing.spec.ts
+++ b/libs/ts/domain/src/lib/music-together-pricing.spec.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeMusicTogetherFamilyPrice,
+  mtSiblingMultiplier,
+} from './music-together-pricing';
+
+/** Default MT prices: $252 full, two $132 installments. */
+const week1 = new Date('2026-09-10T14:00:00.000Z');
+const week5 = new Date('2026-10-08T14:00:00.000Z');
+const section = {
+  priceFullCents: 25200,
+  installmentPlan: [
+    { amountCents: 13200, dueAt: week1 },
+    { amountCents: 13200, dueAt: week5 },
+  ],
+};
+
+describe('mtSiblingMultiplier', () => {
+  it('is 1.0 / 1.5 / 2.0 for 1 / 2 / 3 children', () => {
+    expect(mtSiblingMultiplier(1)).toBe(1);
+    expect(mtSiblingMultiplier(2)).toBe(1.5);
+    expect(mtSiblingMultiplier(3)).toBe(2);
+  });
+
+  it('rejects counts outside 1..MT_MAX_CHILDREN', () => {
+    expect(() => mtSiblingMultiplier(0)).toThrow(RangeError);
+    expect(() => mtSiblingMultiplier(4)).toThrow(RangeError);
+    expect(() => mtSiblingMultiplier(-1)).toThrow(RangeError);
+  });
+
+  it('rejects non-integer counts', () => {
+    expect(() => mtSiblingMultiplier(1.5)).toThrow(RangeError);
+    expect(() => mtSiblingMultiplier(NaN)).toThrow(RangeError);
+  });
+});
+
+describe('computeMusicTogetherFamilyPrice', () => {
+  // The exact owner-confirmed table (issue #599):
+  //   Children | Pay in full | Each installment
+  //   1        | $252        | $132
+  //   2        | $378        | $198
+  //   3        | $504        | $264
+  it.each([
+    [1, 25200, 13200],
+    [2, 37800, 19800],
+    [3, 50400, 26400],
+  ])(
+    '%i child(ren): full = %i cents, each installment = %i cents',
+    (numChildren, expectedFull, expectedInstallment) => {
+      const price = computeMusicTogetherFamilyPrice(section, numChildren);
+      expect(price.fullCents).toBe(expectedFull);
+      expect(price.installments).toHaveLength(2);
+      expect(price.installments[0].amountCents).toBe(expectedInstallment);
+      expect(price.installments[1].amountCents).toBe(expectedInstallment);
+    }
+  );
+
+  it('reports the number of children and the multiplier applied', () => {
+    expect(computeMusicTogetherFamilyPrice(section, 3).multiplier).toBe(2);
+    expect(computeMusicTogetherFamilyPrice(section, 2).numChildren).toBe(2);
+  });
+
+  it('preserves each installment dueAt untouched', () => {
+    const price = computeMusicTogetherFamilyPrice(section, 3);
+    expect(price.installments[0].dueAt).toBe(week1);
+    expect(price.installments[1].dueAt).toBe(week5);
+  });
+
+  it('preserves ISO-string dueAt (public/widget section shape)', () => {
+    const publicSection = {
+      priceFullCents: 25200,
+      installmentPlan: [
+        { amountCents: 13200, dueAt: '2026-09-10T14:00:00.000Z' },
+        { amountCents: 13200, dueAt: '2026-10-08T14:00:00.000Z' },
+      ],
+    };
+    const price = computeMusicTogetherFamilyPrice(publicSection, 2);
+    expect(price.installments[0].amountCents).toBe(19800);
+    expect(price.installments[0].dueAt).toBe('2026-09-10T14:00:00.000Z');
+  });
+
+  it('handles a section with no installment plan (pay-in-full only)', () => {
+    const price = computeMusicTogetherFamilyPrice(
+      { priceFullCents: 25200 },
+      2
+    );
+    expect(price.fullCents).toBe(37800);
+    expect(price.installments).toEqual([]);
+  });
+
+  it('rounds to whole cents rather than leaving fractional cents', () => {
+    // An odd base price × 1.5 would be fractional without rounding.
+    // 33333 * 1.5 = 49999.5 → 50000; 13333 * 1.5 = 19999.5 → 20000.
+    const odd = {
+      priceFullCents: 33333,
+      installmentPlan: [{ amountCents: 13333, dueAt: week1 }],
+    };
+    const price = computeMusicTogetherFamilyPrice(odd, 2);
+    expect(price.fullCents).toBe(50000);
+    expect(price.installments[0].amountCents).toBe(20000);
+    expect(Number.isInteger(price.fullCents)).toBe(true);
+    expect(Number.isInteger(price.installments[0].amountCents)).toBe(true);
+  });
+
+  it('throws on an unsupported child count', () => {
+    expect(() => computeMusicTogetherFamilyPrice(section, 4)).toThrow(
+      RangeError
+    );
+    expect(() => computeMusicTogetherFamilyPrice(section, 0)).toThrow(
+      RangeError
+    );
+  });
+});

--- a/libs/ts/domain/src/lib/music-together-pricing.ts
+++ b/libs/ts/domain/src/lib/music-together-pricing.ts
@@ -1,0 +1,100 @@
+/**
+ * Music Together per-child sibling pricing
+ *
+ * MT tuition is charged PER CHILD with a sibling discount: the first child pays
+ * full price and every additional child (the 2nd and 3rd) is 50% off. The same
+ * multiplier is applied identically to the pay-in-full total AND to every
+ * installment, so a family paying in two installments sees the discount on both
+ * the registration-time charge and the scheduled Week-5 charge.
+ *
+ *   multiplier m = 1 + 0.5 * (numChildren - 1)
+ *     1 child  → 1.0   (full price)
+ *     2 kids   → 1.5   (+50%)
+ *     3 kids   → 2.0   (+100%)
+ *
+ * This is the SINGLE source of truth for the math: both the server
+ * (`createMusicTogetherRegistration`, authoritative) and the public widget
+ * (`MusicTogetherRegistrationWidget`, display) call it so their numbers can
+ * never drift. The server never trusts a client-sent amount — it recomputes
+ * here from the section's configured base prices.
+ *
+ * All amounts are integer cents (`Math.round` after multiplying).
+ */
+import { MT_MAX_CHILDREN } from './music-together-registration';
+
+/**
+ * The minimal shape this helper needs from a section: the pay-in-full base
+ * price and the (optional) installment plan. Generic over the installment
+ * item's `dueAt` type so it works with both the server's `Date` sections and
+ * the public widget's ISO-string sections — the helper only ever multiplies
+ * `amountCents` and passes `dueAt` through untouched.
+ */
+export interface MusicTogetherPriceableSection<Item extends { amountCents: number }> {
+  /** Pay-in-full base price for ONE child, in cents. */
+  priceFullCents: number;
+  /** Configured installment plan (base, one-child amounts). */
+  installmentPlan?: Item[];
+}
+
+/** The discounted family price for a given number of children. */
+export interface MusicTogetherFamilyPrice<Item extends { amountCents: number }> {
+  /** Number of children priced (validated 1..MT_MAX_CHILDREN). */
+  numChildren: number;
+  /** Sibling-discount multiplier applied to every amount. */
+  multiplier: number;
+  /** Discounted pay-in-full total, in cents. */
+  fullCents: number;
+  /**
+   * The section's installment plan with the multiplier applied to each item's
+   * `amountCents`. Ordered like the source plan: item 0 is charged at
+   * registration, items 1..N become scheduled card-on-file charges. Every
+   * non-amount field (e.g. `dueAt`) is preserved unchanged. Empty when the
+   * section has no plan.
+   */
+  installments: Item[];
+}
+
+/**
+ * The sibling-discount multiplier for a family: first child full price, 50% off
+ * each additional child. Throws when `numChildren` is not an integer in
+ * `1..MT_MAX_CHILDREN`.
+ */
+export function mtSiblingMultiplier(numChildren: number): number {
+  if (!Number.isInteger(numChildren)) {
+    throw new RangeError(
+      `Music Together child count must be a whole number, got ${numChildren}`
+    );
+  }
+  if (numChildren < 1 || numChildren > MT_MAX_CHILDREN) {
+    throw new RangeError(
+      `Music Together supports 1 to ${MT_MAX_CHILDREN} children per family, got ${numChildren}`
+    );
+  }
+  return 1 + 0.5 * (numChildren - 1);
+}
+
+/**
+ * Compute the discounted family price (pay-in-full total + discounted
+ * installment plan) for a section and a number of children.
+ *
+ * The multiplier is applied to `priceFullCents` and to EACH installment's
+ * `amountCents`; results are rounded to whole cents. `dueAt` (and any other
+ * installment field) is carried through unchanged, so callers keep whatever
+ * date representation their section uses.
+ *
+ * @throws RangeError if `numChildren` is not an integer in 1..MT_MAX_CHILDREN.
+ */
+export function computeMusicTogetherFamilyPrice<
+  Item extends { amountCents: number }
+>(
+  section: MusicTogetherPriceableSection<Item>,
+  numChildren: number
+): MusicTogetherFamilyPrice<Item> {
+  const multiplier = mtSiblingMultiplier(numChildren);
+  const fullCents = Math.round(section.priceFullCents * multiplier);
+  const installments = (section.installmentPlan ?? []).map((item) => ({
+    ...item,
+    amountCents: Math.round(item.amountCents * multiplier),
+  }));
+  return { numChildren, multiplier, fullCents, installments };
+}


### PR DESCRIPTION
## What & why

Music Together tuition is charged **per child** with a sibling discount: the first child pays full price, the **2nd & 3rd are 50% off**, applied identically to pay-in-full AND every installment (including the scheduled Week-5 charge). Today `create-music-together-registration` charges a **flat** price with no child multiplier, so siblings are effectively free — a real bug before families enroll siblings. Fixes #599.

Owner-confirmed table:

| Children | Pay in full | Each installment |
|---|---|---|
| 1 | $252 | $132 |
| 2 | $378 | $198 |
| 3 | $504 | $264 |

## How

Single shared helper so server + widget can't drift:

`computeMusicTogetherFamilyPrice(section, numChildren)` in `libs/ts/domain` →
`{ numChildren, multiplier, fullCents, installments: {amountCents, dueAt}[] }`.
Applies `m = 1 + 0.5 * (numChildren - 1)` to `priceFullCents` and to **each** `installmentPlan[i].amountCents` (integer cents via `Math.round`); guards `numChildren` to `1..MT_MAX_CHILDREN`. Generic over the installment `dueAt` type so the server (`Date`) and the widget (ISO `string`) share the same math.

- **Server** (`createMusicTogetherRegistration`): computes the family total authoritatively via the helper for the first charge **and** the materialized `musicTogetherScheduledCharges` (installments 2..N discounted too). Validates child count before any Square write; never trusts a client-sent amount.
- **Widget** (`MusicTogetherRegistrationWidget`): uses the **same** helper to update the family total dynamically as children are added/removed — the "Pay in full — $X" / "Two installments — $Y now, $Y on <date>" labels, the card-on-file authorization amount, the pay button, and a small per-child discount note.

Edits kept localized to pricing display + the helper (additive barrel export) so the parallel MT PRs rebase cleanly.

## Verification

- **Unit — pricing helper**: exact 252/378/504 (full) and 132/198/264 (each installment) table, multiplier 1/1.5/2, `Math.round` rounding, `dueAt` preserved (Date + ISO string), guards on 0/4/non-integer.
- **Unit — server** (`vi.mock` Square/repos): asserts Square `createPayment` receives 37800 (2-child full) and 50400 (3-child full), and 26400 for 3-child installment 1 **and** the scheduled charge.
- **Integration** (`./tools/run-integration-tests.sh music-together`, real emulators + Square mock): 2-child full ($378) and 3-child installments ($264 now + $264 scheduled) — **6 files / 42 tests pass**.
- **Widget interaction spec**: total updates $252 → $378 → $504 as children are added; pay button reflects the discounted total — 9 tests pass.
- Typecheck + eslint clean on the affected projects (domain, function, widget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)