### PR TITLE
test(e2e): real-sandbox POS class + product webhook coverage (Tier 1 of 2)

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -595,6 +595,135 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  pos-sandbox-e2e:
+    # Tier-1 real-Square-sandbox POS coverage. The Cloud Functions run in the
+    # Firebase emulator, but the maple-square codebase's .env DELIBERATELY omits
+    # SQUARE_BASE_URL — so the Square SDK inside those functions hits the REAL
+    # sandbox (connect.squareupsandbox.com) with the sandbox access token. The
+    # vitest suite drives the same sandbox directly to stand up real orders /
+    # payments / catalog items, and self-signs inbound webhooks with the known
+    # `mock-key`. This closes the mock-drift gap the mock-backed
+    # functions-integration-tests-class-square suite can't see: it proves the
+    # POS inbound paths (syncClassToSquare → order+payment → payment.updated →
+    # processPosSale; inventory.count.updated → product cache) against ACTUAL
+    # Square responses.
+    #
+    # Named pos-sandbox-e2e (NOT functions-integration-tests-*) so the standard
+    # integration-test matrix — which points SQUARE_BASE_URL at the mock — never
+    # picks it up; only this dedicated real-sandbox job runs it. Same reason
+    # registration-e2e is named that way.
+    name: POS Sandbox E2E
+    needs: [install]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: github.repository == 'Maple-and-Spruce/maple-and-spruce'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Setup Java
+        # Required by Firestore emulator (same as integration-tests job).
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: ${{ needs.install.outputs.cache_key }}
+
+      - name: Build function codebases
+        # All four are required: squareWebhook + processPosSale + syncClassToSquare
+        # live in maple-square, and the class write also fires syncClassToWebflow
+        # in maple-sync (which must reach a Webflow mock, not real Webflow).
+        # firebase.json declares all four source dirs, so the emulator loads them all.
+        run: |
+          pnpm exec nx run functions:build
+          pnpm exec nx run functions-square:build
+          pnpm exec nx run functions-sync:build
+          pnpm exec nx run functions-calendar:build
+
+      - name: Create emulator .env
+        # Copied VERBATIM from the registration-e2e job: we DON'T set
+        # SQUARE_BASE_URL so the SDK uses its built-in sandbox base URL
+        # (connect.squareupsandbox.com) and we feed it the real sandbox access
+        # token. Webflow and Etsy still hit local mock servers because there's
+        # no usable sandbox for either — the class-write trigger's
+        # syncClassToWebflow call goes to the Webflow mock instead of hanging.
+        env:
+          SQUARE_SANDBOX_ACCESS_TOKEN: ${{ secrets.SQUARE_SANDBOX_ACCESS_TOKEN }}
+        run: |
+          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar; do
+            grep -v '^#' .env.dev | grep -v '^$' > "$dir/.env"
+          done
+
+          # maple-core: Etsy mock server URL + fake secrets
+          echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions/.env
+          # tallyLeadWebhook (maple-core) declares these defineSecret params;
+          # without them the emulator silently waits on stdin for each one.
+          printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\nTALLY_WEBHOOK_SECRET=test-tally-secret\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions/.secret.local
+
+          # maple-square: real Square sandbox (no SQUARE_BASE_URL → SDK
+          # uses its built-in sandbox endpoint). Etsy still mocked.
+          echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions-square/.env
+          printf "SQUARE_ACCESS_TOKEN=%s\nSQUARE_WEBHOOK_SIGNATURE_KEY=mock-key\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" "$SQUARE_SANDBOX_ACCESS_TOKEN" > dist/apps/functions-square/.secret.local
+
+          # maple-sync: Webflow + Etsy mock servers
+          echo "WEBFLOW_BASE_URL=http://localhost:9996" >> dist/apps/functions-sync/.env
+          echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions-sync/.env
+          echo "ETSY_TOKEN_URL=http://localhost:9998/v3/public/oauth/token" >> dist/apps/functions-sync/.env
+          printf "WEBFLOW_API_TOKEN=mock-token\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions-sync/.secret.local
+
+      - name: Start mock servers (Webflow + Etsy)
+        # Square is intentionally NOT mocked — the suite exercises the real
+        # sandbox. Webflow and Etsy have no usable sandbox, so the in-repo mock
+        # servers absorb the class-write sync triggers.
+        run: |
+          # Pre-warm npx tsx cache (matches integration-tests pattern)
+          npx tsx --version
+
+          WEBFLOW_MOCK_SERVER_PORT=9996 npx tsx libs/firebase/webflow-test-mock-server/start.ts &
+          echo "WEBFLOW_MOCK_PID=$!" >> $GITHUB_ENV
+          ETSY_MOCK_SERVER_PORT=9998 npx tsx libs/firebase/etsy-test-mock-server/start.ts &
+          echo "ETSY_MOCK_PID=$!" >> $GITHUB_ENV
+          sleep 2
+
+      - name: Run POS sandbox e2e against emulator
+        # firebase emulators:exec manages emulator lifecycle. The TEST process
+        # (vitest) needs the same Square sandbox credentials the functions read,
+        # so it can create real orders/payments/catalog items directly:
+        #   SQUARE_ACCESS_TOKEN  the real sandbox token (repo secret)
+        #   SQUARE_LOCATION_ID   sandbox location id (public, from .env.dev)
+        #   SQUARE_ENV=LOCAL     → SDK sandbox environment
+        #   SALES_TAX_RATE       sales-tax percent (public, from .env.dev)
+        # SQUARE_BASE_URL is intentionally NOT exported, so the test client also
+        # hits the real sandbox.
+        env:
+          SQUARE_ACCESS_TOKEN: ${{ secrets.SQUARE_SANDBOX_ACCESS_TOKEN }}
+          SQUARE_ENV: LOCAL
+        run: |
+          export SQUARE_LOCATION_ID=$(grep '^SQUARE_LOCATION_ID=' .env.dev | cut -d= -f2-)
+          export SALES_TAX_RATE=$(grep '^SALES_TAX_RATE=' .env.dev | cut -d= -f2-)
+
+          npx firebase emulators:exec --project=dev --only auth,firestore,functions \
+            "pnpm exec vitest run --config apps/pos-sandbox-e2e/vitest.config.ts --reporter=verbose"
+
+      - name: Stop mock servers
+        if: always()
+        run: |
+          kill "$WEBFLOW_MOCK_PID" 2>/dev/null || true
+          kill "$ETSY_MOCK_PID" 2>/dev/null || true
+
   storybook:
     name: Storybook Build & Tests
     needs: [install]

--- a/apps/pos-sandbox-e2e/project.json
+++ b/apps/pos-sandbox-e2e/project.json
@@ -1,0 +1,22 @@
+{
+  "name": "pos-sandbox-e2e",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/pos-sandbox-e2e/src",
+  "projectType": "application",
+  "tags": ["type:e2e"],
+  "implicitDependencies": [
+    "firebase-maple-functions-process-pos-sale",
+    "firebase-maple-functions-square-webhook",
+    "firebase-maple-functions-sync-class-to-square",
+    "firebase-integration-test-utils",
+    "square"
+  ],
+  "targets": {
+    "test": {
+      "executor": "@nx/vitest:test",
+      "options": {
+        "config": "apps/pos-sandbox-e2e/vitest.config.ts"
+      }
+    }
+  }
+}

--- a/apps/pos-sandbox-e2e/src/pos-class-sale.spec.ts
+++ b/apps/pos-sandbox-e2e/src/pos-class-sale.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * Tier-1 real-Square-sandbox e2e: POS class sale → source:'pos' registration.
+ *
+ * Unlike the mock-backed `pos-sale-webhook.spec.ts` (which seeds a fabricated
+ * payment→order→customer graph into the Square mock), this suite proves the
+ * inbound POS path against ACTUAL Square sandbox responses — closing the
+ * mock-drift gap:
+ *
+ *   1. Seed a published class with NO Square ids → the `syncClassToSquare`
+ *      Firestore trigger (running in the emulator, SDK pointed at real sandbox)
+ *      creates a REAL sandbox catalog item + variation and writes the variation
+ *      id back onto the class doc.
+ *   2. Create a REAL sandbox order (that variation as a catalog line item, an
+ *      ORDER-scope tax, no referenceId) + payment (sandbox nonce, autocomplete).
+ *   3. Self-sign + POST a `payment.updated` (COMPLETED) to the emulator
+ *      `squareWebhook`, which enqueues `posSaleRequests/{paymentId}`.
+ *   4. `processPosSale` fires, fetches the REAL payment/order/customer from
+ *      Square, and creates a `source:'pos'` registration.
+ *
+ * We assert via Firestore (a `source:'pos'` registration can only exist if the
+ * whole real chain ran) and check the money fields against the REAL order —
+ * relationships (subtotal + tax === paid, all > 0), not hardcoded cents, since
+ * the sandbox is the source of truth.
+ *
+ * REQUIRES: all four function codebases built + loaded in the emulator with the
+ * maple-square `.env` OMITTING SQUARE_BASE_URL (SDK → real sandbox) and a real
+ * SQUARE_ACCESS_TOKEN; the test process needs SQUARE_ACCESS_TOKEN /
+ * SQUARE_LOCATION_ID / SQUARE_ENV / SALES_TAX_RATE. See build-check.yml ::
+ * pos-sandbox-e2e. Cannot run without the sandbox token.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { SquareClient } from 'square';
+import {
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  getFirestoreDoc,
+  listFirestoreDocs,
+  PUBLISHED_CLASS,
+} from '@maple/firebase/integration-test-utils';
+import {
+  sandboxSquare,
+  createPosOrderAndPayment,
+  deleteCatalogItem,
+  paymentUpdatedEvent,
+  postWebhook,
+  pollFor,
+  uniqueId,
+} from './support/square-sandbox';
+
+const SALES_TAX_RATE = process.env['SALES_TAX_RATE'] ?? '6.0';
+
+let client: SquareClient;
+let locationId: string;
+/** Square catalog ITEM ids created during the run (class + any product). */
+const createdItemIds: string[] = [];
+
+/** How long to wait for syncClassToSquare to write the variation id back. */
+const CLASS_SYNC_TIMEOUT_MS = 45000;
+/** How long to wait for the two async trigger hops + Square round-trips. */
+const REGISTRATION_TIMEOUT_MS = 60000;
+
+describe('POS class sale against REAL Square sandbox', () => {
+  beforeAll(async () => {
+    const square = sandboxSquare();
+    client = square.getClient();
+    locationId = square.locationId;
+    await clearFirestoreEmulator();
+  });
+
+  afterAll(async () => {
+    for (const itemId of createdItemIds) {
+      await deleteCatalogItem(client, itemId);
+    }
+    await clearFirestoreEmulator();
+  });
+
+  it('creates a source:pos registration from real sandbox order/payment data', async () => {
+    const classId = uniqueId('pos-class');
+    const className = uniqueId('POS Sandbox Pottery');
+    const priceCents = 4500;
+    const capacity = 8;
+
+    // 1. Seed a published class WITHOUT Square ids → syncClassToSquare creates
+    //    the real sandbox catalog item and writes squareVariationId back.
+    await setFirestoreDoc('classes', classId, {
+      ...PUBLISHED_CLASS,
+      id: classId,
+      name: className,
+      priceCents,
+      capacity,
+      status: 'published',
+    });
+
+    // 2. Poll until the trigger writes the real sandbox variation id back.
+    const { variationId, itemId } = await pollFor(
+      async () => {
+        const doc = await getFirestoreDoc('classes', classId);
+        const variation = doc?.['squareVariationId'] as string | undefined;
+        const item = doc?.['squareCatalogItemId'] as string | undefined;
+        if (variation && item) {
+          return { variationId: variation, itemId: item };
+        }
+        return undefined;
+      },
+      { timeoutMs: CLASS_SYNC_TIMEOUT_MS }
+    );
+    // Track for teardown as soon as we know the real item id.
+    createdItemIds.push(itemId);
+
+    expect(variationId).toBeTruthy();
+
+    // 3. Create a REAL sandbox order (catalog line item, ORDER tax, no
+    //    referenceId) + payment.
+    const { orderId, paymentId, totalCents } = await createPosOrderAndPayment(
+      client,
+      {
+        locationId,
+        catalogObjectId: variationId,
+        quantity: 1,
+        taxPercentage: SALES_TAX_RATE,
+      }
+    );
+    expect(orderId).toBeTruthy();
+    expect(paymentId).toBeTruthy();
+    expect(totalCents).toBeGreaterThan(0);
+
+    // 4. Self-sign + POST payment.updated (COMPLETED) → squareWebhook enqueues.
+    const res = await postWebhook(paymentUpdatedEvent(paymentId, orderId));
+    expect(res.status).toBe(200);
+    expect((res.body as { action?: string }).action).toBe('enqueued');
+
+    // 5. Poll for the source:'pos' registration created by processPosSale.
+    const reg = await pollFor(
+      async () => {
+        const regs = await listFirestoreDocs('registrations');
+        return regs.find(
+          (r) =>
+            r.data['source'] === 'pos' &&
+            r.data['squareOrderId'] === orderId
+        )?.data;
+      },
+      { timeoutMs: REGISTRATION_TIMEOUT_MS }
+    );
+
+    // Backbone assertions: the registration only exists if the full real chain
+    // ran (webhook → posSaleRequests → processPosSale → real Square fetch).
+    expect(reg['classId']).toBe(classId);
+    expect(reg['squareOrderId']).toBe(orderId);
+    expect(reg['squarePaymentId']).toBe(paymentId);
+    expect(reg['status']).toBe('confirmed');
+
+    // Money fields come straight from the REAL order line item, so assert
+    // relationships rather than hardcoded cents.
+    const subtotalCents = reg['subtotalCents'] as number;
+    const taxAmountCents = reg['taxAmountCents'] as number;
+    const pricePaidCents = reg['pricePaidCents'] as number;
+    expect(subtotalCents).toBeGreaterThan(0);
+    expect(taxAmountCents).toBeGreaterThan(0);
+    expect(pricePaidCents).toBeGreaterThan(0);
+    // Pre-tax subtotal is the catalog variation's price (quantity 1).
+    expect(subtotalCents).toBe(priceCents);
+    // Paid == subtotal + tax, and matches the real order total we paid.
+    expect(pricePaidCents).toBe(subtotalCents + taxAmountCents);
+    expect(pricePaidCents).toBe(totalCents);
+  });
+});

--- a/apps/pos-sandbox-e2e/src/pos-product-sale.spec.ts
+++ b/apps/pos-sandbox-e2e/src/pos-product-sale.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * Tier-1 real-Square-sandbox e2e: product inventory webhook → cached quantity.
+ *
+ * Proves the inbound `inventory.count.updated` path against a REAL sandbox
+ * catalog variation id (closing the mock-drift gap the mock-backed suite can't):
+ *
+ *   1. Create a REAL sandbox retail ITEM + variation (trackInventory: true).
+ *   2. Seed a `products` Firestore doc whose variant `squareVariationId`
+ *      matches that real variation, with an initial cached quantity.
+ *   3. Self-sign + POST an `inventory.count.updated` for that variation id with
+ *      a new quantity → `squareWebhook` runs `handleInventoryUpdate` inline.
+ *   4. Assert the product's cached variant quantity is updated to the new value.
+ *
+ * `handleInventoryUpdate` reads the quantity straight from the event payload
+ * (it does NOT call Square), so this validates the variation-id matching +
+ * Firestore write path against a REAL catalog variation id rather than a
+ * fabricated one.
+ *
+ * REQUIRES the same emulator + real-sandbox setup as pos-class-sale.spec.ts.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { SquareClient } from 'square';
+import {
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  getFirestoreDoc,
+} from '@maple/firebase/integration-test-utils';
+import {
+  sandboxSquare,
+  createSandboxProduct,
+  deleteCatalogItem,
+  inventoryUpdatedEvent,
+  postWebhook,
+  pollFor,
+  uniqueId,
+} from './support/square-sandbox';
+
+let client: SquareClient;
+let locationId: string;
+const createdItemIds: string[] = [];
+
+const INITIAL_QUANTITY = 10;
+const UPDATED_QUANTITY = 7;
+const INVENTORY_TIMEOUT_MS = 30000;
+
+describe('POS product inventory webhook against REAL Square sandbox', () => {
+  beforeAll(async () => {
+    const square = sandboxSquare();
+    client = square.getClient();
+    locationId = square.locationId;
+    await clearFirestoreEmulator();
+  });
+
+  afterAll(async () => {
+    for (const itemId of createdItemIds) {
+      await deleteCatalogItem(client, itemId);
+    }
+    await clearFirestoreEmulator();
+  });
+
+  it('decrements the product cached quantity on inventory.count.updated', async () => {
+    // 1. Real sandbox item + variation.
+    const { itemId, variationId } = await createSandboxProduct(client, {
+      name: uniqueId('POS Sandbox Mug'),
+      priceCents: 2500,
+    });
+    createdItemIds.push(itemId);
+    expect(variationId).toBeTruthy();
+
+    // 2. Seed a products doc matching the Product shape docToProduct expects
+    //    (variants[] with squareVariationId, listing-level squareCache, and a
+    //    createdAt so ProductRepository.findAll's orderBy('createdAt') returns
+    //    it). The variant's squareVariationId === the REAL variation id.
+    const productId = uniqueId('pos-product');
+    const now = new Date();
+    await setFirestoreDoc('products', productId, {
+      artistId: 'sandbox-artist',
+      categoryId: 'sandbox-category',
+      status: 'active',
+      createdAt: now,
+      updatedAt: now,
+      variants: [
+        {
+          id: 'variant-1',
+          label: 'Regular',
+          sku: uniqueId('sku'),
+          priceCents: 2500,
+          quantity: INITIAL_QUANTITY,
+          squareVariationId: variationId,
+        },
+      ],
+      squareItemId: itemId,
+      squareVariationId: variationId,
+      squareCatalogVersion: 1,
+      squareLocationId: locationId,
+      squareCache: {
+        name: 'POS Sandbox Mug',
+        description: 'Real sandbox retail item',
+        syncedAt: now,
+        priceCents: 2500,
+        quantity: INITIAL_QUANTITY,
+        sku: 'sandbox-sku',
+      },
+    });
+
+    // 3. Self-sign + POST inventory.count.updated for the real variation id.
+    const res = await postWebhook(
+      inventoryUpdatedEvent(variationId, UPDATED_QUANTITY, locationId)
+    );
+    expect(res.status).toBe(200);
+    expect((res.body as { action?: string }).action).toBe('updated');
+
+    // 4. Assert the cached variant quantity flipped to the new value.
+    //    `handleInventoryUpdate` → ProductRepository.updateCachedQuantity writes
+    //    the variants[] array; squareCache.quantity is re-derived from
+    //    variants[0] at READ time (docToProduct), so the stored variant
+    //    quantity is the source of truth we assert on here.
+    const variantQuantity = await pollFor(
+      async () => {
+        const doc = await getFirestoreDoc('products', productId);
+        const variants = doc?.['variants'] as
+          | Array<Record<string, unknown>>
+          | undefined;
+        const qty = variants?.[0]?.['quantity'] as number | undefined;
+        return qty === UPDATED_QUANTITY ? qty : undefined;
+      },
+      { timeoutMs: INVENTORY_TIMEOUT_MS }
+    );
+
+    expect(variantQuantity).toBe(UPDATED_QUANTITY);
+  });
+});

--- a/apps/pos-sandbox-e2e/src/support/square-sandbox.ts
+++ b/apps/pos-sandbox-e2e/src/support/square-sandbox.ts
@@ -135,7 +135,9 @@ export async function createPosOrderAndPayment(
 
   const paymentResponse = await client.payments.create({
     sourceId: 'cnon:card-nonce-ok',
-    idempotencyKey: uniqueId('pos-pay'),
+    // Square caps the payment idempotency_key at 45 chars — a bare UUID (36)
+    // fits and is unique per attempt; `uniqueId()` (prefix + UUID + seq) is 46+.
+    idempotencyKey: randomUUID(),
     amountMoney: {
       amount: BigInt(totalCents),
       currency: 'USD',

--- a/apps/pos-sandbox-e2e/src/support/square-sandbox.ts
+++ b/apps/pos-sandbox-e2e/src/support/square-sandbox.ts
@@ -1,0 +1,356 @@
+/**
+ * Real-Square-sandbox support for the Tier-1 POS e2e suite.
+ *
+ * The Cloud Functions under test run in the Firebase emulator, but — because
+ * the maple-square codebase's `.env` deliberately omits `SQUARE_BASE_URL` in
+ * this job — the Square SDK inside those functions talks to the REAL Square
+ * sandbox (`connect.squareupsandbox.com`). To drive those paths the TEST
+ * process needs to talk to the same sandbox directly (create a catalog item's
+ * order + payment, create a product's catalog item, tear both down). This
+ * module builds a sandbox-scoped Square client from `process.env` and exposes
+ * the raw SDK plus the self-signed-webhook helpers lifted from the mock-backed
+ * `pos-sale-webhook.spec.ts`.
+ *
+ * Env the test process must provide (the CI job exports these; see
+ * build-check.yml :: pos-sandbox-e2e):
+ *   SQUARE_ACCESS_TOKEN   real sandbox access token (repo secret)
+ *   SQUARE_LOCATION_ID    sandbox location id (public, from .env.dev)
+ *   SQUARE_ENV            'LOCAL' → SDK sandbox environment (default LOCAL)
+ *   SALES_TAX_RATE        e.g. '6.0' (public, from .env.dev)
+ * `SQUARE_BASE_URL` must NOT be set in the test process, or the client would
+ * be redirected away from the real sandbox (the Square wrapper honours it).
+ */
+import { createHmac, randomUUID } from 'crypto';
+import type { SquareClient } from 'square';
+import { Square } from '@maple/firebase/square';
+import { EMULATOR_CONFIG } from '@maple/firebase/integration-test-utils';
+
+/**
+ * A per-run token so Square idempotency keys and catalog item names don't
+ * collide across CI runs against the SHARED sandbox — Square remembers
+ * idempotency keys server-side, so a reused key would replay a prior run's
+ * (now-deleted) catalog object. A module-level counter keeps individual ids
+ * readable and unique within a run.
+ */
+const RUN_ID = randomUUID();
+let seq = 0;
+
+/** A per-run-unique id/idempotency-key with a human-readable prefix. */
+export function uniqueId(prefix: string): string {
+  seq += 1;
+  return `${prefix}-${RUN_ID}-${seq}`;
+}
+
+/**
+ * Build a Square client bound to the real sandbox from `process.env`.
+ *
+ * Reuses the production `Square` wrapper (same credential resolution the
+ * functions use) so the test exercises the same env contract. `.getClient()`
+ * exposes the raw SDK for the direct catalog/order/payment calls below.
+ */
+export function sandboxSquare(): Square {
+  const accessToken = process.env['SQUARE_ACCESS_TOKEN'];
+  if (!accessToken) {
+    throw new Error(
+      'SQUARE_ACCESS_TOKEN must be set in the test process to reach the real ' +
+        'Square sandbox. The CI job exports it from the SQUARE_SANDBOX_ACCESS_TOKEN secret.'
+    );
+  }
+  const locationId = process.env['SQUARE_LOCATION_ID'];
+  if (!locationId) {
+    throw new Error(
+      'SQUARE_LOCATION_ID must be set in the test process (public value from .env.dev).'
+    );
+  }
+  if (process.env['SQUARE_BASE_URL']) {
+    throw new Error(
+      'SQUARE_BASE_URL is set — the test client would be redirected off the ' +
+        'real sandbox. Unset it so this suite hits connect.squareupsandbox.com.'
+    );
+  }
+
+  const secrets = { SQUARE_ACCESS_TOKEN: accessToken };
+  const strings = {
+    SQUARE_ENV: process.env['SQUARE_ENV'] ?? 'LOCAL',
+    SQUARE_LOCATION_ID: locationId,
+    SALES_TAX_RATE: process.env['SALES_TAX_RATE'] ?? '6.0',
+  };
+  return new Square(secrets, strings);
+}
+
+export interface CreatePosSaleInput {
+  /** Square location id to create the order + payment under. */
+  locationId: string;
+  /** Catalog variation id (a class or product variation) to ring up. */
+  catalogObjectId: string;
+  /** Number of units to sell. */
+  quantity: number;
+  /** Sales-tax percentage string (e.g. '6.0'); adds an ORDER-scope tax. */
+  taxPercentage: string;
+}
+
+export interface PosSaleResult {
+  orderId: string;
+  paymentId: string;
+  /** Real order total (incl. tax) in cents, returned by the sandbox. */
+  totalCents: number;
+}
+
+/**
+ * Create a real sandbox ORDER (catalog line item, ORDER-scope tax, NO
+ * referenceId — that's the web-dedup key POS orders leave unset) and pay it
+ * with the sandbox test nonce. Uses the raw SDK directly rather than our
+ * `OrdersService.createOrder`, which builds ad-hoc priced line items and never
+ * sets `catalogObjectId` (the field `processPosSale` maps back to a class).
+ */
+export async function createPosOrderAndPayment(
+  client: SquareClient,
+  input: CreatePosSaleInput
+): Promise<PosSaleResult> {
+  const orderResponse = await client.orders.create({
+    idempotencyKey: uniqueId('pos-order'),
+    order: {
+      locationId: input.locationId,
+      lineItems: [
+        {
+          catalogObjectId: input.catalogObjectId,
+          quantity: String(input.quantity),
+        },
+      ],
+      taxes: [
+        {
+          name: 'WV Sales Tax',
+          percentage: input.taxPercentage,
+          scope: 'ORDER',
+        },
+      ],
+    },
+  });
+
+  const order = orderResponse.order;
+  if (!order?.id) {
+    throw new Error('Sandbox order create returned no order id');
+  }
+  const totalCents = Number(order.totalMoney?.amount ?? 0);
+
+  const paymentResponse = await client.payments.create({
+    sourceId: 'cnon:card-nonce-ok',
+    idempotencyKey: uniqueId('pos-pay'),
+    amountMoney: {
+      amount: BigInt(totalCents),
+      currency: 'USD',
+    },
+    orderId: order.id,
+    locationId: input.locationId,
+    autocomplete: true,
+  });
+
+  const paymentId = paymentResponse.payment?.id;
+  if (!paymentId) {
+    throw new Error('Sandbox payment create returned no payment id');
+  }
+
+  return { orderId: order.id, paymentId, totalCents };
+}
+
+export interface SandboxProduct {
+  itemId: string;
+  variationId: string;
+}
+
+/**
+ * Create a real sandbox retail ITEM + single ITEM_VARIATION with
+ * `trackInventory: true`. Returns the item id (for teardown) and the variation
+ * id used as the `catalog_object_id` in the inventory webhook.
+ */
+export async function createSandboxProduct(
+  client: SquareClient,
+  input: { name: string; priceCents: number }
+): Promise<SandboxProduct> {
+  const sku = uniqueId('sku');
+  const response = await client.catalog.batchUpsert({
+    idempotencyKey: uniqueId('prod-create'),
+    batches: [
+      {
+        objects: [
+          {
+            type: 'ITEM',
+            id: `#item-${sku}`,
+            itemData: {
+              name: input.name,
+              variations: [
+                {
+                  type: 'ITEM_VARIATION',
+                  id: `#var-${sku}`,
+                  itemVariationData: {
+                    name: 'Regular',
+                    sku,
+                    pricingType: 'FIXED_PRICING',
+                    priceMoney: {
+                      amount: BigInt(input.priceCents),
+                      currency: 'USD',
+                    },
+                    trackInventory: true,
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  const item = response.objects?.find((obj) => obj.type === 'ITEM');
+  const variationId = item?.itemData?.variations?.[0]?.id;
+  if (!item?.id || !variationId) {
+    throw new Error('Sandbox product create returned no item/variation id');
+  }
+  return { itemId: item.id, variationId };
+}
+
+/**
+ * Soft-delete a catalog object (item) in the sandbox. Tolerates a
+ * not-found/already-deleted object so teardown never fails a green run.
+ */
+export async function deleteCatalogItem(
+  client: SquareClient,
+  itemId: string
+): Promise<void> {
+  try {
+    await client.catalog.object.delete({ objectId: itemId });
+  } catch {
+    // Already gone / never created — nothing to clean up.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Self-signed webhook helpers (lifted from pos-sale-webhook.spec.ts).
+//
+// Square signs HMAC-SHA256(signatureKey, webhookUrl + rawBody) → base64, where
+// the FUNCTION derives `webhookUrl` from `FirebaseProject.functionUrl(...)` —
+// the DEPLOYED cloudfunctions URL, not the emulator URL — and
+// `rawBody = JSON.stringify(req.body)`. So we sign over `SIGNED_URL +
+// JSON.stringify(body)` with the harness key `mock-key`.
+// ---------------------------------------------------------------------------
+
+/** The emulator squareWebhook endpoint we POST to. */
+export const WEBHOOK_URL = `${EMULATOR_CONFIG.functionsHost}/${EMULATOR_CONFIG.projectId}/${EMULATOR_CONFIG.region}/squareWebhook`;
+
+/**
+ * The URL the function signs over — `FirebaseProject.functionUrl('squareWebhook')`
+ * resolves to `https://us-east4-<projectId>.cloudfunctions.net/squareWebhook`
+ * under the emulator (projectId = GCLOUD_PROJECT = maple-and-spruce-dev).
+ */
+export const SIGNED_URL = `https://us-east4-${EMULATOR_CONFIG.projectId}.cloudfunctions.net/squareWebhook`;
+
+/** Must match SQUARE_WEBHOOK_SIGNATURE_KEY in the CI job's .secret.local. */
+export const SIGNATURE_KEY = 'mock-key';
+
+/** Sign a webhook body exactly the way the function's verifier does. */
+export function signWebhook(body: unknown, secret: string): string {
+  const raw = JSON.stringify(body);
+  return createHmac('sha256', secret)
+    .update(SIGNED_URL + raw)
+    .digest('base64');
+}
+
+/** POST a signed Square webhook to the emulator endpoint. */
+export async function postWebhook(
+  body: unknown
+): Promise<{ status: number; body: unknown }> {
+  const raw = JSON.stringify(body);
+  const response = await fetch(WEBHOOK_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-square-hmacsha256-signature': signWebhook(body, SIGNATURE_KEY),
+    },
+    body: raw,
+  });
+  const text = await response.text();
+  let parsed: unknown = text;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    /* keep raw text */
+  }
+  return { status: response.status, body: parsed };
+}
+
+/**
+ * A `payment.updated` webhook envelope (all strings → the function's
+ * `JSON.stringify(req.body)` round-trips byte-identically to what we sign).
+ */
+export function paymentUpdatedEvent(
+  paymentId: string,
+  orderId: string
+): unknown {
+  return {
+    merchant_id: 'ML-SANDBOX',
+    type: 'payment.updated',
+    event_id: uniqueId('evt-pay'),
+    created_at: new Date().toISOString(),
+    data: {
+      type: 'payment',
+      id: paymentId,
+      object: {
+        payment: {
+          id: paymentId,
+          order_id: orderId,
+          status: 'COMPLETED',
+        },
+      },
+    },
+  };
+}
+
+/**
+ * An `inventory.count.updated` webhook envelope for one variation. `quantity`
+ * is a string per Square's wire format; `handleInventoryUpdate` parses it and
+ * matches `catalog_object_id` against a product's `squareVariationId`.
+ */
+export function inventoryUpdatedEvent(
+  variationId: string,
+  quantity: number,
+  locationId: string
+): unknown {
+  return {
+    merchant_id: 'ML-SANDBOX',
+    type: 'inventory.count.updated',
+    event_id: uniqueId('evt-inv'),
+    created_at: new Date().toISOString(),
+    data: {
+      type: 'inventory_count',
+      id: variationId,
+      object: {
+        inventory_counts: [
+          {
+            catalog_object_id: variationId,
+            quantity: String(quantity),
+            location_id: locationId,
+            state: 'IN_STOCK',
+          },
+        ],
+      },
+    },
+  };
+}
+
+/** Poll `fn` until it returns a defined value or the timeout elapses. */
+export async function pollFor<T>(
+  fn: () => Promise<T | undefined>,
+  { timeoutMs, intervalMs = 1000 }: { timeoutMs: number; intervalMs?: number }
+): Promise<T> {
+  const start = Date.now();
+  for (;;) {
+    const result = await fn();
+    if (result !== undefined) {
+      return result;
+    }
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`pollFor timed out after ${timeoutMs}ms`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}

--- a/apps/pos-sandbox-e2e/tsconfig.json
+++ b/apps/pos-sandbox-e2e/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/apps/pos-sandbox-e2e/tsconfig.spec.json
+++ b/apps/pos-sandbox-e2e/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "types": ["vitest/globals", "node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/pos-sandbox-e2e/vitest.config.ts
+++ b/apps/pos-sandbox-e2e/vitest.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@maple/firebase/integration-test-utils': path.resolve(
+        __dirname,
+        '../../libs/firebase/integration-test-utils/src/index.ts'
+      ),
+      '@maple/firebase/square': path.resolve(
+        __dirname,
+        '../../libs/firebase/square/src/index.ts'
+      ),
+      '@maple/ts/domain': path.resolve(
+        __dirname,
+        '../../libs/ts/domain/src/index.ts'
+      ),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    root: path.resolve(__dirname),
+    include: ['src/**/*.spec.ts'],
+    setupFiles: ['../../libs/firebase/integration-test-utils/src/lib/setup.ts'],
+    // Real Square sandbox round-trips (catalog create, order + payment,
+    // customer fetch) plus the two async Firestore-trigger hops are slower
+    // than the mock-backed suites — give each test generous headroom.
+    testTimeout: 120000,
+    fileParallelism: false,
+    sequence: {
+      concurrent: false,
+    },
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
       'apps/registration-e2e/**',
       'apps/functions-integration-tests/**',
       'apps/functions-integration-tests-*/**',
+      'apps/pos-sandbox-e2e/**',
     ],
     coverage: {
       provider: 'istanbul',
@@ -48,6 +49,7 @@ export default defineConfig({
         'libs/firebase/etsy-test-mock-server/**',
         'libs/firebase/integration-test-utils/**',
         'apps/functions-integration-tests*/**',
+        'apps/pos-sandbox-e2e/**',
         'apps/maple-spruce-e2e/**',
         'apps/maple-spruce/.storybook/**',
       ],


### PR DESCRIPTION
**Tier 1 of 2** of the POS real-sandbox e2e coverage (validating that prod will behave like dev, not just our Square mock).

## What & why
Our POS coverage so far runs against our **own Square mock**, so it can't prove the real `getOrder`/`getPayment`/`getCustomer` mapping matches real Square. This suite closes that gap: functions run in the Firebase emulator, but the Square SDK inside them hits **real sandbox** (`connect.squareupsandbox.com` — no `SQUARE_BASE_URL`), and inbound webhooks are self-signed with the known `mock-key`. Deterministic (no waiting on Square delivery), runs every PR.

New `apps/pos-sandbox-e2e/` suite (named so the mock-backed integration matrix never picks it up) + a dedicated **POS Sandbox E2E** CI job mirroring `registration-e2e`'s real-sandbox env.

### Class POS path
Seed a published class (no Square ids) → `syncClassToSquare` creates the **real sandbox** catalog item and writes back `squareVariationId` → create a real sandbox order (`catalogObjectId` line item, **no** `referenceId`) + completed payment (`cnon:card-nonce-ok`) → self-signed `payment.updated` → `processPosSale` reads **real sandbox** order/payment/customer → assert a `source:'pos'` registration with money relationships consistent with the real order total.

### Product POS path
Create a real sandbox item+variation → seed a matching `products` doc → self-signed `inventory.count.updated` → assert the product's variant cached quantity decrements. (`handleInventoryUpdate` reads quantity from the payload, so this validates matching + write against a real catalog variation id.)

Teardown deletes the sandbox catalog items and Firestore docs each run; idempotency keys are per-run unique so re-runs against the shared sandbox don't replay deleted objects.

## Validation status (important)
- ✅ typecheck, lint, `functions-square:build`, tsconfig validator, index analyzer, project discovery, workflow YAML all pass locally.
- ⚠️ The **real-sandbox execution is unverified locally** — the sandbox access token isn't available outside CI. **This PR's `POS Sandbox E2E` job is the first real run.** If it surfaces real-Square surprises (e.g. line-item money fields, ordering of the async webhook→worker chain), I'll iterate here.

Tier 2 (post-merge real-delivery smoke against deployed dev — Square actually delivers the webhook) follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
