### PR TITLE
test(music-together): end-to-end enrollment E2E (mirror class Registration E2E) (#608)

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -724,6 +724,161 @@ jobs:
           kill "$WEBFLOW_MOCK_PID" 2>/dev/null || true
           kill "$ETSY_MOCK_PID" 2>/dev/null || true
 
+  music-together-e2e:
+    # PR-time FE→BE end-to-end for Music Together enrollment — the higher-layer
+    # counterpart to the MT cloud-function integration suite. Drives the
+    # production MusicTogetherRegistrationWidget (mounted in the shared
+    # registration-test-harness via ?mtSectionId=) against the local Firebase
+    # emulator with the PR's own code, MT's REAL Square sandbox account, and
+    # HTTP mock servers for Webflow + Etsy.
+    #
+    # Money must route to MT's SEPARATE Square account (MT_SQUARE_KEYS), not
+    # Maple & Spruce's — the spec reads each payment back from MT's sandbox and
+    # asserts its location_id. This requires MT's sandbox access token, which
+    # M&S's SQUARE_SANDBOX_ACCESS_TOKEN is NOT (different Square account/app).
+    #
+    # Activation: set the repo secret MT_SQUARE_SANDBOX_ACCESS_TOKEN to MT's
+    # sandbox access token (same value as MT_SQUARE_ACCESS_TOKEN in the
+    # maple-and-spruce-dev Secret Manager). Until it's set, this job no-ops
+    # (steps are gated on the secret) so it stays green; the post-merge
+    # mt_e2e_dev gate already exercises the real flow against deployed dev.
+    name: Music Together E2E
+    needs: [install]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: github.repository == 'Maple-and-Spruce/maple-and-spruce'
+    env:
+      MT_SQUARE_SANDBOX_ACCESS_TOKEN: ${{ secrets.MT_SQUARE_SANDBOX_ACCESS_TOKEN }}
+    steps:
+      - name: Check MT sandbox secret
+        id: gate
+        run: |
+          if [ -n "$MT_SQUARE_SANDBOX_ACCESS_TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Music Together E2E skipped::Set the repo secret MT_SQUARE_SANDBOX_ACCESS_TOKEN (MT's sandbox access token) to activate this gate. The post-merge mt_e2e_dev job still exercises the real flow."
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.gate.outputs.enabled == 'true'
+
+      - name: Setup pnpm
+        if: steps.gate.outputs.enabled == 'true'
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Setup Java
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Restore node_modules cache
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: ${{ needs.install.outputs.cache_key }}
+
+      - name: Install Playwright chromium
+        if: steps.gate.outputs.enabled == 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Build function codebases
+        if: steps.gate.outputs.enabled == 'true'
+        run: |
+          pnpm exec nx run functions:build
+          pnpm exec nx run functions-square:build
+          pnpm exec nx run functions-sync:build
+          pnpm exec nx run functions-calendar:build
+
+      - name: Create emulator .env
+        # Mirrors the Registration E2E job. No SQUARE_BASE_URL, so the Square
+        # SDK uses its built-in sandbox endpoint. The DEFAULT (M&S) Square
+        # client is never invoked by the MT flow, so its token can be a
+        # placeholder; MT_SQUARE_ACCESS_TOKEN gets the REAL MT sandbox token.
+        if: steps.gate.outputs.enabled == 'true'
+        run: |
+          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar; do
+            grep -v '^#' .env.dev | grep -v '^$' > "$dir/.env"
+          done
+
+          echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions/.env
+          printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\nTALLY_WEBHOOK_SECRET=test-tally-secret\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions/.secret.local
+
+          echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions-square/.env
+          printf "SQUARE_ACCESS_TOKEN=unused-mock-token\nMT_SQUARE_ACCESS_TOKEN=%s\nSQUARE_WEBHOOK_SIGNATURE_KEY=mock-key\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" "$MT_SQUARE_SANDBOX_ACCESS_TOKEN" > dist/apps/functions-square/.secret.local
+
+          echo "WEBFLOW_BASE_URL=http://localhost:9996" >> dist/apps/functions-sync/.env
+          echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions-sync/.env
+          echo "ETSY_TOKEN_URL=http://localhost:9998/v3/public/oauth/token" >> dist/apps/functions-sync/.env
+          printf "WEBFLOW_API_TOKEN=mock-token\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions-sync/.secret.local
+
+          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar; do
+            EXISTING=$(grep '^ALLOWED_ORIGINS=' "$dir/.env" | head -1 | cut -d= -f2-)
+            echo "ALLOWED_ORIGINS=$EXISTING,http://127.0.0.1:4173,http://localhost:4173" >> "$dir/.env"
+          done
+
+      - name: Start mock servers (Webflow + Etsy)
+        # Square is intentionally NOT mocked — the spec charges MT's real Square
+        # sandbox. Webflow + Etsy have no usable sandbox so keep the mocks.
+        if: steps.gate.outputs.enabled == 'true'
+        run: |
+          npx tsx --version
+          WEBFLOW_MOCK_SERVER_PORT=9996 npx tsx libs/firebase/webflow-test-mock-server/start.ts &
+          echo "WEBFLOW_MOCK_PID=$!" >> $GITHUB_ENV
+          ETSY_MOCK_SERVER_PORT=9998 npx tsx libs/firebase/etsy-test-mock-server/start.ts &
+          echo "ETSY_MOCK_PID=$!" >> $GITHUB_ENV
+          sleep 2
+
+      - name: Run Playwright against emulator
+        # The harness Vite build gets MT's public Square app/location IDs from
+        # .env.dev; the spec gets MT's token + location + env so it can read the
+        # payment back from MT's sandbox and assert correct account routing.
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          MT_SQUARE_ACCESS_TOKEN: ${{ secrets.MT_SQUARE_SANDBOX_ACCESS_TOKEN }}
+        run: |
+          export VITE_MT_SQUARE_APPLICATION_ID=$(grep '^MT_SQUARE_APPLICATION_ID=' .env.dev | cut -d= -f2-)
+          export VITE_MT_SQUARE_LOCATION_ID=$(grep '^MT_SQUARE_LOCATION_ID=' .env.dev | cut -d= -f2-)
+          export MT_SQUARE_LOCATION_ID=$(grep '^MT_SQUARE_LOCATION_ID=' .env.dev | cut -d= -f2-)
+          export MT_SQUARE_ENV=$(grep '^MT_SQUARE_ENV=' .env.dev | cut -d= -f2-)
+
+          npx firebase emulators:exec --project=dev --only auth,firestore,functions \
+            "pnpm exec nx run music-together-e2e:e2e"
+
+      - name: Stop mock servers
+        if: always() && steps.gate.outputs.enabled == 'true'
+        run: |
+          kill "$WEBFLOW_MOCK_PID" 2>/dev/null || true
+          kill "$ETSY_MOCK_PID" 2>/dev/null || true
+
+      - name: Locate Playwright report paths
+        if: failure() && steps.gate.outputs.enabled == 'true'
+        run: |
+          find . -type d \( -name 'playwright-report' -o -name 'test-results' \) \
+            -not -path '*/node_modules/*' -not -path '*/.next/*' \
+            -print
+
+      - name: Upload Playwright artifacts on failure
+        if: failure() && steps.gate.outputs.enabled == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-music-together-e2e
+          path: |
+            **/playwright-report/**
+            **/test-results/**
+          if-no-files-found: ignore
+          retention-days: 7
+
   storybook:
     name: Storybook Build & Tests
     needs: [install]

--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -489,6 +489,11 @@ jobs:
         run: |
           export VITE_SQUARE_APPLICATION_ID=$(grep '^SQUARE_APPLICATION_ID=' .env.dev | cut -d= -f2-)
           export VITE_SQUARE_LOCATION_ID=$(grep '^SQUARE_LOCATION_ID=' .env.dev | cut -d= -f2-)
+          # Music Together uses a SEPARATE Square account. The same harness
+          # serves the MT widget (?mtSectionId=) for the mt_e2e_dev gate, so
+          # bake MT's public sandbox IDs into the bundle too.
+          export VITE_MT_SQUARE_APPLICATION_ID=$(grep '^MT_SQUARE_APPLICATION_ID=' .env.dev | cut -d= -f2-)
+          export VITE_MT_SQUARE_LOCATION_ID=$(grep '^MT_SQUARE_LOCATION_ID=' .env.dev | cut -d= -f2-)
           pnpm exec nx build registration-test-harness
 
       - name: Ensure Hosting site exists
@@ -692,6 +697,79 @@ jobs:
             apps/registration-e2e/test-results/
           retention-days: 7
 
+  mt_e2e_dev:
+    # Gate: run the Music Together enrollment E2E against the deployed dev
+    # backend + deployed harness (same site as the class E2E, mounts the MT
+    # widget via ?mtSectionId=). Deployed dev already carries MT's sandbox
+    # Square creds in Secret Manager, so money routes to MT's real sandbox
+    # account here — no extra GitHub secret needed. Any failure blocks prod.
+    needs: [prepare_and_build, deploy_functions_dev, deploy_harness_dev]
+    if: >-
+      always() &&
+      (needs.deploy_functions_dev.result == 'success' || needs.deploy_functions_dev.result == 'skipped') &&
+      needs.deploy_harness_dev.result == 'success' &&
+      (needs.prepare_and_build.outputs.has_changes == 'true' ||
+        needs.prepare_and_build.outputs.webflow_components_affected == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Authenticate to Google Cloud (Dev)
+        # Needed so globalSetup's Admin SDK seed can write the MT section to
+        # dev's Firestore via Application Default Credentials.
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/1062803455357/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
+          service_account: 'github-deployer@maple-and-spruce-dev.iam.gserviceaccount.com'
+          create_credentials_file: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          # Pinned to 22.22.3 for the same node-fetch keep-alive reason as
+          # e2e_dev (the Admin SDK dev-Firestore seed).
+          node-version: '22.22.3'
+          cache: 'pnpm'
+
+      - name: Restore node_modules cache
+        id: restore-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: ${{ needs.prepare_and_build.outputs.cache_key }}
+
+      - name: Install dependencies (fallback)
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run Music Together E2E against dev
+        env:
+          E2E_TARGET: dev
+          HARNESS_BASE_URL: https://maple-spruce-registration-test.web.app
+          GOOGLE_CLOUD_PROJECT: maple-and-spruce-dev
+        run: pnpm exec nx run music-together-e2e:e2e
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-mt-dev
+          path: |
+            apps/music-together-e2e/playwright-report/
+            apps/music-together-e2e/test-results/
+          retention-days: 7
+
   approve_prod:
     # Phase 3 manual gate: every prod-side job depends on this, and this
     # job uses the `production` Environment which is configured (in repo
@@ -711,12 +789,20 @@ jobs:
     # frontend-only portal change can still reach this gate; a genuine E2E
     # *failure* (when functions did change) still blocks. `always()` is
     # required because a skipped `needs` would otherwise skip this job too.
-    needs: [prepare_and_build, e2e_dev, deploy_vercel_dev]
+    #
+    # mt_e2e_dev mirrors e2e_dev (Music Together enrollment) and gates prod the
+    # same way: it must pass, or be skipped for the same web-app-only reason.
+    needs: [prepare_and_build, e2e_dev, mt_e2e_dev, deploy_vercel_dev]
     if: >-
       always() &&
       needs.deploy_vercel_dev.result == 'success' &&
       (needs.e2e_dev.result == 'success' ||
         (needs.e2e_dev.result == 'skipped' &&
+          needs.prepare_and_build.outputs.has_changes != 'true' &&
+          needs.prepare_and_build.outputs.webflow_components_affected != 'true' &&
+          needs.prepare_and_build.outputs.web_app_affected == 'true')) &&
+      (needs.mt_e2e_dev.result == 'success' ||
+        (needs.mt_e2e_dev.result == 'skipped' &&
           needs.prepare_and_build.outputs.has_changes != 'true' &&
           needs.prepare_and_build.outputs.webflow_components_affected != 'true' &&
           needs.prepare_and_build.outputs.web_app_affected == 'true'))

--- a/apps/music-together-e2e/playwright.config.ts
+++ b/apps/music-together-e2e/playwright.config.ts
@@ -1,0 +1,88 @@
+import { defineConfig, devices } from '@playwright/test';
+import { workspaceRoot } from '@nx/devkit';
+
+/**
+ * Music Together enrollment E2E config — the higher-layer counterpart to the
+ * MT cloud-function integration suite. Drives the production
+ * `MusicTogetherRegistrationWidget` (mounted in the shared
+ * registration-test-harness via `?mtSectionId=`) end-to-end: family form →
+ * MT Square sandbox tokenize → `createMusicTogetherRegistration` (routing to
+ * MT's SEPARATE Square account) → confirmed registration.
+ *
+ * Mirrors apps/registration-e2e; two targets picked by `E2E_TARGET`:
+ *
+ * - `emulator` (default) — PR check: harness on a local Vite server, callables
+ *   on the local Firebase emulator with the PR's own code, real MT Square
+ *   sandbox, HTTP mock servers for Webflow + Etsy. Boots the harness via the
+ *   `webServer` block. Pair with `firebase emulators:exec`
+ *   (see `tools/run-music-together-e2e.sh`).
+ *
+ * - `dev` — post-merge gate: harness on the deployed Firebase Hosting site
+ *   `maple-spruce-registration-test` (same site serves both widgets), callables
+ *   on deployed `maple-and-spruce-dev`, real MT Square sandbox, real Webflow +
+ *   Etsy dev integrations. No `webServer`; baseURL points at the deployed
+ *   harness URL. Seed runs against real Firestore via Admin SDK (ADC).
+ */
+const target = process.env['E2E_TARGET'] ?? 'emulator';
+const offset = Number.parseInt(process.env['EMULATOR_PORT_OFFSET'] ?? '0', 10);
+const harnessPort = 4173 + offset;
+
+const DEFAULT_DEV_HARNESS_URL =
+  'https://maple-spruce-registration-test.web.app';
+
+const baseURL =
+  process.env['HARNESS_BASE_URL'] ??
+  (target === 'dev'
+    ? DEFAULT_DEV_HARNESS_URL
+    : // `localhost` (not `127.0.0.1`) — Square's Web Payments SDK allows
+      // localhost as a secure-context exception but rejects raw IPs.
+      `http://localhost:${harnessPort}`);
+
+export default defineConfig({
+  testDir: './src',
+  testMatch: '**/*.spec.ts',
+  retries: process.env['CI'] ? 1 : 0,
+  // One worker keeps the seeded section deterministic — the family cap and
+  // "spots remaining" assertions would race with parallel workers on a
+  // shared backend.
+  workers: 1,
+  reporter: process.env['CI']
+    ? [['html', { open: 'never' }], ['list']]
+    : 'list',
+  globalSetup: require.resolve('./src/global-setup.ts'),
+  globalTeardown: require.resolve('./src/global-teardown.ts'),
+  timeout: target === 'dev' ? 60_000 : 30_000,
+  expect: { timeout: target === 'dev' ? 15_000 : 5_000 },
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    video: 'retain-on-failure',
+  },
+  ...(target === 'emulator' && {
+    webServer: {
+      // Spawn Vite directly (not via `nx run …:serve`) so the @nx/playwright
+      // plugin doesn't treat the harness as a build-time `dependsOn`.
+      command: 'npx vite',
+      url: baseURL,
+      reuseExistingServer: !process.env['CI'],
+      cwd: `${workspaceRoot}/apps/registration-test-harness`,
+      timeout: 120_000,
+      env: {
+        EMULATOR_PORT_OFFSET: String(offset),
+        // Forward MT's Square sandbox IDs into the Vite build so the widget
+        // tokenizes against MT's account. Exported by the CI job (and the
+        // local run script) from .env.dev.
+        VITE_MT_SQUARE_APPLICATION_ID:
+          process.env['VITE_MT_SQUARE_APPLICATION_ID'] ?? '',
+        VITE_MT_SQUARE_LOCATION_ID:
+          process.env['VITE_MT_SQUARE_LOCATION_ID'] ?? '',
+      },
+    },
+  }),
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/apps/music-together-e2e/project.json
+++ b/apps/music-together-e2e/project.json
@@ -1,0 +1,27 @@
+{
+  "name": "music-together-e2e",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/music-together-e2e/src",
+  "projectType": "application",
+  "tags": ["scope:webflow", "type:e2e"],
+  "implicitDependencies": ["firebase-integration-test-utils"],
+  "targets": {
+    "e2e": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "apps/music-together-e2e",
+        "command": "playwright test"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "apps/music-together-e2e",
+        "command": "eslint ."
+      },
+      "metadata": {
+        "technologies": ["eslint"]
+      }
+    }
+  }
+}

--- a/apps/music-together-e2e/src/global-setup.ts
+++ b/apps/music-together-e2e/src/global-setup.ts
@@ -1,0 +1,55 @@
+/**
+ * Playwright globalSetup: seed the Music Together section the enrollment E2E
+ * registers against.
+ *
+ * Two modes, picked by `E2E_TARGET`:
+ * - default / `emulator` — full wipe + reseed the local Firestore emulator via
+ *   REST (fast and isolated).
+ * - `dev` — seed the deployed `maple-and-spruce-dev` project via the Admin SDK
+ *   (idempotent; writes a per-run doc ID without wiping the collection).
+ *
+ * The section doc gets a UUID-suffixed ID per run so concurrent runs (and the
+ * post-run teardown) can attribute registrations to the right suite. The ID is
+ * published via `process.env.TEST_MT_SECTION_ID` for the spec + teardown.
+ */
+import { randomUUID } from 'node:crypto';
+
+import {
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  PUBLISHED_MT_SECTION,
+} from '@maple/firebase/integration-test-utils';
+
+import { seedDev } from './seed-dev';
+
+async function seedEmulator(sectionId: string): Promise<void> {
+  await clearFirestoreEmulator();
+  await setFirestoreDoc(
+    'musicTogetherSections',
+    sectionId,
+    PUBLISHED_MT_SECTION
+  );
+}
+
+async function globalSetup(): Promise<void> {
+  const target = process.env['E2E_TARGET'] ?? 'emulator';
+  const sectionId = `test-mt-section-${randomUUID()}`;
+
+  // process.env mutations in globalSetup propagate to spawned Playwright
+  // workers (Playwright forwards parent env at spawn time).
+  process.env['TEST_MT_SECTION_ID'] = sectionId;
+
+  console.log(
+    `[mt-e2e] Seeding MT section for target=${target}, sectionId=${sectionId}…`
+  );
+
+  if (target === 'dev') {
+    await seedDev(sectionId);
+  } else {
+    await seedEmulator(sectionId);
+  }
+
+  console.log(`[mt-e2e] Seeded MT section=${sectionId}`);
+}
+
+export default globalSetup;

--- a/apps/music-together-e2e/src/global-teardown.ts
+++ b/apps/music-together-e2e/src/global-teardown.ts
@@ -1,0 +1,39 @@
+/**
+ * Playwright globalTeardown: clean up seeded MT test data after the run.
+ *
+ * Emulator mode: nothing to do — the emulator exits with the job, taking all
+ * Firestore state with it.
+ *
+ * Dev mode: delete the seeded section + any registrations + scheduled charges
+ * the Pay-flow specs created against it. Without this, every run accumulates
+ * real Firestore docs and MT Square sandbox orders.
+ *
+ * Idempotent — runs even if globalSetup failed half-way. The section ID is read
+ * from process.env.TEST_MT_SECTION_ID; if unset (setup never ran), no-ops.
+ */
+import { teardownDev } from './seed-dev';
+
+async function globalTeardown(): Promise<void> {
+  const target = process.env['E2E_TARGET'] ?? 'emulator';
+  const sectionId = process.env['TEST_MT_SECTION_ID'];
+
+  if (target !== 'dev') {
+    return;
+  }
+
+  if (!sectionId) {
+    console.warn('[mt-e2e] No TEST_MT_SECTION_ID in env — skipping dev teardown');
+    return;
+  }
+
+  console.log(`[mt-e2e] Tearing down dev fixtures for sectionId=${sectionId}…`);
+  try {
+    await teardownDev(sectionId);
+  } catch (err) {
+    // Don't fail the whole job on a teardown hiccup — the test result is the
+    // signal. Surface the error so it's visible in the log.
+    console.error('[mt-e2e] teardown failed (continuing):', err);
+  }
+}
+
+export default globalTeardown;

--- a/apps/music-together-e2e/src/music-together.spec.ts
+++ b/apps/music-together-e2e/src/music-together.spec.ts
@@ -1,0 +1,440 @@
+/**
+ * Music Together enrollment FE→BE E2E.
+ *
+ * Drives the production `MusicTogetherRegistrationWidget` (mounted in the
+ * shared registration-test-harness via `?mtSectionId=`). The same specs cover
+ * two targets, picked by `E2E_TARGET`:
+ *   - emulator (default) — PR check: local Vite harness + local Firebase
+ *     emulator (PR's code) + real MT Square sandbox + HTTP mock servers for
+ *     Webflow / Etsy.
+ *   - dev               — post-merge gate: deployed harness + deployed
+ *     maple-and-spruce-dev + real MT Square sandbox + real Webflow / Etsy.
+ *
+ * Why this suite exists (beyond the MT cloud-function integration suite):
+ * - The integration suite mocks MT Square via SQUARE_BASE_URL and calls the
+ *   callable directly. It can't see the browser widget's arg-shape contract,
+ *   the sibling-discount price the widget renders, or the real Square Web
+ *   Payments tokenize → createMusicTogetherRegistration flow.
+ * - This is the highest-stakes MT flow: a family's money must route to MT's
+ *   SEPARATE Square account (MT_SQUARE_KEYS), never Maple & Spruce's. A nonce
+ *   tokenized against MT's sandbox app can ONLY be charged by MT's account —
+ *   so a green pay-in-full is itself proof of correct multi-account routing.
+ *   The `assertPaymentRoutedToMt` helper makes that explicit by reading the
+ *   payment back from MT's sandbox and checking its location_id.
+ *
+ * The section is seeded per-run (UUID) in global-setup and its ID flows through
+ * process.env.TEST_MT_SECTION_ID.
+ */
+import { test, expect, Page, FrameLocator } from '@playwright/test';
+import {
+  getFirestoreDoc,
+  listFirestoreDocs,
+} from '@maple/firebase/integration-test-utils';
+
+const SECTION_ID = process.env['TEST_MT_SECTION_ID'];
+if (!SECTION_ID) {
+  throw new Error(
+    'TEST_MT_SECTION_ID missing — globalSetup must run before specs to seed the per-run MT section doc ID.'
+  );
+}
+
+const TARGET = process.env['E2E_TARGET'] ?? 'emulator';
+const IS_EMULATOR = TARGET !== 'dev';
+
+// PUBLISHED_MT_SECTION.priceFullCents = 25200 ($252). Sibling discount: 2
+// children → 1.5× = $378.00. Installment 1 = $132.00.
+const PRICE_FULL_1_CHILD = '$252.00';
+const PRICE_FULL_2_CHILDREN = '$378.00';
+const INSTALLMENT_1 = '$132.00';
+
+// Square sandbox test card (approved). Shared across accounts — the SDK binds
+// the nonce to whatever application ID the widget was built with (MT's).
+const SANDBOX_CARD_SUCCESS = '4111 1111 1111 1111';
+const SANDBOX_EXP = '12/30';
+const SANDBOX_CVV = '111';
+const SANDBOX_ZIP = '26554';
+
+interface FamilyChild {
+  name: string;
+  dob: string;
+}
+
+async function openWidget(page: Page): Promise<void> {
+  await page.goto(`/?mtSectionId=${SECTION_ID}`);
+  // The "Pay in full" tuition option only renders once
+  // getPublicMusicTogetherSection resolved AND the section is enrollment-open
+  // with spots remaining. Its presence proves the load round-trip succeeded.
+  // Match by role (regex, dash-agnostic) to survive typography churn.
+  await expect(
+    page.getByRole('radio', { name: /Pay in full/ })
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+test('loads the section and shows the pay-in-full tuition from the backend', async ({
+  page,
+}) => {
+  await openWidget(page);
+  await expect(
+    page.getByRole('heading', { name: /Register/ })
+  ).toBeVisible();
+  await expect(page.getByText(/family spots remaining/)).toBeVisible();
+  // 1 child (default) → un-discounted base price on the tuition option.
+  await expect(
+    page.getByRole('radio', { name: /\$252\.00/ })
+  ).toBeVisible();
+});
+
+test.describe('Enrollment pay flow', () => {
+  test.setTimeout(120_000);
+
+  test('pay-in-full (1 child) routes money to MT and confirms the registration', async ({
+    page,
+  }) => {
+    await openWidget(page);
+
+    const email = `mt-e2e-full+${Date.now()}@maplespruce.test`;
+    await fillFamily(page, {
+      adultFirstName: 'Jamie',
+      adultLastName: 'Rivera',
+      children: [{ name: 'Sky', dob: '2023-04-01' }],
+      email,
+      phone: '304-555-1212',
+      address: '123 Spruce St, Morgantown, WV 26505',
+      plan: 'full',
+    });
+
+    // With 1 child the pay button reflects the un-discounted full price.
+    const payButton = page.getByRole('button', { name: /Register/ });
+    await fillSquareCard(page, payButton, {
+      number: SANDBOX_CARD_SUCCESS,
+      exp: SANDBOX_EXP,
+      cvv: SANDBOX_CVV,
+      zip: SANDBOX_ZIP,
+    });
+    await expect(payButton).toHaveText(/\$252\.00/);
+    await payButton.click();
+
+    // Confirmed view: proves tokenize (MT app) → createMusicTogetherRegistration
+    // (MT account) → Square charge → Firestore write → widget transition.
+    await expect(page.getByText(/You're registered/i)).toBeVisible({
+      timeout: 60_000,
+    });
+    await expect(page.getByText(`${PRICE_FULL_1_CHILD} paid today`)).toBeVisible();
+    // Pay-in-full has no scheduled installments, so no card-on-file notice.
+    await expect(
+      page.getByText(/automatically charged/i)
+    ).toHaveCount(0);
+
+    if (IS_EMULATOR) {
+      const reg = await findConfirmedRegistration(email);
+      expect(reg.pricePaidCents).toBe(25200);
+      expect(reg.scheduledChargeCount).toBe(0);
+      expect(String(reg.squareReceiptUrl)).toMatch(/^http/);
+      await assertPaymentRoutedToMt(String(reg.squarePaymentId));
+    }
+  });
+
+  test('sibling discount: 2 children pay-in-full is charged the backend-authoritative $378', async ({
+    page,
+  }) => {
+    await openWidget(page);
+
+    const email = `mt-e2e-sibling+${Date.now()}@maplespruce.test`;
+    await fillFamily(page, {
+      adultFirstName: 'Morgan',
+      adultLastName: 'Lee',
+      children: [
+        { name: 'Robin', dob: '2022-02-02' },
+        { name: 'Wren', dob: '2024-03-03' },
+      ],
+      email,
+      phone: '304-555-3434',
+      address: '77 Maple Ave, Morgantown, WV 26505',
+      plan: 'full',
+    });
+
+    // Two children → 1.5× sibling multiplier → $378.00 shown on the tuition
+    // option AND the pay button (both come from computeMusicTogetherFamilyPrice).
+    await expect(
+      page.getByRole('radio', { name: /\$378\.00/ })
+    ).toBeVisible();
+    const payButton = page.getByRole('button', { name: /Register/ });
+    await fillSquareCard(page, payButton, {
+      number: SANDBOX_CARD_SUCCESS,
+      exp: SANDBOX_EXP,
+      cvv: SANDBOX_CVV,
+      zip: SANDBOX_ZIP,
+    });
+    await expect(payButton).toHaveText(/\$378\.00/);
+    await payButton.click();
+
+    await expect(page.getByText(/You're registered/i)).toBeVisible({
+      timeout: 60_000,
+    });
+    await expect(page.getByText(`${PRICE_FULL_2_CHILDREN} paid today`)).toBeVisible();
+
+    if (IS_EMULATOR) {
+      const reg = await findConfirmedRegistration(email);
+      // Backend-authoritative: $252 base × 1.5 (2 kids) = $378 = 37800¢.
+      expect(reg.pricePaidCents).toBe(37800);
+      await assertPaymentRoutedToMt(String(reg.squarePaymentId));
+    }
+  });
+
+  test('two-installment plan vaults a card and materializes the Week-5 scheduled charge', async ({
+    page,
+  }) => {
+    await openWidget(page);
+
+    const email = `mt-e2e-installments+${Date.now()}@maplespruce.test`;
+    await fillFamily(page, {
+      adultFirstName: 'Casey',
+      adultLastName: 'Nguyen',
+      children: [{ name: 'Juniper', dob: '2023-06-15' }],
+      email,
+      phone: '304-555-5656',
+      address: '9 Birch Ln, Morgantown, WV 26505',
+      plan: 'installments',
+    });
+
+    const payButton = page.getByRole('button', { name: /Register/ });
+    await fillSquareCard(page, payButton, {
+      number: SANDBOX_CARD_SUCCESS,
+      exp: SANDBOX_EXP,
+      cvv: SANDBOX_CVV,
+      zip: SANDBOX_ZIP,
+    });
+    // Installments charge only the first installment today ($132.00).
+    await expect(payButton).toHaveText(/\$132\.00/);
+    await payButton.click();
+
+    await expect(page.getByText(/You're registered/i)).toBeVisible({
+      timeout: 60_000,
+    });
+    await expect(page.getByText(`${INSTALLMENT_1} paid today`)).toBeVisible();
+    // The card-on-file notice confirms a card was vaulted + a future charge set.
+    await expect(page.getByText(/automatically charged/i)).toBeVisible();
+
+    if (IS_EMULATOR) {
+      const reg = await findConfirmedRegistration(email);
+      expect(reg.pricePaidCents).toBe(13200);
+      expect(reg.scheduledChargeCount).toBe(1);
+      expect(String(reg.squareCustomerId)).toMatch(/.+/);
+      expect(String(reg.squareCardId)).toMatch(/.+/);
+      await assertPaymentRoutedToMt(String(reg.squarePaymentId));
+
+      // A scheduled card-on-file charge row was materialized for installment 2.
+      const charges = (
+        await listFirestoreDocs('musicTogetherScheduledCharges')
+      )
+        .map((c) => c.data as Record<string, unknown>)
+        .filter((c) => c['registrationId'] === reg.id);
+      expect(charges).toHaveLength(1);
+      expect(charges[0]['status']).toBe('scheduled');
+      expect(charges[0]['amountCents']).toBe(13200);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Form driving
+// ---------------------------------------------------------------------------
+
+async function fillFamily(
+  page: Page,
+  opts: {
+    adultFirstName: string;
+    adultLastName: string;
+    children: FamilyChild[];
+    email: string;
+    phone: string;
+    address: string;
+    plan: 'full' | 'installments';
+  }
+): Promise<void> {
+  // Anchored regexes: MUI appends " *" to required labels, so exact-string
+  // matching fails; and a bare "First name" substring would also match
+  // "Child's first name". `^First name` matches only the adult field.
+  await page.getByLabel(/^First name/).fill(opts.adultFirstName);
+  await page.getByLabel(/^Last name/).fill(opts.adultLastName);
+
+  // Add child rows as needed (one row is present by default).
+  for (let i = 1; i < opts.children.length; i++) {
+    await page.getByRole('button', { name: /Add another child/ }).click();
+  }
+  const nameInputs = page.getByLabel(/Child's first name/);
+  const dobInputs = page.getByLabel(/Date of birth/);
+  for (let i = 0; i < opts.children.length; i++) {
+    await nameInputs.nth(i).fill(opts.children[i].name);
+    await dobInputs.nth(i).fill(opts.children[i].dob);
+  }
+
+  await page.getByLabel(/^Email/).fill(opts.email);
+  await page.getByLabel(/^Phone/).fill(opts.phone);
+  await page.getByLabel(/Full mailing address/).fill(opts.address);
+
+  if (opts.plan === 'installments') {
+    await page.getByRole('radio', { name: /Two installments/ }).check();
+  }
+
+  // Consent checkboxes: [0] policies, [1] privacy, [2] card-on-file (only when
+  // the installment plan is selected). Order is stable in the widget markup.
+  const checkboxes = page.getByRole('checkbox');
+  await checkboxes.nth(0).check(); // policies
+  await checkboxes.nth(1).check(); // privacy
+  if (opts.plan === 'installments') {
+    await checkboxes.nth(2).check(); // card-on-file authorization
+  }
+}
+
+/**
+ * Drive Square's Web Payments SDK card form, then wait for the given pay button
+ * to enable. Identical strategy to the class registration E2E: wait for the
+ * button to enable (proves the SDK loaded + form is valid), then fill whichever
+ * iframe input is present. Selectors use HTML autocomplete attributes — stable
+ * across Square SDK minor versions.
+ */
+async function fillSquareCard(
+  page: Page,
+  payButton: ReturnType<Page['getByRole']>,
+  card: { number: string; exp: string; cvv: string; zip: string }
+): Promise<void> {
+  const alert = page.getByRole('alert');
+  try {
+    await expect(payButton).toBeEnabled({ timeout: 45_000 });
+  } catch (err) {
+    const original = err instanceof Error ? err.message : String(err);
+    const alertText = (await alert.count())
+      ? await alert.allInnerTexts()
+      : ['(no alert visible)'];
+    const bodyText = await page
+      .locator('body')
+      .innerText()
+      .catch(
+        (readErr: unknown) =>
+          `(could not read body: ${readErr instanceof Error ? readErr.message : String(readErr)})`
+      );
+    throw new Error(
+      `Pay button never enabled — SDK failed to init or the family form is invalid.\nOriginal: ${original}\nAlerts: ${JSON.stringify(alertText)}\nPage text (first 600 chars):\n${bodyText.slice(0, 600)}`
+    );
+  }
+
+  const iframeNames = await page
+    .locator('#square-card-container iframe')
+    .evaluateAll((els) =>
+      (els as HTMLIFrameElement[]).map((el) => el.getAttribute('name') ?? '')
+    );
+
+  const fillers: Array<[selector: string, value: string]> = [
+    ['input[autocomplete="cc-number"]', card.number],
+    ['input[autocomplete="cc-exp"]', card.exp],
+    ['input[autocomplete="cc-csc"]', card.cvv],
+    ['input[autocomplete="postal-code"]', card.zip],
+  ];
+  const filled = await fillCardFields(page, iframeNames, fillers);
+
+  if (filled.size < fillers.length) {
+    const missing = fillers
+      .filter(([sel]) => !filled.has(sel))
+      .map(([sel]) => sel);
+    throw new Error(
+      `fillSquareCard: did not find input selectors ${JSON.stringify(missing)} in any iframe (saw frames=${JSON.stringify(iframeNames)})`
+    );
+  }
+}
+
+/** Fill each card field into whichever Square iframe contains it. */
+async function fillCardFields(
+  page: Page,
+  iframeNames: string[],
+  fillers: Array<[selector: string, value: string]>
+): Promise<Set<string>> {
+  const filled = new Set<string>();
+  for (const name of iframeNames) {
+    if (!name) continue;
+    const frame: FrameLocator = page.frameLocator(`iframe[name="${name}"]`);
+    for (const [selector, value] of fillers) {
+      if (filled.has(selector)) continue;
+      const input = frame.locator(selector);
+      if ((await input.count()) > 0) {
+        await input.fill(value);
+        filled.add(selector);
+      }
+    }
+  }
+  return filled;
+}
+
+// ---------------------------------------------------------------------------
+// Backend assertions (emulator target only)
+// ---------------------------------------------------------------------------
+
+/** Find the confirmed MT registration this run created, matched by email. */
+async function findConfirmedRegistration(
+  email: string
+): Promise<Record<string, unknown> & { id: string }> {
+  const docs = await listFirestoreDocs('musicTogetherRegistrations');
+  const match = docs.find(
+    (d) =>
+      (d.data as { email?: string }).email === email &&
+      (d.data as { status?: string }).status === 'confirmed'
+  );
+  if (!match) {
+    throw new Error(
+      `No confirmed musicTogetherRegistrations doc for ${email} (found ${docs.length} docs)`
+    );
+  }
+  // Re-read the single doc so the shape matches getFirestoreDoc parsing.
+  const reg = await getFirestoreDoc('musicTogetherRegistrations', match.id);
+  return { ...(reg ?? match.data), id: match.id };
+}
+
+/**
+ * Assert the payment landed in MT's SEPARATE Square account, not Maple &
+ * Spruce's — the core multi-account-routing guarantee. Reads the payment back
+ * from MT's sandbox and checks its `location_id` equals MT's location.
+ *
+ * Guarded by the presence of MT_SQUARE_ACCESS_TOKEN + MT_SQUARE_LOCATION_ID in
+ * the runner env (set by CI). When absent (e.g. a local run without MT sandbox
+ * creds) the assertion is skipped with a note — the successful charge of an
+ * MT-app-tokenized nonce is already strong routing evidence on its own.
+ */
+async function assertPaymentRoutedToMt(paymentId: string): Promise<void> {
+  const token = process.env['MT_SQUARE_ACCESS_TOKEN'];
+  const expectedLocation = process.env['MT_SQUARE_LOCATION_ID'];
+  if (!token || !expectedLocation) {
+    console.warn(
+      '[mt-e2e] Skipping MT-routing assertion — MT_SQUARE_ACCESS_TOKEN / MT_SQUARE_LOCATION_ID not in env. A successful charge of an MT-app nonce already implies MT routing.'
+    );
+    return;
+  }
+  expect(paymentId, 'registration is missing a Square payment id').toMatch(
+    /.+/
+  );
+
+  const isProd =
+    (process.env['MT_SQUARE_ENV'] ?? 'LOCAL').toUpperCase() === 'PROD';
+  const base = isProd
+    ? 'https://connect.squareup.com'
+    : 'https://connect.squareupsandbox.com';
+
+  const res = await fetch(`${base}/v2/payments/${paymentId}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Square-Version': '2024-01-18',
+      'Content-Type': 'application/json',
+    },
+  });
+  expect(
+    res.ok,
+    `MT Square payments.get failed (${res.status}) — payment ${paymentId} not found in MT's account, which would mean money routed to the wrong Square account`
+  ).toBe(true);
+
+  const body = (await res.json()) as {
+    payment?: { location_id?: string };
+  };
+  expect(
+    body.payment?.location_id,
+    'payment landed in the wrong Square location — routing did not use MT_SQUARE_KEYS'
+  ).toBe(expectedLocation);
+}

--- a/apps/music-together-e2e/src/seed-dev.ts
+++ b/apps/music-together-e2e/src/seed-dev.ts
@@ -1,0 +1,102 @@
+/**
+ * Seed / tear down the deployed dev Firestore for the MT enrollment E2E.
+ *
+ * Used when E2E_TARGET=dev. Talks to the real `maple-and-spruce-dev` Firestore
+ * via Application Default Credentials (GOOGLE_APPLICATION_CREDENTIALS in CI via
+ * google-github-actions/auth, or `gcloud auth application-default login`
+ * locally).
+ *
+ * The section doc ID is unique per run (generated in globalSetup) so concurrent
+ * CI runs can't collide and the registrations + scheduled charges created
+ * during the suite can be cleanly attributed and deleted afterward.
+ */
+import { initializeApp, getApps } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+import { PUBLISHED_MT_SECTION } from '@maple/firebase/integration-test-utils';
+
+const DEV_PROJECT_ID = 'maple-and-spruce-dev';
+
+function getAdminDb() {
+  if (getApps().length === 0) {
+    initializeApp({ projectId: DEV_PROJECT_ID });
+  }
+  return getFirestore();
+}
+
+/**
+ * Retry a Firestore operation on transient connection failures. In CI the
+ * Admin SDK gets credentials keylessly (Workload Identity Federation); the
+ * first STS token exchange intermittently drops with "Premature close" — a
+ * connection blip, not an auth/quota error. Mirrors registration-e2e/seed-dev.
+ */
+async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  const MAX_ATTEMPTS = 4;
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      const msg = err instanceof Error ? err.message : String(err);
+      const transient =
+        /Premature close|metadata from plugin|sts\.googleapis\.com|ECONNRESET|ETIMEDOUT|EAI_AGAIN|socket hang up|fetch failed|UNAVAILABLE|DEADLINE_EXCEEDED|Getting metadata|503|429/i.test(
+          msg
+        );
+      if (!transient || attempt === MAX_ATTEMPTS) break;
+      const delayMs = 1000 * 2 ** (attempt - 1); // 1s, 2s, 4s
+      console.warn(
+        `[mt-e2e] ${label} attempt ${attempt}/${MAX_ATTEMPTS} failed (${msg}); retrying in ${delayMs}ms`
+      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  throw lastErr;
+}
+
+export async function seedDev(sectionId: string): Promise<void> {
+  const db = getAdminDb();
+  await withRetry('seedDev', () =>
+    db.collection('musicTogetherSections').doc(sectionId).set(PUBLISHED_MT_SECTION)
+  );
+}
+
+/**
+ * Remove the seeded section plus any registrations + scheduled charges it
+ * accumulated during the run. Idempotent: missing docs are silently ignored.
+ *
+ * The registration + charge cleanup matters: the Pay-flow specs create real MT
+ * Square sandbox orders + Firestore docs. Without this they'd pile up in dev.
+ */
+export async function teardownDev(sectionId: string): Promise<void> {
+  const db = getAdminDb();
+
+  const regs = await withRetry('teardownDev:queryRegs', () =>
+    db
+      .collection('musicTogetherRegistrations')
+      .where('sectionId', '==', sectionId)
+      .get()
+  );
+  const regIds = regs.docs.map((d) => d.id);
+  await withRetry('teardownDev:deleteRegs', () =>
+    Promise.all(regs.docs.map((d) => d.ref.delete()))
+  );
+
+  // Scheduled charges are keyed by sectionId too — delete them directly.
+  const charges = await withRetry('teardownDev:queryCharges', () =>
+    db
+      .collection('musicTogetherScheduledCharges')
+      .where('sectionId', '==', sectionId)
+      .get()
+  );
+  await withRetry('teardownDev:deleteCharges', () =>
+    Promise.all(charges.docs.map((d) => d.ref.delete()))
+  );
+
+  await withRetry('teardownDev:deleteSection', () =>
+    db.collection('musicTogetherSections').doc(sectionId).delete()
+  );
+
+  console.log(
+    `[mt-e2e] teardownDev removed section=${sectionId}, registrations=${regIds.length}, charges=${charges.size}`
+  );
+}

--- a/apps/music-together-e2e/tsconfig.json
+++ b/apps/music-together-e2e/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "allowJs": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["playwright.config.ts", "src/**/*.ts"]
+}

--- a/apps/registration-test-harness/src/main.tsx
+++ b/apps/registration-test-harness/src/main.tsx
@@ -29,6 +29,8 @@ import { createRoot } from 'react-dom/client';
 // disabled inline here.
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { RegistrationWidget } from '../../webflow-components/src/RegistrationWidget';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { MusicTogetherRegistrationWidget } from '../../webflow-components/src/MusicTogetherRegistrationWidget';
 
 const targetEnv = import.meta.env['VITE_TARGET_ENV'] ?? 'emulator';
 
@@ -52,9 +54,74 @@ const port = Number.parseInt(
 const squareApplicationId = import.meta.env['VITE_SQUARE_APPLICATION_ID'];
 const squareLocationId = import.meta.env['VITE_SQUARE_LOCATION_ID'];
 
+// Music Together's SEPARATE Square account — bound to the MT widget so a card
+// tokenized here can only be charged by MT's account (see routing assertion in
+// the music-together-e2e spec).
+const mtSquareApplicationId = import.meta.env['VITE_MT_SQUARE_APPLICATION_ID'];
+const mtSquareLocationId = import.meta.env['VITE_MT_SQUARE_LOCATION_ID'];
+
+function HarnessBanner({ label }: { label: string }) {
+  // Small banner so a human visiting the deployed harness can tell which
+  // backend + widget it's pointing at.
+  return (
+    <div
+      data-testid="harness-banner"
+      style={{
+        padding: '4px 8px',
+        fontFamily: 'system-ui',
+        fontSize: 12,
+        background: targetEnv === 'dev' ? '#fff7c2' : '#e2e2e2',
+        borderBottom: '1px solid #ccc',
+      }}
+    >
+      {label} — backend: <strong>{targetEnv}</strong>
+    </div>
+  );
+}
+
+/**
+ * Music Together enrollment harness view. Selected by `?mtSectionId=<id>`.
+ * Mounts the production `MusicTogetherRegistrationWidget` with MT's own Square
+ * sandbox credentials so the enrollment E2E drives the real family checkout.
+ */
+function MusicTogetherApp({ sectionId }: { sectionId: string }) {
+  if (!mtSquareApplicationId || !mtSquareLocationId) {
+    return (
+      <div style={{ padding: 24, fontFamily: 'system-ui' }}>
+        <h2>Missing Music Together Square sandbox credentials</h2>
+        <p>
+          The harness build did not receive{' '}
+          <code>VITE_MT_SQUARE_APPLICATION_ID</code> /{' '}
+          <code>VITE_MT_SQUARE_LOCATION_ID</code>. Check the workflow that
+          built this bundle.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <HarnessBanner label="Music Together registration test harness" />
+      <MusicTogetherRegistrationWidget
+        sectionId={sectionId}
+        squareAppId={mtSquareApplicationId}
+        squareLocationId={mtSquareLocationId}
+        env={targetEnv}
+        policiesUrl="https://www.mapleandsprucefolkarts.com/music-together-policies"
+      />
+    </>
+  );
+}
+
 function App() {
   const params = new URLSearchParams(window.location.search);
+  const mtSectionId = params.get('mtSectionId') ?? '';
   const classId = params.get('classId') ?? '';
+
+  // Music Together enrollment flow takes precedence when its param is present.
+  if (mtSectionId) {
+    return <MusicTogetherApp sectionId={mtSectionId} />;
+  }
 
   if (!classId) {
     return (

--- a/apps/registration-test-harness/vite.config.ts
+++ b/apps/registration-test-harness/vite.config.ts
@@ -23,6 +23,12 @@ const functionsPort = 5001 + offset;
 const targetEnv = process.env['VITE_TARGET_ENV'] ?? 'emulator';
 const squareApplicationId = process.env['VITE_SQUARE_APPLICATION_ID'] ?? '';
 const squareLocationId = process.env['VITE_SQUARE_LOCATION_ID'] ?? '';
+// Music Together uses a SEPARATE Square account (Stephanie's LLC). When the
+// harness mounts the MT widget (`?mtSectionId=`), tokenization must bind to
+// MT's sandbox app so payment routes to MT's account, not Maple & Spruce's.
+const mtSquareApplicationId =
+  process.env['VITE_MT_SQUARE_APPLICATION_ID'] ?? '';
+const mtSquareLocationId = process.env['VITE_MT_SQUARE_LOCATION_ID'] ?? '';
 
 export default defineConfig({
   root: __dirname,
@@ -58,5 +64,9 @@ export default defineConfig({
       JSON.stringify(squareApplicationId),
     'import.meta.env.VITE_SQUARE_LOCATION_ID':
       JSON.stringify(squareLocationId),
+    'import.meta.env.VITE_MT_SQUARE_APPLICATION_ID':
+      JSON.stringify(mtSquareApplicationId),
+    'import.meta.env.VITE_MT_SQUARE_LOCATION_ID':
+      JSON.stringify(mtSquareLocationId),
   },
 });

--- a/libs/firebase/integration-test-utils/src/index.ts
+++ b/libs/firebase/integration-test-utils/src/index.ts
@@ -38,6 +38,11 @@ export {
   CLASS_IDS,
 } from './lib/fixtures/class.fixtures.js';
 export {
+  PUBLISHED_MT_SECTION,
+  MT_SECTION_PRICE_FULL_CENTS,
+  MT_SECTION_INSTALLMENT_CENTS,
+} from './lib/fixtures/music-together.fixtures.js';
+export {
   PERCENT_DISCOUNT,
   AMOUNT_DISCOUNT,
   AMOUNT_BEFORE_DATE_DISCOUNT,

--- a/libs/firebase/integration-test-utils/src/lib/fixtures/index.ts
+++ b/libs/firebase/integration-test-utils/src/lib/fixtures/index.ts
@@ -12,6 +12,11 @@ export {
   CLASS_IDS,
 } from './class.fixtures.js';
 export {
+  PUBLISHED_MT_SECTION,
+  MT_SECTION_PRICE_FULL_CENTS,
+  MT_SECTION_INSTALLMENT_CENTS,
+} from './music-together.fixtures.js';
+export {
   PERCENT_DISCOUNT,
   AMOUNT_DISCOUNT,
   AMOUNT_BEFORE_DATE_DISCOUNT,

--- a/libs/firebase/integration-test-utils/src/lib/fixtures/music-together.fixtures.ts
+++ b/libs/firebase/integration-test-utils/src/lib/fixtures/music-together.fixtures.ts
@@ -1,0 +1,54 @@
+/**
+ * Music Together section fixtures for the enrollment E2E.
+ *
+ * Written directly to Firestore via the emulator REST API (or the Admin SDK
+ * for the dev target), so dates are real `Date` objects — the firestore-helper
+ * serializes `Date` → Firestore timestamp, and the section repository parses
+ * them back to `Date`. Amounts are the MT program defaults ($252 full, two
+ * $132 installments) so the spec can assert concrete dollar labels the widget
+ * renders, including the per-child sibling discount (2 kids → $378).
+ *
+ * The section is deliberately `visible: true` + `enrollmentActive: true` with
+ * no scheduled open/close window, so `mtSectionEnrollmentOpen` resolves to
+ * `true` and the widget shows the registration form (not the "opens soon" or
+ * waitlist panels).
+ */
+
+/** A future date, `days` days from now. */
+function futureDate(days: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+/**
+ * Base tuition ($252.00). The sibling discount multiplies this: 1 child →
+ * $252.00, 2 children → $378.00, 3 children → $504.00. The spec asserts the
+ * 1-child and 2-child totals to lock in the backend-authoritative pricing.
+ */
+export const MT_SECTION_PRICE_FULL_CENTS = 25200;
+
+/** Per-installment base amount ($132.00) for the two-installment plan. */
+export const MT_SECTION_INSTALLMENT_CENTS = 13200;
+
+/**
+ * An open, enrolling Music Together section with a two-installment plan.
+ * Session 1 is ~7 days out; the second installment is due at ~week 5.
+ */
+export const PUBLISHED_MT_SECTION = {
+  name: 'E2E Spring — Tuesdays 10am',
+  description: 'End-to-end test section for Music Together enrollment.',
+  sessions: [{ dateTime: futureDate(7) }],
+  capacityFamilies: 8,
+  priceFullCents: MT_SECTION_PRICE_FULL_CENTS,
+  installmentPlan: [
+    { amountCents: MT_SECTION_INSTALLMENT_CENTS, dueAt: futureDate(7) },
+    { amountCents: MT_SECTION_INSTALLMENT_CENTS, dueAt: futureDate(35) },
+  ],
+  visible: true,
+  enrollmentActive: true,
+  location: 'Maple & Spruce Studio',
+  room: 'Main Room',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};

--- a/tools/run-music-together-e2e.sh
+++ b/tools/run-music-together-e2e.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# Run the Music Together enrollment FE→BE E2E against local Firebase emulators.
+#
+# Mirrors tools/run-registration-e2e.sh. Drives the MusicTogetherRegistrationWidget
+# (mounted in the shared registration-test-harness via ?mtSectionId=) against the
+# emulator, the harness Vite server, and MT's Square sandbox.
+#
+# Two Square modes, chosen automatically:
+#   - REAL MT sandbox — if MT_SQUARE_ACCESS_TOKEN is already exported in your
+#     shell (a real MT sandbox token). The function charges MT's real sandbox
+#     account and the spec's MT-routing assertion runs.
+#   - MOCK Square      — otherwise. A local Square mock server is started and the
+#     MT Square client is pointed at it via SQUARE_BASE_URL (token = mock-token).
+#     The full browser→function→confirmation flow still runs; only the real
+#     charge + routing assertion are skipped (they self-skip without a token).
+#
+# The widget still tokenizes against MT's REAL Square sandbox app in BOTH modes
+# (MT_SQUARE_APPLICATION_ID is public, in .env.dev), so a network connection is
+# required.
+#
+# Usage:
+#   ./tools/run-music-together-e2e.sh            # headless
+#   ./tools/run-music-together-e2e.sh --ui       # Playwright UI mode
+#   ./tools/run-music-together-e2e.sh --debug    # Playwright debug mode
+#
+# Port isolation: respects EMULATOR_PORT_OFFSET (source .env.worktree) so
+# parallel worktrees never collide.
+#
+# Prerequisites: Java 21+, pnpm, network access (for Square tokenize).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$ROOT_DIR"
+
+OFFSET="${EMULATOR_PORT_OFFSET:-0}"
+FUNCTIONS_PORT=$((5001 + OFFSET))
+FIRESTORE_PORT=$((8080 + OFFSET))
+AUTH_PORT=$((9099 + OFFSET))
+UI_PORT=$((4000 + OFFSET))
+HARNESS_PORT=$((4173 + OFFSET))
+SQUARE_MOCK_PORT=$((9997 + OFFSET))
+
+PLAYWRIGHT_EXTRA_ARGS=()
+case "${1:-}" in
+  --ui)    PLAYWRIGHT_EXTRA_ARGS+=("--ui") ;;
+  --debug) PLAYWRIGHT_EXTRA_ARGS+=("--debug") ;;
+esac
+
+# Kill stale processes on OUR ports (leave other worktrees alone).
+for port in "$FUNCTIONS_PORT" "$FIRESTORE_PORT" "$AUTH_PORT" "$UI_PORT" "$HARNESS_PORT" "$SQUARE_MOCK_PORT"; do
+  lsof -ti:"$port" 2>/dev/null | xargs kill -9 2>/dev/null || true
+done
+sleep 1
+
+echo "Building function codebases…"
+pnpm exec nx reset 2>/dev/null || true
+pnpm exec nx run-many \
+  --target=build \
+  --projects=functions,functions-calendar,functions-square,functions-sync \
+  --parallel=4
+
+# Decide Square mode.
+USE_REAL_MT_SQUARE=false
+if [ -n "${MT_SQUARE_ACCESS_TOKEN:-}" ]; then
+  USE_REAL_MT_SQUARE=true
+  echo "MT Square: REAL sandbox (MT_SQUARE_ACCESS_TOKEN provided)."
+else
+  echo "MT Square: MOCK (no MT_SQUARE_ACCESS_TOKEN in env)."
+fi
+
+echo "Setting up emulator environment…"
+for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar; do
+  grep -v '^#' .env.dev | grep -v '^$' > "$dir/.env"
+done
+echo "ETSY_API_BASE=http://127.0.0.1:1/v3/application" >> dist/apps/functions/.env
+printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\nTALLY_WEBHOOK_SECRET=test\nGA4_API_SECRET=test\nMETA_CAPI_TOKEN=test\n" > dist/apps/functions/.secret.local
+
+# functions-square holds BOTH the default (M&S) and MT Square clients.
+MT_TOKEN_VALUE="${MT_SQUARE_ACCESS_TOKEN:-mock-token}"
+printf "SQUARE_ACCESS_TOKEN=mock-token\nMT_SQUARE_ACCESS_TOKEN=%s\nSQUARE_WEBHOOK_SIGNATURE_KEY=mock-key\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" "$MT_TOKEN_VALUE" > dist/apps/functions-square/.secret.local
+
+if [ "$USE_REAL_MT_SQUARE" = false ]; then
+  # Point BOTH Square clients at the local mock server. The MT client honors
+  # SQUARE_BASE_URL just like the default one (see square.utility.ts).
+  echo "SQUARE_BASE_URL=http://localhost:${SQUARE_MOCK_PORT}" >> dist/apps/functions-square/.env
+fi
+
+# Webflow/Etsy → closed ports so the MT section-write triggers fail fast.
+echo "WEBFLOW_BASE_URL=http://127.0.0.1:1" >> dist/apps/functions-sync/.env
+echo "ETSY_API_BASE=http://127.0.0.1:1" >> dist/apps/functions-sync/.env
+echo "ETSY_TOKEN_URL=http://127.0.0.1:1" >> dist/apps/functions-sync/.env
+printf "WEBFLOW_API_TOKEN=mock-token\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions-sync/.secret.local
+
+# CORS: add the harness origin to every codebase.
+HARNESS_ORIGINS="http://127.0.0.1:$HARNESS_PORT,http://localhost:$HARNESS_PORT"
+for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar; do
+  EXISTING=$(grep '^ALLOWED_ORIGINS=' "$dir/.env" | head -1 | cut -d= -f2-)
+  echo "ALLOWED_ORIGINS=$EXISTING,$HARNESS_ORIGINS" >> "$dir/.env"
+done
+
+# Start the Square mock server in mock mode.
+SQUARE_MOCK_PID=""
+if [ "$USE_REAL_MT_SQUARE" = false ]; then
+  echo "Starting Square mock server on port ${SQUARE_MOCK_PORT} ..."
+  SQUARE_MOCK_SERVER_PORT="$SQUARE_MOCK_PORT" npx tsx libs/firebase/square-test-mock-server/start.ts &
+  SQUARE_MOCK_PID=$!
+  sleep 2
+fi
+cleanup() { [ -n "$SQUARE_MOCK_PID" ] && kill "$SQUARE_MOCK_PID" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# Harness: MT Square public IDs (widget tokenizes against MT's sandbox app).
+export VITE_MT_SQUARE_APPLICATION_ID=$(grep '^MT_SQUARE_APPLICATION_ID=' .env.dev | cut -d= -f2-)
+export VITE_MT_SQUARE_LOCATION_ID=$(grep '^MT_SQUARE_LOCATION_ID=' .env.dev | cut -d= -f2-)
+# Routing assertion inputs (spec self-skips it when the token is absent).
+export MT_SQUARE_LOCATION_ID=$(grep '^MT_SQUARE_LOCATION_ID=' .env.dev | cut -d= -f2-)
+export MT_SQUARE_ENV=$(grep '^MT_SQUARE_ENV=' .env.dev | cut -d= -f2-)
+
+# Pick a firebase.json with shifted ports for non-zero offset.
+FIREBASE_CONFIG_FILE="firebase.json"
+if [ "$OFFSET" != "0" ]; then
+  FIREBASE_CONFIG_FILE="firebase.e2e.worktree.json"
+  node -e "
+    const fs = require('fs');
+    const cfg = JSON.parse(fs.readFileSync('firebase.json', 'utf8'));
+    cfg.emulators.functions.port = $FUNCTIONS_PORT;
+    cfg.emulators.firestore.port = $FIRESTORE_PORT;
+    cfg.emulators.auth.port = $AUTH_PORT;
+    cfg.emulators.ui.port = $UI_PORT;
+    fs.writeFileSync('$FIREBASE_CONFIG_FILE', JSON.stringify(cfg, null, 2));
+  "
+fi
+
+PLAYWRIGHT_CMD=(pnpm exec nx run music-together-e2e:e2e)
+if [ ${#PLAYWRIGHT_EXTRA_ARGS[@]} -gt 0 ]; then
+  PLAYWRIGHT_CMD+=("--" "${PLAYWRIGHT_EXTRA_ARGS[@]}")
+fi
+
+EXIT_CODE=0
+EMULATOR_PORT_OFFSET="$OFFSET" \
+  npx firebase --config "$FIREBASE_CONFIG_FILE" emulators:exec \
+    --project=dev \
+    --only auth,firestore,functions \
+    "${PLAYWRIGHT_CMD[*]}" || EXIT_CODE=$?
+
+if [ $EXIT_CODE -eq 0 ]; then
+  echo ""
+  echo "Music Together E2E tests passed."
+else
+  echo ""
+  echo "Music Together E2E tests FAILED (exit $EXIT_CODE)."
+fi
+
+exit $EXIT_CODE

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
       'apps/functions-integration-tests/**',
       'apps/functions-integration-tests-*/**',
       'apps/pos-sandbox-e2e/**',
+      'apps/music-together-e2e/**',
     ],
     coverage: {
       provider: 'istanbul',
@@ -50,6 +51,7 @@ export default defineConfig({
         'libs/firebase/integration-test-utils/**',
         'apps/functions-integration-tests*/**',
         'apps/pos-sandbox-e2e/**',
+        'apps/music-together-e2e/**',
         'apps/maple-spruce-e2e/**',
         'apps/maple-spruce/.storybook/**',
       ],


### PR DESCRIPTION
Closes #608.

## What
An end-to-end test for **Music Together enrollment**, mirroring the existing **Registration E2E** job the class program has. It drives the production `MusicTogetherRegistrationWidget` through the real family checkout: form → Square sandbox tokenize → public `createMusicTogetherRegistration` (routing to MT's **SEPARATE** Square account via `MT_SQUARE_KEYS`) → confirmed registration.

This is the higher layer the MT program was missing — there's already a strong cloud-function integration suite (`apps/functions-integration-tests-music-together`), but nothing exercised the browser widget + real Square infra.

## How it mirrors the class Registration E2E
| Class E2E | This PR (MT) |
|---|---|
| `apps/registration-e2e` Playwright project | **new** `apps/music-together-e2e` (same config/setup/teardown/seed-dev shape, `E2E_TARGET=emulator\|dev`) |
| `registration-test-harness` mounts `RegistrationWidget` on `?classId=` | **extended additively** to also mount `MusicTogetherRegistrationWidget` on `?mtSectionId=` with MT's own Square sandbox app/location IDs |
| `PUBLISHED_CLASS` fixture | **new** `PUBLISHED_MT_SECTION` fixture |
| `tools/run-registration-e2e.sh` | **new** `tools/run-music-together-e2e.sh` |
| PR check `Registration E2E` + post-merge `e2e_dev` | **new** `Music Together E2E` (PR) + `mt_e2e_dev` (post-merge), wired into the prod approval gate |

No new Firebase Hosting site — the same deployed harness serves both widgets, keeping CI surface minimal.

## Coverage (happy path)
- **Pay-in-full (1 child)** → confirmed, `$252` charged, `squareReceiptUrl` present.
- **Sibling discount (2 children)** → **backend-authoritative `$378`** (`$252 × 1.5`), locking in the per-child pricing from #607.
- **Two-installment plan** → card vaulted + a `musicTogetherScheduledCharges` row materialized (installment 2), `$132` charged today + the card-on-file notice shown.
- **Multi-account routing** → reads each payment back from **MT's** sandbox and asserts `location_id == MT_SQUARE_LOCATION_ID`. (A nonce tokenized against MT's app can only be charged by MT's account, so a green pay-in-full is itself routing proof; this makes it explicit.)

## CI wiring
- **PR check `Music Together E2E`** (`build-check.yml`): local emulator with the PR's own code + **real MT Square sandbox** + mocked Webflow/Etsy — exactly like the class E2E, except no `SQUARE_BASE_URL` and `MT_SQUARE_ACCESS_TOKEN` fed from a repo secret.
- **Post-merge `mt_e2e_dev`** (`firebase-functions-merge.yml`): deployed dev (already carries MT's sandbox creds in Secret Manager) + deployed harness. Added to the `approve_prod` gate next to `e2e_dev`.

### ⚠️ Action required to activate the PR-time gate
The MT sandbox is a **separate Square account** from M&S, so `SQUARE_SANDBOX_ACCESS_TOKEN` cannot charge it. Add a repo secret **`MT_SQUARE_SANDBOX_ACCESS_TOKEN`** = MT's sandbox access token (the same value as `MT_SQUARE_ACCESS_TOKEN` in the `maple-and-spruce-dev` Secret Manager). Until it's set, the PR-check job **no-ops (stays green)** with a notice; the post-merge `mt_e2e_dev` gate already exercises the real flow against deployed dev, so routing is covered either way.

## Verification
Ran `tools/run-music-together-e2e.sh` locally against the Firebase emulator (mock Square, since I don't have the MT sandbox token): **all 4 specs pass**. The routing assertion self-skips without the token, as designed; in CI (real MT sandbox token) it runs the `location_id` check. Typecheck + lint clean.

Note: #607 (sibling discount) is already on `main`, so the `$378` assertion is a hard assertion here — not deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)