### PR TITLE
feat: route POS admin alerts per-environment (ADMIN_ALERT_EMAIL)

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -70,3 +70,8 @@ CRAFT_CLUB_MANAGE_URL=https://mapleandsprucefolkarts.com/craft-club-manage
 # Music Together self-service payment-method page (Webflow); update-card magic
 # links point here. The page reads ?token= to open the manage session.
 MUSIC_TOGETHER_MANAGE_URL=https://mapleandsprucefolkarts.com/music-together/manage-payment
+
+# Recipient for admin alerts (e.g. "POS sale needs an attendee email"). Dev uses
+# a +dev alias so lower-environment/test alerts stay out of the production inbox
+# but remain filterable. Prod value lives in .env.prod.
+ADMIN_ALERT_EMAIL=katie+dev@mapleandsprucefolkarts.com

--- a/.env.prod
+++ b/.env.prod
@@ -71,3 +71,6 @@ CRAFT_CLUB_MANAGE_URL=https://mapleandsprucefolkarts.com/craft-club-manage
 # Music Together self-service payment-method page (Webflow); update-card magic
 # links point here. The page reads ?token= to open the manage session.
 MUSIC_TOGETHER_MANAGE_URL=https://mapleandsprucefolkarts.com/music-together/manage-payment
+
+# Recipient for admin alerts (e.g. "POS sale needs an attendee email").
+ADMIN_ALERT_EMAIL=katie@mapleandsprucefolkarts.com

--- a/apps/functions-integration-tests-class-square/src/pos-sale-webhook.spec.ts
+++ b/apps/functions-integration-tests-class-square/src/pos-sale-webhook.spec.ts
@@ -51,7 +51,9 @@ const SIGNED_URL = `https://us-east4-${EMULATOR_CONFIG.projectId}.cloudfunctions
 // Must match SQUARE_WEBHOOK_SIGNATURE_KEY in tools/run-integration-tests.sh.
 const SIGNATURE_KEY = 'mock-key';
 
-const ADMIN_EMAIL = 'katie@mapleandsprucefolkarts.com';
+// The emulator loads .env.dev, where ADMIN_ALERT_EMAIL is the +dev alias — so
+// the alert routes there, not the production inbox.
+const ADMIN_EMAIL = 'katie+dev@mapleandsprucefolkarts.com';
 
 /** Sign a webhook body exactly the way the function's verifier does. */
 function signWebhook(body: unknown, secret: string): string {

--- a/libs/firebase/maple-functions/process-pos-sale/src/lib/process-pos-sale.spec.ts
+++ b/libs/firebase/maple-functions/process-pos-sale/src/lib/process-pos-sale.spec.ts
@@ -303,7 +303,9 @@ describe('processPosSale — registration creation', () => {
     expect(mocks.getCustomer).not.toHaveBeenCalled();
     expect(mocks.mailAdd).toHaveBeenCalledTimes(1);
     const mailDoc = mocks.mailAdd.mock.calls[0][0];
-    expect(mailDoc.to).toBe('katie@mapleandsprucefolkarts.com');
+    // Recipient now comes from the ADMIN_ALERT_EMAIL param; the params mock
+    // returns `mock-<NAME>`, proving the alert reads the env-configured value.
+    expect(mailDoc.to).toBe('mock-ADMIN_ALERT_EMAIL');
     expect(mailDoc.message.subject).toMatch(/needs an attendee email/i);
     expect(mailDoc.message.text).toContain('ORDER-1');
     expect(mocks.markProcessed).toHaveBeenCalledWith('PAY-1');

--- a/libs/firebase/maple-functions/process-pos-sale/src/lib/process-pos-sale.ts
+++ b/libs/firebase/maple-functions/process-pos-sale/src/lib/process-pos-sale.ts
@@ -42,12 +42,14 @@ const squareSecretParams = SQUARE_SECRET_NAMES.map((name) => defineSecret(name))
 const squareStringParams = SQUARE_STRING_NAMES.map((name) => defineString(name));
 
 /**
- * Where the "POS sale needs an attendee email" alert goes. This is the
- * business owner's inbox — the same address used as the global git identity
- * for the maple-and-spruce projects. There is no dedicated admin-notification
- * env var in this repo yet; if one is added, swap this constant for it.
+ * Where the "POS sale needs an attendee email" alert goes — configured per
+ * environment so lower environments never email the production inbox. Set in
+ * `.env.prod` (katie@…) and `.env.dev` (katie+dev@…, filterable). Defaults to
+ * the prod inbox as a fail-safe if the value is ever missing.
  */
-const ADMIN_EMAIL = 'katie@mapleandsprucefolkarts.com';
+const adminAlertEmail = defineString('ADMIN_ALERT_EMAIL', {
+  default: 'katie@mapleandsprucefolkarts.com',
+});
 
 function formatCurrency(cents: number): string {
   return `$${(cents / 100).toFixed(2)}`;
@@ -197,7 +199,7 @@ export const processPosSale = onDocumentWritten(
         // phone and backfill the registration.
         if (!customerEmail) {
           await db.collection('mail').add({
-            to: ADMIN_EMAIL,
+            to: adminAlertEmail.value(),
             message: {
               subject: `POS class sale needs an attendee email — ${classEntity.name}`,
               text: [


### PR DESCRIPTION
## Why
The "POS sale needs an attendee email" admin alert (`process-pos-sale.ts`) was a **hardcoded constant** pointed at the production inbox (`katie@mapleandsprucefolkarts.com`). So dev/sandbox testing — including the Tier-2 real-delivery e2e smoke — sent **real alert emails to the prod inbox for fake "POS Dev Smoke Class" sales**. (This surfaced when a dev-run alert landed in Katie's inbox.)

## Change
Make the recipient an environment-configured `defineString('ADMIN_ALERT_EMAIL')` param:
- **prod** (`.env.prod`) → `katie@mapleandsprucefolkarts.com`
- **dev** (`.env.dev`) → `katie+dev@mapleandsprucefolkarts.com` — reaches the same mailbox but is trivially filterable, so lower-env/test alerts stay out of the way
- **default** `katie@…` as a fail-safe if the value is ever missing (fail-to-prod, not fail-silent)

Added `ADMIN_ALERT_EMAIL` to **both** `.env.dev` and `.env.prod` so the emulator and deploy don't silently hang on the new param (the known `defineString` gotcha). Generalizes to any future admin notification.

## Verification (all local)
- [x] `process-pos-sale` unit test (asserts the alert reads the param)
- [x] `functions-square:build`, `maple-spruce:typecheck`, `validate-function-tsconfigs.sh`
- [x] **`class-square` integration suite 8/8** — the no-email alert test now routes to the `+dev` alias, confirming the emulator picks up `.env.dev`'s value end-to-end (no hang)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
