### PR TITLE
feat(auth): role framework — scoped roles + any-of requiringRole (behavior-neutral, PR 1 of 3)

### DIFF
--- a/apps/functions-integration-tests-utility/src/utility-functions.spec.ts
+++ b/apps/functions-integration-tests-utility/src/utility-functions.spec.ts
@@ -7,7 +7,14 @@ import {
 } from '@maple/firebase/integration-test-utils';
 import type { TestUser } from '@maple/firebase/integration-test-utils';
 import { ADMIN_USER, NON_ADMIN_USER } from '@maple/firebase/integration-test-utils';
-import type { CheckAdminStatusResponse } from '@maple/ts/firebase/api-types';
+import type {
+  CheckAdminStatusResponse,
+  GetMyRolesResponse,
+  GrantRoleRequest,
+  GrantRoleResponse,
+  RevokeRoleRequest,
+  RevokeRoleResponse,
+} from '@maple/ts/firebase/api-types';
 
 describe('Utility Functions', () => {
   let adminUser: TestUser;
@@ -133,6 +140,174 @@ describe('Utility Functions', () => {
 
       expect(result.status).toBe(200);
       expect(result.data?.isAdmin).toBe(false);
+    });
+  });
+
+  describe('role framework (getMyRoles / grantRole / revokeRole)', () => {
+    // Fresh user so role mutations here can't bleed into the tests above
+    let scopedUser: TestUser;
+
+    beforeAll(async () => {
+      scopedUser = await createTestUser(
+        'scoped-roles-user@test.maple',
+        'test-password-123!'
+      );
+    });
+
+    it('getMyRoles rejects unauthenticated requests', async () => {
+      const result = await callFunction({ functionName: 'getMyRoles' });
+      expect(result.status).toBe(401);
+    });
+
+    it('getMyRoles returns [admin] for an admins/{uid} user (back-compat)', async () => {
+      const result = await callFunction<
+        Record<string, never>,
+        GetMyRolesResponse
+      >({
+        functionName: 'getMyRoles',
+        idToken: adminUser.idToken,
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.data?.roles).toEqual(['admin']);
+    });
+
+    it('getMyRoles returns [] for a user with no roles', async () => {
+      const result = await callFunction<
+        Record<string, never>,
+        GetMyRolesResponse
+      >({
+        functionName: 'getMyRoles',
+        idToken: scopedUser.idToken,
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.data?.roles).toEqual([]);
+    });
+
+    it('grantRole is admin-only (403 for non-admin caller)', async () => {
+      const result = await callFunction<GrantRoleRequest, GrantRoleResponse>({
+        functionName: 'grantRole',
+        idToken: scopedUser.idToken,
+        data: { uid: scopedUser.uid, role: 'mt-teacher' },
+      });
+
+      expect(result.status).toBe(403);
+    });
+
+    it('grantRole rejects the admin role (admins/{uid} stays authoritative)', async () => {
+      const result = await callFunction<GrantRoleRequest, GrantRoleResponse>({
+        functionName: 'grantRole',
+        idToken: adminUser.idToken,
+        data: { uid: scopedUser.uid, role: 'admin' },
+      });
+
+      expect(result.status).toBe(400);
+    });
+
+    it('admin grants a scoped role; it shows in getMyRoles but not admin status', async () => {
+      const grant = await callFunction<GrantRoleRequest, GrantRoleResponse>({
+        functionName: 'grantRole',
+        idToken: adminUser.idToken,
+        data: { uid: scopedUser.uid, role: 'mt-teacher' },
+      });
+      expect(grant.status).toBe(200);
+      expect(grant.data?.success).toBe(true);
+
+      const roles = await callFunction<
+        Record<string, never>,
+        GetMyRolesResponse
+      >({
+        functionName: 'getMyRoles',
+        idToken: scopedUser.idToken,
+      });
+      expect(roles.data?.roles).toEqual(['mt-teacher']);
+
+      // A scoped role must NOT confer admin (back-compat contract)
+      const adminStatus = await callFunction<
+        Record<string, never>,
+        CheckAdminStatusResponse
+      >({
+        functionName: 'checkAdminStatus',
+        idToken: scopedUser.idToken,
+      });
+      expect(adminStatus.data?.isAdmin).toBe(false);
+    });
+
+    it('a scoped role does not open admin-only functions (any-of not wildcard)', async () => {
+      // scopedUser now holds mt-teacher; grantRole itself requires admin
+      const result = await callFunction<GrantRoleRequest, GrantRoleResponse>({
+        functionName: 'grantRole',
+        idToken: scopedUser.idToken,
+        data: { uid: scopedUser.uid, role: 'clerk' },
+      });
+
+      expect(result.status).toBe(403);
+    });
+
+    it('users can hold multiple roles at once', async () => {
+      await callFunction<GrantRoleRequest, GrantRoleResponse>({
+        functionName: 'grantRole',
+        idToken: adminUser.idToken,
+        data: { uid: scopedUser.uid, role: 'clerk' },
+      });
+      await callFunction<GrantRoleRequest, GrantRoleResponse>({
+        functionName: 'grantRole',
+        idToken: adminUser.idToken,
+        data: { uid: scopedUser.uid, role: 'lesson-teacher' },
+      });
+
+      const roles = await callFunction<
+        Record<string, never>,
+        GetMyRolesResponse
+      >({
+        functionName: 'getMyRoles',
+        idToken: scopedUser.idToken,
+      });
+
+      expect(roles.data?.roles).toEqual(
+        expect.arrayContaining(['mt-teacher', 'clerk', 'lesson-teacher'])
+      );
+      expect(roles.data?.roles).toHaveLength(3);
+    });
+
+    it('revokeRole removes a single role and leaves the rest', async () => {
+      const revoke = await callFunction<
+        RevokeRoleRequest,
+        RevokeRoleResponse
+      >({
+        functionName: 'revokeRole',
+        idToken: adminUser.idToken,
+        data: { uid: scopedUser.uid, role: 'mt-teacher' },
+      });
+      expect(revoke.status).toBe(200);
+      expect(revoke.data?.success).toBe(true);
+
+      const roles = await callFunction<
+        Record<string, never>,
+        GetMyRolesResponse
+      >({
+        functionName: 'getMyRoles',
+        idToken: scopedUser.idToken,
+      });
+
+      expect(roles.data?.roles).toEqual(
+        expect.arrayContaining(['clerk', 'lesson-teacher'])
+      );
+      expect(roles.data?.roles).not.toContain('mt-teacher');
+    });
+
+    it('revokeRole is admin-only (403 for non-admin caller)', async () => {
+      const result = await callFunction<
+        RevokeRoleRequest,
+        RevokeRoleResponse
+      >({
+        functionName: 'revokeRole',
+        idToken: scopedUser.idToken,
+        data: { uid: scopedUser.uid, role: 'clerk' },
+      });
+
+      expect(result.status).toBe(403);
     });
   });
 

--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -228,6 +228,9 @@ export { getPayouts } from '@maple/firebase/maple-functions/get-payouts';
 export { listUsers } from '@maple/firebase/maple-functions/list-users';
 export { grantAdminRole } from '@maple/firebase/maple-functions/grant-admin-role';
 export { revokeAdminRole } from '@maple/firebase/maple-functions/revoke-admin-role';
+export { getMyRoles } from '@maple/firebase/maple-functions/get-my-roles';
+export { grantRole } from '@maple/firebase/maple-functions/grant-role';
+export { revokeRole } from '@maple/firebase/maple-functions/revoke-role';
 
 // Lead attribution (Tally newsletter signups → GA4 Measurement Protocol + Meta CAPI)
 export { tallyLeadWebhook } from '@maple/firebase/maple-functions/tally-lead-webhook';

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -7,6 +7,9 @@
   "include": [
     "src/**/*.ts",
     "../../libs/firebase/maple-functions/check-admin-status/**/*.ts",
+    "../../libs/firebase/maple-functions/get-my-roles/**/*.ts",
+    "../../libs/firebase/maple-functions/grant-role/**/*.ts",
+    "../../libs/firebase/maple-functions/revoke-role/**/*.ts",
     "../../libs/firebase/maple-functions/get-artists/**/*.ts",
     "../../libs/firebase/maple-functions/get-artist/**/*.ts",
     "../../libs/firebase/maple-functions/create-artist/**/*.ts",

--- a/docs/reference/deployed-functions.md
+++ b/docs/reference/deployed-functions.md
@@ -93,11 +93,14 @@ Core CRUD operations, auth, triggers, and admin functions. No heavy third-party 
 
 ### Auth
 - `checkAdminStatus` _(returns `{ isAdmin, isEmployee, role }` — `role` is the highest-privilege role)_
+- `getMyRoles` _(auth only — returns every role the caller holds: admin from `admins/{uid}` + scoped roles from `userRoles/{uid}`; client nav gating)_
 
 ### User & role administration
 - `listUsers` _(admin only — Firebase Auth users joined with admin records; powers `/users` page; capped at 1000 per call)_
 - `grantAdminRole` _(admin only — promotes another user to admin)_
 - `revokeAdminRole` _(admin only — demotes another admin; self-protection: cannot revoke your own admin)_
+- `grantRole` _(admin only — grants a scoped role: `mt-teacher`, `clerk`, `lesson-teacher`; writes `userRoles/{uid}.roles`; rejects `admin`)_
+- `revokeRole` _(admin only — revokes a scoped role; rejects `admin`)_
 
 ### Infrastructure
 - `healthCheck`

--- a/docs/reference/implementation-status.md
+++ b/docs/reference/implementation-status.md
@@ -22,6 +22,7 @@
 | Functions app | Complete | `apps/functions/` |
 | Authentication | Complete | `libs/react/auth/` (re-exported via app barrel) |
 | Admin authorization (UI) | Complete | `AdminGuard` + `useAdminStatus` + `checkAdminStatus` Cloud Function |
+| Scoped roles framework (PR 1 of epic #617) | Complete | `Role` enum (admin, mt-teacher, clerk, lesson-teacher) + `userRoles/{uid}` + any-of `requiringRole([...])` + `getMyRoles`/`grantRole`/`revokeRole`; behavior-neutral — client plumbing #614, re-scoping #615 |
 | Navigation (responsive) | Complete | `libs/react/layout/` (re-exported via app barrel) |
 | Storybook | Complete | `apps/maple-spruce/.storybook/` |
 | Component stories | Complete | `apps/maple-spruce/src/components/**/*.stories.tsx`, `libs/react/*/src/**/*.stories.tsx` |

--- a/libs/firebase/functions/src/lib/auth.utility.spec.ts
+++ b/libs/firebase/functions/src/lib/auth.utility.spec.ts
@@ -4,35 +4,48 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  * Tests for auth.utility.ts
  *
  * Uses vi.hoisted + vi.mock for proper module mocking with Vitest.
+ * The Firestore mock routes by collection name so admin checks
+ * (`admins/{uid}`) and scoped-role checks (`userRoles/{uid}`) can be
+ * configured independently.
  * @see https://vitest.dev/guide/mocking/modules
  */
 
 // Define mocks using vi.hoisted so they're available in vi.mock factory
 const mocks = vi.hoisted(() => {
   return {
-    docGet: vi.fn(),
-    docSet: vi.fn(),
-    docDelete: vi.fn(),
-    collectionGet: vi.fn(),
+    // admins/{uid}
+    adminDocGet: vi.fn(),
+    adminDocSet: vi.fn(),
+    adminDocDelete: vi.fn(),
+    adminCollectionGet: vi.fn(),
+    // userRoles/{uid}
+    userRolesDocGet: vi.fn(),
+    userRolesDocSet: vi.fn(),
     getDb: vi.fn(),
   };
 });
 
 // Mock @maple/firebase/database module
 vi.mock('@maple/firebase/database', () => {
-  const mockDocRef = {
-    get: mocks.docGet,
-    set: mocks.docSet,
-    delete: mocks.docDelete,
+  const adminDocRef = {
+    get: mocks.adminDocGet,
+    set: mocks.adminDocSet,
+    delete: mocks.adminDocDelete,
   };
-
-  const mockCollectionRef = {
-    doc: vi.fn().mockReturnValue(mockDocRef),
-    get: mocks.collectionGet,
+  const userRolesDocRef = {
+    get: mocks.userRolesDocGet,
+    set: mocks.userRolesDocSet,
   };
 
   const mockDb = {
-    collection: vi.fn().mockReturnValue(mockCollectionRef),
+    collection: vi.fn((name: string) =>
+      name === 'userRoles'
+        ? { doc: vi.fn().mockReturnValue(userRolesDocRef) }
+        : {
+            doc: vi.fn().mockReturnValue(adminDocRef),
+            get: mocks.adminCollectionGet,
+          }
+    ),
   };
 
   mocks.getDb.mockReturnValue(mockDb);
@@ -42,17 +55,34 @@ vi.mock('@maple/firebase/database', () => {
   };
 });
 
+// FieldValue sentinels — assertions only need stable identities
+vi.mock('firebase-admin/firestore', () => ({
+  FieldValue: {
+    arrayUnion: (...values: unknown[]) => ({ __arrayUnion: values }),
+    arrayRemove: (...values: unknown[]) => ({ __arrayRemove: values }),
+  },
+}));
+
 describe('auth.utility', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
     // Setup default mock returns
-    mocks.docGet.mockResolvedValue({ exists: false });
-    mocks.collectionGet.mockResolvedValue({ docs: [] });
+    mocks.adminDocGet.mockResolvedValue({ exists: false });
+    mocks.userRolesDocGet.mockResolvedValue({ exists: false });
+    mocks.adminCollectionGet.mockResolvedValue({ docs: [] });
 
     // Reset module cache to get fresh imports
     vi.resetModules();
   });
+
+  /** Configure the userRoles/{uid} doc returned by the mock */
+  function setUserRolesDoc(roles: unknown): void {
+    mocks.userRolesDocGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ roles }),
+    });
+  }
 
   describe('hasRole', () => {
     it('should call getDb to get Firestore instance', async () => {
@@ -64,7 +94,7 @@ describe('auth.utility', () => {
     });
 
     it('should return true when admin document exists', async () => {
-      mocks.docGet.mockResolvedValue({ exists: true });
+      mocks.adminDocGet.mockResolvedValue({ exists: true });
 
       const { hasRole, Role } = await import('./auth.utility');
 
@@ -74,13 +104,166 @@ describe('auth.utility', () => {
     });
 
     it('should return false when admin document does not exist', async () => {
-      mocks.docGet.mockResolvedValue({ exists: false });
+      mocks.adminDocGet.mockResolvedValue({ exists: false });
 
       const { hasRole, Role } = await import('./auth.utility');
 
       const result = await hasRole('non-admin-uid', Role.Admin);
 
       expect(result).toBe(false);
+    });
+
+    it('resolves scoped roles from the userRoles doc, not admins', async () => {
+      setUserRolesDoc(['mt-teacher']);
+
+      const { hasRole, Role } = await import('./auth.utility');
+
+      expect(await hasRole('stephanie-uid', Role.MtTeacher)).toBe(true);
+      expect(await hasRole('stephanie-uid', Role.Clerk)).toBe(false);
+      expect(mocks.adminDocGet).not.toHaveBeenCalled();
+    });
+
+    it('returns false for a scoped role when no userRoles doc exists', async () => {
+      const { hasRole, Role } = await import('./auth.utility');
+
+      expect(await hasRole('nobody-uid', Role.Clerk)).toBe(false);
+    });
+
+    it('ignores unknown strings stored in the roles array', async () => {
+      setUserRolesDoc(['superuser', 42, 'clerk']);
+
+      const { hasRole, Role } = await import('./auth.utility');
+
+      expect(await hasRole('nathan-uid', Role.Clerk)).toBe(true);
+      expect(await hasRole('nathan-uid', Role.MtTeacher)).toBe(false);
+    });
+
+    it('tolerates a malformed roles field (not an array)', async () => {
+      setUserRolesDoc('clerk');
+
+      const { hasRole, Role } = await import('./auth.utility');
+
+      expect(await hasRole('weird-uid', Role.Clerk)).toBe(false);
+    });
+  });
+
+  describe('hasAnyRole', () => {
+    it('returns false for an empty role set', async () => {
+      const { hasAnyRole } = await import('./auth.utility');
+
+      expect(await hasAnyRole('any-uid', [])).toBe(false);
+      expect(mocks.adminDocGet).not.toHaveBeenCalled();
+      expect(mocks.userRolesDocGet).not.toHaveBeenCalled();
+    });
+
+    it('admin passes an [Admin, MtTeacher] check via admins/{uid}', async () => {
+      mocks.adminDocGet.mockResolvedValue({ exists: true });
+
+      const { hasAnyRole, Role } = await import('./auth.utility');
+
+      expect(
+        await hasAnyRole('admin-uid', [Role.Admin, Role.MtTeacher])
+      ).toBe(true);
+    });
+
+    it('mt-teacher passes an [Admin, MtTeacher] check via userRoles', async () => {
+      setUserRolesDoc(['mt-teacher']);
+
+      const { hasAnyRole, Role } = await import('./auth.utility');
+
+      expect(
+        await hasAnyRole('stephanie-uid', [Role.Admin, Role.MtTeacher])
+      ).toBe(true);
+    });
+
+    it('fails when the user holds none of the required roles', async () => {
+      setUserRolesDoc(['lesson-teacher']);
+
+      const { hasAnyRole, Role } = await import('./auth.utility');
+
+      expect(
+        await hasAnyRole('teacher-uid', [Role.Admin, Role.Clerk])
+      ).toBe(false);
+    });
+
+    it('does not read admins/{uid} when Admin is not in the set', async () => {
+      setUserRolesDoc(['clerk']);
+
+      const { hasAnyRole, Role } = await import('./auth.utility');
+
+      expect(await hasAnyRole('nathan-uid', [Role.Clerk])).toBe(true);
+      expect(mocks.adminDocGet).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getUserRoles', () => {
+    it('combines admin (admins/{uid}) with scoped roles (userRoles)', async () => {
+      mocks.adminDocGet.mockResolvedValue({ exists: true });
+      setUserRolesDoc(['clerk', 'lesson-teacher']);
+
+      const { getUserRoles, Role } = await import('./auth.utility');
+
+      const roles = await getUserRoles('katie-uid');
+
+      expect(roles).toContain(Role.Admin);
+      expect(roles).toContain(Role.Clerk);
+      expect(roles).toContain(Role.LessonTeacher);
+      expect(roles).toHaveLength(3);
+    });
+
+    it('returns empty for a user with no roles', async () => {
+      const { getUserRoles } = await import('./auth.utility');
+
+      expect(await getUserRoles('nobody-uid')).toEqual([]);
+    });
+  });
+
+  describe('grantRole', () => {
+    it('arrayUnions the role onto userRoles/{uid} with audit fields', async () => {
+      const { grantRole, Role } = await import('./auth.utility');
+
+      await grantRole('nathan-uid', Role.Clerk, 'katie-uid');
+
+      expect(mocks.userRolesDocSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          roles: { __arrayUnion: ['clerk'] },
+          grantedBy: 'katie-uid',
+        }),
+        { merge: true }
+      );
+    });
+
+    it('rejects granting Role.Admin', async () => {
+      const { grantRole, Role } = await import('./auth.utility');
+
+      await expect(
+        grantRole('x-uid', Role.Admin, 'katie-uid')
+      ).rejects.toThrow(/grantAdminRole/);
+      expect(mocks.userRolesDocSet).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('revokeRole', () => {
+    it('arrayRemoves the role from userRoles/{uid}', async () => {
+      const { revokeRole, Role } = await import('./auth.utility');
+
+      await revokeRole('nathan-uid', Role.Clerk);
+
+      expect(mocks.userRolesDocSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          roles: { __arrayRemove: ['clerk'] },
+        }),
+        { merge: true }
+      );
+    });
+
+    it('rejects revoking Role.Admin', async () => {
+      const { revokeRole, Role } = await import('./auth.utility');
+
+      await expect(revokeRole('x-uid', Role.Admin)).rejects.toThrow(
+        /revokeAdminRole/
+      );
+      expect(mocks.userRolesDocSet).not.toHaveBeenCalled();
     });
   });
 
@@ -91,7 +274,7 @@ describe('auth.utility', () => {
       await grantAdminRole('new-admin-uid', 'granter-uid');
 
       expect(mocks.getDb).toHaveBeenCalled();
-      expect(mocks.docSet).toHaveBeenCalledWith(
+      expect(mocks.adminDocSet).toHaveBeenCalledWith(
         expect.objectContaining({
           grantedBy: 'granter-uid',
         })
@@ -106,13 +289,13 @@ describe('auth.utility', () => {
       await revokeAdminRole('admin-uid');
 
       expect(mocks.getDb).toHaveBeenCalled();
-      expect(mocks.docDelete).toHaveBeenCalled();
+      expect(mocks.adminDocDelete).toHaveBeenCalled();
     });
   });
 
   describe('getAdminUids', () => {
     it('should return array of admin UIDs', async () => {
-      mocks.collectionGet.mockResolvedValue({
+      mocks.adminCollectionGet.mockResolvedValue({
         docs: [{ id: 'admin1' }, { id: 'admin2' }],
       });
 
@@ -126,10 +309,13 @@ describe('auth.utility', () => {
   });
 
   describe('Role enum', () => {
-    it('should export Admin role with correct value', async () => {
+    it('should export all roles with their wire values', async () => {
       const { Role } = await import('./auth.utility');
 
       expect(Role.Admin).toBe('admin');
+      expect(Role.MtTeacher).toBe('mt-teacher');
+      expect(Role.Clerk).toBe('clerk');
+      expect(Role.LessonTeacher).toBe('lesson-teacher');
     });
   });
 });

--- a/libs/firebase/functions/src/lib/auth.utility.ts
+++ b/libs/firebase/functions/src/lib/auth.utility.ts
@@ -11,6 +11,7 @@
  * @see https://github.com/MountainSOLSchool/platform/blob/main/libs/firebase/functions/src/lib/utilities/auth.utility.ts
  */
 import { getDb } from '@maple/firebase/database';
+import { FieldValue } from 'firebase-admin/firestore';
 
 /**
  * Roles available in the system
@@ -18,13 +19,50 @@ import { getDb } from '@maple/firebase/database';
 export enum Role {
   /** Full administrative access */
   Admin = 'admin',
+  /** Manage the Music Together program (sections, semesters, rosters, registrations) */
+  MtTeacher = 'mt-teacher',
+  /** Operational access: POS checkout, registrations & rosters, store inventory & orders, refunds */
+  Clerk = 'clerk',
+  /** Music lesson teacher: read all lessons, manage own (scoping lands in phase 2) */
+  LessonTeacher = 'lesson-teacher',
+}
+
+/** Firestore collection holding non-admin role grants, keyed by UID */
+const USER_ROLES_COLLECTION = 'userRoles';
+
+/** Shape of a `userRoles/{uid}` document */
+interface UserRolesDoc {
+  roles?: unknown;
+  grantedBy?: string;
+  updatedAt?: Date;
+}
+
+/** All enum values, for filtering unknown strings out of stored role arrays */
+const KNOWN_ROLES = new Set<string>(Object.values(Role));
+
+/**
+ * Read the non-admin roles stored on `userRoles/{uid}`.
+ *
+ * Unknown strings (e.g. roles removed from the enum) are filtered out.
+ */
+async function getStoredRoles(uid: string): Promise<Role[]> {
+  const db = getDb();
+  const doc = await db.collection(USER_ROLES_COLLECTION).doc(uid).get();
+  if (!doc.exists) return [];
+  const roles = (doc.data() as UserRolesDoc).roles;
+  if (!Array.isArray(roles)) return [];
+  return roles.filter(
+    (role): role is Role => typeof role === 'string' && KNOWN_ROLES.has(role)
+  );
 }
 
 /**
  * Check if a user has a specific role.
  *
- * Roles are stored in per-role collections keyed by UID:
- * - Role.Admin -> admins/{uid}
+ * Role storage:
+ * - Role.Admin -> existence of `admins/{uid}` (legacy per-role collection,
+ *   kept as the source of truth for admin)
+ * - All other roles -> membership in the `roles` array on `userRoles/{uid}`
  *
  * @param uid - The user's Firebase Auth UID
  * @param role - The role to check
@@ -38,9 +76,117 @@ export async function hasRole(uid: string, role: Role): Promise<boolean> {
       const adminDoc = await db.collection('admins').doc(uid).get();
       return adminDoc.exists;
     }
-    default:
-      return false;
+    default: {
+      const roles = await getStoredRoles(uid);
+      return roles.includes(role);
+    }
   }
+}
+
+/**
+ * Check if a user has ANY of the given roles (any-of semantics).
+ *
+ * Reads at most two documents regardless of how many roles are checked:
+ * `admins/{uid}` (only when Role.Admin is in the set) and `userRoles/{uid}`
+ * (only when a non-admin role is in the set), in parallel.
+ *
+ * @param uid - The user's Firebase Auth UID
+ * @param roles - Roles to check; an empty array always returns false
+ * @returns True if the user has at least one of the roles
+ */
+export async function hasAnyRole(
+  uid: string,
+  roles: readonly Role[]
+): Promise<boolean> {
+  const nonAdminRoles = roles.filter((role) => role !== Role.Admin);
+
+  const checks: Promise<boolean>[] = [];
+  if (roles.includes(Role.Admin)) {
+    checks.push(hasRole(uid, Role.Admin));
+  }
+  if (nonAdminRoles.length > 0) {
+    checks.push(
+      getStoredRoles(uid).then((stored) =>
+        nonAdminRoles.some((role) => stored.includes(role))
+      )
+    );
+  }
+
+  const results = await Promise.all(checks);
+  return results.some(Boolean);
+}
+
+/**
+ * Get every role a user holds: admin (from `admins/{uid}`) plus any
+ * roles on `userRoles/{uid}`. Used by the getMyRoles callable so the
+ * client can gate navigation.
+ *
+ * @param uid - The user's Firebase Auth UID
+ * @returns The user's roles (may be empty)
+ */
+export async function getUserRoles(uid: string): Promise<Role[]> {
+  const [isAdmin, stored] = await Promise.all([
+    hasRole(uid, Role.Admin),
+    getStoredRoles(uid),
+  ]);
+  const roles = new Set<Role>(stored);
+  if (isAdmin) roles.add(Role.Admin);
+  return [...roles];
+}
+
+/**
+ * Grant a non-admin role to a user by adding it to the `roles` array
+ * on `userRoles/{uid}`.
+ *
+ * Role.Admin is intentionally rejected — `admins/{uid}` remains the
+ * source of truth for admin; use {@link grantAdminRole} instead.
+ *
+ * @param uid - The user's Firebase Auth UID
+ * @param role - The role to grant (must not be Role.Admin)
+ * @param grantedBy - UID of the admin granting the role
+ */
+export async function grantRole(
+  uid: string,
+  role: Role,
+  grantedBy: string
+): Promise<void> {
+  if (role === Role.Admin) {
+    throw new Error('Use grantAdminRole to grant the admin role');
+  }
+  const db = getDb();
+  await db.collection(USER_ROLES_COLLECTION).doc(uid).set(
+    {
+      roles: FieldValue.arrayUnion(role),
+      grantedBy,
+      updatedAt: new Date(),
+    },
+    { merge: true }
+  );
+}
+
+/**
+ * Revoke a non-admin role from a user by removing it from the `roles`
+ * array on `userRoles/{uid}`.
+ *
+ * Role.Admin is intentionally rejected — use {@link revokeAdminRole}.
+ *
+ * @param uid - The user's Firebase Auth UID
+ * @param role - The role to revoke (must not be Role.Admin)
+ */
+export async function revokeRole(uid: string, role: Role): Promise<void> {
+  if (role === Role.Admin) {
+    throw new Error('Use revokeAdminRole to revoke the admin role');
+  }
+  const db = getDb();
+  // set + merge (not update) so revoking from a user with no doc is a no-op
+  // rather than a NOT_FOUND error
+  await db.collection(USER_ROLES_COLLECTION).doc(uid).set(
+    {
+      roles: FieldValue.arrayRemove(role),
+      updatedAt: new Date(),
+    },
+    { merge: true }
+  );
 }
 
 /**

--- a/libs/firebase/functions/src/lib/functions.utility.spec.ts
+++ b/libs/firebase/functions/src/lib/functions.utility.spec.ts
@@ -8,7 +8,7 @@ const mocks = vi.hoisted(() => ({
   defineSecret: vi.fn(),
   defineString: vi.fn(),
   verifyIdToken: vi.fn(),
-  hasRole: vi.fn(),
+  hasAnyRole: vi.fn(),
   initializeApp: vi.fn(),
   apps: [] as unknown[],
 }));
@@ -53,8 +53,13 @@ vi.mock('firebase-admin', () => ({
 }));
 
 vi.mock('./auth.utility', () => ({
-  Role: { Admin: 'admin' },
-  hasRole: mocks.hasRole,
+  Role: {
+    Admin: 'admin',
+    MtTeacher: 'mt-teacher',
+    Clerk: 'clerk',
+    LessonTeacher: 'lesson-teacher',
+  },
+  hasAnyRole: mocks.hasAnyRole,
 }));
 
 import {
@@ -341,7 +346,7 @@ describe('Functions.endpoint (chain + handle)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.verifyIdToken.mockReset();
-    mocks.hasRole.mockReset();
+    mocks.hasAnyRole.mockReset();
     mocks.onRequest.mockClear();
     mocks.apps.length = 0;
   });
@@ -425,7 +430,7 @@ describe('Functions.endpoint (chain + handle)', () => {
 
   it('requiringRole(Admin): 403 when user lacks role', async () => {
     mocks.verifyIdToken.mockResolvedValue({ uid: 'u1' });
-    mocks.hasRole.mockResolvedValue(false);
+    mocks.hasAnyRole.mockResolvedValue(false);
     const handler = vi.fn();
     const endpoint = Functions.endpoint.requiringRole(Role.Admin).handle(handler);
 
@@ -440,7 +445,7 @@ describe('Functions.endpoint (chain + handle)', () => {
 
   it('requiringRole(Admin): passes when user has role', async () => {
     mocks.verifyIdToken.mockResolvedValue({ uid: 'admin-uid' });
-    mocks.hasRole.mockResolvedValue(true);
+    mocks.hasAnyRole.mockResolvedValue(true);
     const handler = vi.fn(async () => ({ ok: true }));
     const endpoint = Functions.endpoint.requiringRole(Role.Admin).handle(handler);
 
@@ -450,7 +455,45 @@ describe('Functions.endpoint (chain + handle)', () => {
     );
 
     expect(res.statusCode).toBe(200);
-    expect(mocks.hasRole).toHaveBeenCalledWith('admin-uid', Role.Admin);
+    expect(mocks.hasAnyRole).toHaveBeenCalledWith('admin-uid', [Role.Admin]);
+  });
+
+  it('requiringRole([Admin, MtTeacher]): passes the role set through (any-of)', async () => {
+    mocks.verifyIdToken.mockResolvedValue({ uid: 'stephanie-uid' });
+    mocks.hasAnyRole.mockResolvedValue(true);
+    const handler = vi.fn(async () => ({ ok: true }));
+    const endpoint = Functions.endpoint
+      .requiringRole([Role.Admin, Role.MtTeacher])
+      .handle(handler);
+
+    const res = await invoke(
+      endpoint,
+      makeReq({ headers: { origin: 'https://example.test', authorization: 'Bearer t' } })
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(mocks.hasAnyRole).toHaveBeenCalledWith('stephanie-uid', [
+      Role.Admin,
+      Role.MtTeacher,
+    ]);
+  });
+
+  it('requiringRole([...]): 403 names every accepted role', async () => {
+    mocks.verifyIdToken.mockResolvedValue({ uid: 'u1' });
+    mocks.hasAnyRole.mockResolvedValue(false);
+    const handler = vi.fn();
+    const endpoint = Functions.endpoint
+      .requiringRole([Role.Admin, Role.Clerk])
+      .handle(handler);
+
+    const res = await invoke(
+      endpoint,
+      makeReq({ headers: { origin: 'https://example.test', authorization: 'Bearer t' } })
+    );
+
+    expect(res.statusCode).toBe(403);
+    expect((res.body as { error: string }).error).toContain('admin or clerk');
+    expect(handler).not.toHaveBeenCalled();
   });
 
   it('validating: rejects invalid input before invoking handler', async () => {
@@ -615,7 +658,7 @@ describe('Functions.endpoint (chain + handle)', () => {
       );
 
       expect(res.statusCode).toBe(200);
-      expect(mocks.hasRole).not.toHaveBeenCalled();
+      expect(mocks.hasAnyRole).not.toHaveBeenCalled();
       expect(handler).not.toHaveBeenCalled();
     });
 
@@ -732,7 +775,7 @@ describe('legacy wrappers', () => {
 
   it('createAdminFunction: requires admin role', async () => {
     mocks.verifyIdToken.mockResolvedValue({ uid: 'u1' });
-    mocks.hasRole.mockResolvedValue(false);
+    mocks.hasAnyRole.mockResolvedValue(false);
     const handler = vi.fn();
     const endpoint = createAdminFunction(handler);
     const res = await invoke(

--- a/libs/firebase/functions/src/lib/functions.utility.ts
+++ b/libs/firebase/functions/src/lib/functions.utility.ts
@@ -21,7 +21,7 @@ import {
 } from 'firebase-functions/params';
 import type { Request } from 'firebase-functions/v2/https';
 import type { Response } from 'express';
-import { Role, hasRole } from './auth.utility';
+import { Role, hasAnyRole } from './auth.utility';
 import { throwAlreadyExists, throwValidationError } from './errors.utility';
 import { getAuth } from 'firebase-admin/auth';
 import admin from 'firebase-admin';
@@ -102,8 +102,8 @@ export type UniquenessCheck<T = Record<string, unknown>> = {
 export interface FunctionOptions {
   /** Require user to be authenticated */
   requireAuth?: boolean;
-  /** Require user to have a specific role */
-  requiredRole?: Role;
+  /** Require user to have a specific role (or ANY of an array of roles) */
+  requiredRole?: Role | readonly Role[];
   /** Runtime configuration for the Cloud Function */
   runtime?: RuntimeOptions;
   /** Run this validator on the request data before invoking the handler */
@@ -377,9 +377,15 @@ class FunctionBuilder<
   }
 
   /**
-   * Require a specific role
+   * Require a specific role, or ANY of an array of roles (any-of).
+   *
+   * @example
+   * .requiringRole(Role.Admin)                    // admin only
+   * .requiringRole([Role.Admin, Role.MtTeacher])  // admin OR MT teacher
    */
-  requiringRole(role: Role): FunctionBuilder<SecretNames, StringNames> {
+  requiringRole(
+    role: Role | readonly Role[]
+  ): FunctionBuilder<SecretNames, StringNames> {
     return new FunctionBuilder(this.secrets, this.strings, {
       ...this.options,
       requiredRole: role,
@@ -514,15 +520,17 @@ class FunctionBuilder<
               }
             }
 
-            // Check role if required
+            // Check role if required (any-of when an array is given)
             if (this.options.requiredRole) {
-              const userHasRole = await hasRole(
-                auth!.uid,
+              const requiredRoles: readonly Role[] = Array.isArray(
                 this.options.requiredRole
-              );
+              )
+                ? this.options.requiredRole
+                : [this.options.requiredRole as Role];
+              const userHasRole = await hasAnyRole(auth!.uid, requiredRoles);
               if (!userHasRole) {
                 res.status(403).json({
-                  error: `Forbidden: You must be a ${this.options.requiredRole} to perform this action`,
+                  error: `Forbidden: You must be a ${requiredRoles.join(' or ')} to perform this action`,
                 });
                 return;
               }

--- a/libs/firebase/functions/src/lib/index.ts
+++ b/libs/firebase/functions/src/lib/index.ts
@@ -36,6 +36,10 @@ export {
 export {
   Role,
   hasRole,
+  hasAnyRole,
+  getUserRoles,
+  grantRole,
+  revokeRole,
   grantAdminRole,
   revokeAdminRole,
   getAdminUids,

--- a/libs/firebase/maple-functions/get-my-roles/project.json
+++ b/libs/firebase/maple-functions/get-my-roles/project.json
@@ -1,0 +1,11 @@
+{
+  "name": "firebase-maple-functions-get-my-roles",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/get-my-roles/src",
+  "projectType": "library",
+  "tags": [
+    "scope:firebase",
+    "type:feature"
+  ],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/get-my-roles/src/index.ts
+++ b/libs/firebase/maple-functions/get-my-roles/src/index.ts
@@ -1,0 +1,1 @@
+export { getMyRoles } from './lib/get-my-roles';

--- a/libs/firebase/maple-functions/get-my-roles/src/lib/get-my-roles.spec.ts
+++ b/libs/firebase/maple-functions/get-my-roles/src/lib/get-my-roles.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getUserRoles: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/functions', () => ({
+  Functions: {
+    endpoint: {
+      requiringAuth: () => ({
+        handle: <TReq, TRes>(
+          handler: (data: TReq, ctx: unknown) => Promise<TRes>
+        ) => handler,
+      }),
+    },
+  },
+  getUserRoles: mocks.getUserRoles,
+}));
+
+import { getMyRoles } from './get-my-roles';
+
+type Handler = (data: unknown, ctx?: unknown) => Promise<unknown>;
+const handler = getMyRoles as unknown as Handler;
+
+describe('getMyRoles', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns the caller's roles", async () => {
+    mocks.getUserRoles.mockResolvedValue(['clerk', 'lesson-teacher']);
+
+    const result = (await handler({}, { uid: 'nathan-uid' })) as {
+      roles: string[];
+    };
+
+    expect(result.roles).toEqual(['clerk', 'lesson-teacher']);
+    expect(mocks.getUserRoles).toHaveBeenCalledWith('nathan-uid');
+  });
+
+  it('returns empty roles without a uid (defensive)', async () => {
+    const result = (await handler({}, {})) as { roles: string[] };
+
+    expect(result.roles).toEqual([]);
+    expect(mocks.getUserRoles).not.toHaveBeenCalled();
+  });
+});

--- a/libs/firebase/maple-functions/get-my-roles/src/lib/get-my-roles.ts
+++ b/libs/firebase/maple-functions/get-my-roles/src/lib/get-my-roles.ts
@@ -1,0 +1,26 @@
+/**
+ * Get My Roles Cloud Function
+ *
+ * Returns every role the authenticated user holds (admin from
+ * `admins/{uid}`, scoped roles from `userRoles/{uid}`). Requires
+ * authentication but NO role — any logged-in user can ask about
+ * themselves. The client uses this to gate navigation; enforcement
+ * stays server-side in each function's role check.
+ */
+import { Functions, getUserRoles } from '@maple/firebase/functions';
+import type {
+  GetMyRolesRequest,
+  GetMyRolesResponse,
+  UserRole,
+} from '@maple/ts/firebase/api-types';
+
+export const getMyRoles = Functions.endpoint
+  .requiringAuth()
+  .handle<GetMyRolesRequest, GetMyRolesResponse>(async (_data, context) => {
+    if (!context.uid) {
+      return { roles: [] };
+    }
+
+    const roles = await getUserRoles(context.uid);
+    return { roles: roles as UserRole[] };
+  });

--- a/libs/firebase/maple-functions/get-my-roles/tsconfig.json
+++ b/libs/firebase/maple-functions/get-my-roles/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/get-my-roles/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/get-my-roles/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/grant-role/project.json
+++ b/libs/firebase/maple-functions/grant-role/project.json
@@ -1,0 +1,11 @@
+{
+  "name": "firebase-maple-functions-grant-role",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/grant-role/src",
+  "projectType": "library",
+  "tags": [
+    "scope:firebase",
+    "type:feature"
+  ],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/grant-role/src/index.ts
+++ b/libs/firebase/maple-functions/grant-role/src/index.ts
@@ -1,0 +1,1 @@
+export { grantRole } from './lib/grant-role';

--- a/libs/firebase/maple-functions/grant-role/src/lib/grant-role.spec.ts
+++ b/libs/firebase/maple-functions/grant-role/src/lib/grant-role.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  grantRoleUtil: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/functions', () => ({
+  Functions: {
+    endpoint: {
+      requiringRole: () => ({
+        handle: <TReq, TRes>(
+          handler: (data: TReq, ctx: unknown) => Promise<TRes>
+        ) => handler,
+      }),
+    },
+  },
+  Role: {
+    Admin: 'admin',
+    MtTeacher: 'mt-teacher',
+    Clerk: 'clerk',
+    LessonTeacher: 'lesson-teacher',
+  },
+  grantRole: mocks.grantRoleUtil,
+  throwInvalidArgument: (msg: string) => {
+    throw new Error(msg);
+  },
+}));
+
+import { grantRole } from './grant-role';
+
+type Handler = (data: unknown, ctx?: unknown) => Promise<unknown>;
+const handler = grantRole as unknown as Handler;
+
+describe('grantRole', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('grants a scoped role with the calling admin as grantedBy', async () => {
+    mocks.grantRoleUtil.mockResolvedValue(undefined);
+
+    const result = (await handler(
+      { uid: 'stephanie-uid', role: 'mt-teacher' },
+      { uid: 'katie-uid' }
+    )) as { success: boolean };
+
+    expect(result.success).toBe(true);
+    expect(mocks.grantRoleUtil).toHaveBeenCalledWith(
+      'stephanie-uid',
+      'mt-teacher',
+      'katie-uid'
+    );
+  });
+
+  it('rejects granting the admin role (grantAdminRole owns it)', async () => {
+    await expect(
+      handler({ uid: 'x-uid', role: 'admin' }, { uid: 'katie-uid' })
+    ).rejects.toThrow(/Role must be one of/);
+    expect(mocks.grantRoleUtil).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown role', async () => {
+    await expect(
+      handler({ uid: 'x-uid', role: 'superuser' }, { uid: 'katie-uid' })
+    ).rejects.toThrow(/Role must be one of/);
+  });
+
+  it('rejects missing target uid', async () => {
+    await expect(
+      handler({ role: 'clerk' }, { uid: 'katie-uid' })
+    ).rejects.toThrow(/Target user UID is required/);
+  });
+
+  it('rejects missing caller uid (defensive)', async () => {
+    await expect(
+      handler({ uid: 'x-uid', role: 'clerk' }, {})
+    ).rejects.toThrow(/Authentication required/);
+  });
+});

--- a/libs/firebase/maple-functions/grant-role/src/lib/grant-role.ts
+++ b/libs/firebase/maple-functions/grant-role/src/lib/grant-role.ts
@@ -1,0 +1,40 @@
+/**
+ * Grant Role Cloud Function
+ *
+ * Admin-only. Grants a scoped role (mt-teacher, clerk, lesson-teacher)
+ * to another user by adding it to the `roles` array on `userRoles/{uid}`.
+ * Records the granting admin's UID for audit purposes.
+ *
+ * The admin role itself is intentionally NOT grantable here —
+ * `admins/{uid}` stays the source of truth for admin; use grantAdminRole.
+ */
+import {
+  Functions,
+  Role,
+  grantRole as grantRoleUtil,
+  throwInvalidArgument,
+} from '@maple/firebase/functions';
+import type {
+  GrantRoleRequest,
+  GrantRoleResponse,
+} from '@maple/ts/firebase/api-types';
+
+/** Roles this function may grant (everything except admin) */
+const GRANTABLE_ROLES = new Set<string>(
+  Object.values(Role).filter((role) => role !== Role.Admin)
+);
+
+export const grantRole = Functions.endpoint
+  .requiringRole(Role.Admin)
+  .handle<GrantRoleRequest, GrantRoleResponse>(async (data, context) => {
+    if (!context.uid) throwInvalidArgument('Authentication required');
+    if (!data.uid) throwInvalidArgument('Target user UID is required');
+    if (!data.role || !GRANTABLE_ROLES.has(data.role)) {
+      throwInvalidArgument(
+        `Role must be one of: ${[...GRANTABLE_ROLES].join(', ')}`
+      );
+    }
+
+    await grantRoleUtil(data.uid, data.role as Role, context.uid);
+    return { success: true };
+  });

--- a/libs/firebase/maple-functions/grant-role/tsconfig.json
+++ b/libs/firebase/maple-functions/grant-role/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/grant-role/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/grant-role/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/revoke-role/project.json
+++ b/libs/firebase/maple-functions/revoke-role/project.json
@@ -1,0 +1,11 @@
+{
+  "name": "firebase-maple-functions-revoke-role",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/revoke-role/src",
+  "projectType": "library",
+  "tags": [
+    "scope:firebase",
+    "type:feature"
+  ],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/revoke-role/src/index.ts
+++ b/libs/firebase/maple-functions/revoke-role/src/index.ts
@@ -1,0 +1,1 @@
+export { revokeRole } from './lib/revoke-role';

--- a/libs/firebase/maple-functions/revoke-role/src/lib/revoke-role.spec.ts
+++ b/libs/firebase/maple-functions/revoke-role/src/lib/revoke-role.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  revokeRoleUtil: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/functions', () => ({
+  Functions: {
+    endpoint: {
+      requiringRole: () => ({
+        handle: <TReq, TRes>(
+          handler: (data: TReq, ctx: unknown) => Promise<TRes>
+        ) => handler,
+      }),
+    },
+  },
+  Role: {
+    Admin: 'admin',
+    MtTeacher: 'mt-teacher',
+    Clerk: 'clerk',
+    LessonTeacher: 'lesson-teacher',
+  },
+  revokeRole: mocks.revokeRoleUtil,
+  throwInvalidArgument: (msg: string) => {
+    throw new Error(msg);
+  },
+}));
+
+import { revokeRole } from './revoke-role';
+
+type Handler = (data: unknown, ctx?: unknown) => Promise<unknown>;
+const handler = revokeRole as unknown as Handler;
+
+describe('revokeRole', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('revokes a scoped role', async () => {
+    mocks.revokeRoleUtil.mockResolvedValue(undefined);
+
+    const result = (await handler(
+      { uid: 'nathan-uid', role: 'clerk' },
+      { uid: 'katie-uid' }
+    )) as { success: boolean };
+
+    expect(result.success).toBe(true);
+    expect(mocks.revokeRoleUtil).toHaveBeenCalledWith('nathan-uid', 'clerk');
+  });
+
+  it('rejects revoking the admin role (revokeAdminRole owns it)', async () => {
+    await expect(
+      handler({ uid: 'x-uid', role: 'admin' }, { uid: 'katie-uid' })
+    ).rejects.toThrow(/Role must be one of/);
+    expect(mocks.revokeRoleUtil).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown role', async () => {
+    await expect(
+      handler({ uid: 'x-uid', role: 'superuser' }, { uid: 'katie-uid' })
+    ).rejects.toThrow(/Role must be one of/);
+  });
+
+  it('rejects missing target uid', async () => {
+    await expect(
+      handler({ role: 'clerk' }, { uid: 'katie-uid' })
+    ).rejects.toThrow(/Target user UID is required/);
+  });
+});

--- a/libs/firebase/maple-functions/revoke-role/src/lib/revoke-role.ts
+++ b/libs/firebase/maple-functions/revoke-role/src/lib/revoke-role.ts
@@ -1,0 +1,38 @@
+/**
+ * Revoke Role Cloud Function
+ *
+ * Admin-only. Revokes a scoped role (mt-teacher, clerk, lesson-teacher)
+ * from a user by removing it from the `roles` array on `userRoles/{uid}`.
+ *
+ * The admin role itself is intentionally NOT revocable here —
+ * `admins/{uid}` stays the source of truth for admin; use revokeAdminRole.
+ */
+import {
+  Functions,
+  Role,
+  revokeRole as revokeRoleUtil,
+  throwInvalidArgument,
+} from '@maple/firebase/functions';
+import type {
+  RevokeRoleRequest,
+  RevokeRoleResponse,
+} from '@maple/ts/firebase/api-types';
+
+/** Roles this function may revoke (everything except admin) */
+const REVOCABLE_ROLES = new Set<string>(
+  Object.values(Role).filter((role) => role !== Role.Admin)
+);
+
+export const revokeRole = Functions.endpoint
+  .requiringRole(Role.Admin)
+  .handle<RevokeRoleRequest, RevokeRoleResponse>(async (data, _context) => {
+    if (!data.uid) throwInvalidArgument('Target user UID is required');
+    if (!data.role || !REVOCABLE_ROLES.has(data.role)) {
+      throwInvalidArgument(
+        `Role must be one of: ${[...REVOCABLE_ROLES].join(', ')}`
+      );
+    }
+
+    await revokeRoleUtil(data.uid, data.role as Role);
+    return { success: true };
+  });

--- a/libs/firebase/maple-functions/revoke-role/tsconfig.json
+++ b/libs/firebase/maple-functions/revoke-role/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/revoke-role/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/revoke-role/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/ts/firebase/api-types/src/lib/auth.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/auth.types.ts
@@ -11,3 +11,17 @@ export type CheckAdminStatusRequest = Record<string, never>;
 export interface CheckAdminStatusResponse {
   isAdmin: boolean;
 }
+
+/**
+ * Roles a portal user can hold. Mirrors the server-side `Role` enum in
+ * `@maple/firebase/functions` (which client code cannot import).
+ */
+export type UserRole = 'admin' | 'mt-teacher' | 'clerk' | 'lesson-teacher';
+
+/** Request for getMyRoles - no data needed, uses auth context */
+export type GetMyRolesRequest = Record<string, never>;
+
+/** Response from getMyRoles */
+export interface GetMyRolesResponse {
+  roles: UserRole[];
+}

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -211,6 +211,9 @@ export type {
 export type {
   CheckAdminStatusRequest,
   CheckAdminStatusResponse,
+  UserRole,
+  GetMyRolesRequest,
+  GetMyRolesResponse,
 } from './auth.types';
 
 // User & role administration
@@ -221,6 +224,10 @@ export type {
   GrantAdminRoleResponse,
   RevokeAdminRoleRequest,
   RevokeAdminRoleResponse,
+  GrantRoleRequest,
+  GrantRoleResponse,
+  RevokeRoleRequest,
+  RevokeRoleResponse,
 } from './user.types';
 
 // Phase 4.5: Calendar Event types

--- a/libs/ts/firebase/api-types/src/lib/user.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/user.types.ts
@@ -2,6 +2,7 @@
  * User & role administration API types
  */
 import type { AppUser } from '@maple/ts/domain';
+import type { UserRole } from './auth.types';
 
 // ============================================================================
 // List Users (admin)
@@ -35,5 +36,29 @@ export interface RevokeAdminRoleRequest {
 }
 
 export interface RevokeAdminRoleResponse {
+  success: boolean;
+}
+
+// ============================================================================
+// Grant / Revoke Scoped Roles (mt-teacher, clerk, lesson-teacher)
+// ============================================================================
+
+export interface GrantRoleRequest {
+  uid: string;
+  /** Role to grant. 'admin' is rejected — use grantAdminRole. */
+  role: UserRole;
+}
+
+export interface GrantRoleResponse {
+  success: boolean;
+}
+
+export interface RevokeRoleRequest {
+  uid: string;
+  /** Role to revoke. 'admin' is rejected — use revokeAdminRole. */
+  role: UserRole;
+}
+
+export interface RevokeRoleResponse {
   success: boolean;
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -389,6 +389,15 @@
       "@maple/firebase/maple-functions/check-admin-status": [
         "libs/firebase/maple-functions/check-admin-status/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/get-my-roles": [
+        "libs/firebase/maple-functions/get-my-roles/src/index.ts"
+      ],
+      "@maple/firebase/maple-functions/grant-role": [
+        "libs/firebase/maple-functions/grant-role/src/index.ts"
+      ],
+      "@maple/firebase/maple-functions/revoke-role": [
+        "libs/firebase/maple-functions/revoke-role/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/get-calendar-events": [
         "libs/firebase/maple-functions/get-calendar-events/src/index.ts"
       ],


### PR DESCRIPTION
Closes #613. PR 1 of 3 for the scoped-roles epic (#617) — next up: client plumbing (#614), then function re-scoping (#615).

## What

**Behavior-neutral role framework.** No function is re-scoped in this PR — existing admins behave exactly as before. This lays the plumbing so #615 can scope Music Together to Stephanie (mt-teacher) and store/POS/registrations to Nathan (clerk) with one-line `requiringRole([...])` changes.

- **`Role` enum** gains `MtTeacher = 'mt-teacher'`, `Clerk = 'clerk'`, `LessonTeacher = 'lesson-teacher'`
- **`userRoles/{uid}`** Firestore doc (`{ roles: string[], grantedBy, updatedAt }`) stores scoped roles; `admins/{uid}` remains the source of truth for admin (full back-compat)
- **`hasAnyRole(uid, roles)`** — any-of check, at most 2 doc reads regardless of set size
- **`requiringRole()` / `requiredRole`** now accept a single `Role` or an any-of array; 403 message names every accepted role
- **New callables** (maple-core): `getMyRoles` (auth-only, for client nav gating in #614), `grantRole` / `revokeRole` (admin-only; reject `'admin'` — `grantAdminRole`/`revokeAdminRole` keep owning it)
- **api-types**: `UserRole` union + request/response types shared with the client

## Design notes

- Unknown strings in a stored `roles` array are filtered out, so removing a role from the enum degrades safely.
- `revokeRole` uses set+merge with `arrayRemove` so revoking from a user with no doc is a no-op, not a NOT_FOUND.
- No composite indexes needed (doc-ID reads only) — index analyzer passes.

## Verification

- **Unit** (2312 passed, full repo run): collection-routed Firestore mocks for `auth.utility`; builder any-of tests (`[Admin, MtTeacher]` pass-through, 403 message naming all roles); per-function specs.
- **Integration** (utility suite, 17 passed against real emulators): grant → getMyRoles → revoke round trip; multi-role users; scoped role does **not** confer admin (`checkAdminStatus` false, admin-only fns 403); `grantRole`/`revokeRole` 403 for non-admin callers; `admin` role rejected with 400.
- All 4 function codebases build; `validate-function-tsconfigs.sh` and the Firestore index analyzer pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
