### PR TITLE
feat(portal): role-aware client — RolesProvider, RoleGuard, filtered nav, /users role toggles (PR 2 of 3)

### DIFF
--- a/apps/functions-integration-tests-utility/src/utility-functions.spec.ts
+++ b/apps/functions-integration-tests-utility/src/utility-functions.spec.ts
@@ -297,6 +297,26 @@ describe('Utility Functions', () => {
       expect(roles.data?.roles).not.toContain('mt-teacher');
     });
 
+    it('listUsers joins scoped roles onto each user (powers /users UI)', async () => {
+      // scopedUser holds clerk + lesson-teacher at this point in the suite
+      const result = await callFunction<
+        Record<string, never>,
+        { users: Array<{ uid: string; isAdmin: boolean; roles: string[] }> }
+      >({
+        functionName: 'listUsers',
+        idToken: adminUser.idToken,
+      });
+
+      expect(result.status).toBe(200);
+      const byUid = new Map(result.data?.users.map((u) => [u.uid, u]));
+      expect(byUid.get(scopedUser.uid)?.roles).toEqual(
+        expect.arrayContaining(['clerk', 'lesson-teacher'])
+      );
+      expect(byUid.get(scopedUser.uid)?.isAdmin).toBe(false);
+      expect(byUid.get(adminUser.uid)?.isAdmin).toBe(true);
+      expect(byUid.get(adminUser.uid)?.roles).toEqual([]);
+    });
+
     it('revokeRole is admin-only (403 for non-admin caller)', async () => {
       const result = await callFunction<
         RevokeRoleRequest,

--- a/apps/maple-spruce/next-env.d.ts
+++ b/apps/maple-spruce/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/maple-spruce/src/app/(admin)/layout.tsx
+++ b/apps/maple-spruce/src/app/(admin)/layout.tsx
@@ -1,16 +1,21 @@
 'use client';
 
 import { ReactNode } from 'react';
-import { AdminGuard } from '@maple/react/auth';
+import { RoleGuard, RolesProvider } from '@maple/react/auth';
 import { AppShell } from '../../components/layout';
 
 /**
  * Layout for the admin app's authenticated routes.
  *
- * Lives at the route-group level so AppShell — and its `useAdminStatus`
- * state — is preserved across navigations within the group. Without this,
- * every navigation remounted AppShell and re-fired `checkAdminStatus`,
- * briefly flashing the loading nav before the response resolved.
+ * Lives at the route-group level so AppShell — and the roles state — is
+ * preserved across navigations within the group. Without this, every
+ * navigation remounted AppShell and re-fired the roles check, briefly
+ * flashing the loading nav before the response resolved.
+ *
+ * RolesProvider fetches getMyRoles ONCE; both the nav (role filtering in
+ * AppShellWrapper) and the gate (RoleGuard) read from it. Any user with
+ * at least one role passes the gate; what they can see/do is scoped by
+ * nav filtering here and `requiringRole` server-side.
  */
 export default function AdminGroupLayout({
   children,
@@ -18,8 +23,10 @@ export default function AdminGroupLayout({
   children: ReactNode;
 }) {
   return (
-    <AppShell>
-      <AdminGuard>{children}</AdminGuard>
-    </AppShell>
+    <RolesProvider>
+      <AppShell>
+        <RoleGuard>{children}</RoleGuard>
+      </AppShell>
+    </RolesProvider>
   );
 }

--- a/apps/maple-spruce/src/app/(admin)/users/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/users/page.tsx
@@ -2,13 +2,14 @@
 
 import { useCallback, useState } from 'react';
 import { Alert, Box, CircularProgress, Stack, Typography } from '@mui/material';
-import type { AppUser } from '@maple/ts/domain';
+import type { AppUser, ScopedUserRole } from '@maple/ts/domain';
 import { UserList, UserRolesDialog } from '@maple/react/users';
 import { useAuth, useUsers } from '../../../hooks';
 
 export default function UsersPage() {
   const { user } = useAuth();
-  const { usersState, grantAdmin, revokeAdmin } = useUsers();
+  const { usersState, grantAdmin, revokeAdmin, grantRole, revokeRole } =
+    useUsers();
 
   const [selected, setSelected] = useState<AppUser | null>(null);
 
@@ -34,6 +35,30 @@ export default function UsersPage() {
     [revokeAdmin]
   );
 
+  const handleGrantRole = useCallback(
+    async (uid: string, role: ScopedUserRole) => {
+      await grantRole(uid, role);
+      setSelected((prev) =>
+        prev?.uid === uid && !prev.roles.includes(role)
+          ? { ...prev, roles: [...prev.roles, role] }
+          : prev
+      );
+    },
+    [grantRole]
+  );
+
+  const handleRevokeRole = useCallback(
+    async (uid: string, role: ScopedUserRole) => {
+      await revokeRole(uid, role);
+      setSelected((prev) =>
+        prev?.uid === uid
+          ? { ...prev, roles: prev.roles.filter((r) => r !== role) }
+          : prev
+      );
+    },
+    [revokeRole]
+  );
+
   return (
     <>
       <Box sx={{ mb: 3 }}>
@@ -41,8 +66,9 @@ export default function UsersPage() {
           Users
         </Typography>
         <Typography variant="body2" color="text.secondary">
-          Everyone who&apos;s signed up to the admin app. Grant admin
-          access to those who need it.
+          Everyone who&apos;s signed up to the admin app. Grant admin or a
+          scoped role (MT teacher, clerk, lesson teacher) to those who need
+          it.
         </Typography>
       </Box>
 
@@ -73,6 +99,8 @@ export default function UsersPage() {
         onClose={() => setSelected(null)}
         onGrantAdmin={handleGrantAdmin}
         onRevokeAdmin={handleRevokeAdmin}
+        onGrantRole={handleGrantRole}
+        onRevokeRole={handleRevokeRole}
       />
     </>
   );

--- a/apps/maple-spruce/src/components/layout/AppShell.stories.tsx
+++ b/apps/maple-spruce/src/components/layout/AppShell.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from 'storybook/test';
 import { Box, Typography } from '@mui/material';
+import { StaticRolesProvider } from '@maple/react/auth';
 import { AppShell } from '.';
 
 /**
@@ -7,11 +9,20 @@ import { AppShell } from '.';
  *
  * Note: This component uses Next.js navigation (usePathname) and
  * the UserMenu component which requires Firebase auth. In Storybook,
- * these are mocked via the nextjs framework integration.
+ * these are mocked via the nextjs framework integration. Nav items are
+ * filtered by the current user's roles, provided here via
+ * StaticRolesProvider (admin = full nav).
  */
 const meta = {
   component: AppShell,
   title: 'Layout/AppShell',
+  decorators: [
+    (Story) => (
+      <StaticRolesProvider roles={['admin']}>
+        <Story />
+      </StaticRolesProvider>
+    ),
+  ],
   parameters: {
     layout: 'fullscreen',
     nextjs: {
@@ -115,5 +126,59 @@ export const ArtistsPage: Story = {
         pathname: '/artists',
       },
     },
+  },
+};
+
+/**
+ * Nav filtered for an MT teacher (Stephanie): Music Together + shared
+ * calendar items only — no Store operations, no Admin group.
+ */
+export const MtTeacherNav: Story = {
+  args: {
+    children: <SampleContent />,
+    maxWidth: 'lg',
+  },
+  decorators: [
+    (Story) => (
+      <StaticRolesProvider roles={['mt-teacher']}>
+        <Story />
+      </StaticRolesProvider>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText('Sections')).toBeInTheDocument();
+    await expect(canvas.getByText('Spruce Room Schedule')).toBeInTheDocument();
+    await expect(canvas.queryByText('Inventory')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Users')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Students')).not.toBeInTheDocument();
+  },
+};
+
+/**
+ * Nav filtered for a clerk + lesson teacher (Nathan): store operations,
+ * registrations, and students — no class definitions, no Admin group.
+ */
+export const ClerkLessonTeacherNav: Story = {
+  args: {
+    children: <SampleContent />,
+    maxWidth: 'lg',
+  },
+  decorators: [
+    (Story) => (
+      <StaticRolesProvider roles={['clerk', 'lesson-teacher']}>
+        <Story />
+      </StaticRolesProvider>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText('Inventory')).toBeInTheDocument();
+    await expect(canvas.getByText('Registrations')).toBeInTheDocument();
+    await expect(canvas.getByText('Students')).toBeInTheDocument();
+    await expect(canvas.queryByText('Instructors')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Teacher Payouts')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Users')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Sections')).not.toBeInTheDocument();
   },
 };

--- a/apps/maple-spruce/src/components/layout/AppShellWrapper.tsx
+++ b/apps/maple-spruce/src/components/layout/AppShellWrapper.tsx
@@ -1,31 +1,10 @@
 'use client';
 
 import { ReactNode, useMemo } from 'react';
-import HomeIcon from '@mui/icons-material/Home';
-import InventoryIcon from '@mui/icons-material/Inventory';
-import PointOfSaleIcon from '@mui/icons-material/PointOfSale';
-import PeopleIcon from '@mui/icons-material/People';
-import CategoryIcon from '@mui/icons-material/Category';
-import SyncProblemIcon from '@mui/icons-material/SyncProblem';
-import SchoolIcon from '@mui/icons-material/School';
-import MusicNoteIcon from '@mui/icons-material/MusicNote';
-import ChildCareIcon from '@mui/icons-material/ChildCare';
-import PaymentsIcon from '@mui/icons-material/Payments';
-import EventIcon from '@mui/icons-material/Event';
-import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
-import MeetingRoomIcon from '@mui/icons-material/MeetingRoom';
-import EventNoteIcon from '@mui/icons-material/EventNote';
-import TuneIcon from '@mui/icons-material/Tune';
-import LinkIcon from '@mui/icons-material/Link';
-import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
-import SettingsIcon from '@mui/icons-material/Settings';
-import LocalOfferIcon from '@mui/icons-material/LocalOffer';
-import HowToRegIcon from '@mui/icons-material/HowToReg';
-import GavelIcon from '@mui/icons-material/Gavel';
-import CardMembershipIcon from '@mui/icons-material/CardMembership';
-import ManageAccountsIcon from '@mui/icons-material/ManageAccounts';
 import { AppShell, type NavGroup } from '@maple/react/layout';
 import { useSyncConflictSummary } from '@maple/react/data';
+import { useRoles } from '@maple/react/auth';
+import { buildNavGroups } from './nav-groups';
 
 interface AppShellWrapperProps {
   children: ReactNode;
@@ -34,16 +13,17 @@ interface AppShellWrapperProps {
 
 /**
  * App-specific wrapper around the library's AppShell component.
- * Provides the grouped navigation configuration for the admin app.
- *
- * Only admins reach this layout (via AdminGuard in (admin)/layout.tsx),
- * so the nav is the same for everyone who sees it.
+ * Provides the grouped navigation configuration for the admin app,
+ * filtered to the current user's roles (from RolesProvider — see
+ * `nav-groups.tsx` for the role map). This filtering is UX only;
+ * enforcement is server-side in each function's `requiringRole` check.
  */
 export function AppShellWrapper({
   children,
   maxWidth = 'lg',
 }: AppShellWrapperProps): ReactNode {
   const { summaryState } = useSyncConflictSummary();
+  const { roles } = useRoles();
 
   const pendingConflicts = useMemo(() => {
     if (summaryState.status !== 'success') return 0;
@@ -51,149 +31,8 @@ export function AppShellWrapper({
   }, [summaryState]);
 
   const navGroups: NavGroup[] = useMemo(
-    () => [
-      {
-        label: 'Store',
-        items: [
-          { label: 'Home', href: '/', icon: <HomeIcon /> },
-          {
-            label: 'Inventory',
-            href: '/inventory',
-            icon: <InventoryIcon />,
-          },
-          {
-            label: 'Sales',
-            href: '/sales',
-            icon: <PointOfSaleIcon />,
-          },
-          {
-            label: 'Categories',
-            href: '/categories',
-            icon: <CategoryIcon />,
-          },
-          { label: 'Artists', href: '/artists', icon: <PeopleIcon /> },
-          {
-            label: 'Artist Payouts',
-            href: '/payouts/artist-payouts',
-            icon: <AccountBalanceWalletIcon />,
-          },
-          {
-            label: 'Sync',
-            href: '/sync-conflicts',
-            icon: <SyncProblemIcon />,
-            badge: pendingConflicts,
-            badgeColor: 'warning',
-          },
-        ],
-      },
-      {
-        label: 'Classes',
-        items: [
-          { label: 'Classes', href: '/classes', icon: <EventIcon /> },
-          {
-            label: 'Class Categories',
-            href: '/class-categories',
-            icon: <CategoryIcon />,
-          },
-          {
-            label: 'Instructors',
-            href: '/instructors',
-            icon: <SchoolIcon />,
-          },
-          {
-            label: 'Discounts',
-            href: '/discounts',
-            icon: <LocalOfferIcon />,
-          },
-          {
-            label: 'Registrations',
-            href: '/registrations',
-            icon: <HowToRegIcon />,
-          },
-          {
-            label: 'Agreements',
-            href: '/agreements',
-            icon: <GavelIcon />,
-          },
-          {
-            label: 'Craft Club',
-            href: '/craft-club',
-            icon: <CardMembershipIcon />,
-          },
-        ],
-      },
-      {
-        label: 'Music Lessons',
-        items: [
-          {
-            label: 'Students',
-            href: '/students',
-            icon: <MusicNoteIcon />,
-          },
-          {
-            label: 'Teacher Payouts',
-            href: '/payouts',
-            icon: <PaymentsIcon />,
-          },
-        ],
-      },
-      {
-        label: 'Music Together',
-        items: [
-          {
-            label: 'Sections',
-            href: '/music-together',
-            icon: <ChildCareIcon />,
-          },
-        ],
-      },
-      {
-        label: 'Calendar',
-        items: [
-          {
-            label: 'Events',
-            href: '/events',
-            icon: <CalendarMonthIcon />,
-          },
-          {
-            label: 'Spruce Room Schedule',
-            href: '/room-schedule',
-            icon: <EventNoteIcon />,
-          },
-          {
-            label: 'Book the Spruce Room',
-            href: '/book-room',
-            icon: <MeetingRoomIcon />,
-          },
-          {
-            label: 'Embed Settings',
-            href: '/calendar-embed',
-            icon: <TuneIcon />,
-          },
-          {
-            label: 'Calendar Links',
-            href: '/calendar-links',
-            icon: <LinkIcon />,
-          },
-        ],
-      },
-      {
-        label: 'Admin',
-        items: [
-          {
-            label: 'Users',
-            href: '/users',
-            icon: <ManageAccountsIcon />,
-          },
-          {
-            label: 'Settings',
-            href: '/settings',
-            icon: <SettingsIcon />,
-          },
-        ],
-      },
-    ],
-    [pendingConflicts]
+    () => buildNavGroups(roles, pendingConflicts),
+    [roles, pendingConflicts]
   );
 
   return (

--- a/apps/maple-spruce/src/components/layout/nav-filter.spec.ts
+++ b/apps/maple-spruce/src/components/layout/nav-filter.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { filterNavGroupsByRoles } from './nav-filter';
+
+// Icon-free fixture mirroring the real nav's role semantics: an
+// admin-only item, a clerk item, an all-roles item, and a group that
+// disappears entirely for non-admins. The concrete production nav map
+// is asserted by the AppShell.stories.tsx play tests.
+const GROUPS = [
+  {
+    label: 'Store',
+    items: [
+      { label: 'Home', roles: ['mt-teacher', 'clerk', 'lesson-teacher'] },
+      { label: 'Inventory', roles: ['clerk'] },
+      { label: 'Artists' }, // admin only
+    ],
+  },
+  {
+    label: 'Music Together',
+    items: [{ label: 'Sections', roles: ['mt-teacher'] }],
+  },
+  {
+    label: 'Admin',
+    items: [{ label: 'Users' }, { label: 'Settings' }],
+  },
+] as const;
+
+function labels(groups: ReturnType<typeof filterNavGroupsByRoles>) {
+  return Object.fromEntries(
+    groups.map((g) => [g.label, g.items.map((i) => i.label)])
+  );
+}
+
+describe('filterNavGroupsByRoles', () => {
+  it('admin sees every item, including un-annotated (admin-only) ones', () => {
+    expect(labels(filterNavGroupsByRoles(GROUPS, ['admin']))).toEqual({
+      Store: ['Home', 'Inventory', 'Artists'],
+      'Music Together': ['Sections'],
+      Admin: ['Users', 'Settings'],
+    });
+  });
+
+  it('a scoped role sees only items listing it; empty groups drop', () => {
+    expect(labels(filterNavGroupsByRoles(GROUPS, ['mt-teacher']))).toEqual({
+      Store: ['Home'],
+      'Music Together': ['Sections'],
+    });
+  });
+
+  it('multi-role users see the union of their roles', () => {
+    expect(
+      labels(filterNavGroupsByRoles(GROUPS, ['mt-teacher', 'clerk']))
+    ).toEqual({
+      Store: ['Home', 'Inventory'],
+      'Music Together': ['Sections'],
+    });
+  });
+
+  it('unresolved roles (empty) hide everything', () => {
+    expect(filterNavGroupsByRoles(GROUPS, [])).toEqual([]);
+  });
+
+  it('strips the internal roles annotation from returned items', () => {
+    for (const group of filterNavGroupsByRoles(GROUPS, ['admin'])) {
+      for (const item of group.items) {
+        expect('roles' in item).toBe(false);
+      }
+    }
+  });
+
+  it('preserves extra item fields (badge etc.) through filtering', () => {
+    const groups = [
+      {
+        label: 'Store',
+        items: [{ label: 'Sync', badge: 7, badgeColor: 'warning' }],
+      },
+    ];
+    const [store] = filterNavGroupsByRoles(groups, ['admin']);
+    expect(store.items[0]).toEqual({
+      label: 'Sync',
+      badge: 7,
+      badgeColor: 'warning',
+    });
+  });
+});

--- a/apps/maple-spruce/src/components/layout/nav-filter.ts
+++ b/apps/maple-spruce/src/components/layout/nav-filter.ts
@@ -1,0 +1,33 @@
+import type { UserRole } from '@maple/ts/domain';
+
+/**
+ * Role-based nav filtering, kept free of JSX so it's unit-testable
+ * (app .tsx components are exercised via Storybook play tests instead).
+ *
+ * An item's `roles` lists the non-admin roles that may see it; omitted =
+ * admin only. Admins always see everything. Groups left with no visible
+ * items are dropped. While roles are unresolved (empty array), nothing
+ * is visible — the nav skeleton renders and fills in when roles land.
+ */
+export interface RoleAnnotated {
+  roles?: readonly UserRole[];
+}
+
+export function filterNavGroupsByRoles<Item extends RoleAnnotated>(
+  groups: ReadonlyArray<{ label: string; items: Item[] }>,
+  roles: readonly UserRole[]
+): Array<{ label: string; items: Array<Omit<Item, 'roles'>> }> {
+  const isAdmin = roles.includes('admin');
+
+  return groups
+    .map((group) => ({
+      label: group.label,
+      items: group.items
+        .filter(
+          (item) =>
+            isAdmin || item.roles?.some((role) => roles.includes(role))
+        )
+        .map(({ roles: _roles, ...item }) => item),
+    }))
+    .filter((group) => group.items.length > 0);
+}

--- a/apps/maple-spruce/src/components/layout/nav-groups.tsx
+++ b/apps/maple-spruce/src/components/layout/nav-groups.tsx
@@ -1,0 +1,210 @@
+import HomeIcon from '@mui/icons-material/Home';
+import InventoryIcon from '@mui/icons-material/Inventory';
+import PointOfSaleIcon from '@mui/icons-material/PointOfSale';
+import PeopleIcon from '@mui/icons-material/People';
+import CategoryIcon from '@mui/icons-material/Category';
+import SyncProblemIcon from '@mui/icons-material/SyncProblem';
+import SchoolIcon from '@mui/icons-material/School';
+import MusicNoteIcon from '@mui/icons-material/MusicNote';
+import ChildCareIcon from '@mui/icons-material/ChildCare';
+import PaymentsIcon from '@mui/icons-material/Payments';
+import EventIcon from '@mui/icons-material/Event';
+import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
+import MeetingRoomIcon from '@mui/icons-material/MeetingRoom';
+import EventNoteIcon from '@mui/icons-material/EventNote';
+import TuneIcon from '@mui/icons-material/Tune';
+import LinkIcon from '@mui/icons-material/Link';
+import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
+import SettingsIcon from '@mui/icons-material/Settings';
+import LocalOfferIcon from '@mui/icons-material/LocalOffer';
+import HowToRegIcon from '@mui/icons-material/HowToReg';
+import GavelIcon from '@mui/icons-material/Gavel';
+import CardMembershipIcon from '@mui/icons-material/CardMembership';
+import ManageAccountsIcon from '@mui/icons-material/ManageAccounts';
+import type { NavGroup, NavItem } from '@maple/react/layout';
+import type { UserRole } from '@maple/ts/domain';
+import { filterNavGroupsByRoles } from './nav-filter';
+
+/**
+ * A nav item annotated with the roles that may see it. Omitted = admin
+ * only. Admins always see everything, so 'admin' never needs listing.
+ *
+ * This is UX-side filtering ONLY — enforcement is each Cloud Function's
+ * `requiringRole(...)` check (epic #617; re-scoping lands with #615).
+ * Keep this map in sync with the access matrix on the epic.
+ */
+type RoleNavItem = NavItem & { roles?: readonly UserRole[] };
+type RoleNavGroup = { label: string; items: RoleNavItem[] };
+
+/** Every non-admin role — for items any portal user should see. */
+const ALL_ROLES = ['mt-teacher', 'clerk', 'lesson-teacher'] as const;
+
+function roleNavGroups(pendingConflicts: number): RoleNavGroup[] {
+  return [
+    {
+      label: 'Store',
+      items: [
+        // Home stays visible to every role: it's the landing route, and a
+        // nav with no '/' entry strands non-admin users on sign-in.
+        { label: 'Home', href: '/', icon: <HomeIcon />, roles: ALL_ROLES },
+        {
+          label: 'Inventory',
+          href: '/inventory',
+          icon: <InventoryIcon />,
+          roles: ['clerk'],
+        },
+        {
+          label: 'Sales',
+          href: '/sales',
+          icon: <PointOfSaleIcon />,
+          roles: ['clerk'],
+        },
+        {
+          label: 'Categories',
+          href: '/categories',
+          icon: <CategoryIcon />,
+          roles: ['clerk'],
+        },
+        { label: 'Artists', href: '/artists', icon: <PeopleIcon /> },
+        {
+          label: 'Artist Payouts',
+          href: '/payouts/artist-payouts',
+          icon: <AccountBalanceWalletIcon />,
+        },
+        {
+          label: 'Sync',
+          href: '/sync-conflicts',
+          icon: <SyncProblemIcon />,
+          badge: pendingConflicts,
+          badgeColor: 'warning',
+        },
+      ],
+    },
+    {
+      label: 'Classes',
+      items: [
+        { label: 'Classes', href: '/classes', icon: <EventIcon /> },
+        {
+          label: 'Class Categories',
+          href: '/class-categories',
+          icon: <CategoryIcon />,
+        },
+        {
+          label: 'Instructors',
+          href: '/instructors',
+          icon: <SchoolIcon />,
+        },
+        {
+          label: 'Discounts',
+          href: '/discounts',
+          icon: <LocalOfferIcon />,
+        },
+        {
+          label: 'Registrations',
+          href: '/registrations',
+          icon: <HowToRegIcon />,
+          roles: ['clerk'],
+        },
+        {
+          label: 'Agreements',
+          href: '/agreements',
+          icon: <GavelIcon />,
+        },
+        {
+          label: 'Craft Club',
+          href: '/craft-club',
+          icon: <CardMembershipIcon />,
+        },
+      ],
+    },
+    {
+      label: 'Music Lessons',
+      items: [
+        {
+          label: 'Students',
+          href: '/students',
+          icon: <MusicNoteIcon />,
+          roles: ['lesson-teacher'],
+        },
+        {
+          label: 'Teacher Payouts',
+          href: '/payouts',
+          icon: <PaymentsIcon />,
+        },
+      ],
+    },
+    {
+      label: 'Music Together',
+      items: [
+        {
+          label: 'Sections',
+          href: '/music-together',
+          icon: <ChildCareIcon />,
+          roles: ['mt-teacher'],
+        },
+      ],
+    },
+    {
+      label: 'Calendar',
+      items: [
+        {
+          label: 'Events',
+          href: '/events',
+          icon: <CalendarMonthIcon />,
+          roles: ALL_ROLES,
+        },
+        {
+          label: 'Spruce Room Schedule',
+          href: '/room-schedule',
+          icon: <EventNoteIcon />,
+          roles: ALL_ROLES,
+        },
+        {
+          label: 'Book the Spruce Room',
+          href: '/book-room',
+          icon: <MeetingRoomIcon />,
+          roles: ALL_ROLES,
+        },
+        {
+          label: 'Embed Settings',
+          href: '/calendar-embed',
+          icon: <TuneIcon />,
+        },
+        {
+          label: 'Calendar Links',
+          href: '/calendar-links',
+          icon: <LinkIcon />,
+        },
+      ],
+    },
+    {
+      label: 'Admin',
+      items: [
+        {
+          label: 'Users',
+          href: '/users',
+          icon: <ManageAccountsIcon />,
+        },
+        {
+          label: 'Settings',
+          href: '/settings',
+          icon: <SettingsIcon />,
+        },
+      ],
+    },
+  ];
+}
+
+/**
+ * Build the nav for a user's roles: admins see everything; other roles
+ * see only the items listing one of their roles (see
+ * `filterNavGroupsByRoles` in nav-filter.ts for the semantics and its
+ * unit tests; the concrete role map here is asserted by the
+ * AppShell.stories.tsx play tests).
+ */
+export function buildNavGroups(
+  roles: readonly UserRole[],
+  pendingConflicts: number
+): NavGroup[] {
+  return filterNavGroupsByRoles(roleNavGroups(pendingConflicts), roles);
+}

--- a/apps/maple-spruce/src/lib/warmup.ts
+++ b/apps/maple-spruce/src/lib/warmup.ts
@@ -7,13 +7,13 @@ import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
  * with the Firebase auth handshake hides that cold start from the user.
  *
  * Keep this in sync with the functions the shell + dashboard call on mount:
- * - AdminGuard           -> checkAdminStatus
+ * - RolesProvider        -> getMyRoles
  * - AppShell             -> getSyncConflictSummary
  * - DashboardPage        -> getClasses / getRegistrations / getProducts
  * - room schedule widget -> getRoomSchedule
  */
 export const DASHBOARD_WARMUP_FUNCTIONS = [
-  'checkAdminStatus',
+  'getMyRoles',
   'getSyncConflictSummary',
   'getClasses',
   'getRegistrations',

--- a/docs/architecture/DECISIONS.md
+++ b/docs/architecture/DECISIONS.md
@@ -1125,6 +1125,37 @@ Create a dedicated Nx app (`apps/functions-integration-tests/`) that tests Cloud
 
 ---
 
+## ADR-028: Plain RBAC with Firestore Role Docs (not custom claims, ABAC, or ReBAC)
+
+**Status:** Accepted
+**Date:** 2026-07-16
+
+### Context
+The portal needs scoped access for more kinds of staff: Stephanie manages only Music Together, Nathan is a clerk (store/POS/registrations) *and* a lesson teacher, and future lesson teachers should read all lessons but mutate only their own. Access was binary admin (`admins/{uid}` doc existence). Researched RBAC vs ABAC vs ReBAC/Zanzibar (OpenFGA, SpiceDB) vs policy libraries (Cedar, Casbin) vs SaaS authz, and Firestore role docs vs Firebase custom claims, grounded in this codebase (epic #617).
+
+### Decision
+Plain RBAC: a `Role` enum (`admin`, `mt-teacher`, `clerk`, `lesson-teacher`), a `userRoles/{uid}` Firestore doc holding a roles array (multi-role, any-of checks via `requiringRole([...])`), with `admins/{uid}` remaining authoritative for admin. The one record-level rule — lesson teachers mutate only their own lessons — is an ownership predicate (`assertOwnerOrAdmin`-style helper) layered on the role gate, not a new authorization model. Client role state comes from a single `getMyRoles` callable via `RolesProvider`; nav filtering is UX only, enforcement is server-side per function.
+
+### Rationale
+- ~4 stable roles mapping 1:1 to job functions, <10 users, single tenant: the textbook RBAC profile
+- One enforcement point (the callable FunctionBuilder) — the roles check lands in one file and is trivially testable
+- **Custom claims' main benefit is moot here**: the client has zero direct Firestore reads (all data flows through callables; `firestore.rules` is deny-all), so there is no rules integration to gain. The doc gives instant revocation (claims lag up to ~1h on token TTL), console visibility, and is cost-neutral (the per-invocation `admins/{uid}` read already existed)
+- An ownership check is one foreign-key comparison; a relationship store (ReBAC) or policy DSL (ABAC/Cedar) to express one `if` is pure overhead
+
+### Alternatives Considered
+- **Firebase custom claims**: zero-read checks, but stale up to a token refresh, invisible in the console, and needs sync plumbing; its rules-integration advantage doesn't apply to this architecture
+- **ReBAC / Zanzibar (OpenFGA, SpiceDB)**: built for per-object sharing graphs; requires a sidecar service and tuple sync — operational cost far exceeds benefit at this scale
+- **ABAC / policy libraries (Cedar, Casbin, Oso)**: no context/time/tenant conditions exist to express; adds a second language to review
+- **SaaS authz (Permit.io, AWS Verified Permissions)**: external dependency + latency in the hot path of cold-start-sensitive callables
+
+### Consequences
+- Scoping a function to roles is a one-line `requiringRole([...])` change (#615)
+- Phase-2 lesson ownership needs a teacher↔uid link on the instructor record (#616)
+- A CI analyzer should assert every exported callable declares a role or sits on an explicit public allowlist (#620)
+- Revisit if: >8–10 roles / one-off permission combos (→ policy library), per-resource grants or customer-scoped logins (→ ReBAC), multi-tenancy, or the client regains direct Firestore reads (→ reopen custom claims)
+
+---
+
 ## ADR-XXX: [Title]
 
 **Status:** Proposed | Accepted | Deprecated | Superseded
@@ -1148,4 +1179,4 @@ What becomes easier or harder as a result?
 
 ---
 
-*Last updated: 2026-03-30 (ADR-027 added for integration testing with Firebase emulators)*
+*Last updated: 2026-07-16 (ADR-028 added for plain RBAC with Firestore role docs)*

--- a/docs/reference/deployed-functions.md
+++ b/docs/reference/deployed-functions.md
@@ -96,7 +96,7 @@ Core CRUD operations, auth, triggers, and admin functions. No heavy third-party 
 - `getMyRoles` _(auth only — returns every role the caller holds: admin from `admins/{uid}` + scoped roles from `userRoles/{uid}`; client nav gating)_
 
 ### User & role administration
-- `listUsers` _(admin only — Firebase Auth users joined with admin records; powers `/users` page; capped at 1000 per call)_
+- `listUsers` _(admin only — Firebase Auth users joined with admin records + scoped roles from `userRoles/{uid}`; powers `/users` page; capped at 1000 per call)_
 - `grantAdminRole` _(admin only — promotes another user to admin)_
 - `revokeAdminRole` _(admin only — demotes another admin; self-protection: cannot revoke your own admin)_
 - `grantRole` _(admin only — grants a scoped role: `mt-teacher`, `clerk`, `lesson-teacher`; writes `userRoles/{uid}.roles`; rejects `admin`)_

--- a/docs/reference/implementation-status.md
+++ b/docs/reference/implementation-status.md
@@ -23,6 +23,7 @@
 | Authentication | Complete | `libs/react/auth/` (re-exported via app barrel) |
 | Admin authorization (UI) | Complete | `AdminGuard` + `useAdminStatus` + `checkAdminStatus` Cloud Function |
 | Scoped roles framework (PR 1 of epic #617) | Complete | `Role` enum (admin, mt-teacher, clerk, lesson-teacher) + `userRoles/{uid}` + any-of `requiringRole([...])` + `getMyRoles`/`grantRole`/`revokeRole`; behavior-neutral — client plumbing #614, re-scoping #615 |
+| Scoped roles client plumbing (PR 2 of epic #617) | Complete | `RolesProvider`/`useRoles`/`RoleGuard` (ADR-028), role-filtered nav (`nav-groups.tsx`), `/users` scoped-role toggles, `listUsers` roles join — enforcement re-scoping is #615 |
 | Navigation (responsive) | Complete | `libs/react/layout/` (re-exported via app barrel) |
 | Storybook | Complete | `apps/maple-spruce/.storybook/` |
 | Component stories | Complete | `apps/maple-spruce/src/components/**/*.stories.tsx`, `libs/react/*/src/**/*.stories.tsx` |

--- a/libs/firebase/functions/src/lib/auth.utility.ts
+++ b/libs/firebase/functions/src/lib/auth.utility.ts
@@ -135,6 +135,29 @@ export async function getUserRoles(uid: string): Promise<Role[]> {
 }
 
 /**
+ * Read every user's scoped roles in one collection scan — powers the
+ * admin /users page join (mirrors getAdminUids, avoids N+1 reads).
+ *
+ * @returns Map of uid -> scoped roles (users without a doc are absent)
+ */
+export async function getAllUserRoles(): Promise<Map<string, Role[]>> {
+  const db = getDb();
+  const snapshot = await db.collection(USER_ROLES_COLLECTION).get();
+  const byUid = new Map<string, Role[]>();
+  for (const doc of snapshot.docs) {
+    const roles = (doc.data() as UserRolesDoc).roles;
+    if (!Array.isArray(roles)) continue;
+    byUid.set(
+      doc.id,
+      roles.filter(
+        (role): role is Role => typeof role === 'string' && KNOWN_ROLES.has(role)
+      )
+    );
+  }
+  return byUid;
+}
+
+/**
  * Grant a non-admin role to a user by adding it to the `roles` array
  * on `userRoles/{uid}`.
  *

--- a/libs/firebase/functions/src/lib/index.ts
+++ b/libs/firebase/functions/src/lib/index.ts
@@ -38,6 +38,7 @@ export {
   hasRole,
   hasAnyRole,
   getUserRoles,
+  getAllUserRoles,
   grantRole,
   revokeRole,
   grantAdminRole,

--- a/libs/firebase/maple-functions/list-users/src/lib/list-users.spec.ts
+++ b/libs/firebase/maple-functions/list-users/src/lib/list-users.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   getAdminUids: vi.fn(),
+  getAllUserRoles: vi.fn(),
   authListUsers: vi.fn(),
   adminApps: [] as unknown[],
   adminInitializeApp: vi.fn(),
@@ -12,6 +13,7 @@ vi.mock('@maple/firebase/functions', () => ({
     handler: (data: TReq, ctx: unknown) => Promise<TRes>
   ) => handler,
   getAdminUids: mocks.getAdminUids,
+  getAllUserRoles: mocks.getAllUserRoles,
   throwInvalidArgument: (msg: string) => {
     throw new Error(msg);
   },
@@ -78,6 +80,7 @@ describe('listUsers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.adminApps.length = 0;
+    mocks.getAllUserRoles.mockResolvedValue(new Map());
   });
 
   it('marks users with admin records as isAdmin', async () => {
@@ -156,5 +159,25 @@ describe('listUsers', () => {
       hasMore: boolean;
     };
     expect(result.hasMore).toBe(true);
+  });
+
+  it('joins scoped roles from userRoles/{uid}; users without a doc get []', async () => {
+    mocks.getAdminUids.mockResolvedValue(['katie-uid']);
+    mocks.getAllUserRoles.mockResolvedValue(
+      new Map([['nathan-uid', ['clerk', 'lesson-teacher']]])
+    );
+    mocks.authListUsers.mockResolvedValue({
+      users: [authUserNathan, authUserKatie],
+    });
+
+    const result = (await handler({}, { uid: 'katie-uid' })) as {
+      users: Array<{ uid: string; isAdmin: boolean; roles: string[] }>;
+    };
+
+    const byUid = new Map(result.users.map((u) => [u.uid, u]));
+    expect(byUid.get('nathan-uid')?.roles).toEqual(['clerk', 'lesson-teacher']);
+    expect(byUid.get('nathan-uid')?.isAdmin).toBe(false);
+    expect(byUid.get('katie-uid')?.roles).toEqual([]);
+    expect(byUid.get('katie-uid')?.isAdmin).toBe(true);
   });
 });

--- a/libs/firebase/maple-functions/list-users/src/lib/list-users.ts
+++ b/libs/firebase/maple-functions/list-users/src/lib/list-users.ts
@@ -10,11 +10,12 @@
 import {
   createAdminFunction,
   getAdminUids,
+  getAllUserRoles,
   throwInvalidArgument,
 } from '@maple/firebase/functions';
 import { getAuth } from 'firebase-admin/auth';
 import admin from 'firebase-admin';
-import type { AppUser } from '@maple/ts/domain';
+import type { AppUser, ScopedUserRole } from '@maple/ts/domain';
 import type {
   GetUsersRequest,
   GetUsersResponse,
@@ -39,8 +40,9 @@ export const listUsers = createAdminFunction<
 
   ensureAdmin();
 
-  const [adminUids, page] = await Promise.all([
+  const [adminUids, rolesByUid, page] = await Promise.all([
     getAdminUids(),
+    getAllUserRoles(),
     getAuth().listUsers(limit),
   ]);
 
@@ -58,6 +60,9 @@ export const listUsers = createAdminFunction<
       ? new Date(u.metadata.lastSignInTime)
       : undefined,
     isAdmin: adminSet.has(u.uid),
+    // Role enum wire values are the ScopedUserRole strings; 'admin' never
+    // appears here (grantRole rejects it — admins/{uid} is authoritative)
+    roles: (rolesByUid.get(u.uid) ?? []) as ScopedUserRole[],
   }));
 
   // Sort: most recent sign-in first; users who never signed in (e.g. just

--- a/libs/react/auth/src/index.ts
+++ b/libs/react/auth/src/index.ts
@@ -1,5 +1,18 @@
 export { useAuth } from './lib/useAuth';
 export { useAdminStatus } from './lib/useAdminStatus';
+export { useMyRoles } from './lib/useMyRoles';
+export {
+  RolesProvider,
+  StaticRolesProvider,
+  useRoles,
+  type RolesContextValue,
+} from './lib/RolesProvider';
+export {
+  RoleGuard,
+  RoleGuardView,
+  type RoleGuardProps,
+  type RoleGuardViewProps,
+} from './lib/RoleGuard';
 export {
   AuthGuard,
   useAuthStatus,

--- a/libs/react/auth/src/lib/RoleGuard.stories.tsx
+++ b/libs/react/auth/src/lib/RoleGuard.stories.tsx
@@ -1,0 +1,159 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn, expect, within, userEvent } from 'storybook/test';
+import { Box, Typography } from '@mui/material';
+import type { RequestState, UserRole } from '@maple/ts/domain';
+import { RoleGuard } from './RoleGuard';
+import { RoleGuardView } from './RoleGuard';
+import { StaticRolesProvider } from './RolesProvider';
+
+/**
+ * Sample children content to render when access is granted.
+ */
+const GuardedContent = () => (
+  <Box sx={{ p: 4 }}>
+    <Typography variant="h4" gutterBottom>
+      Portal Content
+    </Typography>
+    <Typography>This content is only visible to users with a role.</Typography>
+  </Box>
+);
+
+const successState: RequestState<UserRole[]> = {
+  status: 'success',
+  data: ['mt-teacher'],
+};
+
+const errorState: RequestState<UserRole[]> = {
+  status: 'error',
+  error: 'Network request failed',
+};
+
+const meta = {
+  component: RoleGuardView,
+  title: 'Auth/RoleGuard',
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    onSignOut: fn(),
+    children: <GuardedContent />,
+  },
+} satisfies Meta<typeof RoleGuardView>;
+
+export default meta;
+type Story = StoryObj<typeof RoleGuardView>;
+
+// ============================================================
+// VISUAL STORIES (presentational view)
+// ============================================================
+
+/**
+ * Checking — spinner shown while roles resolve; children stay mounted
+ * but hidden so their data hooks fetch in parallel.
+ */
+export const Checking: Story = {
+  args: {
+    hasAccess: false,
+    isChecking: true,
+    rolesState: { status: 'loading' },
+  },
+};
+
+/**
+ * Access granted — children visible.
+ */
+export const HasAccess: Story = {
+  args: {
+    hasAccess: true,
+    isChecking: false,
+    rolesState: successState,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Portal Content')).toBeVisible();
+  },
+};
+
+/**
+ * No roles — friendly onboarding message, no content leak.
+ */
+export const NoAccess: Story = {
+  args: {
+    hasAccess: false,
+    isChecking: false,
+    rolesState: { status: 'success', data: [] },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText(/don't currently have access/i)
+    ).toBeInTheDocument();
+    await expect(
+      canvas.queryByText('Portal Content')
+    ).not.toBeInTheDocument();
+  },
+};
+
+/**
+ * Roles check failed — generic error with sign-out.
+ */
+export const CheckFailed: Story = {
+  args: {
+    hasAccess: false,
+    isChecking: false,
+    rolesState: errorState,
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText(/something went wrong/i)
+    ).toBeInTheDocument();
+    await userEvent.click(canvas.getByRole('button', { name: /sign out/i }));
+    await expect(args.onSignOut).toHaveBeenCalled();
+  },
+};
+
+// ============================================================
+// CONNECTED STORIES (RoleGuard + StaticRolesProvider)
+// ============================================================
+
+/**
+ * Full RoleGuard wired through a roles context: an mt-teacher passes the
+ * default any-role gate.
+ */
+export const ConnectedAnyRolePasses: Story = {
+  render: () => (
+    <StaticRolesProvider roles={['mt-teacher']}>
+      <RoleGuard>
+        <GuardedContent />
+      </RoleGuard>
+    </StaticRolesProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Portal Content')).toBeVisible();
+  },
+};
+
+/**
+ * Per-page scoping: an mt-teacher is refused by a clerk-only guard,
+ * while an admin would pass (admins always pass).
+ */
+export const ConnectedScopedRefusal: Story = {
+  render: () => (
+    <StaticRolesProvider roles={['mt-teacher']}>
+      <RoleGuard allowedRoles={['clerk']}>
+        <GuardedContent />
+      </RoleGuard>
+    </StaticRolesProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText(/don't currently have access/i)
+    ).toBeInTheDocument();
+    await expect(
+      canvas.queryByText('Portal Content')
+    ).not.toBeInTheDocument();
+  },
+};

--- a/libs/react/auth/src/lib/RoleGuard.tsx
+++ b/libs/react/auth/src/lib/RoleGuard.tsx
@@ -9,39 +9,44 @@ import {
   Paper,
 } from '@mui/material';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
-import type { RequestState } from '@maple/ts/domain';
-import { useAdminStatus } from './useAdminStatus';
+import type { RequestState, UserRole } from '@maple/ts/domain';
+import { useRoles } from './RolesProvider';
 import { useAuth } from './useAuth';
 
-export interface AdminGuardProps {
+export interface RoleGuardProps {
   children: ReactNode;
+  /**
+   * Roles that may pass. Omit to admit any user with at least one role
+   * (the route-group gate). Admins always pass.
+   */
+  allowedRoles?: readonly UserRole[];
 }
 
 /**
- * Props for the presentational AdminGuardView component.
+ * Props for the presentational RoleGuardView component.
  * Exposed for Storybook testing.
  */
-export interface AdminGuardViewProps {
+export interface RoleGuardViewProps {
   children: ReactNode;
-  isAdmin: boolean;
-  isCheckingAdmin: boolean;
-  adminState: RequestState<boolean>;
+  hasAccess: boolean;
+  isChecking: boolean;
+  rolesState: RequestState<UserRole[]>;
   onSignOut: () => void;
 }
 
 /**
- * Presentational component for AdminGuard states.
+ * Presentational component for RoleGuard states.
  * Accepts all state as props for testability in Storybook.
  */
-export function AdminGuardView({
+export function RoleGuardView({
   children,
-  isAdmin,
-  isCheckingAdmin,
-  adminState,
+  hasAccess,
+  isChecking,
+  rolesState,
   onSignOut,
-}: AdminGuardViewProps) {
-  // If check failed with error, show a generic message
-  if (adminState.status === 'error') {
+}: RoleGuardViewProps) {
+  // If the roles check failed, show a generic message
+  if (rolesState.status === 'error') {
     return (
       <Box
         sx={{
@@ -78,9 +83,9 @@ export function AdminGuardView({
     );
   }
 
-  // Resolved and not an admin — show the friendly onboarding message.
+  // Resolved and no access — show the friendly onboarding message.
   // (While still checking, fall through to render children hidden below.)
-  if (!isCheckingAdmin && !isAdmin) {
+  if (!isChecking && !hasAccess) {
     return (
       <Box
         sx={{
@@ -121,22 +126,22 @@ export function AdminGuardView({
     );
   }
 
-  // Admin confirmed, or still checking: render children in a STABLE wrapper
-  // so that resolving admin status doesn't remount them — a remount refires
+  // Access confirmed, or still checking: render children in a STABLE wrapper
+  // so that resolving the check doesn't remount them — a remount refires
   // every data hook (the dashboard was fetching each query a second time the
   // instant the check resolved). While still checking, hide the children
   // behind a spinner overlay; their data hooks fetch in parallel with the
-  // admin check (admin-only functions reject non-admins server-side, so the
-  // early fetch is safe).
+  // roles check (protected functions reject unauthorized users server-side,
+  // so the early fetch is safe).
   return (
     <Box sx={{ position: 'relative', minHeight: '100vh' }}>
       <Box
-        sx={{ visibility: isCheckingAdmin ? 'hidden' : 'visible' }}
-        aria-hidden={isCheckingAdmin || undefined}
+        sx={{ visibility: isChecking ? 'hidden' : 'visible' }}
+        aria-hidden={isChecking || undefined}
       >
         {children}
       </Box>
-      {isCheckingAdmin && (
+      {isChecking && (
         <Box
           sx={{
             position: 'absolute',
@@ -155,28 +160,33 @@ export function AdminGuardView({
 }
 
 /**
- * Guards content that requires admin access.
+ * Guards content behind the user's roles (from RolesProvider — mount one
+ * above this in the tree).
  *
- * Shows a loading spinner while checking admin status,
- * a friendly message if the user is not an admin,
- * or renders children if the user is an admin.
+ * With no `allowedRoles`, any user holding at least one role passes — the
+ * route-group gate that replaces the old binary AdminGuard. With
+ * `allowedRoles`, only those roles (or admin) pass — per-page scoping.
  *
- * @deprecated Use RoleGuard (with RolesProvider) instead — it admits
- * scoped roles and shares one getMyRoles fetch with the nav. This
- * remains only until per-page scoping fully replaces it (#615).
+ * NOTE: this is UX only. Enforcement lives server-side in each Cloud
+ * Function's `requiringRole(...)` check.
  */
-export function AdminGuard({ children }: AdminGuardProps) {
-  const { isAdmin, isCheckingAdmin, adminState } = useAdminStatus();
+export function RoleGuard({ children, allowedRoles }: RoleGuardProps) {
+  const { roles, isAdmin, hasAnyRole, isCheckingRoles, rolesState } =
+    useRoles();
   const { signOut } = useAuth();
 
+  const hasAccess = allowedRoles
+    ? isAdmin || roles.some((role) => allowedRoles.includes(role))
+    : hasAnyRole;
+
   return (
-    <AdminGuardView
-      isAdmin={isAdmin}
-      isCheckingAdmin={isCheckingAdmin}
-      adminState={adminState}
+    <RoleGuardView
+      hasAccess={hasAccess}
+      isChecking={isCheckingRoles}
+      rolesState={rolesState}
       onSignOut={signOut}
     >
       {children}
-    </AdminGuardView>
+    </RoleGuardView>
   );
 }

--- a/libs/react/auth/src/lib/RolesProvider.tsx
+++ b/libs/react/auth/src/lib/RolesProvider.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { createContext, useContext, type ReactNode } from 'react';
+import type { RequestState, UserRole } from '@maple/ts/domain';
+import { useMyRoles } from './useMyRoles';
+
+export interface RolesContextValue {
+  rolesState: RequestState<UserRole[]>;
+  /** Resolved roles; empty while loading or when the user has none. */
+  roles: UserRole[];
+  isAdmin: boolean;
+  /** True once the user holds at least one role. */
+  hasAnyRole: boolean;
+  isCheckingRoles: boolean;
+}
+
+const EMPTY: RolesContextValue = {
+  rolesState: { status: 'idle' },
+  roles: [],
+  isAdmin: false,
+  hasAnyRole: false,
+  isCheckingRoles: true,
+};
+
+const RolesContext = createContext<RolesContextValue>(EMPTY);
+
+/**
+ * Fetches the current user's roles ONCE and shares them via context, so
+ * the guard and the nav don't each fire their own getMyRoles call.
+ * Mount above AppShell in the (admin) route-group layout.
+ */
+export function RolesProvider({ children }: { children: ReactNode }) {
+  const value = useMyRoles();
+  return (
+    <RolesContext.Provider value={value}>{children}</RolesContext.Provider>
+  );
+}
+
+/**
+ * Fixed-value provider for Storybook and tests — no network, no Firebase.
+ */
+export function StaticRolesProvider({
+  roles,
+  isChecking = false,
+  children,
+}: {
+  roles: UserRole[];
+  isChecking?: boolean;
+  children: ReactNode;
+}) {
+  const value: RolesContextValue = {
+    rolesState: isChecking
+      ? { status: 'loading' }
+      : { status: 'success', data: roles },
+    roles: isChecking ? [] : roles,
+    isAdmin: !isChecking && roles.includes('admin'),
+    hasAnyRole: !isChecking && roles.length > 0,
+    isCheckingRoles: isChecking,
+  };
+  return (
+    <RolesContext.Provider value={value}>{children}</RolesContext.Provider>
+  );
+}
+
+/**
+ * Read the current user's roles from RolesProvider.
+ *
+ * Outside a provider this returns a safe "still checking" value rather
+ * than throwing — components render their loading state, never a crash.
+ */
+export function useRoles(): RolesContextValue {
+  return useContext(RolesContext);
+}

--- a/libs/react/auth/src/lib/useAdminStatus.ts
+++ b/libs/react/auth/src/lib/useAdminStatus.ts
@@ -15,6 +15,10 @@ import { useAuth } from './useAuth';
  *
  * Calls the checkAdminStatus Cloud Function after authentication.
  * Re-checks when the user changes.
+ *
+ * @deprecated Use useRoles() (from RolesProvider) / useMyRoles() —
+ * roles include admin plus the scoped roles (mt-teacher, clerk,
+ * lesson-teacher).
  */
 export function useAdminStatus() {
   const { user, isLoading: authLoading } = useAuth();

--- a/libs/react/auth/src/lib/useMyRoles.ts
+++ b/libs/react/auth/src/lib/useMyRoles.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { httpsCallable } from 'firebase/functions';
+import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
+import type { RequestState, UserRole } from '@maple/ts/domain';
+import type {
+  GetMyRolesRequest,
+  GetMyRolesResponse,
+} from '@maple/ts/firebase/api-types';
+import { useAuth } from './useAuth';
+
+/**
+ * Hook for fetching every role the current user holds (admin + scoped).
+ *
+ * Calls the getMyRoles Cloud Function after authentication and re-checks
+ * when the user changes. Prefer consuming roles via `useRoles()` from
+ * RolesProvider — this hook fires its own network request, so mounting it
+ * in more than one place duplicates the call.
+ */
+export function useMyRoles() {
+  const { user, isLoading: authLoading } = useAuth();
+  const [rolesState, setRolesState] = useState<RequestState<UserRole[]>>({
+    status: 'idle',
+  });
+
+  const fetchRoles = useCallback(async () => {
+    setRolesState({ status: 'loading' });
+
+    try {
+      const functions = getMapleFunctions();
+      const getMyRoles = httpsCallable<GetMyRolesRequest, GetMyRolesResponse>(
+        functions,
+        'getMyRoles'
+      );
+
+      const result = await getMyRoles({});
+      setRolesState({ status: 'success', data: result.data.roles });
+    } catch (error) {
+      console.error('Failed to fetch roles:', error);
+      setRolesState({
+        status: 'error',
+        error:
+          error instanceof Error ? error.message : 'Failed to fetch roles',
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (authLoading) return;
+
+    if (user) {
+      fetchRoles();
+    } else {
+      setRolesState({ status: 'idle' });
+    }
+  }, [user, authLoading, fetchRoles]);
+
+  const roles = rolesState.status === 'success' ? rolesState.data : [];
+
+  return {
+    rolesState,
+    roles,
+    isAdmin: roles.includes('admin'),
+    hasAnyRole: roles.length > 0,
+    isCheckingRoles: rolesState.status === 'loading' || authLoading,
+  };
+}

--- a/libs/react/data/src/lib/useUsers.ts
+++ b/libs/react/data/src/lib/useUsers.ts
@@ -46,6 +46,32 @@ function hydrateUser(raw: AppUser): AppUser {
 }
 
 /**
+ * Optimistic-update helpers for the users list. Top-level (not inline in
+ * the setState callbacks) so the state updaters stay shallow.
+ */
+function withRoleAdded(
+  users: AppUser[],
+  uid: string,
+  role: ScopedUserRole
+): AppUser[] {
+  return users.map((u) =>
+    u.uid === uid && !u.roles.includes(role)
+      ? { ...u, roles: [...u.roles, role] }
+      : u
+  );
+}
+
+function withRoleRemoved(
+  users: AppUser[],
+  uid: string,
+  role: ScopedUserRole
+): AppUser[] {
+  return users.map((u) =>
+    u.uid === uid ? { ...u, roles: u.roles.filter((r) => r !== role) } : u
+  );
+}
+
+/**
  * Hook for the admin /users page.
  *
  * Returns the list of all Firebase Auth users with their admin status,
@@ -124,14 +150,7 @@ export function useUsers() {
       await fn({ uid, role });
       setUsersState((prev) =>
         prev.status === 'success'
-          ? {
-              ...prev,
-              data: prev.data.map((u) =>
-                u.uid === uid && !u.roles.includes(role)
-                  ? { ...u, roles: [...u.roles, role] }
-                  : u
-              ),
-            }
+          ? { ...prev, data: withRoleAdded(prev.data, uid, role) }
           : prev
       );
     },
@@ -147,14 +166,7 @@ export function useUsers() {
       await fn({ uid, role });
       setUsersState((prev) =>
         prev.status === 'success'
-          ? {
-              ...prev,
-              data: prev.data.map((u) =>
-                u.uid === uid
-                  ? { ...u, roles: u.roles.filter((r) => r !== role) }
-                  : u
-              ),
-            }
+          ? { ...prev, data: withRoleRemoved(prev.data, uid, role) }
           : prev
       );
     },

--- a/libs/react/data/src/lib/useUsers.ts
+++ b/libs/react/data/src/lib/useUsers.ts
@@ -3,7 +3,11 @@
 import { useState, useCallback, useEffect } from 'react';
 import { httpsCallable } from 'firebase/functions';
 import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
-import type { AppUser, RequestState } from '@maple/ts/domain';
+import type {
+  AppUser,
+  RequestState,
+  ScopedUserRole,
+} from '@maple/ts/domain';
 import type {
   GetUsersRequest,
   GetUsersResponse,
@@ -11,6 +15,10 @@ import type {
   GrantAdminRoleResponse,
   RevokeAdminRoleRequest,
   RevokeAdminRoleResponse,
+  GrantRoleRequest,
+  GrantRoleResponse,
+  RevokeRoleRequest,
+  RevokeRoleResponse,
 } from '@maple/ts/firebase/api-types';
 
 /**
@@ -107,6 +115,52 @@ export function useUsers() {
     );
   }, []);
 
+  const grantRole = useCallback(
+    async (uid: string, role: ScopedUserRole): Promise<void> => {
+      const fn = httpsCallable<GrantRoleRequest, GrantRoleResponse>(
+        getMapleFunctions(),
+        'grantRole'
+      );
+      await fn({ uid, role });
+      setUsersState((prev) =>
+        prev.status === 'success'
+          ? {
+              ...prev,
+              data: prev.data.map((u) =>
+                u.uid === uid && !u.roles.includes(role)
+                  ? { ...u, roles: [...u.roles, role] }
+                  : u
+              ),
+            }
+          : prev
+      );
+    },
+    []
+  );
+
+  const revokeRole = useCallback(
+    async (uid: string, role: ScopedUserRole): Promise<void> => {
+      const fn = httpsCallable<RevokeRoleRequest, RevokeRoleResponse>(
+        getMapleFunctions(),
+        'revokeRole'
+      );
+      await fn({ uid, role });
+      setUsersState((prev) =>
+        prev.status === 'success'
+          ? {
+              ...prev,
+              data: prev.data.map((u) =>
+                u.uid === uid
+                  ? { ...u, roles: u.roles.filter((r) => r !== role) }
+                  : u
+              ),
+            }
+          : prev
+      );
+    },
+    []
+  );
+
   useEffect(() => {
     fetchUsers();
   }, [fetchUsers]);
@@ -117,5 +171,7 @@ export function useUsers() {
     fetchUsers,
     grantAdmin,
     revokeAdmin,
+    grantRole,
+    revokeRole,
   };
 }

--- a/libs/react/users/src/lib/UserRolesDialog.stories.tsx
+++ b/libs/react/users/src/lib/UserRolesDialog.stories.tsx
@@ -1,0 +1,135 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn, expect, within, userEvent, waitFor } from 'storybook/test';
+import type { AppUser } from '@maple/ts/domain';
+import { UserRolesDialog } from './UserRolesDialog';
+
+const baseUser: AppUser = {
+  uid: 'nathan-uid',
+  email: 'nathan@example.com',
+  displayName: 'Nathan',
+  emailVerified: true,
+  disabled: false,
+  createdAt: new Date('2026-04-01T12:00:00Z'),
+  lastSignInAt: new Date('2026-07-01T09:30:00Z'),
+  isAdmin: false,
+  roles: [],
+};
+
+const meta = {
+  component: UserRolesDialog,
+  title: 'Users/UserRolesDialog',
+  args: {
+    open: true,
+    callerUid: 'katie-uid',
+    onClose: fn(),
+    onGrantAdmin: fn(),
+    onRevokeAdmin: fn(),
+    onGrantRole: fn(),
+    onRevokeRole: fn(),
+  },
+} satisfies Meta<typeof UserRolesDialog>;
+
+export default meta;
+type Story = StoryObj<typeof UserRolesDialog>;
+
+/**
+ * A user with no access: grant-admin button plus all three scoped-role
+ * toggles, all off.
+ */
+export const NoAccess: Story = {
+  args: { user: baseUser },
+  play: async () => {
+    const dialog = within(document.body);
+    await expect(
+      await dialog.findByRole('button', { name: /grant admin/i })
+    ).toBeInTheDocument();
+    await expect(
+      dialog.getByRole('checkbox', { name: 'MT Teacher' })
+    ).not.toBeChecked();
+    await expect(
+      dialog.getByRole('checkbox', { name: 'Clerk' })
+    ).not.toBeChecked();
+    await expect(
+      dialog.getByRole('checkbox', { name: 'Lesson Teacher' })
+    ).not.toBeChecked();
+  },
+};
+
+/**
+ * Toggling a scoped role on calls onGrantRole with the role's wire value.
+ */
+export const GrantScopedRole: Story = {
+  args: { user: baseUser },
+  play: async ({ args }) => {
+    const dialog = within(document.body);
+    await userEvent.click(
+      await dialog.findByRole('checkbox', { name: 'MT Teacher' })
+    );
+    await waitFor(() =>
+      expect(args.onGrantRole).toHaveBeenCalledWith('nathan-uid', 'mt-teacher')
+    );
+    await expect(args.onRevokeRole).not.toHaveBeenCalled();
+  },
+};
+
+/**
+ * Toggling a held role off calls onRevokeRole.
+ */
+export const RevokeScopedRole: Story = {
+  args: {
+    user: { ...baseUser, roles: ['clerk', 'lesson-teacher'] },
+  },
+  play: async ({ args }) => {
+    const dialog = within(document.body);
+    const clerkSwitch = await dialog.findByRole('checkbox', { name: 'Clerk' });
+    await expect(clerkSwitch).toBeChecked();
+    await userEvent.click(clerkSwitch);
+    await waitFor(() =>
+      expect(args.onRevokeRole).toHaveBeenCalledWith('nathan-uid', 'clerk')
+    );
+    await expect(args.onGrantRole).not.toHaveBeenCalled();
+  },
+};
+
+/**
+ * Admins hold every permission implicitly, so scoped toggles are hidden;
+ * only the revoke-admin action shows.
+ */
+export const AdminUser: Story = {
+  args: {
+    user: { ...baseUser, uid: 'katie2-uid', isAdmin: true },
+  },
+  play: async ({ args }) => {
+    const dialog = within(document.body);
+    await expect(
+      await dialog.findByRole('button', { name: /revoke admin/i })
+    ).toBeInTheDocument();
+    await expect(
+      dialog.queryByRole('checkbox', { name: 'MT Teacher' })
+    ).not.toBeInTheDocument();
+    await userEvent.click(
+      dialog.getByRole('button', { name: /revoke admin/i })
+    );
+    await waitFor(() =>
+      expect(args.onRevokeAdmin).toHaveBeenCalledWith('katie2-uid')
+    );
+  },
+};
+
+/**
+ * Self-protection: an admin can't revoke their own admin role.
+ */
+export const SelfAdmin: Story = {
+  args: {
+    user: { ...baseUser, uid: 'katie-uid', isAdmin: true },
+  },
+  play: async () => {
+    const dialog = within(document.body);
+    await expect(
+      await dialog.findByRole('button', { name: /revoke admin/i })
+    ).toBeDisabled();
+    await expect(
+      dialog.getByText(/can't revoke your own admin role/i)
+    ).toBeInTheDocument();
+  },
+};

--- a/libs/react/users/src/lib/UserRolesDialog.tsx
+++ b/libs/react/users/src/lib/UserRolesDialog.tsx
@@ -9,10 +9,13 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  Divider,
   Stack,
+  Switch,
   Typography,
 } from '@mui/material';
-import type { AppUser } from '@maple/ts/domain';
+import type { AppUser, ScopedUserRole } from '@maple/ts/domain';
+import { SCOPED_USER_ROLES, USER_ROLE_LABELS } from '@maple/ts/domain';
 
 export interface UserRolesDialogProps {
   open: boolean;
@@ -22,12 +25,25 @@ export interface UserRolesDialogProps {
   onClose: () => void;
   onGrantAdmin: (uid: string) => Promise<void>;
   onRevokeAdmin: (uid: string) => Promise<void>;
+  onGrantRole: (uid: string, role: ScopedUserRole) => Promise<void>;
+  onRevokeRole: (uid: string, role: ScopedUserRole) => Promise<void>;
 }
 
+/** What each scoped role unlocks — shown under the toggle. */
+const ROLE_DESCRIPTIONS: Record<ScopedUserRole, string> = {
+  'mt-teacher':
+    'Manage Music Together: sections, semesters, rosters, and registrations.',
+  clerk:
+    'Store operations: inventory, sales, class registrations, and refunds.',
+  'lesson-teacher':
+    'Music lessons: see all lessons, manage their own students and schedule.',
+};
+
 /**
- * Dialog for granting / revoking admin access on a single user. Hours
- * and payroll for non-admin staff live in Square Shifts, so the only
- * role this app gates on is admin.
+ * Dialog for managing a single user's access: the admin role (full
+ * access) plus scoped roles (MT teacher, clerk, lesson teacher).
+ * Admins implicitly hold every permission, so the scoped toggles are
+ * hidden while a user is an admin.
  */
 export function UserRolesDialog({
   open,
@@ -36,6 +52,8 @@ export function UserRolesDialog({
   onClose,
   onGrantAdmin,
   onRevokeAdmin,
+  onGrantRole,
+  onRevokeRole,
 }: UserRolesDialogProps) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -81,8 +99,7 @@ export function UserRolesDialog({
 
           <Box>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              Admins can manage classes, instructors, products, and these
-              role assignments.
+              Admins have full access, including these role assignments.
             </Typography>
             {user.isAdmin ? (
               <Stack spacing={1}>
@@ -114,6 +131,59 @@ export function UserRolesDialog({
               </Button>
             )}
           </Box>
+
+          {!user.isAdmin && (
+            <>
+              <Divider />
+              <Box>
+                <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                  Scoped roles
+                </Typography>
+                <Stack spacing={1.5}>
+                  {SCOPED_USER_ROLES.map((role) => {
+                    const hasRole = (user.roles ?? []).includes(role);
+                    return (
+                      <Box
+                        key={role}
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'flex-start',
+                          justifyContent: 'space-between',
+                          gap: 2,
+                        }}
+                      >
+                        <Box>
+                          <Typography variant="body2">
+                            {USER_ROLE_LABELS[role]}
+                          </Typography>
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                          >
+                            {ROLE_DESCRIPTIONS[role]}
+                          </Typography>
+                        </Box>
+                        <Switch
+                          checked={hasRole}
+                          disabled={busy}
+                          inputProps={{
+                            'aria-label': USER_ROLE_LABELS[role],
+                          }}
+                          onChange={() =>
+                            wrapAction(async () =>
+                              hasRole
+                                ? onRevokeRole(user.uid, role)
+                                : onGrantRole(user.uid, role)
+                            )
+                          }
+                        />
+                      </Box>
+                    );
+                  })}
+                </Stack>
+              </Box>
+            </>
+          )}
         </Stack>
       </DialogContent>
       <DialogActions>

--- a/libs/react/users/src/lib/describeUserRoles.ts
+++ b/libs/react/users/src/lib/describeUserRoles.ts
@@ -1,4 +1,5 @@
 import type { AppUser } from '@maple/ts/domain';
+import { USER_ROLE_LABELS } from '@maple/ts/domain';
 
 export interface UserRoleChip {
   label: string;
@@ -6,13 +7,19 @@ export interface UserRoleChip {
 }
 
 /**
- * Reduce an AppUser's role state to chips for the list. Currently
- * just admin / no access — the only role this app gates on. Hours and
- * payroll for non-admin staff live in Square Shifts, not here.
+ * Reduce an AppUser's role state to chips for the list: Admin, then any
+ * scoped roles (MT Teacher, Clerk, Lesson Teacher), else "No access".
  */
 export function describeUserRoles(user: AppUser): UserRoleChip[] {
+  const chips: UserRoleChip[] = [];
   if (user.isAdmin) {
-    return [{ label: 'Admin', color: 'primary' }];
+    chips.push({ label: USER_ROLE_LABELS.admin, color: 'primary' });
   }
-  return [{ label: 'No access', color: 'default' }];
+  for (const role of user.roles ?? []) {
+    chips.push({ label: USER_ROLE_LABELS[role] ?? role, color: 'success' });
+  }
+  if (chips.length === 0) {
+    return [{ label: 'No access', color: 'default' }];
+  }
+  return chips;
 }

--- a/libs/ts/domain/src/lib/app-user.ts
+++ b/libs/ts/domain/src/lib/app-user.ts
@@ -9,6 +9,29 @@
  * but we keep the type honest.
  */
 
+/**
+ * Roles a portal user can hold. Wire values match the server-side `Role`
+ * enum in `@maple/firebase/functions` (which client code cannot import).
+ */
+export type UserRole = 'admin' | 'mt-teacher' | 'clerk' | 'lesson-teacher';
+
+/** Scoped (non-admin) roles, in display order. */
+export const SCOPED_USER_ROLES = [
+  'mt-teacher',
+  'clerk',
+  'lesson-teacher',
+] as const satisfies readonly UserRole[];
+
+export type ScopedUserRole = (typeof SCOPED_USER_ROLES)[number];
+
+/** Human-readable labels for each role. */
+export const USER_ROLE_LABELS: Record<UserRole, string> = {
+  admin: 'Admin',
+  'mt-teacher': 'MT Teacher',
+  clerk: 'Clerk',
+  'lesson-teacher': 'Lesson Teacher',
+};
+
 export interface AppUser {
   uid: string;
   email: string | null;
@@ -20,4 +43,6 @@ export interface AppUser {
   lastSignInAt?: Date;
   /** True if the user has an `admins/{uid}` record. */
   isAdmin: boolean;
+  /** Scoped roles from `userRoles/{uid}` (never includes 'admin'). */
+  roles: ScopedUserRole[];
 }

--- a/libs/ts/firebase/api-types/src/lib/auth.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/auth.types.ts
@@ -13,10 +13,12 @@ export interface CheckAdminStatusResponse {
 }
 
 /**
- * Roles a portal user can hold. Mirrors the server-side `Role` enum in
- * `@maple/firebase/functions` (which client code cannot import).
+ * Roles a portal user can hold. Canonical definition lives in
+ * `@maple/ts/domain` (app-user.ts); re-exported here so API consumers can
+ * import request/response types and the role union from one place.
  */
-export type UserRole = 'admin' | 'mt-teacher' | 'clerk' | 'lesson-teacher';
+export type { UserRole } from '@maple/ts/domain';
+import type { UserRole } from '@maple/ts/domain';
 
 /** Request for getMyRoles - no data needed, uses auth context */
 export type GetMyRolesRequest = Record<string, never>;


### PR DESCRIPTION
Closes #614. PR 2 of 3 for the scoped-roles epic (#617). PR 1 (#619) is merged; this is based on main.

## What

Client-side role plumbing. Still no function re-scoping (#615 does that) — but the portal now understands roles end to end:

- **`RolesProvider` + `useRoles()`** — one `getMyRoles` fetch shared by the gate and the nav (no duplicate callable on load; warmup list swaps `checkAdminStatus` → `getMyRoles`)
- **`RoleGuard`** replaces `AdminGuard` in the `(admin)` layout: any user with ≥1 role passes the gate; `allowedRoles` prop enables per-page scoping in #615. `AdminGuard`/`useAdminStatus` marked `@deprecated`
- **Role-filtered nav** (`nav-groups.tsx` role map, pure `nav-filter.ts` core): mt-teacher → MT + shared calendar; clerk → inventory/sales/categories + registrations; lesson-teacher → students; admin sees everything unchanged. *UX only — enforcement stays server-side.*
- **/users page**: scoped-role Switch toggles per user (hidden for admins, who hold everything implicitly), role chips in the list, `grantRole`/`revokeRole` wired through `useUsers` with optimistic updates
- **`listUsers`** joins `userRoles/{uid}` via new `getAllUserRoles()` (one collection scan, no N+1); `AppUser` gains `roles`; `UserRole`/`SCOPED_USER_ROLES`/`USER_ROLE_LABELS` canonicalized in `@maple/ts/domain`
- **ADR-028** records the model decision: plain RBAC + Firestore role docs over custom claims / ABAC / ReBAC, with the growth triggers that would flip it

## Verification

- **Unit**: 2,319 pass (full repo) — `nav-filter` semantics, `listUsers` roles join, existing suites
- **Storybook interaction**: 400 pass (49 files) — new play tests: role-filtered nav for mt-teacher and clerk+lesson-teacher (asserts absent items too), RoleGuard states incl. scoped refusal, UserRolesDialog grant/revoke toggles + self-admin protection
- **Integration** (utility suite, 18 pass on real emulators): `listUsers` returns joined roles after grants
- Next app build + all 4 function codebases build clean

## After merge (manual, once #615 lands)

Grant Stephanie `mt-teacher`; grant Nathan `clerk` + `lesson-teacher` — via the /users page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
