### PR TITLE
fix(payments): verify buyer (STORE intent) so card-on-file vaults survive real Square (#622)

### DIFF
--- a/apps/functions-integration-tests-music-together/src/create-music-together-registration.spec.ts
+++ b/apps/functions-integration-tests-music-together/src/create-music-together-registration.spec.ts
@@ -132,6 +132,7 @@ describe('createMusicTogetherRegistration', () => {
         email: 'installments@test.com',
         paymentPlan: 'installments',
         cardOnFileAuth: true,
+        cardVerificationToken: 'verf:store-token',
       }),
     });
 
@@ -194,6 +195,7 @@ describe('createMusicTogetherRegistration', () => {
         email: 'threekids@test.com',
         paymentPlan: 'installments',
         cardOnFileAuth: true,
+        cardVerificationToken: 'verf:store-token',
         children: [
           { name: 'Sky', dob: '2023-04-01' },
           { name: 'River', dob: '2024-05-02' },
@@ -239,6 +241,19 @@ describe('createMusicTogetherRegistration', () => {
         email: 'noauth@test.com',
         paymentPlan: 'installments',
         cardOnFileAuth: false,
+      }),
+    });
+    expect(result.status).not.toBe(200);
+  });
+
+  it('rejects installments without a card verification token (real Square needs it to vault a card)', async () => {
+    const result = await callFunction<CreateMusicTogetherRegistrationRequest>({
+      functionName: 'createMusicTogetherRegistration',
+      data: family({
+        email: 'noverify@test.com',
+        paymentPlan: 'installments',
+        cardOnFileAuth: true,
+        // cardVerificationToken deliberately omitted.
       }),
     });
     expect(result.status).not.toBe(200);

--- a/apps/functions-integration-tests-music-together/src/update-music-together-payment-method.spec.ts
+++ b/apps/functions-integration-tests-music-together/src/update-music-together-payment-method.spec.ts
@@ -178,7 +178,11 @@ describe('updateMusicTogetherPaymentMethod — end-to-end card replacement', () 
       UpdateMusicTogetherPaymentMethodResponse
     >({
       functionName: 'updateMusicTogetherPaymentMethod',
-      data: { sessionToken, paymentNonce: 'cnon:new-card' },
+      data: {
+        sessionToken,
+        paymentNonce: 'cnon:new-card',
+        cardVerificationToken: 'verf:store-token',
+      },
     });
 
     expect(result.status).toBe(200);
@@ -193,7 +197,13 @@ describe('updateMusicTogetherPaymentMethod — end-to-end card replacement', () 
     // MT Square mock saw a card create AND a disable of the old card. The card
     // id contains a colon; the SDK may URL-encode it, so match tolerantly.
     const cardReqs = await getSquareRequests('/v2/cards');
-    expect(cardReqs.some((r) => r.path === '/v2/cards')).toBe(true);
+    const createReq = cardReqs.find((r) => r.path === '/v2/cards');
+    expect(createReq).toBeDefined();
+    // The card vault request must carry the STORE-intent verification token —
+    // the mock now enforces this, mirroring real Square (#622).
+    expect(
+      (createReq?.body as Record<string, unknown>)['verification_token']
+    ).toBe('verf:store-token');
     const oldCardEncoded = encodeURIComponent(OLD_CARD_ID);
     expect(
       cardReqs.some(
@@ -210,7 +220,11 @@ describe('updateMusicTogetherPaymentMethod — end-to-end card replacement', () 
       UpdateMusicTogetherPaymentMethodResponse
     >({
       functionName: 'updateMusicTogetherPaymentMethod',
-      data: { sessionToken: 'not-a-real-session', paymentNonce: 'cnon:x' },
+      data: {
+        sessionToken: 'not-a-real-session',
+        paymentNonce: 'cnon:x',
+        cardVerificationToken: 'verf:store-token',
+      },
     });
     expect(result.status).not.toBe(200);
   });

--- a/apps/functions-integration-tests-square/src/craft-club-self-service.spec.ts
+++ b/apps/functions-integration-tests-square/src/craft-club-self-service.spec.ts
@@ -99,7 +99,11 @@ describe('Craft Club self-service', () => {
     // 5. Change the payment method (Square card-on-file + subscription update).
     const update = await callFunction({
       functionName: 'updateCraftClubPaymentMethod',
-      data: { sessionToken, paymentNonce: 'cnon:new-card' },
+      data: {
+        sessionToken,
+        paymentNonce: 'cnon:new-card',
+        cardVerificationToken: 'verf:store-token',
+      },
     });
     expect(update.status).toBe(200);
 

--- a/apps/functions-integration-tests-square/src/create-craft-club-subscription.spec.ts
+++ b/apps/functions-integration-tests-square/src/create-craft-club-subscription.spec.ts
@@ -64,6 +64,7 @@ describe('createCraftClubSubscription', () => {
         email: APPROVED_EMAIL,
         name: 'Approved Member',
         paymentNonce: 'cnon:card-nonce-ok',
+        cardVerificationToken: 'verf:store-token',
       },
     });
 
@@ -117,6 +118,23 @@ describe('createCraftClubSubscription', () => {
         email: 'not-an-email',
         name: 'X',
         paymentNonce: 'cnon:card-nonce-ok',
+      },
+    });
+
+    expect(result.status).not.toBe(200);
+  });
+
+  it('rejects a subscription without a card verification token (real Square needs it to vault a card)', async () => {
+    const result = await callFunction<
+      CreateCraftClubSubscriptionRequest,
+      CreateCraftClubSubscriptionResponse
+    >({
+      functionName: 'createCraftClubSubscription',
+      data: {
+        email: APPROVED_EMAIL,
+        name: 'Approved Member',
+        paymentNonce: 'cnon:card-nonce-ok',
+        // cardVerificationToken deliberately omitted.
       },
     });
 

--- a/apps/webflow-components/src/CraftClubManageWidget.spec.tsx
+++ b/apps/webflow-components/src/CraftClubManageWidget.spec.tsx
@@ -48,11 +48,16 @@ vi.mock('@maple/react/registrations', () => ({
     afterCardContent,
   }: {
     onReady?: () => void;
-    onTokenizeRef: (fn: () => Promise<string>) => void;
+    onTokenizeRef: (
+      fn: () => Promise<{ nonce: string; verificationToken?: string }>
+    ) => void;
     afterCardContent?: React.ReactNode;
   }) => {
     useEffect(() => {
-      onTokenizeRef(async () => 'cnon:new-card');
+      onTokenizeRef(async () => ({
+        nonce: 'cnon:new-card',
+        verificationToken: 'verf:test-token',
+      }));
       onReady?.();
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
@@ -135,6 +140,7 @@ describe('CraftClubManageWidget', () => {
       expect(calls['updateCraftClubPaymentMethod']).toMatchObject({
         sessionToken: 'sess-1',
         paymentNonce: 'cnon:new-card',
+        cardVerificationToken: 'verf:test-token',
       })
     );
   });

--- a/apps/webflow-components/src/CraftClubManageWidget.tsx
+++ b/apps/webflow-components/src/CraftClubManageWidget.tsx
@@ -23,6 +23,7 @@ import {
 import { httpsCallable } from 'firebase/functions';
 import { theme } from '@maple/react/theme';
 import { SquareCardForm } from '@maple/react/registrations';
+import type { CardTokenizeResult } from '@maple/react/registrations';
 import {
   CRAFT_CLUB_MONTHLY_PRICE_CENTS,
   type CraftClubMemberPublicView,
@@ -82,7 +83,7 @@ export function CraftClubManageWidget({
   // Change-card sub-flow
   const [changingCard, setChangingCard] = useState(false);
   const [cardReady, setCardReady] = useState(false);
-  const tokenizeRef = useRef<(() => Promise<string>) | null>(null);
+  const tokenizeRef = useRef<(() => Promise<CardTokenizeResult>) | null>(null);
 
   // Exchange the magic-link token for a session on mount.
   useEffect(() => {
@@ -160,7 +161,7 @@ export function CraftClubManageWidget({
     setError(null);
     setBusy(true);
     try {
-      const nonce = await tokenizeRef.current();
+      const { nonce, verificationToken } = await tokenizeRef.current();
       const call = httpsCallable<
         UpdateCraftClubPaymentMethodRequest,
         UpdateCraftClubPaymentMethodResponse
@@ -168,6 +169,7 @@ export function CraftClubManageWidget({
       const res = await call({
         sessionToken: sessionTokenRef.current,
         paymentNonce: nonce,
+        cardVerificationToken: verificationToken,
       });
       setMember(res.data.member);
       setChangingCard(false);
@@ -271,6 +273,11 @@ export function CraftClubManageWidget({
                   locationId={squareLocationId}
                   env={env}
                   totalCents={CRAFT_CLUB_MONTHLY_PRICE_CENTS}
+                  // Vaulting the replacement card needs a STORE-intent
+                  // verifyBuyer token (real Square requirement for cards on
+                  // file).
+                  verifyBuyerForStore
+                  billingContact={{ givenName: member.name, email: member.email }}
                   onReady={() => setCardReady(true)}
                   onTokenizeRef={(fn) => {
                     tokenizeRef.current = fn;

--- a/apps/webflow-components/src/CraftClubSignupWidget.spec.tsx
+++ b/apps/webflow-components/src/CraftClubSignupWidget.spec.tsx
@@ -47,11 +47,16 @@ vi.mock('@maple/react/registrations', () => ({
     afterCardContent,
   }: {
     onReady?: () => void;
-    onTokenizeRef: (fn: () => Promise<string>) => void;
+    onTokenizeRef: (
+      fn: () => Promise<{ nonce: string; verificationToken?: string }>
+    ) => void;
     afterCardContent?: React.ReactNode;
   }) => {
     useEffect(() => {
-      onTokenizeRef(async () => 'cnon:test-nonce');
+      onTokenizeRef(async () => ({
+        nonce: 'cnon:test-nonce',
+        verificationToken: 'verf:test-token',
+      }));
       onReady?.();
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
@@ -123,6 +128,9 @@ describe('CraftClubSignupWidget', () => {
       email: 'approved@example.com',
       name: 'Ada Lovelace',
       paymentNonce: 'cnon:test-nonce',
+      // Card is vaulted on file for the subscription — the STORE-intent
+      // verifyBuyer token must be forwarded so real Square accepts the vault.
+      cardVerificationToken: 'verf:test-token',
     });
   });
 

--- a/apps/webflow-components/src/CraftClubSignupWidget.tsx
+++ b/apps/webflow-components/src/CraftClubSignupWidget.tsx
@@ -28,6 +28,7 @@ import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { httpsCallable } from 'firebase/functions';
 import { theme, fonts } from '@maple/react/theme';
 import { SquareCardForm } from '@maple/react/registrations';
+import type { CardTokenizeResult } from '@maple/react/registrations';
 import { CRAFT_CLUB_MONTHLY_PRICE_CENTS } from '@maple/ts/domain';
 import type {
   CheckCraftClubEligibilityRequest,
@@ -77,7 +78,7 @@ export function CraftClubSignupWidget({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [cardReady, setCardReady] = useState(false);
-  const tokenizeRef = useRef<(() => Promise<string>) | null>(null);
+  const tokenizeRef = useRef<(() => Promise<CardTokenizeResult>) | null>(null);
 
   const emailValid = EMAIL_RE.test(email.trim());
   const payDisabled = busy || !cardReady || !name.trim();
@@ -114,7 +115,7 @@ export function CraftClubSignupWidget({
     setError(null);
     setBusy(true);
     try {
-      const nonce = await tokenizeRef.current();
+      const { nonce, verificationToken } = await tokenizeRef.current();
       const call = httpsCallable<
         CreateCraftClubSubscriptionRequest,
         CreateCraftClubSubscriptionResponse
@@ -124,6 +125,7 @@ export function CraftClubSignupWidget({
         name: name.trim(),
         phone: phone.trim() || undefined,
         paymentNonce: nonce,
+        cardVerificationToken: verificationToken,
       });
       setStep('success');
     } catch (err) {
@@ -231,6 +233,10 @@ export function CraftClubSignupWidget({
               env={env}
               totalCents={CRAFT_CLUB_MONTHLY_PRICE_CENTS}
               maxWidth={480}
+              // The subscription vaults this card on file — real Square needs a
+              // STORE-intent verifyBuyer token to do so.
+              verifyBuyerForStore
+              billingContact={{ givenName: name.trim(), email: email.trim() }}
               onReady={() => setCardReady(true)}
               onTokenizeRef={(fn) => {
                 tokenizeRef.current = fn;

--- a/apps/webflow-components/src/MusicTogetherManageWidget.spec.tsx
+++ b/apps/webflow-components/src/MusicTogetherManageWidget.spec.tsx
@@ -51,11 +51,16 @@ vi.mock('@maple/react/registrations', () => ({
     afterCardContent,
   }: {
     onReady?: () => void;
-    onTokenizeRef: (fn: () => Promise<string>) => void;
+    onTokenizeRef: (
+      fn: () => Promise<{ nonce: string; verificationToken?: string }>
+    ) => void;
     afterCardContent?: React.ReactNode;
   }) => {
     useEffect(() => {
-      onTokenizeRef(async () => 'cnon:new-card');
+      onTokenizeRef(async () => ({
+        nonce: 'cnon:new-card',
+        verificationToken: 'verf:test-token',
+      }));
       onReady?.();
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
@@ -115,6 +120,7 @@ describe('MusicTogetherManageWidget', () => {
       expect(calls['updateMusicTogetherPaymentMethod']).toMatchObject({
         sessionToken: 'sess-1',
         paymentNonce: 'cnon:new-card',
+        cardVerificationToken: 'verf:test-token',
       })
     );
     expect(await screen.findByText(/card was updated/i)).toBeInTheDocument();

--- a/apps/webflow-components/src/MusicTogetherManageWidget.tsx
+++ b/apps/webflow-components/src/MusicTogetherManageWidget.tsx
@@ -29,6 +29,7 @@ import {
 import { httpsCallable } from 'firebase/functions';
 import { theme } from '@maple/react/theme';
 import { SquareCardForm } from '@maple/react/registrations';
+import type { CardTokenizeResult } from '@maple/react/registrations';
 import type {
   RequestMusicTogetherManageLinkRequest,
   RequestMusicTogetherManageLinkResponse,
@@ -80,7 +81,7 @@ export function MusicTogetherManageWidget({
 
   // Save-card sub-flow
   const [cardReady, setCardReady] = useState(false);
-  const tokenizeRef = useRef<(() => Promise<string>) | null>(null);
+  const tokenizeRef = useRef<(() => Promise<CardTokenizeResult>) | null>(null);
 
   // Exchange the magic-link token for a session on mount.
   useEffect(() => {
@@ -138,7 +139,7 @@ export function MusicTogetherManageWidget({
     setError(null);
     setBusy(true);
     try {
-      const nonce = await tokenizeRef.current();
+      const { nonce, verificationToken } = await tokenizeRef.current();
       const call = httpsCallable<
         UpdateMusicTogetherPaymentMethodRequest,
         UpdateMusicTogetherPaymentMethodResponse
@@ -146,6 +147,7 @@ export function MusicTogetherManageWidget({
       const res = await call({
         sessionToken: sessionTokenRef.current,
         paymentNonce: nonce,
+        cardVerificationToken: verificationToken,
       });
       setRegistration(res.data.registration);
       setNewCardLast4(res.data.cardLast4 ?? null);
@@ -227,6 +229,10 @@ export function MusicTogetherManageWidget({
               applicationId={squareAppId}
               locationId={squareLocationId}
               totalCents={registration.nextInstallment?.amountCents ?? 0}
+              // Vaulting the replacement card needs a STORE-intent verifyBuyer
+              // token (real Square requirement for cards on file).
+              verifyBuyerForStore
+              billingContact={{ givenName: registration.parentName }}
               onReady={() => setCardReady(true)}
               onTokenizeRef={(fn) => {
                 tokenizeRef.current = fn;

--- a/apps/webflow-components/src/MusicTogetherRegistrationWidget.spec.tsx
+++ b/apps/webflow-components/src/MusicTogetherRegistrationWidget.spec.tsx
@@ -77,11 +77,16 @@ vi.mock('@maple/react/registrations', () => ({
     afterCardContent,
   }: {
     onReady?: () => void;
-    onTokenizeRef: (fn: () => Promise<string>) => void;
+    onTokenizeRef: (
+      fn: () => Promise<{ nonce: string; verificationToken?: string }>
+    ) => void;
     afterCardContent?: React.ReactNode;
   }) => {
     useEffect(() => {
-      onTokenizeRef(async () => 'cnon:test-nonce');
+      onTokenizeRef(async () => ({
+        nonce: 'cnon:test-nonce',
+        verificationToken: 'verf:test-token',
+      }));
       onReady?.();
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
@@ -232,6 +237,9 @@ describe('MusicTogetherRegistrationWidget', () => {
     expect(calls['createMusicTogetherRegistration']).toMatchObject({
       paymentPlan: 'installments',
       cardOnFileAuth: true,
+      // The installment plan vaults a card on file — the widget must forward
+      // the STORE-intent verifyBuyer token so real Square accepts the vault.
+      cardVerificationToken: 'verf:test-token',
     });
   });
 

--- a/apps/webflow-components/src/MusicTogetherRegistrationWidget.tsx
+++ b/apps/webflow-components/src/MusicTogetherRegistrationWidget.tsx
@@ -38,6 +38,7 @@ import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { httpsCallable } from 'firebase/functions';
 import { theme, fonts } from '@maple/react/theme';
 import { SquareCardForm } from '@maple/react/registrations';
+import type { CardTokenizeResult } from '@maple/react/registrations';
 import {
   MT_MAX_CHILDREN,
   computeMusicTogetherFamilyPrice,
@@ -273,7 +274,7 @@ export function MusicTogetherRegistrationWidget({
   const [busy, setBusy] = useState(false);
   const [payError, setPayError] = useState<string | null>(null);
   const [cardReady, setCardReady] = useState(false);
-  const tokenizeRef = useRef<(() => Promise<string>) | null>(null);
+  const tokenizeRef = useRef<(() => Promise<CardTokenizeResult>) | null>(null);
 
   // Load the section on mount
   useEffect(() => {
@@ -399,7 +400,7 @@ export function MusicTogetherRegistrationWidget({
     setPayError(null);
     setBusy(true);
     try {
-      const nonce = await tokenizeRef.current();
+      const { nonce, verificationToken } = await tokenizeRef.current();
       const call = httpsCallable<
         CreateMusicTogetherRegistrationRequest,
         CreateMusicTogetherRegistrationResponse
@@ -424,6 +425,10 @@ export function MusicTogetherRegistrationWidget({
         privacyConsent,
         cardOnFileAuth: paymentPlan === 'installments' ? cardOnFileAuth : undefined,
         paymentNonce: nonce,
+        // STORE-intent verification token — only produced (and only required)
+        // for the installment plan, which vaults the card on file.
+        cardVerificationToken:
+          paymentPlan === 'installments' ? verificationToken : undefined,
         notes: notes.trim() || undefined,
       });
       setState({
@@ -786,6 +791,15 @@ export function MusicTogetherRegistrationWidget({
                     // Square app for testing.
                     totalCents={amountNowCents}
                     maxWidth={WIDGET_MAX_WIDTH}
+                    // Installments vault a card on file — real Square needs a
+                    // STORE-intent verifyBuyer token to do that. Pay-in-full is
+                    // a one-time charge and skips it.
+                    verifyBuyerForStore={paymentPlan === 'installments'}
+                    billingContact={{
+                      givenName: adultFirstName.trim(),
+                      familyName: adultLastName.trim(),
+                      email: email.trim(),
+                    }}
                     onReady={() => setCardReady(true)}
                     onTokenizeRef={(fn) => {
                       tokenizeRef.current = fn;

--- a/libs/firebase/maple-functions/create-craft-club-subscription/src/lib/create-craft-club-subscription.spec.ts
+++ b/libs/firebase/maple-functions/create-craft-club-subscription/src/lib/create-craft-club-subscription.spec.ts
@@ -76,6 +76,7 @@ const validPayload = {
   email: 'member@example.com',
   name: 'Member Person',
   paymentNonce: 'cnon:card-nonce-abcdef',
+  cardVerificationToken: 'verf:store-token',
 };
 
 describe('createCraftClubSubscription', () => {
@@ -102,8 +103,14 @@ describe('createCraftClubSubscription', () => {
     };
 
     expect(mocks.upsertByEmail).toHaveBeenCalled();
+    // The STORE-intent verification token must reach the card vault — real
+    // Square rejects cards.create without it (#622).
     expect(mocks.createCardOnFile).toHaveBeenCalledWith(
-      expect.objectContaining({ sourceId: 'cnon:card-nonce-abcdef', customerId: 'cust-1' })
+      expect.objectContaining({
+        sourceId: 'cnon:card-nonce-abcdef',
+        customerId: 'cust-1',
+        verificationToken: 'verf:store-token',
+      })
     );
     expect(mocks.subscriptionCreate).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -160,6 +167,20 @@ describe('createCraftClubSubscription', () => {
       run({ email: 'bad', name: 'X', paymentNonce: 'n' })
     ).rejects.toThrow(/validation/);
     expect(mocks.findByEmail).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing card verification token before the approval gate or any Square call', async () => {
+    await expect(
+      run({
+        email: 'member@example.com',
+        name: 'Member Person',
+        paymentNonce: 'cnon:card-nonce-abcdef',
+        // cardVerificationToken omitted — real Square can't vault a card on file
+        // for the subscription without it.
+      })
+    ).rejects.toThrow(/card verification is required/i);
+    expect(mocks.findByEmail).not.toHaveBeenCalled();
+    expect(mocks.createCardOnFile).not.toHaveBeenCalled();
   });
 
   it('fails clearly when the plan is not configured', async () => {

--- a/libs/firebase/maple-functions/create-craft-club-subscription/src/lib/create-craft-club-subscription.ts
+++ b/libs/firebase/maple-functions/create-craft-club-subscription/src/lib/create-craft-club-subscription.ts
@@ -49,6 +49,11 @@ export const createCraftClubSubscription = Functions.endpoint
     if (!data.paymentNonce) {
       throwInvalidArgument('Payment information is required');
     }
+    // The card is vaulted on file for the subscription; real Square requires the
+    // STORE-intent verification token from the client's verifyBuyer call.
+    if (!data.cardVerificationToken) {
+      throwInvalidArgument('Card verification is required.');
+    }
 
     // 2. Server-side approval gate — never trust the client's eligibility check.
     const member = await CraftClubMemberRepository.findByEmail(data.email);
@@ -90,6 +95,7 @@ export const createCraftClubSubscription = Functions.endpoint
       sourceId: data.paymentNonce,
       customerId,
       cardholderName: data.name,
+      verificationToken: data.cardVerificationToken,
       // Nonce is unique per tokenization, so this is unique per attempt.
       idempotencyKey: `cccard-${member.id}-${data.paymentNonce.slice(-8)}`,
     });

--- a/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.spec.ts
+++ b/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.spec.ts
@@ -209,11 +209,18 @@ describe('createMusicTogetherRegistration', () => {
       ...baseFamily,
       paymentPlan: 'installments',
       cardOnFileAuth: true,
+      cardVerificationToken: 'verf:store-token',
     })) as { amountChargedCents: number; scheduledChargeCount: number; cardLast4?: string };
 
     expect(mocks.upsertByEmail).toHaveBeenCalled();
+    // The STORE-intent verification token must be threaded into the card vault —
+    // real Square rejects cards.create without it (#622).
     expect(mocks.createCardOnFile).toHaveBeenCalledWith(
-      expect.objectContaining({ sourceId: 'cnon:card-nonce-abc', customerId: 'cust-1' })
+      expect.objectContaining({
+        sourceId: 'cnon:card-nonce-abc',
+        customerId: 'cust-1',
+        verificationToken: 'verf:store-token',
+      })
     );
     // installment 1 charges the STORED card (with customerId), not the nonce
     expect(mocks.createPayment).toHaveBeenCalledWith(
@@ -291,6 +298,7 @@ describe('createMusicTogetherRegistration', () => {
       ],
       paymentPlan: 'installments',
       cardOnFileAuth: true,
+      cardVerificationToken: 'verf:store-token',
     })) as { amountChargedCents: number; scheduledChargeCount: number };
 
     // Installment 1 charged now at the discounted $264.
@@ -374,6 +382,23 @@ describe('createMusicTogetherRegistration', () => {
     await expect(
       run({ ...baseFamily, paymentPlan: 'installments', cardOnFileAuth: false })
     ).rejects.toThrow(/validation/);
+  });
+
+  it('rejects installments without a card verification token — before reserving a seat or touching Square', async () => {
+    mocks.sectionFindById.mockResolvedValue(openWithInstallments);
+    await expect(
+      run({
+        ...baseFamily,
+        paymentPlan: 'installments',
+        cardOnFileAuth: true,
+        // cardVerificationToken deliberately omitted — real Square can't vault
+        // a card on file without it.
+      })
+    ).rejects.toThrow(/card verification is required/i);
+    expect(mocks.txSet).not.toHaveBeenCalled();
+    expect(mocks.upsertByEmail).not.toHaveBeenCalled();
+    expect(mocks.createCardOnFile).not.toHaveBeenCalled();
+    expect(mocks.createPayment).not.toHaveBeenCalled();
   });
 
   it('cancels the reservation when payment fails', async () => {

--- a/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.ts
+++ b/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.ts
@@ -136,6 +136,14 @@ export const createMusicTogetherRegistration = Functions.endpoint
         'This section does not offer an installment plan.'
       );
     }
+    // The installment plan vaults a card on file, which real Square only allows
+    // with a STORE-intent verification token from the client's verifyBuyer call.
+    // Fail before reserving the seat / touching Square if it's missing.
+    if (data.paymentPlan === 'installments' && !data.cardVerificationToken) {
+      throwInvalidArgument(
+        'Card verification is required for the installment plan.'
+      );
+    }
     const numChildren = data.children?.length ?? 0;
     if (numChildren < 1 || numChildren > MT_MAX_CHILDREN) {
       throwInvalidArgument(
@@ -231,6 +239,7 @@ export const createMusicTogetherRegistration = Functions.endpoint
           sourceId: data.paymentNonce,
           customerId: squareCustomerId,
           cardholderName: parentNames[0],
+          verificationToken: data.cardVerificationToken,
           idempotencyKey: `mtcard-${regRef.id}`,
         });
         squareCardId = card.cardId;

--- a/libs/firebase/maple-functions/update-craft-club-payment-method/src/lib/update-craft-club-payment-method.spec.ts
+++ b/libs/firebase/maple-functions/update-craft-club-payment-method/src/lib/update-craft-club-payment-method.spec.ts
@@ -90,10 +90,17 @@ describe('updateCraftClubPaymentMethod', () => {
     const result = (await run({
       sessionToken: 'sess',
       paymentNonce: 'cnon:new',
+      cardVerificationToken: 'verf:store-token',
     })) as { cardLast4?: string };
 
+    // The STORE-intent verification token must reach the card vault — real
+    // Square rejects cards.create without it (#622).
     expect(mocks.createCardOnFile).toHaveBeenCalledWith(
-      expect.objectContaining({ sourceId: 'cnon:new', customerId: 'cust-1' })
+      expect.objectContaining({
+        sourceId: 'cnon:new',
+        customerId: 'cust-1',
+        verificationToken: 'verf:store-token',
+      })
     );
     expect(mocks.updateCard).toHaveBeenCalledWith('sub-1', 'card-new');
     expect(mocks.update).toHaveBeenCalledWith({
@@ -109,10 +116,22 @@ describe('updateCraftClubPaymentMethod', () => {
     );
   });
 
+  it('rejects a missing card verification token before any Square call', async () => {
+    await expect(
+      run({ sessionToken: 'sess', paymentNonce: 'cnon:new' })
+    ).rejects.toThrow(/card verification is required/i);
+    expect(mocks.resolveSession).not.toHaveBeenCalled();
+    expect(mocks.createCardOnFile).not.toHaveBeenCalled();
+  });
+
   it('rejects an expired session before any Square call', async () => {
     mocks.resolveSession.mockResolvedValue(undefined);
     await expect(
-      run({ sessionToken: 'bad', paymentNonce: 'cnon:new' })
+      run({
+        sessionToken: 'bad',
+        paymentNonce: 'cnon:new',
+        cardVerificationToken: 'verf:store-token',
+      })
     ).rejects.toThrow(/session has expired/);
     expect(mocks.createCardOnFile).not.toHaveBeenCalled();
   });

--- a/libs/firebase/maple-functions/update-craft-club-payment-method/src/lib/update-craft-club-payment-method.ts
+++ b/libs/firebase/maple-functions/update-craft-club-payment-method/src/lib/update-craft-club-payment-method.ts
@@ -33,6 +33,10 @@ export const updateCraftClubPaymentMethod = Functions.endpoint
     if (!data.paymentNonce) {
       throwInvalidArgument('Payment information is required');
     }
+    // Vaulting a new card on file requires the STORE-intent verification token.
+    if (!data.cardVerificationToken) {
+      throwInvalidArgument('Card verification is required.');
+    }
 
     const memberId = await CraftClubTokenRepository.resolveSession(
       data.sessionToken
@@ -56,6 +60,7 @@ export const updateCraftClubPaymentMethod = Functions.endpoint
       sourceId: data.paymentNonce,
       customerId: member.squareCustomerId,
       cardholderName: member.name,
+      verificationToken: data.cardVerificationToken,
       idempotencyKey: `cccard-update-${member.id}-${data.paymentNonce.slice(-8)}`,
     });
 

--- a/libs/firebase/maple-functions/update-music-together-payment-method/src/lib/update-music-together-payment-method.spec.ts
+++ b/libs/firebase/maple-functions/update-music-together-payment-method/src/lib/update-music-together-payment-method.spec.ts
@@ -113,10 +113,17 @@ describe('updateMusicTogetherPaymentMethod', () => {
     const result = (await run({
       sessionToken: 'sess',
       paymentNonce: 'cnon:new',
+      cardVerificationToken: 'verf:store-token',
     })) as { cardLast4?: string; registration: { nextInstallment?: unknown } };
 
+    // The STORE-intent verification token must reach the card vault — real
+    // Square rejects cards.create without it (#622).
     expect(mocks.createCardOnFile).toHaveBeenCalledWith(
-      expect.objectContaining({ sourceId: 'cnon:new', customerId: 'cust-1' })
+      expect.objectContaining({
+        sourceId: 'cnon:new',
+        customerId: 'cust-1',
+        verificationToken: 'verf:store-token',
+      })
     );
     // Registration repointed BEFORE the old card is disabled.
     expect(mocks.updateRegistration).toHaveBeenCalledWith({
@@ -152,6 +159,7 @@ describe('updateMusicTogetherPaymentMethod', () => {
     const result = (await run({
       sessionToken: 'sess',
       paymentNonce: 'cnon:new',
+      cardVerificationToken: 'verf:store-token',
     })) as { cardLast4?: string };
 
     expect(result.cardLast4).toBe('4242');
@@ -165,10 +173,22 @@ describe('updateMusicTogetherPaymentMethod', () => {
     expect(mocks.resolveSession).not.toHaveBeenCalled();
   });
 
+  it('rejects a missing card verification token before any Square call', async () => {
+    await expect(
+      run({ sessionToken: 'sess', paymentNonce: 'cnon:new' })
+    ).rejects.toThrow(/card verification is required/i);
+    expect(mocks.resolveSession).not.toHaveBeenCalled();
+    expect(mocks.createCardOnFile).not.toHaveBeenCalled();
+  });
+
   it('rejects an expired session before any Square call', async () => {
     mocks.resolveSession.mockResolvedValue(undefined);
     await expect(
-      run({ sessionToken: 'bad', paymentNonce: 'cnon:new' })
+      run({
+        sessionToken: 'bad',
+        paymentNonce: 'cnon:new',
+        cardVerificationToken: 'verf:store-token',
+      })
     ).rejects.toThrow(/session has expired/);
     expect(mocks.createCardOnFile).not.toHaveBeenCalled();
   });
@@ -180,7 +200,11 @@ describe('updateMusicTogetherPaymentMethod', () => {
       paymentPlan: 'full',
     });
     await expect(
-      run({ sessionToken: 'sess', paymentNonce: 'cnon:new' })
+      run({
+        sessionToken: 'sess',
+        paymentNonce: 'cnon:new',
+        cardVerificationToken: 'verf:store-token',
+      })
     ).rejects.toThrow(/no card on file/i);
     expect(mocks.createCardOnFile).not.toHaveBeenCalled();
   });
@@ -192,7 +216,11 @@ describe('updateMusicTogetherPaymentMethod', () => {
       status: 'cancelled',
     });
     await expect(
-      run({ sessionToken: 'sess', paymentNonce: 'cnon:new' })
+      run({
+        sessionToken: 'sess',
+        paymentNonce: 'cnon:new',
+        cardVerificationToken: 'verf:store-token',
+      })
     ).rejects.toThrow(/can no longer be managed/i);
     expect(mocks.createCardOnFile).not.toHaveBeenCalled();
   });

--- a/libs/firebase/maple-functions/update-music-together-payment-method/src/lib/update-music-together-payment-method.ts
+++ b/libs/firebase/maple-functions/update-music-together-payment-method/src/lib/update-music-together-payment-method.ts
@@ -48,6 +48,10 @@ export const updateMusicTogetherPaymentMethod = Functions.endpoint
     if (!data.paymentNonce) {
       throwInvalidArgument('Payment information is required');
     }
+    // Vaulting a new card on file requires the STORE-intent verification token.
+    if (!data.cardVerificationToken) {
+      throwInvalidArgument('Card verification is required.');
+    }
 
     const registrationId = await MusicTogetherTokenRepository.resolveSession(
       data.sessionToken
@@ -86,6 +90,7 @@ export const updateMusicTogetherPaymentMethod = Functions.endpoint
       sourceId: data.paymentNonce,
       customerId: registration.squareCustomerId,
       cardholderName: registration.parentNames[0],
+      verificationToken: data.cardVerificationToken,
       idempotencyKey: `mtcard-update-${registration.id}-${data.paymentNonce.slice(-8)}`,
     });
 

--- a/libs/firebase/square-test-mock-server/src/lib/routes/square.ts
+++ b/libs/firebase/square-test-mock-server/src/lib/routes/square.ts
@@ -446,9 +446,32 @@ function registerCraftClubRoutes(server: SquareMockServer): void {
     return { status: 200, body: { customer } };
   });
 
-  // Create card on file (from a Web Payments SDK nonce)
+  // Create card on file (from a Web Payments SDK nonce).
+  //
+  // Real Square REQUIRES a `verification_token` (from the client's
+  // verifyBuyer({ intent: 'STORE' }) SCA step) to vault a card on file, and
+  // rejects the request without it. The mock enforces the same contract so that
+  // integration tests catch a missing token — a gap that previously only the
+  // real-Square e2e (#622) could surface.
   server.post('/v2/cards', (req) => {
     const body = req.body as Record<string, unknown>;
+    const verificationToken = body['verification_token'];
+    if (typeof verificationToken !== 'string' || verificationToken.length === 0) {
+      return {
+        status: 400,
+        body: {
+          errors: [
+            {
+              category: 'INVALID_REQUEST_ERROR',
+              code: 'MISSING_REQUIRED_PARAMETER',
+              detail:
+                'Missing required parameter: verification_token. A STORE-intent verifyBuyer token is required to store a card on file.',
+              field: 'verification_token',
+            },
+          ],
+        },
+      };
+    }
     cardCounter++;
     const id = `ccof:mock-card-${cardCounter}`;
     const cardInput = (body['card'] as Record<string, unknown>) ?? {};

--- a/libs/firebase/square/src/lib/cards.service.ts
+++ b/libs/firebase/square/src/lib/cards.service.ts
@@ -16,6 +16,13 @@ export interface CreateCardOnFileInput {
   customerId: string;
   /** Cardholder name for display (optional). */
   cardholderName?: string;
+  /**
+   * SCA verification token from the Web Payments SDK
+   * `verifyBuyer({ intent: 'STORE' })`. Real Square REQUIRES this to vault a
+   * card on file — omitting it makes `cards.create` fail (the sandbox mock is
+   * lenient, real Square is not). Always thread it through from the client.
+   */
+  verificationToken?: string;
   /** Idempotency key — repeated calls with the same key are de-duped. */
   idempotencyKey: string;
 }
@@ -39,6 +46,7 @@ export class CardsService {
     const response = await this.client.cards.create({
       idempotencyKey: input.idempotencyKey,
       sourceId: input.sourceId,
+      verificationToken: input.verificationToken,
       card: {
         customerId: input.customerId,
         cardholderName: input.cardholderName,

--- a/libs/react/registrations/src/index.ts
+++ b/libs/react/registrations/src/index.ts
@@ -5,3 +5,7 @@ export { RegistrationCheckoutForm } from './lib/RegistrationCheckoutForm';
 export type { RequiredAgreementTemplate } from './lib/RegistrationCheckoutForm';
 export { CostSummary } from './lib/CostSummary';
 export { SquareCardForm } from './lib/SquareCardForm';
+export type {
+  CardTokenizeResult,
+  SquareBillingContact,
+} from './lib/SquareCardForm';

--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.spec.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.spec.tsx
@@ -53,8 +53,10 @@ let capturedDigitalWalletTokenCallback: ((token: string) => void) | undefined;
 // Allow individual tests to override how the mocked tokenize function
 // behaves (e.g. to keep the promise pending and simulate Square's SDK
 // taking a moment to produce a nonce). Default is an instant resolve.
-let mockTokenizeImpl: () => Promise<string> = () =>
-  Promise.resolve('test-nonce');
+let mockTokenizeImpl: () => Promise<{
+  nonce: string;
+  verificationToken?: string;
+}> = () => Promise.resolve({ nonce: 'test-nonce' });
 
 // Mock SquareCardForm — the real one loads Square's Web Payments SDK
 // from a CDN, which isn't available in jsdom. We emulate the minimum
@@ -68,7 +70,9 @@ vi.mock('./SquareCardForm', () => ({
     afterCardContent,
   }: {
     onReady?: () => void;
-    onTokenizeRef: (fn: () => Promise<string>) => void;
+    onTokenizeRef: (
+      fn: () => Promise<{ nonce: string; verificationToken?: string }>
+    ) => void;
     onDigitalWalletToken?: (token: string) => void;
     afterCardContent?: React.ReactNode;
   }) => {
@@ -234,9 +238,9 @@ describe('RegistrationCheckoutForm submit flow', () => {
     // Square's tokenize call is the first await in the click handler. Hold
     // its promise pending so we can observe the button state *before* the
     // backend onSubmit is ever reached.
-    let resolveTokenize!: (nonce: string) => void;
+    let resolveTokenize!: (result: { nonce: string }) => void;
     mockTokenizeImpl = () =>
-      new Promise<string>((resolve) => {
+      new Promise<{ nonce: string }>((resolve) => {
         resolveTokenize = resolve;
       });
 
@@ -279,7 +283,7 @@ describe('RegistrationCheckoutForm submit flow', () => {
 
     // Resolve tokenize → onSubmit runs → onSuccess fires.
     await act(async () => {
-      resolveTokenize('square-nonce');
+      resolveTokenize({ nonce: 'square-nonce' });
     });
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));

--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
@@ -24,6 +24,7 @@ import AddIcon from '@mui/icons-material/Add';
 import CloseIcon from '@mui/icons-material/Close';
 import { fonts } from '@maple/react/theme';
 import { SquareCardForm } from './SquareCardForm';
+import type { CardTokenizeResult } from './SquareCardForm';
 import { CostSummary } from './CostSummary';
 import { SigningForm } from '@maple/react/agreements';
 import type {
@@ -261,7 +262,7 @@ export function RegistrationCheckoutForm({
   };
 
   // Tokenize ref from SquareCardForm — a function handle, not state.
-  const tokenizeRef = useRef<(() => Promise<string>) | null>(null);
+  const tokenizeRef = useRef<(() => Promise<CardTokenizeResult>) | null>(null);
 
   const calculateCost = useCallback(
     async (qty: number, code: string) => {
@@ -465,7 +466,7 @@ export function RegistrationCheckoutForm({
         return;
       }
 
-      const nonce = await tokenizeRef.current();
+      const { nonce } = await tokenizeRef.current();
       await performSubmit(nonce);
     } catch (error) {
       submitError.value = extractErrorMessage(error);

--- a/libs/react/registrations/src/lib/SquareCardForm.spec.tsx
+++ b/libs/react/registrations/src/lib/SquareCardForm.spec.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it } from 'vitest';
-import { cleanup, render } from '@testing-library/react';
-import { SquareCardForm } from './SquareCardForm';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { SquareCardForm, type CardTokenizeResult } from './SquareCardForm';
 
 /**
  * Guards the Square SDK environment-selection contract that the Webflow
@@ -78,5 +78,86 @@ describe('SquareCardForm SDK environment selection', () => {
       />
     );
     expect(injectedSquareScriptSrcs()).toContain(PROD_CDN);
+  });
+});
+
+/**
+ * Locks the card-on-file contract that a real-Square e2e (#622) had to catch:
+ * vaulting a card requires a STORE-intent `verifyBuyer` token in addition to
+ * the tokenize nonce. `verifyBuyerForStore` must produce it; a one-time charge
+ * (default) must NOT call verifyBuyer.
+ */
+describe('SquareCardForm buyer verification (card on file)', () => {
+  function installFakeSquare() {
+    const tokenize = vi.fn().mockResolvedValue({
+      status: 'OK',
+      token: 'cnon:card-nonce',
+    });
+    const verifyBuyer = vi.fn().mockResolvedValue({ token: 'verf:store-token' });
+    const card = {
+      attach: vi.fn().mockResolvedValue(undefined),
+      tokenize,
+      destroy: vi.fn().mockResolvedValue(undefined),
+    };
+    const payments = {
+      card: vi.fn().mockResolvedValue(card),
+      verifyBuyer,
+    };
+    (window as unknown as { Square: unknown }).Square = {
+      payments: vi.fn().mockResolvedValue(payments),
+    };
+    return { verifyBuyer };
+  }
+
+  it('runs verifyBuyer({ intent: STORE }) and returns its token alongside the nonce when verifyBuyerForStore is set', async () => {
+    const { verifyBuyer } = installFakeSquare();
+    let tokenize: (() => Promise<CardTokenizeResult>) | undefined;
+
+    render(
+      <SquareCardForm
+        applicationId="sandbox-sq0idb-abc123"
+        locationId="LOC1"
+        totalCents={13200}
+        verifyBuyerForStore
+        billingContact={{ givenName: 'Jamie', email: 'jamie@test.com' }}
+        onTokenizeRef={(fn) => {
+          tokenize = fn;
+        }}
+      />
+    );
+
+    await waitFor(() => expect(tokenize).toBeDefined());
+
+    const result = await tokenize!();
+    expect(result).toEqual({
+      nonce: 'cnon:card-nonce',
+      verificationToken: 'verf:store-token',
+    });
+    expect(verifyBuyer).toHaveBeenCalledWith(
+      'cnon:card-nonce',
+      expect.objectContaining({ intent: 'STORE' })
+    );
+  });
+
+  it('does NOT call verifyBuyer for a one-time charge (verifyBuyerForStore unset)', async () => {
+    const { verifyBuyer } = installFakeSquare();
+    let tokenize: (() => Promise<CardTokenizeResult>) | undefined;
+
+    render(
+      <SquareCardForm
+        applicationId="sandbox-sq0idb-abc123"
+        locationId="LOC1"
+        totalCents={25200}
+        onTokenizeRef={(fn) => {
+          tokenize = fn;
+        }}
+      />
+    );
+
+    await waitFor(() => expect(tokenize).toBeDefined());
+
+    const result = await tokenize!();
+    expect(result).toEqual({ nonce: 'cnon:card-nonce', verificationToken: undefined });
+    expect(verifyBuyer).not.toHaveBeenCalled();
   });
 });

--- a/libs/react/registrations/src/lib/SquareCardForm.tsx
+++ b/libs/react/registrations/src/lib/SquareCardForm.tsx
@@ -11,6 +11,21 @@ interface SquarePaymentRequest {
   update: (options: { total: { amount: string; label: string } }) => void;
 }
 
+interface SquareVerifyBuyerDetails {
+  /** 'STORE' when vaulting a card on file; 'CHARGE' for a one-time payment. */
+  intent: 'STORE' | 'CHARGE';
+  /** Recommended by Square for SCA risk scoring / mandate on STORE. */
+  billingContact?: SquareBillingContact;
+  /** Required for CHARGE intent only. */
+  amount?: string;
+  /** Required for CHARGE intent only. */
+  currencyCode?: string;
+}
+
+interface SquareVerifyBuyerResult {
+  token: string;
+}
+
 interface SquarePayments {
   card: () => Promise<SquareCard>;
   paymentRequest: (options: {
@@ -20,6 +35,15 @@ interface SquarePayments {
   }) => unknown;
   applePay: (paymentRequest: unknown) => Promise<SquareDigitalWallet>;
   googlePay: (paymentRequest: unknown) => Promise<SquareDigitalWallet>;
+  /**
+   * Strong Customer Authentication step. For `intent: 'STORE'` this produces
+   * the verification token real Square requires to vault a card on file via the
+   * Cards API — without it, `cards.create` is rejected.
+   */
+  verifyBuyer: (
+    source: string,
+    details: SquareVerifyBuyerDetails
+  ) => Promise<SquareVerifyBuyerResult>;
 }
 
 interface SquareCard {
@@ -51,6 +75,24 @@ interface SquareTokenizeResult {
   errors?: Array<{ message: string }>;
 }
 
+/** Billing contact passed to `verifyBuyer` for STORE-intent SCA. */
+export interface SquareBillingContact {
+  givenName?: string;
+  familyName?: string;
+  email?: string;
+}
+
+/**
+ * Result of the card entry step. `nonce` is the single-use payment token from
+ * `card.tokenize()`. `verificationToken` is present only when the form was told
+ * to verify the buyer for STORE intent (`verifyBuyerForStore`) — it is the token
+ * real Square requires to vault the nonce as a card on file.
+ */
+export interface CardTokenizeResult {
+  nonce: string;
+  verificationToken?: string;
+}
+
 declare global {
   interface Window {
     Square?: {
@@ -74,7 +116,17 @@ interface SquareCardFormProps {
   /** Called when the form is ready to tokenize */
   onReady?: () => void;
   /** Ref function to expose tokenize to parent */
-  onTokenizeRef: (tokenize: () => Promise<string>) => void;
+  onTokenizeRef: (tokenize: () => Promise<CardTokenizeResult>) => void;
+  /**
+   * When true, the card entry step also runs `verifyBuyer({ intent: 'STORE' })`
+   * and returns its `verificationToken` alongside the nonce. Set this for any
+   * card-on-file / vaulting flow (installments, subscriptions, saved-card
+   * updates) — real Square rejects `cards.create` without it. Leave unset for
+   * one-time charges.
+   */
+  verifyBuyerForStore?: boolean;
+  /** Billing contact used for STORE-intent SCA verification (recommended). */
+  billingContact?: SquareBillingContact;
   /** Called when a digital wallet (Apple Pay / Google Pay) completes tokenization directly */
   onDigitalWalletToken?: (token: string) => void;
   /**
@@ -141,6 +193,8 @@ export function SquareCardForm({
   showDigitalWallets = false,
   onReady,
   onTokenizeRef,
+  verifyBuyerForStore = false,
+  billingContact,
   onDigitalWalletToken,
   afterCardContent,
   maxWidth,
@@ -158,6 +212,13 @@ export function SquareCardForm({
   const paymentRequestRef = useRef<SquarePaymentRequest | null>(null);
   const onDigitalWalletTokenRef = useRef(onDigitalWalletToken);
   onDigitalWalletTokenRef.current = onDigitalWalletToken;
+  // Kept in refs so changing them doesn't re-init the SDK, and so the tokenize
+  // closure always reads the latest values (billing contact fills in as the
+  // family types).
+  const verifyBuyerForStoreRef = useRef(verifyBuyerForStore);
+  verifyBuyerForStoreRef.current = verifyBuyerForStore;
+  const billingContactRef = useRef(billingContact);
+  billingContactRef.current = billingContact;
   const placeholderRef = useRef<HTMLDivElement>(null);
   const applePayContainerRef = useRef<HTMLDivElement>(null);
   const googlePayContainerRef = useRef<HTMLDivElement>(null);
@@ -391,7 +452,26 @@ export function SquareCardForm({
           throw new Error(errorMessage);
         }
 
-        return result.token;
+        const nonce = result.token;
+
+        // Card-on-file flows must additionally verify the buyer for STORE
+        // intent — real Square requires the resulting token to vault the card
+        // via the Cards API (SCA / mandate). One-time charges skip this.
+        let verificationToken: string | undefined;
+        if (verifyBuyerForStoreRef.current) {
+          const verification = await payments.verifyBuyer(nonce, {
+            intent: 'STORE',
+            billingContact: billingContactRef.current ?? {},
+          });
+          verificationToken = verification?.token;
+          if (!verificationToken) {
+            throw new Error(
+              'Card verification failed. Please try a different card.'
+            );
+          }
+        }
+
+        return { nonce, verificationToken };
       });
 
       onReady?.();

--- a/libs/ts/firebase/api-types/src/lib/craft-club.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/craft-club.types.ts
@@ -106,6 +106,12 @@ export interface CreateCraftClubSubscriptionRequest {
   phone?: string;
   /** Nonce from the Square Web Payments SDK card tokenization. */
   paymentNonce: string;
+  /**
+   * STORE-intent verification token from `verifyBuyer` — required to vault the
+   * card on file for the subscription (real Square rejects the vault without
+   * it).
+   */
+  cardVerificationToken?: string;
 }
 
 export interface CreateCraftClubSubscriptionResponse {
@@ -177,6 +183,11 @@ export interface UpdateCraftClubPaymentMethodRequest {
   sessionToken: string;
   /** New nonce from the Square Web Payments SDK card tokenization. */
   paymentNonce: string;
+  /**
+   * STORE-intent verification token from `verifyBuyer` — required to vault the
+   * new card on file (real Square rejects the vault without it).
+   */
+  cardVerificationToken?: string;
 }
 
 export interface UpdateCraftClubPaymentMethodResponse {

--- a/libs/ts/firebase/api-types/src/lib/music-together.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/music-together.types.ts
@@ -178,6 +178,12 @@ export interface CreateMusicTogetherRegistrationRequest {
   cardOnFileAuth?: boolean;
   /** Nonce from the Square Web Payments SDK card tokenization. */
   paymentNonce: string;
+  /**
+   * STORE-intent verification token from `verifyBuyer` — REQUIRED for the
+   * installment plan (the card is vaulted on file; real Square rejects the
+   * vault without it). Unused for pay-in-full.
+   */
+  cardVerificationToken?: string;
   notes?: string;
 }
 
@@ -338,6 +344,11 @@ export interface UpdateMusicTogetherPaymentMethodRequest {
   sessionToken: string;
   /** New nonce from the Square Web Payments SDK card tokenization. */
   paymentNonce: string;
+  /**
+   * STORE-intent verification token from `verifyBuyer` — required to vault the
+   * new card on file (real Square rejects the vault without it).
+   */
+  cardVerificationToken?: string;
 }
 
 export interface UpdateMusicTogetherPaymentMethodResponse {


### PR DESCRIPTION
Fixes #622.

## What the e2e caught
The post-merge `mt_e2e_dev` gate (real MT Square sandbox) fails the **two-installment** MT enrollment deterministically while pay-in-full ($252) and the 2-child sibling ($378) pay-in-full pass. The installment path is the only one that **vaults a card on file**.

## Root cause (confirmed by code inspection; log/trace access blocked)
The card-on-file path stores a card via the Cards API but never produces or passes a Square **`verification_token`**. Real Square **requires** a STORE-intent `verifyBuyer` token to create a card on file (SCA/mandate). The Square **test mock accepted anything**, so every mock-backed integration test passed and only the real-Square e2e surfaced the gap.

- `MusicTogetherRegistrationWidget` `cardOnFileAuth` was a consent checkbox, not a token.
- Neither the widget nor `SquareCardForm` called `verifyBuyer`.
- `CardsService.createCardOnFile` sent `sourceId` + `card` but no `verification_token`.

> I could **not** confirm from logs directly: `firebase functions:log` isn't installed and `gcloud logging read` failed reauth (non-interactive), and the CI workflow name didn't resolve for the trace artifact. The diagnosis is code-inspection + the e2e's deterministic signal (installments-only failure = the vault-only path). Everything else is confirmed.

## Craft Club shares the gap (flagged + fixed)
All four paths that call `CardsService.createCardOnFile` had the same missing token — so **Craft Club card-on-file (subscription signup + saved-card update) was also broken against real Square**:
- `createMusicTogetherRegistration` (installments)
- `createCraftClubSubscription`
- `updateMusicTogetherPaymentMethod`
- `updateCraftClubPaymentMethod`

All four are fixed here.

## Fix
- **`SquareCardForm`**: new `verifyBuyerForStore` prop. After `card.tokenize()` it runs `payments.verifyBuyer(nonce, { intent: 'STORE', billingContact })` and returns `{ nonce, verificationToken }`. One-time charges (class registration, MT **pay-in-full**) are unchanged and never call `verifyBuyer`.
- Thread `cardVerificationToken` end-to-end: card-on-file widget → request type → Cloud Function → `CardsService.createCardOnFile` → Cards API `verification_token`.
- Each card-on-file function now **rejects** a request missing the token before reserving a seat or calling Square.

## Lock the contract so mocks catch this next time
- Square mock `POST /v2/cards` now **requires** `verification_token` and returns 400 without it, mirroring real Square (per this repo's "integration tests lock the user-facing contract" philosophy).
- Integration + unit tests send the token; **new tests assert a missing token is rejected**, and the MT update-payment integration test asserts the vault request body actually carries `verification_token`.

## Verification
- Unit: **212 passed** (incl. new `SquareCardForm` verifyBuyer STORE / no-verify-on-charge tests).
- MT integration (`./tools/run-integration-tests.sh music-together`): **64 passed** with the mock enforcing the token.
- Square integration (Craft Club): **43 passed**.
- Typecheck (webflow-components, functions-square, mock-server, square lib, integration suites, maple-spruce) clean; eslint **0 errors**.
- **Cannot run `mt_e2e_dev` locally** (no MT sandbox token — secrets not read). The real proof is that gate going **green post-merge** against real Square.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>