### PR TITLE
feat(auth): enforce the scoped-role matrix — 46 functions re-scoped + route guards (PR 3 of 3)

### DIFF
--- a/apps/functions-integration-tests-utility/src/role-matrix.spec.ts
+++ b/apps/functions-integration-tests-utility/src/role-matrix.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Role access matrix — integration proof of the scoped-roles enforcement
+ * (epic #617, re-scope #615).
+ *
+ * Table-driven: each case is (caller role, function, expected status), so
+ * this spec IS the access matrix. Samples 2-4 representative functions
+ * per group rather than every callable — the requiringRole change is
+ * uniform, and the callable-coverage analyzer (#620) will guarantee no
+ * endpoint is left undeclared.
+ *
+ * Callers are seeded directly into Firestore (admins/{uid} and
+ * userRoles/{uid}) — the grant/revoke round trip is covered in
+ * utility-functions.spec.ts.
+ */
+import {
+  createTestUser,
+  clearAuthEmulator,
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  callFunction,
+} from '@maple/firebase/integration-test-utils';
+import type { TestUser } from '@maple/firebase/integration-test-utils';
+
+type CallerKey = 'admin' | 'stephanie' | 'nathan' | 'noRole';
+
+interface MatrixCase {
+  /** Which seeded user makes the call */
+  as: CallerKey;
+  functionName: string;
+  data?: Record<string, unknown>;
+  /** 200 = allowed; 403 = forbidden by the role check */
+  expect: 200 | 403;
+}
+
+const ROOM_SCHEDULE_REQ = {
+  room: 'spruce',
+  start: '2026-07-01T00:00:00.000Z',
+  end: '2026-07-31T00:00:00.000Z',
+};
+
+const CASES: MatrixCase[] = [
+  // ── Stephanie: mt-teacher ─────────────────────────────────────────
+  { as: 'stephanie', functionName: 'getMusicTogetherSections', expect: 200 },
+  { as: 'stephanie', functionName: 'getMusicTogetherSemesters', expect: 200 },
+  { as: 'stephanie', functionName: 'getMusicTogetherInterest', expect: 200 },
+  { as: 'stephanie', functionName: 'getCalendarEvents', expect: 200 },
+  {
+    as: 'stephanie',
+    functionName: 'getRoomSchedule',
+    data: ROOM_SCHEDULE_REQ,
+    expect: 200,
+  },
+  { as: 'stephanie', functionName: 'getProducts', expect: 403 },
+  { as: 'stephanie', functionName: 'getClasses', expect: 403 },
+  { as: 'stephanie', functionName: 'getRegistrations', expect: 403 },
+  { as: 'stephanie', functionName: 'getStudents', expect: 403 },
+  { as: 'stephanie', functionName: 'getLessons', expect: 403 },
+  { as: 'stephanie', functionName: 'listUsers', expect: 403 },
+  { as: 'stephanie', functionName: 'createClass', expect: 403 },
+  { as: 'stephanie', functionName: 'getSyncConflictSummary', expect: 403 },
+
+  // ── Nathan: clerk + lesson-teacher (multi-role union) ─────────────
+  { as: 'nathan', functionName: 'getProducts', expect: 200 },
+  { as: 'nathan', functionName: 'getCategories', expect: 200 },
+  { as: 'nathan', functionName: 'getSales', expect: 200 },
+  { as: 'nathan', functionName: 'getClasses', expect: 200 },
+  { as: 'nathan', functionName: 'getRegistrations', expect: 200 },
+  { as: 'nathan', functionName: 'getClassWaitlistCounts', expect: 200 },
+  { as: 'nathan', functionName: 'getLessons', expect: 200 },
+  { as: 'nathan', functionName: 'getStudents', expect: 200 },
+  { as: 'nathan', functionName: 'getInvoices', expect: 200 },
+  { as: 'nathan', functionName: 'getCalendarEvents', expect: 200 },
+  { as: 'nathan', functionName: 'getMusicTogetherSections', expect: 403 },
+  { as: 'nathan', functionName: 'getMusicTogetherRoster', expect: 403 },
+  { as: 'nathan', functionName: 'createClass', expect: 403 },
+  { as: 'nathan', functionName: 'updateClass', expect: 403 },
+  { as: 'nathan', functionName: 'getTeacherPayouts', expect: 403 },
+  { as: 'nathan', functionName: 'getArtists', expect: 403 },
+  { as: 'nathan', functionName: 'listUsers', expect: 403 },
+  { as: 'nathan', functionName: 'grantRole', expect: 403 },
+  { as: 'nathan', functionName: 'getDiscounts', expect: 403 },
+
+  // ── Admin: unchanged, everything passes (spot checks per group) ───
+  { as: 'admin', functionName: 'getMusicTogetherSections', expect: 200 },
+  { as: 'admin', functionName: 'getProducts', expect: 200 },
+  { as: 'admin', functionName: 'getLessons', expect: 200 },
+  { as: 'admin', functionName: 'getCalendarEvents', expect: 200 },
+  { as: 'admin', functionName: 'listUsers', expect: 200 },
+  { as: 'admin', functionName: 'getArtists', expect: 200 },
+
+  // ── No roles at all: nothing opens ────────────────────────────────
+  { as: 'noRole', functionName: 'getCalendarEvents', expect: 403 },
+  { as: 'noRole', functionName: 'getProducts', expect: 403 },
+  { as: 'noRole', functionName: 'getMusicTogetherSections', expect: 403 },
+];
+
+describe('Role access matrix (scoped-roles enforcement)', () => {
+  const users = {} as Record<CallerKey, TestUser>;
+
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+
+    users.admin = await createTestUser(
+      'matrix-admin@test.maple',
+      'test-password-123!'
+    );
+    users.stephanie = await createTestUser(
+      'matrix-stephanie@test.maple',
+      'test-password-123!'
+    );
+    users.nathan = await createTestUser(
+      'matrix-nathan@test.maple',
+      'test-password-123!'
+    );
+    users.noRole = await createTestUser(
+      'matrix-norole@test.maple',
+      'test-password-123!'
+    );
+
+    await setFirestoreDoc('admins', users.admin.uid, {
+      userId: users.admin.uid,
+      email: users.admin.email,
+    });
+    await setFirestoreDoc('userRoles', users.stephanie.uid, {
+      roles: ['mt-teacher'],
+      grantedBy: users.admin.uid,
+    });
+    await setFirestoreDoc('userRoles', users.nathan.uid, {
+      roles: ['clerk', 'lesson-teacher'],
+      grantedBy: users.admin.uid,
+    });
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  it.each(CASES.map((c) => [c.as, c.functionName, c.expect, c] as const))(
+    '%s -> %s expects %d',
+    async (_as, _fn, _status, c) => {
+      const result = await callFunction({
+        functionName: c.functionName,
+        idToken: users[c.as].idToken,
+        data: c.data ?? {},
+      });
+
+      expect(result.status).toBe(c.expect);
+    }
+  );
+});

--- a/apps/maple-spruce/src/app/(admin)/layout.tsx
+++ b/apps/maple-spruce/src/app/(admin)/layout.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { ReactNode } from 'react';
-import { RoleGuard, RolesProvider } from '@maple/react/auth';
-import { AppShell } from '../../components/layout';
+import { RolesProvider } from '@maple/react/auth';
+import { AppShell, PathRoleGuard } from '../../components/layout';
 
 /**
  * Layout for the admin app's authenticated routes.
@@ -13,9 +13,9 @@ import { AppShell } from '../../components/layout';
  * flashing the loading nav before the response resolved.
  *
  * RolesProvider fetches getMyRoles ONCE; both the nav (role filtering in
- * AppShellWrapper) and the gate (RoleGuard) read from it. Any user with
- * at least one role passes the gate; what they can see/do is scoped by
- * nav filtering here and `requiringRole` server-side.
+ * AppShellWrapper) and the gate (PathRoleGuard) read from it. The guard
+ * resolves the current route to its allowed roles via the same map that
+ * filters the nav; real enforcement is `requiringRole` server-side.
  */
 export default function AdminGroupLayout({
   children,
@@ -25,7 +25,7 @@ export default function AdminGroupLayout({
   return (
     <RolesProvider>
       <AppShell>
-        <RoleGuard>{children}</RoleGuard>
+        <PathRoleGuard>{children}</PathRoleGuard>
       </AppShell>
     </RolesProvider>
   );

--- a/apps/maple-spruce/src/app/(admin)/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/page.tsx
@@ -32,6 +32,7 @@ import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import StorefrontIcon from '@mui/icons-material/Storefront';
 import SyncProblemIcon from '@mui/icons-material/SyncProblem';
 import { formatClassPrice } from '@maple/ts/domain';
+import { useRoles } from '@maple/react/auth';
 import { useSyncConflictSummary } from '@maple/react/data';
 import { RoomStatusCard } from '@maple/react/events';
 import { useClasses, useRegistrations, useProducts } from '../../hooks';
@@ -69,11 +70,17 @@ function formatTime(date: Date): string {
   });
 }
 
-export default function DashboardPage() {
+/**
+ * Business widgets (classes / registrations / low stock / sync) — mounted
+ * only for roles whose server-side access matches what they fetch
+ * (admin + clerk; the sync card is admin-only). Hooks live inside so the
+ * calls never fire for roles that would just get 403s.
+ */
+function StoreOverviewWidgets({ showSync }: { showSync: boolean }) {
   const { classesState } = useClasses();
   const { registrationsState } = useRegistrations();
   const { productsState } = useProducts();
-  const { summaryState } = useSyncConflictSummary();
+  const { summaryState } = useSyncConflictSummary(showSync);
 
   // Upcoming published classes in the next 7 days
   const upcomingClasses = useMemo(() => {
@@ -159,21 +166,7 @@ export default function DashboardPage() {
 
   return (
     <>
-      <Typography variant="h4" component="h1" gutterBottom>
-        Dashboard
-      </Typography>
-
-      <Grid container spacing={3}>
-        {/* Spruce Room status */}
-        <Grid size={12}>
-          <RoomStatusCard
-            room="spruce"
-            bookHref="/book-room"
-            scheduleHref="/room-schedule"
-          />
-        </Grid>
-
-        {/* Upcoming Classes */}
+      {/* Upcoming Classes */}
         <Grid size={{ xs: 12, md: 6 }}>
           <Typography variant="h6" gutterBottom>
             <EventIcon
@@ -422,7 +415,36 @@ export default function DashboardPage() {
           </Grid>
         )}
 
-        {/* Quick Links */}
+    </>
+  );
+}
+
+export default function DashboardPage() {
+  const { isAdmin, roles } = useRoles();
+  const isClerk = roles.includes('clerk');
+
+  return (
+    <>
+      <Typography variant="h4" component="h1" gutterBottom>
+        Dashboard
+      </Typography>
+
+      <Grid container spacing={3}>
+        {/* Spruce Room status — visible to every role */}
+        <Grid size={12}>
+          <RoomStatusCard
+            room="spruce"
+            bookHref="/book-room"
+            scheduleHref="/room-schedule"
+          />
+        </Grid>
+
+        {/* Business widgets — admin + clerk only; their hooks call
+            role-gated functions, so don't mount them for other roles */}
+        {(isAdmin || isClerk) && <StoreOverviewWidgets showSync={isAdmin} />}
+
+        {/* Quick Links — external business accounts, admin only */}
+        {isAdmin && (
         <Grid size={12}>
           <Typography variant="h6" gutterBottom sx={{ mt: 1 }}>
             <StorefrontIcon
@@ -460,6 +482,7 @@ export default function DashboardPage() {
             })}
           </Grid>
         </Grid>
+        )}
       </Grid>
     </>
   );

--- a/apps/maple-spruce/src/components/layout/AppShellWrapper.tsx
+++ b/apps/maple-spruce/src/components/layout/AppShellWrapper.tsx
@@ -22,8 +22,9 @@ export function AppShellWrapper({
   children,
   maxWidth = 'lg',
 }: AppShellWrapperProps): ReactNode {
-  const { summaryState } = useSyncConflictSummary();
-  const { roles } = useRoles();
+  const { roles, isAdmin } = useRoles();
+  // Sync badge is admin-only; skip the (admin-gated) call for other roles
+  const { summaryState } = useSyncConflictSummary(isAdmin);
 
   const pendingConflicts = useMemo(() => {
     if (summaryState.status !== 'success') return 0;

--- a/apps/maple-spruce/src/components/layout/PathRoleGuard.tsx
+++ b/apps/maple-spruce/src/components/layout/PathRoleGuard.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { usePathname } from 'next/navigation';
+import { RoleGuard } from '@maple/react/auth';
+import { pageRolesForPath } from './nav-groups';
+
+/**
+ * Route-aware guard for the (admin) group: resolves the current path to
+ * its allowed roles (same map that filters the nav) and applies RoleGuard
+ * with them. Admins always pass; a scoped user deep-linking to a page
+ * outside their roles gets the no-access screen instead of a wall of
+ * failed requests. Unknown routes default to admin-only.
+ *
+ * UX only — real enforcement is each Cloud Function's requiringRole check.
+ */
+export function PathRoleGuard({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  return (
+    <RoleGuard allowedRoles={pageRolesForPath(pathname ?? '/')}>
+      {children}
+    </RoleGuard>
+  );
+}

--- a/apps/maple-spruce/src/components/layout/index.ts
+++ b/apps/maple-spruce/src/components/layout/index.ts
@@ -1,2 +1,3 @@
 // Re-export the wrapper as AppShell for backward compatibility
 export { AppShellWrapper as AppShell } from './AppShellWrapper';
+export { PathRoleGuard } from './PathRoleGuard';

--- a/apps/maple-spruce/src/components/layout/nav-filter.spec.ts
+++ b/apps/maple-spruce/src/components/layout/nav-filter.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { filterNavGroupsByRoles } from './nav-filter';
+import { allowedRolesForPath, filterNavGroupsByRoles } from './nav-filter';
 
 // Icon-free fixture mirroring the real nav's role semantics: an
 // admin-only item, a clerk item, an all-roles item, and a group that
@@ -80,5 +80,82 @@ describe('filterNavGroupsByRoles', () => {
       badge: 7,
       badgeColor: 'warning',
     });
+  });
+});
+
+describe('allowedRolesForPath', () => {
+  const GROUPS_WITH_HREFS = [
+    {
+      label: 'Store',
+      items: [
+        {
+          label: 'Home',
+          href: '/',
+          roles: ['mt-teacher', 'clerk', 'lesson-teacher'] as const,
+        },
+        { label: 'Inventory', href: '/inventory', roles: ['clerk'] as const },
+        { label: 'Artists', href: '/artists' }, // admin only
+        {
+          label: 'Artist Payouts',
+          href: '/payouts/artist-payouts',
+        }, // admin only, nested under /payouts
+      ],
+    },
+    {
+      label: 'Music Lessons',
+      items: [
+        {
+          label: 'Teacher Payouts',
+          href: '/payouts',
+          roles: ['lesson-teacher'] as const,
+        },
+      ],
+    },
+  ];
+
+  it('resolves an exact match to its roles', () => {
+    expect(allowedRolesForPath(GROUPS_WITH_HREFS, '/inventory')).toEqual([
+      'clerk',
+    ]);
+  });
+
+  it('detail routes inherit their section via prefix match', () => {
+    expect(
+      allowedRolesForPath(GROUPS_WITH_HREFS, '/inventory/product-123')
+    ).toEqual(['clerk']);
+  });
+
+  it('longest prefix wins (/payouts/artist-payouts over /payouts)', () => {
+    expect(
+      allowedRolesForPath(GROUPS_WITH_HREFS, '/payouts/artist-payouts')
+    ).toEqual([]); // admin only
+    expect(allowedRolesForPath(GROUPS_WITH_HREFS, '/payouts')).toEqual([
+      'lesson-teacher',
+    ]);
+  });
+
+  it('"/" matches only exactly — it never swallows other routes', () => {
+    expect(allowedRolesForPath(GROUPS_WITH_HREFS, '/')).toEqual([
+      'mt-teacher',
+      'clerk',
+      'lesson-teacher',
+    ]);
+    expect(allowedRolesForPath(GROUPS_WITH_HREFS, '/settings')).toEqual([]);
+  });
+
+  it('unknown routes are admin-only (empty roles)', () => {
+    expect(allowedRolesForPath(GROUPS_WITH_HREFS, '/brand-new-page')).toEqual(
+      []
+    );
+  });
+
+  it('un-annotated items resolve to admin-only', () => {
+    expect(allowedRolesForPath(GROUPS_WITH_HREFS, '/artists')).toEqual([]);
+  });
+
+  it('does not treat sibling prefixes as matches (/inventory-x vs /inventory)', () => {
+    expect(allowedRolesForPath(GROUPS_WITH_HREFS, '/inventory-archive')).toEqual(
+      []
+    );
   });
 });

--- a/apps/maple-spruce/src/components/layout/nav-filter.ts
+++ b/apps/maple-spruce/src/components/layout/nav-filter.ts
@@ -13,6 +13,34 @@ export interface RoleAnnotated {
   roles?: readonly UserRole[];
 }
 
+/**
+ * Resolve which roles may view a route, from the same annotations that
+ * drive nav filtering. Longest-prefix match so detail routes inherit
+ * their section's roles (`/classes/abc` -> `/classes`); `/` only matches
+ * exactly (it would otherwise swallow every route). Unknown routes
+ * return [] = admin-only (safe default for new pages).
+ */
+export function allowedRolesForPath<
+  Item extends RoleAnnotated & { href: string },
+>(
+  groups: ReadonlyArray<{ label: string; items: Item[] }>,
+  pathname: string
+): readonly UserRole[] {
+  let best: { href: string; roles: readonly UserRole[] } | undefined;
+  for (const group of groups) {
+    for (const item of group.items) {
+      const matches =
+        item.href === '/'
+          ? pathname === '/'
+          : pathname === item.href || pathname.startsWith(`${item.href}/`);
+      if (matches && (!best || item.href.length > best.href.length)) {
+        best = { href: item.href, roles: item.roles ?? [] };
+      }
+    }
+  }
+  return best?.roles ?? [];
+}
+
 export function filterNavGroupsByRoles<Item extends RoleAnnotated>(
   groups: ReadonlyArray<{ label: string; items: Item[] }>,
   roles: readonly UserRole[]

--- a/apps/maple-spruce/src/components/layout/nav-groups.tsx
+++ b/apps/maple-spruce/src/components/layout/nav-groups.tsx
@@ -23,7 +23,7 @@ import CardMembershipIcon from '@mui/icons-material/CardMembership';
 import ManageAccountsIcon from '@mui/icons-material/ManageAccounts';
 import type { NavGroup, NavItem } from '@maple/react/layout';
 import type { UserRole } from '@maple/ts/domain';
-import { filterNavGroupsByRoles } from './nav-filter';
+import { allowedRolesForPath, filterNavGroupsByRoles } from './nav-filter';
 
 /**
  * A nav item annotated with the roles that may see it. Omitted = admin
@@ -207,4 +207,14 @@ export function buildNavGroups(
   pendingConflicts: number
 ): NavGroup[] {
   return filterNavGroupsByRoles(roleNavGroups(pendingConflicts), roles);
+}
+
+/**
+ * Which roles may view a route — derived from the SAME role map as the
+ * nav, so page guarding can't drift from nav visibility. Longest-prefix
+ * match; unknown routes are admin-only. Used by PathRoleGuard in the
+ * (admin) layout. UX only — server enforcement is per-function.
+ */
+export function pageRolesForPath(pathname: string): readonly UserRole[] {
+  return allowedRolesForPath(roleNavGroups(0), pathname);
 }

--- a/docs/reference/deployed-functions.md
+++ b/docs/reference/deployed-functions.md
@@ -95,6 +95,8 @@ Core CRUD operations, auth, triggers, and admin functions. No heavy third-party 
 - `checkAdminStatus` _(returns `{ isAdmin, isEmployee, role }` — `role` is the highest-privilege role)_
 - `getMyRoles` _(auth only — returns every role the caller holds: admin from `admins/{uid}` + scoped roles from `userRoles/{uid}`; client nav gating)_
 
+> **Roles (epic #617, ADR-028):** "admin only" annotations below predate the scoped-roles matrix. Since PR 3, callables are gated by role sets: Music Together mgmt → admin + `mt-teacher`; store inventory/sales/categories + class registrations/rosters/waitlists/refunds + class reads → admin + `clerk`; lesson/student/invoice/instructor **reads** → admin + `lesson-teacher`; calendar events + room schedule → all staff roles. Everything else remains admin-only. The authoritative table is `apps/functions-integration-tests-utility/src/role-matrix.spec.ts`.
+
 ### User & role administration
 - `listUsers` _(admin only — Firebase Auth users joined with admin records + scoped roles from `userRoles/{uid}`; powers `/users` page; capped at 1000 per call)_
 - `grantAdminRole` _(admin only — promotes another user to admin)_

--- a/docs/reference/implementation-status.md
+++ b/docs/reference/implementation-status.md
@@ -24,6 +24,7 @@
 | Admin authorization (UI) | Complete | `AdminGuard` + `useAdminStatus` + `checkAdminStatus` Cloud Function |
 | Scoped roles framework (PR 1 of epic #617) | Complete | `Role` enum (admin, mt-teacher, clerk, lesson-teacher) + `userRoles/{uid}` + any-of `requiringRole([...])` + `getMyRoles`/`grantRole`/`revokeRole`; behavior-neutral — client plumbing #614, re-scoping #615 |
 | Scoped roles client plumbing (PR 2 of epic #617) | Complete | `RolesProvider`/`useRoles`/`RoleGuard` (ADR-028), role-filtered nav (`nav-groups.tsx`), `/users` scoped-role toggles, `listUsers` roles join — enforcement re-scoping is #615 |
+| Scoped roles enforcement (PR 3 of epic #617) | Complete | 46 fns re-scoped to role sets (MT→mt-teacher, store/registrations→clerk, lesson reads→lesson-teacher, calendar→all staff); auth-only reads tightened; `PathRoleGuard` route gating; role-gated dashboard; matrix integration spec (`role-matrix.spec.ts`). Phase 2 ownership = #616, analyzer = #620 |
 | Navigation (responsive) | Complete | `libs/react/layout/` (re-exported via app barrel) |
 | Storybook | Complete | `apps/maple-spruce/.storybook/` |
 | Component stories | Complete | `apps/maple-spruce/src/components/**/*.stories.tsx`, `libs/react/*/src/**/*.stories.tsx` |

--- a/libs/firebase/functions/src/lib/functions.utility.spec.ts
+++ b/libs/firebase/functions/src/lib/functions.utility.spec.ts
@@ -69,6 +69,7 @@ import {
   createPublicFunction,
   createAuthenticatedFunction,
   createAdminFunction,
+  createRoleFunction,
   isOriginAllowed,
 } from './functions.utility';
 import {
@@ -475,6 +476,24 @@ describe('Functions.endpoint (chain + handle)', () => {
     expect(mocks.hasAnyRole).toHaveBeenCalledWith('stephanie-uid', [
       Role.Admin,
       Role.MtTeacher,
+    ]);
+  });
+
+  it('createRoleFunction: passes the role set to the any-of check', async () => {
+    mocks.verifyIdToken.mockResolvedValue({ uid: 'nathan-uid' });
+    mocks.hasAnyRole.mockResolvedValue(true);
+    const handler = vi.fn(async () => ({ ok: true }));
+    const endpoint = createRoleFunction(handler, [Role.Admin, Role.Clerk]);
+
+    const res = await invoke(
+      endpoint,
+      makeReq({ headers: { origin: 'https://example.test', authorization: 'Bearer t' } })
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(mocks.hasAnyRole).toHaveBeenCalledWith('nathan-uid', [
+      Role.Admin,
+      Role.Clerk,
     ]);
   });
 

--- a/libs/firebase/functions/src/lib/functions.utility.ts
+++ b/libs/firebase/functions/src/lib/functions.utility.ts
@@ -663,3 +663,18 @@ export function createAdminFunction<TRequest, TResponse>(
 ) {
   return createFunction(handler, { requiredRole: Role.Admin });
 }
+
+/**
+ * Create a function callable by ANY of the given roles (any-of).
+ *
+ * Legacy-style counterpart to createAdminFunction for the scoped-roles
+ * matrix (epic #617) — lets a createAdminFunction/createAuthenticatedFunction
+ * call site widen or tighten to a role set as a one-line change. For new
+ * functions prefer Functions.endpoint.requiringRole([...]).handle().
+ */
+export function createRoleFunction<TRequest, TResponse>(
+  handler: (data: TRequest, context: FunctionContext) => Promise<TResponse>,
+  roles: readonly Role[]
+) {
+  return createFunction(handler, { requiredRole: roles });
+}

--- a/libs/firebase/functions/src/lib/index.ts
+++ b/libs/firebase/functions/src/lib/index.ts
@@ -22,6 +22,7 @@ export {
   createPublicFunction,
   createAuthenticatedFunction,
   createAdminFunction,
+  createRoleFunction,
   assertValid,
   runChecks,
   type FunctionContext,

--- a/libs/firebase/maple-functions/cancel-music-together-registration/src/lib/cancel-music-together-registration.ts
+++ b/libs/firebase/maple-functions/cancel-music-together-registration/src/lib/cancel-music-together-registration.ts
@@ -56,7 +56,7 @@ import type {
 export const cancelMusicTogetherRegistration = Functions.endpoint
   .usingSecrets(...MT_SQUARE_SECRET_NAMES)
   .usingStrings(...MT_SQUARE_STRING_NAMES)
-  .requiringRole(Role.Admin)
+  .requiringRole([Role.Admin, Role.MtTeacher])
   .handle<
     CancelMusicTogetherRegistrationRequest,
     CancelMusicTogetherRegistrationResponse

--- a/libs/firebase/maple-functions/cancel-registration/src/lib/cancel-registration.ts
+++ b/libs/firebase/maple-functions/cancel-registration/src/lib/cancel-registration.ts
@@ -26,7 +26,7 @@ import type {
 export const cancelRegistration = Functions.endpoint
   .usingSecrets(...SQUARE_SECRET_NAMES)
   .usingStrings(...SQUARE_STRING_NAMES)
-  .requiringRole(Role.Admin)
+  .requiringRole([Role.Admin, Role.Clerk])
   .handle<CancelRegistrationRequest, CancelRegistrationResponse>(
     async (data, _context, secrets, strings) => {
       // The `registrationValidation` Vest suite covers registration form

--- a/libs/firebase/maple-functions/create-calendar-event/src/lib/create-calendar-event.ts
+++ b/libs/firebase/maple-functions/create-calendar-event/src/lib/create-calendar-event.ts
@@ -4,7 +4,10 @@
  * Creates a new calendar event.
  * Deployed to us-east4 via CI/CD pipeline.
  */
-import { createAdminFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+} from '@maple/firebase/functions';
 import { CalendarEventRepository } from '@maple/firebase/database';
 import { calendarEventValidation } from '@maple/ts/validation';
 import type {
@@ -12,7 +15,7 @@ import type {
   CreateCalendarEventResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const createCalendarEvent = createAdminFunction<
+export const createCalendarEvent = createRoleFunction<
   CreateCalendarEventRequest,
   CreateCalendarEventResponse
 >(async (data) => {
@@ -29,4 +32,4 @@ export const createCalendarEvent = createAdminFunction<
   const calendarEvent = await CalendarEventRepository.create(data);
 
   return { calendarEvent };
-});
+}, [Role.Admin, Role.MtTeacher, Role.Clerk, Role.LessonTeacher]);

--- a/libs/firebase/maple-functions/create-category/src/lib/create-category.ts
+++ b/libs/firebase/maple-functions/create-category/src/lib/create-category.ts
@@ -3,7 +3,10 @@
  *
  * Creates a new category (admin only).
  */
-import { createAdminFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+} from '@maple/firebase/functions';
 import { CategoryRepository } from '@maple/firebase/database';
 import { categoryValidation } from '@maple/ts/validation';
 import type {
@@ -11,7 +14,7 @@ import type {
   CreateCategoryResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const createCategory = createAdminFunction<
+export const createCategory = createRoleFunction<
   CreateCategoryRequest,
   CreateCategoryResponse
 >(async (data) => {
@@ -34,4 +37,4 @@ export const createCategory = createAdminFunction<
   const category = await CategoryRepository.create(data);
 
   return { category };
-});
+}, [Role.Admin, Role.Clerk]);

--- a/libs/firebase/maple-functions/create-music-together-section/src/lib/create-music-together-section.ts
+++ b/libs/firebase/maple-functions/create-music-together-section/src/lib/create-music-together-section.ts
@@ -13,7 +13,7 @@ import type {
 } from '@maple/ts/firebase/api-types';
 
 export const createMusicTogetherSection = Functions.endpoint
-  .requiringRole(Role.Admin)
+  .requiringRole([Role.Admin, Role.MtTeacher])
   .validating(musicTogetherSectionValidation)
   .handle<
     CreateMusicTogetherSectionRequest,

--- a/libs/firebase/maple-functions/create-music-together-semester/src/lib/create-music-together-semester.ts
+++ b/libs/firebase/maple-functions/create-music-together-semester/src/lib/create-music-together-semester.ts
@@ -14,7 +14,7 @@ import type {
 } from '@maple/ts/firebase/api-types';
 
 export const createMusicTogetherSemester = Functions.endpoint
-  .requiringRole(Role.Admin)
+  .requiringRole([Role.Admin, Role.MtTeacher])
   .validating(musicTogetherSemesterValidation)
   .handle<
     CreateMusicTogetherSemesterRequest,

--- a/libs/firebase/maple-functions/create-product/src/lib/create-product.ts
+++ b/libs/firebase/maple-functions/create-product/src/lib/create-product.ts
@@ -26,7 +26,7 @@ import type {
 export const createProduct = Functions.endpoint
   .usingSecrets(...SQUARE_SECRET_NAMES)
   .usingStrings(...SQUARE_STRING_NAMES)
-  .requiringRole(Role.Admin)
+  .requiringRole([Role.Admin, Role.Clerk])
   .handle<CreateProductRequest, CreateProductResponse>(
     async (data, _context, secrets, strings) => {
       console.log('createProduct called with:', {

--- a/libs/firebase/maple-functions/delete-calendar-event/src/lib/delete-calendar-event.ts
+++ b/libs/firebase/maple-functions/delete-calendar-event/src/lib/delete-calendar-event.ts
@@ -4,14 +4,17 @@
  * Deletes an existing calendar event.
  * Deployed to us-east4 via CI/CD pipeline.
  */
-import { createAdminFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+} from '@maple/firebase/functions';
 import { CalendarEventRepository } from '@maple/firebase/database';
 import type {
   DeleteCalendarEventRequest,
   DeleteCalendarEventResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const deleteCalendarEvent = createAdminFunction<
+export const deleteCalendarEvent = createRoleFunction<
   DeleteCalendarEventRequest,
   DeleteCalendarEventResponse
 >(async (data) => {
@@ -24,4 +27,4 @@ export const deleteCalendarEvent = createAdminFunction<
   await CalendarEventRepository.delete(data.id);
 
   return { success: true };
-});
+}, [Role.Admin, Role.MtTeacher, Role.Clerk, Role.LessonTeacher]);

--- a/libs/firebase/maple-functions/delete-category/src/lib/delete-category.ts
+++ b/libs/firebase/maple-functions/delete-category/src/lib/delete-category.ts
@@ -4,14 +4,18 @@
  * Deletes a category (admin only).
  * Will fail if products are using this category.
  */
-import { createAdminFunction, throwNotFound } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  throwNotFound,
+  Role,
+} from '@maple/firebase/functions';
 import { CategoryRepository } from '@maple/firebase/database';
 import type {
   DeleteCategoryRequest,
   DeleteCategoryResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const deleteCategory = createAdminFunction<
+export const deleteCategory = createRoleFunction<
   DeleteCategoryRequest,
   DeleteCategoryResponse
 >(async (data) => {
@@ -35,4 +39,4 @@ export const deleteCategory = createAdminFunction<
   await CategoryRepository.delete(data.id);
 
   return { success: true };
-});
+}, [Role.Admin, Role.Clerk]);

--- a/libs/firebase/maple-functions/delete-product/src/lib/delete-product.ts
+++ b/libs/firebase/maple-functions/delete-product/src/lib/delete-product.ts
@@ -3,14 +3,18 @@
  *
  * Deletes a product (admin only).
  */
-import { createAdminFunction, throwNotFound } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  throwNotFound,
+  Role,
+} from '@maple/firebase/functions';
 import { ProductRepository } from '@maple/firebase/database';
 import type {
   DeleteProductRequest,
   DeleteProductResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const deleteProduct = createAdminFunction<
+export const deleteProduct = createRoleFunction<
   DeleteProductRequest,
   DeleteProductResponse
 >(async (data) => {
@@ -23,4 +27,4 @@ export const deleteProduct = createAdminFunction<
   await ProductRepository.delete(data.id);
 
   return { success: true };
-});
+}, [Role.Admin, Role.Clerk]);

--- a/libs/firebase/maple-functions/duplicate-music-together-section/src/lib/duplicate-music-together-section.spec.ts
+++ b/libs/firebase/maple-functions/duplicate-music-together-section/src/lib/duplicate-music-together-section.spec.ts
@@ -17,7 +17,7 @@ vi.mock('@maple/firebase/functions', async () => {
     );
   return {
     ...actual,
-    createAdminFunction: <TReq, TRes>(
+    createRoleFunction: <TReq, TRes>(
       handler: (data: TReq, ctx: unknown) => Promise<TRes>
     ) => handler,
   };

--- a/libs/firebase/maple-functions/duplicate-music-together-section/src/lib/duplicate-music-together-section.ts
+++ b/libs/firebase/maple-functions/duplicate-music-together-section/src/lib/duplicate-music-together-section.ts
@@ -23,9 +23,10 @@
  * so pre-filling the schedule is the point.
  */
 import {
-  createAdminFunction,
+  createRoleFunction,
   throwInvalidArgument,
   throwNotFound,
+  Role,
 } from '@maple/firebase/functions';
 import { MusicTogetherSectionRepository } from '@maple/firebase/database';
 import type { CreateMusicTogetherSectionInput } from '@maple/ts/domain';
@@ -34,7 +35,7 @@ import type {
   DuplicateMusicTogetherSectionResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const duplicateMusicTogetherSection = createAdminFunction<
+export const duplicateMusicTogetherSection = createRoleFunction<
   DuplicateMusicTogetherSectionRequest,
   DuplicateMusicTogetherSectionResponse
 >(async (data) => {
@@ -69,4 +70,4 @@ export const duplicateMusicTogetherSection = createAdminFunction<
   const created = await MusicTogetherSectionRepository.create(input);
 
   return { section: created };
-});
+}, [Role.Admin, Role.MtTeacher]);

--- a/libs/firebase/maple-functions/get-calendar-event/src/lib/get-calendar-event.ts
+++ b/libs/firebase/maple-functions/get-calendar-event/src/lib/get-calendar-event.ts
@@ -4,14 +4,17 @@
  * Retrieves a single calendar event by ID.
  * Deployed to us-east4 via CI/CD pipeline.
  */
-import { createAuthenticatedFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+} from '@maple/firebase/functions';
 import { CalendarEventRepository } from '@maple/firebase/database';
 import type {
   GetCalendarEventRequest,
   GetCalendarEventResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getCalendarEvent = createAuthenticatedFunction<
+export const getCalendarEvent = createRoleFunction<
   GetCalendarEventRequest,
   GetCalendarEventResponse
 >(async (data) => {
@@ -22,4 +25,4 @@ export const getCalendarEvent = createAuthenticatedFunction<
   }
 
   return { calendarEvent };
-});
+}, [Role.Admin, Role.MtTeacher, Role.Clerk, Role.LessonTeacher]);

--- a/libs/firebase/maple-functions/get-calendar-events/src/lib/get-calendar-events.ts
+++ b/libs/firebase/maple-functions/get-calendar-events/src/lib/get-calendar-events.ts
@@ -4,14 +4,17 @@
  * Retrieves all calendar events with optional filters.
  * Deployed to us-east4 via CI/CD pipeline.
  */
-import { createAuthenticatedFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+} from '@maple/firebase/functions';
 import { CalendarEventRepository } from '@maple/firebase/database';
 import type {
   GetCalendarEventsRequest,
   GetCalendarEventsResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getCalendarEvents = createAuthenticatedFunction<
+export const getCalendarEvents = createRoleFunction<
   GetCalendarEventsRequest,
   GetCalendarEventsResponse
 >(async (data) => {
@@ -21,4 +24,4 @@ export const getCalendarEvents = createAuthenticatedFunction<
   });
 
   return { calendarEvents };
-});
+}, [Role.Admin, Role.MtTeacher, Role.Clerk, Role.LessonTeacher]);

--- a/libs/firebase/maple-functions/get-categories/src/lib/get-categories.ts
+++ b/libs/firebase/maple-functions/get-categories/src/lib/get-categories.ts
@@ -4,18 +4,21 @@
  * Retrieves all categories, ordered by display order.
  * Deployed to us-east4 via CI/CD pipeline.
  */
-import { createAuthenticatedFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+} from '@maple/firebase/functions';
 import { CategoryRepository } from '@maple/firebase/database';
 import type {
   GetCategoriesRequest,
   GetCategoriesResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getCategories = createAuthenticatedFunction<
+export const getCategories = createRoleFunction<
   GetCategoriesRequest,
   GetCategoriesResponse
 >(async () => {
   const categories = await CategoryRepository.findAll();
 
   return { categories };
-});
+}, [Role.Admin, Role.Clerk]);

--- a/libs/firebase/maple-functions/get-class-categories/src/lib/get-class-categories.ts
+++ b/libs/firebase/maple-functions/get-class-categories/src/lib/get-class-categories.ts
@@ -4,18 +4,21 @@
  * Retrieves all class categories ordered by display order.
  * Deployed to us-east4 via CI/CD pipeline.
  */
-import { createAuthenticatedFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+} from '@maple/firebase/functions';
 import { ClassCategoryRepository } from '@maple/firebase/database';
 import type {
   GetClassCategoriesRequest,
   GetClassCategoriesResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getClassCategories = createAuthenticatedFunction<
+export const getClassCategories = createRoleFunction<
   GetClassCategoriesRequest,
   GetClassCategoriesResponse
 >(async () => {
   const categories = await ClassCategoryRepository.findAll();
 
   return { categories };
-});
+}, [Role.Admin, Role.Clerk]);

--- a/libs/firebase/maple-functions/get-class-waitlist-counts/src/lib/get-class-waitlist-counts.spec.ts
+++ b/libs/firebase/maple-functions/get-class-waitlist-counts/src/lib/get-class-waitlist-counts.spec.ts
@@ -5,7 +5,13 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@maple/firebase/functions', () => ({
-  createAdminFunction: <Req, Res>(handler: (data: Req) => Promise<Res>) =>
+  Role: {
+    Admin: 'admin',
+    MtTeacher: 'mt-teacher',
+    Clerk: 'clerk',
+    LessonTeacher: 'lesson-teacher',
+  },
+  createRoleFunction: <Req, Res>(handler: (data: Req) => Promise<Res>) =>
     handler,
 }));
 

--- a/libs/firebase/maple-functions/get-class-waitlist-counts/src/lib/get-class-waitlist-counts.ts
+++ b/libs/firebase/maple-functions/get-class-waitlist-counts/src/lib/get-class-waitlist-counts.ts
@@ -7,17 +7,20 @@
  *
  * Deployed to us-east4 via CI/CD pipeline.
  */
-import { createAdminFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+} from '@maple/firebase/functions';
 import { ClassWaitlistRepository } from '@maple/firebase/database';
 import type {
   GetClassWaitlistCountsRequest,
   GetClassWaitlistCountsResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getClassWaitlistCounts = createAdminFunction<
+export const getClassWaitlistCounts = createRoleFunction<
   GetClassWaitlistCountsRequest,
   GetClassWaitlistCountsResponse
 >(async () => {
   const counts = await ClassWaitlistRepository.countsByClass();
   return { counts };
-});
+}, [Role.Admin, Role.Clerk]);

--- a/libs/firebase/maple-functions/get-class-waitlist/src/lib/get-class-waitlist.spec.ts
+++ b/libs/firebase/maple-functions/get-class-waitlist/src/lib/get-class-waitlist.spec.ts
@@ -8,7 +8,13 @@ const mocks = vi.hoisted(() => ({
 // in a unit test — stub it to return the raw handler and surface the thrown
 // HttpsError codes verbatim.
 vi.mock('@maple/firebase/functions', () => ({
-  createAdminFunction: <Req, Res>(handler: (data: Req) => Promise<Res>) =>
+  Role: {
+    Admin: 'admin',
+    MtTeacher: 'mt-teacher',
+    Clerk: 'clerk',
+    LessonTeacher: 'lesson-teacher',
+  },
+  createRoleFunction: <Req, Res>(handler: (data: Req) => Promise<Res>) =>
     handler,
   throwInvalidArgument: (message: string) => {
     throw new Error(`invalid-argument: ${message}`);

--- a/libs/firebase/maple-functions/get-class-waitlist/src/lib/get-class-waitlist.ts
+++ b/libs/firebase/maple-functions/get-class-waitlist/src/lib/get-class-waitlist.ts
@@ -9,8 +9,9 @@
  * Deployed to us-east4 via CI/CD pipeline.
  */
 import {
-  createAdminFunction,
+  createRoleFunction,
   throwInvalidArgument,
+  Role,
 } from '@maple/firebase/functions';
 import { ClassWaitlistRepository } from '@maple/firebase/database';
 import type {
@@ -18,7 +19,7 @@ import type {
   GetClassWaitlistResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getClassWaitlist = createAdminFunction<
+export const getClassWaitlist = createRoleFunction<
   GetClassWaitlistRequest,
   GetClassWaitlistResponse
 >(async (data) => {
@@ -31,4 +32,4 @@ export const getClassWaitlist = createAdminFunction<
   entries.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
 
   return { entries, count: entries.length };
-});
+}, [Role.Admin, Role.Clerk]);

--- a/libs/firebase/maple-functions/get-class/src/lib/get-class.ts
+++ b/libs/firebase/maple-functions/get-class/src/lib/get-class.ts
@@ -4,14 +4,17 @@
  * Retrieves a single class by ID.
  * Deployed to us-east4 via CI/CD pipeline.
  */
-import { createAuthenticatedFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+} from '@maple/firebase/functions';
 import { ClassRepository } from '@maple/firebase/database';
 import type {
   GetClassRequest,
   GetClassResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getClass = createAuthenticatedFunction<
+export const getClass = createRoleFunction<
   GetClassRequest,
   GetClassResponse
 >(async (data) => {
@@ -22,4 +25,4 @@ export const getClass = createAuthenticatedFunction<
   }
 
   return { class: classItem };
-});
+}, [Role.Admin, Role.Clerk]);

--- a/libs/firebase/maple-functions/get-classes/src/lib/get-classes.ts
+++ b/libs/firebase/maple-functions/get-classes/src/lib/get-classes.ts
@@ -4,14 +4,17 @@
  * Retrieves all classes with optional filters.
  * Deployed to us-east4 via CI/CD pipeline.
  */
-import { createAuthenticatedFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+} from '@maple/firebase/functions';
 import { ClassRepository } from '@maple/firebase/database';
 import type {
   GetClassesRequest,
   GetClassesResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getClasses = createAuthenticatedFunction<
+export const getClasses = createRoleFunction<
   GetClassesRequest,
   GetClassesResponse
 >(async (data) => {
@@ -23,4 +26,4 @@ export const getClasses = createAuthenticatedFunction<
   });
 
   return { classes };
-});
+}, [Role.Admin, Role.Clerk]);

--- a/libs/firebase/maple-functions/get-instructor/src/lib/get-instructor.ts
+++ b/libs/firebase/maple-functions/get-instructor/src/lib/get-instructor.ts
@@ -3,14 +3,18 @@
  *
  * Retrieves a single instructor by ID.
  */
-import { createAuthenticatedFunction, throwNotFound } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  throwNotFound,
+  Role,
+} from '@maple/firebase/functions';
 import { InstructorRepository } from '@maple/firebase/database';
 import type {
   GetInstructorRequest,
   GetInstructorResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getInstructor = createAuthenticatedFunction<
+export const getInstructor = createRoleFunction<
   GetInstructorRequest,
   GetInstructorResponse
 >(async (data) => {
@@ -21,4 +25,4 @@ export const getInstructor = createAuthenticatedFunction<
   }
 
   return { instructor };
-});
+}, [Role.Admin, Role.LessonTeacher]);

--- a/libs/firebase/maple-functions/get-instructors/src/lib/get-instructors.ts
+++ b/libs/firebase/maple-functions/get-instructors/src/lib/get-instructors.ts
@@ -4,14 +4,17 @@
  * Retrieves all instructors, optionally filtered by status.
  * Deployed to us-east4 via CI/CD pipeline.
  */
-import { createAuthenticatedFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+} from '@maple/firebase/functions';
 import { InstructorRepository } from '@maple/firebase/database';
 import type {
   GetInstructorsRequest,
   GetInstructorsResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getInstructors = createAuthenticatedFunction<
+export const getInstructors = createRoleFunction<
   GetInstructorsRequest,
   GetInstructorsResponse
 >(async (data) => {
@@ -20,4 +23,4 @@ export const getInstructors = createAuthenticatedFunction<
   });
 
   return { instructors };
-});
+}, [Role.Admin, Role.LessonTeacher]);

--- a/libs/firebase/maple-functions/get-invoices/src/lib/get-invoices.ts
+++ b/libs/firebase/maple-functions/get-invoices/src/lib/get-invoices.ts
@@ -4,14 +4,17 @@
  * Lists private-pay invoices, filterable by studentId or status. Ordered
  * newest-created first.
  */
-import { createAuthenticatedFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+} from '@maple/firebase/functions';
 import { InvoiceRepository } from '@maple/firebase/database';
 import type {
   GetInvoicesRequest,
   GetInvoicesResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getInvoices = createAuthenticatedFunction<
+export const getInvoices = createRoleFunction<
   GetInvoicesRequest,
   GetInvoicesResponse
 >(async (data) => {
@@ -21,4 +24,4 @@ export const getInvoices = createAuthenticatedFunction<
   });
 
   return { invoices };
-});
+}, [Role.Admin, Role.LessonTeacher]);

--- a/libs/firebase/maple-functions/get-lessons/src/lib/get-lessons.ts
+++ b/libs/firebase/maple-functions/get-lessons/src/lib/get-lessons.ts
@@ -4,14 +4,17 @@
  * Lists music lessons with optional filters. Dates arrive as ISO strings
  * over the wire and are coerced to Date before querying.
  */
-import { createAuthenticatedFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+} from '@maple/firebase/functions';
 import { LessonRepository } from '@maple/firebase/database';
 import type {
   GetLessonsRequest,
   GetLessonsResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getLessons = createAuthenticatedFunction<
+export const getLessons = createRoleFunction<
   GetLessonsRequest,
   GetLessonsResponse
 >(async (data) => {
@@ -25,4 +28,4 @@ export const getLessons = createAuthenticatedFunction<
   });
 
   return { lessons };
-});
+}, [Role.Admin, Role.LessonTeacher]);

--- a/libs/firebase/maple-functions/get-music-together-interest/src/lib/get-music-together-interest.spec.ts
+++ b/libs/firebase/maple-functions/get-music-together-interest/src/lib/get-music-together-interest.spec.ts
@@ -6,7 +6,13 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@maple/firebase/functions', () => ({
-  createAuthenticatedFunction: (h: unknown) => h,
+  Role: {
+    Admin: 'admin',
+    MtTeacher: 'mt-teacher',
+    Clerk: 'clerk',
+    LessonTeacher: 'lesson-teacher',
+  },
+  createRoleFunction: (h: unknown) => h,
 }));
 vi.mock('@maple/firebase/database', () => ({
   MusicTogetherInterestRepository: { findAll: mocks.interestFindAll },

--- a/libs/firebase/maple-functions/get-music-together-interest/src/lib/get-music-together-interest.ts
+++ b/libs/firebase/maple-functions/get-music-together-interest/src/lib/get-music-together-interest.ts
@@ -6,7 +6,10 @@
  * admin can see which section times to add, and a section-id → name map for
  * rendering. Deployed to us-east4 via CI/CD (maple-core codebase).
  */
-import { createAuthenticatedFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+} from '@maple/firebase/functions';
 import {
   MusicTogetherInterestRepository,
   MusicTogetherSectionRepository,
@@ -17,7 +20,7 @@ import type {
   GetMusicTogetherInterestResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getMusicTogetherInterest = createAuthenticatedFunction<
+export const getMusicTogetherInterest = createRoleFunction<
   GetMusicTogetherInterestRequest,
   GetMusicTogetherInterestResponse
 >(async () => {
@@ -36,4 +39,4 @@ export const getMusicTogetherInterest = createAuthenticatedFunction<
     demand: mtInterestDemandBySection(entries),
     sectionNames,
   };
-});
+}, [Role.Admin, Role.MtTeacher]);

--- a/libs/firebase/maple-functions/get-music-together-roster/src/lib/get-music-together-roster.spec.ts
+++ b/libs/firebase/maple-functions/get-music-together-roster/src/lib/get-music-together-roster.spec.ts
@@ -7,7 +7,13 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@maple/firebase/functions', () => ({
-  createAdminFunction: (h: unknown) => h,
+  Role: {
+    Admin: 'admin',
+    MtTeacher: 'mt-teacher',
+    Clerk: 'clerk',
+    LessonTeacher: 'lesson-teacher',
+  },
+  createRoleFunction: (h: unknown) => h,
   throwNotFound: (entity: string, id: string) => {
     throw new Error(`${entity} not found: ${id}`);
   },

--- a/libs/firebase/maple-functions/get-music-together-roster/src/lib/get-music-together-roster.ts
+++ b/libs/firebase/maple-functions/get-music-together-roster/src/lib/get-music-together-roster.ts
@@ -10,7 +10,11 @@
  *
  * Deployed to us-east4 via CI/CD (maple-core codebase).
  */
-import { createAdminFunction, throwNotFound } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  throwNotFound,
+  Role,
+} from '@maple/firebase/functions';
 import {
   MusicTogetherSectionRepository,
   MusicTogetherRegistrationRepository,
@@ -23,7 +27,7 @@ import type {
   MusicTogetherRosterEntry,
 } from '@maple/ts/firebase/api-types';
 
-export const getMusicTogetherRoster = createAdminFunction<
+export const getMusicTogetherRoster = createRoleFunction<
   GetMusicTogetherRosterRequest,
   GetMusicTogetherRosterResponse
 >(async (data) => {
@@ -66,4 +70,4 @@ export const getMusicTogetherRoster = createAdminFunction<
   );
 
   return { section, entries };
-});
+}, [Role.Admin, Role.MtTeacher]);

--- a/libs/firebase/maple-functions/get-music-together-sections/src/lib/get-music-together-sections.spec.ts
+++ b/libs/firebase/maple-functions/get-music-together-sections/src/lib/get-music-together-sections.spec.ts
@@ -6,7 +6,13 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@maple/firebase/functions', () => ({
-  createAuthenticatedFunction: (h: unknown) => h,
+  Role: {
+    Admin: 'admin',
+    MtTeacher: 'mt-teacher',
+    Clerk: 'clerk',
+    LessonTeacher: 'lesson-teacher',
+  },
+  createRoleFunction: (h: unknown) => h,
 }));
 vi.mock('@maple/firebase/database', () => ({
   MusicTogetherSectionRepository: { findAll: mocks.findAll },

--- a/libs/firebase/maple-functions/get-music-together-sections/src/lib/get-music-together-sections.ts
+++ b/libs/firebase/maple-functions/get-music-together-sections/src/lib/get-music-together-sections.ts
@@ -7,7 +7,10 @@
  * section's overall status is DERIVED client-side from its explicit controls.
  * Deployed to us-east4 via CI/CD (maple-core codebase).
  */
-import { createAuthenticatedFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+} from '@maple/firebase/functions';
 import {
   MusicTogetherSectionRepository,
   MusicTogetherRegistrationRepository,
@@ -19,7 +22,7 @@ import type {
   MusicTogetherSectionCounts,
 } from '@maple/ts/firebase/api-types';
 
-export const getMusicTogetherSections = createAuthenticatedFunction<
+export const getMusicTogetherSections = createRoleFunction<
   GetMusicTogetherSectionsRequest,
   GetMusicTogetherSectionsResponse
 >(async (data) => {
@@ -44,4 +47,4 @@ export const getMusicTogetherSections = createAuthenticatedFunction<
   }
 
   return { sections, counts };
-});
+}, [Role.Admin, Role.MtTeacher]);

--- a/libs/firebase/maple-functions/get-music-together-semesters/src/lib/get-music-together-semesters.spec.ts
+++ b/libs/firebase/maple-functions/get-music-together-semesters/src/lib/get-music-together-semesters.spec.ts
@@ -3,7 +3,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const mocks = vi.hoisted(() => ({ findAll: vi.fn() }));
 
 vi.mock('@maple/firebase/functions', () => ({
-  createAuthenticatedFunction: (h: unknown) => h,
+  Role: {
+    Admin: 'admin',
+    MtTeacher: 'mt-teacher',
+    Clerk: 'clerk',
+    LessonTeacher: 'lesson-teacher',
+  },
+  createRoleFunction: (h: unknown) => h,
 }));
 vi.mock('@maple/firebase/database', () => ({
   MusicTogetherSemesterRepository: { findAll: mocks.findAll },

--- a/libs/firebase/maple-functions/get-music-together-semesters/src/lib/get-music-together-semesters.ts
+++ b/libs/firebase/maple-functions/get-music-together-semesters/src/lib/get-music-together-semesters.ts
@@ -6,17 +6,20 @@
  * is DERIVED client-side from each term's dates. Deployed to us-east4 via CI/CD
  * (maple-core codebase).
  */
-import { createAuthenticatedFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+} from '@maple/firebase/functions';
 import { MusicTogetherSemesterRepository } from '@maple/firebase/database';
 import type {
   GetMusicTogetherSemestersRequest,
   GetMusicTogetherSemestersResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getMusicTogetherSemesters = createAuthenticatedFunction<
+export const getMusicTogetherSemesters = createRoleFunction<
   GetMusicTogetherSemestersRequest,
   GetMusicTogetherSemestersResponse
 >(async () => {
   const semesters = await MusicTogetherSemesterRepository.findAll();
   return { semesters };
-});
+}, [Role.Admin, Role.MtTeacher]);

--- a/libs/firebase/maple-functions/get-product/src/lib/get-product.ts
+++ b/libs/firebase/maple-functions/get-product/src/lib/get-product.ts
@@ -3,14 +3,18 @@
  *
  * Retrieves a single product by ID.
  */
-import { createAuthenticatedFunction, throwNotFound } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  throwNotFound,
+  Role,
+} from '@maple/firebase/functions';
 import { ProductRepository } from '@maple/firebase/database';
 import type {
   GetProductRequest,
   GetProductResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getProduct = createAuthenticatedFunction<
+export const getProduct = createRoleFunction<
   GetProductRequest,
   GetProductResponse
 >(async (data) => {
@@ -21,4 +25,4 @@ export const getProduct = createAuthenticatedFunction<
   }
 
   return { product };
-});
+}, [Role.Admin, Role.Clerk]);

--- a/libs/firebase/maple-functions/get-products/src/lib/get-products.ts
+++ b/libs/firebase/maple-functions/get-products/src/lib/get-products.ts
@@ -3,14 +3,17 @@
  *
  * Retrieves all products, optionally filtered by artistId or status.
  */
-import { createAuthenticatedFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+} from '@maple/firebase/functions';
 import { ProductRepository } from '@maple/firebase/database';
 import type {
   GetProductsRequest,
   GetProductsResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getProducts = createAuthenticatedFunction<
+export const getProducts = createRoleFunction<
   GetProductsRequest,
   GetProductsResponse
 >(async (data) => {
@@ -20,4 +23,4 @@ export const getProducts = createAuthenticatedFunction<
   });
 
   return { products };
-});
+}, [Role.Admin, Role.Clerk]);

--- a/libs/firebase/maple-functions/get-registration/src/lib/get-registration.ts
+++ b/libs/firebase/maple-functions/get-registration/src/lib/get-registration.ts
@@ -5,14 +5,17 @@
  * Admin-only endpoint.
  * Deployed to us-east4 via CI/CD pipeline.
  */
-import { createAdminFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+} from '@maple/firebase/functions';
 import { RegistrationRepository } from '@maple/firebase/database';
 import type {
   GetRegistrationRequest,
   GetRegistrationResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getRegistration = createAdminFunction<
+export const getRegistration = createRoleFunction<
   GetRegistrationRequest,
   GetRegistrationResponse
 >(async (data) => {
@@ -26,4 +29,4 @@ export const getRegistration = createAdminFunction<
   }
 
   return { registration };
-});
+}, [Role.Admin, Role.Clerk]);

--- a/libs/firebase/maple-functions/get-registrations/src/lib/get-registrations.ts
+++ b/libs/firebase/maple-functions/get-registrations/src/lib/get-registrations.ts
@@ -5,14 +5,17 @@
  * Admin-only endpoint for viewing registration rosters.
  * Deployed to us-east4 via CI/CD pipeline.
  */
-import { createAdminFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+} from '@maple/firebase/functions';
 import { RegistrationRepository } from '@maple/firebase/database';
 import type {
   GetRegistrationsRequest,
   GetRegistrationsResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getRegistrations = createAdminFunction<
+export const getRegistrations = createRoleFunction<
   GetRegistrationsRequest,
   GetRegistrationsResponse
 >(async (data) => {
@@ -24,4 +27,4 @@ export const getRegistrations = createAdminFunction<
   });
 
   return { registrations };
-});
+}, [Role.Admin, Role.Clerk]);

--- a/libs/firebase/maple-functions/get-room-schedule/src/lib/get-room-schedule.spec.ts
+++ b/libs/firebase/maple-functions/get-room-schedule/src/lib/get-room-schedule.spec.ts
@@ -22,7 +22,13 @@ vi.mock('@maple/firebase/database', () => ({
 
 // Unwrap createAdminFunction so we can invoke the handler directly
 vi.mock('@maple/firebase/functions', () => ({
-  createAdminFunction: (handler: (data: unknown) => unknown) => handler,
+  Role: {
+    Admin: 'admin',
+    MtTeacher: 'mt-teacher',
+    Clerk: 'clerk',
+    LessonTeacher: 'lesson-teacher',
+  },
+  createRoleFunction: (handler: (data: unknown) => unknown) => handler,
   throwInvalidArgument: (message: string): never => {
     throw new Error(message);
   },

--- a/libs/firebase/maple-functions/get-room-schedule/src/lib/get-room-schedule.ts
+++ b/libs/firebase/maple-functions/get-room-schedule/src/lib/get-room-schedule.ts
@@ -10,8 +10,9 @@
  * not be publicly callable.
  */
 import {
-  createAdminFunction,
+  createRoleFunction,
   throwInvalidArgument,
+  Role,
 } from '@maple/firebase/functions';
 import { CalendarEventRepository } from '@maple/firebase/database';
 import { ROOMS } from '@maple/ts/domain';
@@ -20,7 +21,7 @@ import type {
   GetRoomScheduleResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getRoomSchedule = createAdminFunction<
+export const getRoomSchedule = createRoleFunction<
   GetRoomScheduleRequest,
   GetRoomScheduleResponse
 >(async (data) => {
@@ -53,4 +54,4 @@ export const getRoomSchedule = createAdminFunction<
       end: e.endDateTime.toISOString(),
     })),
   };
-});
+}, [Role.Admin, Role.MtTeacher, Role.Clerk, Role.LessonTeacher]);

--- a/libs/firebase/maple-functions/get-sales/src/lib/get-sales.spec.ts
+++ b/libs/firebase/maple-functions/get-sales/src/lib/get-sales.spec.ts
@@ -9,7 +9,13 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@maple/firebase/functions', () => ({
-  createAdminFunction: <TReq, TRes>(
+  Role: {
+    Admin: 'admin',
+    MtTeacher: 'mt-teacher',
+    Clerk: 'clerk',
+    LessonTeacher: 'lesson-teacher',
+  },
+  createRoleFunction: <TReq, TRes>(
     handler: (data: TReq, ctx: unknown) => Promise<TRes>
   ) => handler,
 }));

--- a/libs/firebase/maple-functions/get-sales/src/lib/get-sales.ts
+++ b/libs/firebase/maple-functions/get-sales/src/lib/get-sales.ts
@@ -4,14 +4,17 @@
  * Retrieves sales with optional filters.
  * Admin-only function.
  */
-import { createAdminFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+} from '@maple/firebase/functions';
 import { SaleRepository } from '@maple/firebase/database';
 import type {
   GetSalesRequest,
   GetSalesResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getSales = createAdminFunction<
+export const getSales = createRoleFunction<
   GetSalesRequest,
   GetSalesResponse
 >(async (data) => {
@@ -23,4 +26,4 @@ export const getSales = createAdminFunction<
   });
 
   return { sales };
-});
+}, [Role.Admin, Role.Clerk]);

--- a/libs/firebase/maple-functions/get-students/src/lib/get-students.ts
+++ b/libs/firebase/maple-functions/get-students/src/lib/get-students.ts
@@ -4,14 +4,17 @@
  * Retrieves music lesson students, optionally filtered by status, primary
  * teacher, or Hope Scholarship flag.
  */
-import { createAuthenticatedFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+} from '@maple/firebase/functions';
 import { StudentRepository } from '@maple/firebase/database';
 import type {
   GetStudentsRequest,
   GetStudentsResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getStudents = createAuthenticatedFunction<
+export const getStudents = createRoleFunction<
   GetStudentsRequest,
   GetStudentsResponse
 >(async (data) => {
@@ -22,4 +25,4 @@ export const getStudents = createAuthenticatedFunction<
   });
 
   return { students };
-});
+}, [Role.Admin, Role.LessonTeacher]);

--- a/libs/firebase/maple-functions/record-sale/src/lib/record-sale.spec.ts
+++ b/libs/firebase/maple-functions/record-sale/src/lib/record-sale.spec.ts
@@ -17,7 +17,13 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@maple/firebase/functions', () => ({
-  createAdminFunction: <TReq, TRes>(
+  Role: {
+    Admin: 'admin',
+    MtTeacher: 'mt-teacher',
+    Clerk: 'clerk',
+    LessonTeacher: 'lesson-teacher',
+  },
+  createRoleFunction: <TReq, TRes>(
     handler: (data: TReq, ctx: unknown) => Promise<TRes>
   ) => handler,
   throwInvalidArgument: (msg: string) => {

--- a/libs/firebase/maple-functions/record-sale/src/lib/record-sale.ts
+++ b/libs/firebase/maple-functions/record-sale/src/lib/record-sale.ts
@@ -9,9 +9,10 @@
  * 4. Decrements variant quantity on the product
  */
 import {
-  createAdminFunction,
+  createRoleFunction,
   throwInvalidArgument,
   throwNotFound,
+  Role,
 } from '@maple/firebase/functions';
 import {
   ProductRepository,
@@ -30,7 +31,7 @@ import type {
   RecordProductSaleResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const recordSale = createAdminFunction<
+export const recordSale = createRoleFunction<
   RecordProductSaleRequest,
   RecordProductSaleResponse
 >(async (data) => {
@@ -130,4 +131,4 @@ export const recordSale = createAdminFunction<
   );
 
   return { sale };
-});
+}, [Role.Admin, Role.Clerk]);

--- a/libs/firebase/maple-functions/reorder-categories/src/lib/reorder-categories.ts
+++ b/libs/firebase/maple-functions/reorder-categories/src/lib/reorder-categories.ts
@@ -4,14 +4,17 @@
  * Reorders all categories by updating their order values based on position in the provided array.
  * This is an admin-only operation that uses batch writes for atomicity.
  */
-import { createAdminFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+} from '@maple/firebase/functions';
 import { CategoryRepository } from '@maple/firebase/database';
 import type {
   ReorderCategoriesRequest,
   ReorderCategoriesResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const reorderCategories = createAdminFunction<
+export const reorderCategories = createRoleFunction<
   ReorderCategoriesRequest,
   ReorderCategoriesResponse
 >(async (data) => {
@@ -41,4 +44,4 @@ export const reorderCategories = createAdminFunction<
   const categories = await CategoryRepository.reorderAll(categoryIds);
 
   return { categories };
-});
+}, [Role.Admin, Role.Clerk]);

--- a/libs/firebase/maple-functions/send-music-together-reminders/src/lib/send-music-together-reminders.ts
+++ b/libs/firebase/maple-functions/send-music-together-reminders/src/lib/send-music-together-reminders.ts
@@ -274,7 +274,7 @@ export const sendMusicTogetherReminders = onSchedule(
 
 /** Admin-callable manual trigger — same logic on demand (and drives tests). */
 export const triggerMusicTogetherReminders = Functions.endpoint
-  .requiringRole(Role.Admin)
+  .requiringRole([Role.Admin, Role.MtTeacher])
   .handle<Record<string, never>, SendMusicTogetherRemindersResult>(async () => {
     return runSendMusicTogetherReminders(new Date());
   });

--- a/libs/firebase/maple-functions/sync-inventory-to-square/src/lib/sync-inventory-to-square.ts
+++ b/libs/firebase/maple-functions/sync-inventory-to-square/src/lib/sync-inventory-to-square.ts
@@ -29,7 +29,7 @@ interface SyncInventoryToSquareResponse {
 export const syncInventoryToSquare = Functions.endpoint
   .usingSecrets(...SQUARE_SECRET_NAMES)
   .usingStrings(...SQUARE_STRING_NAMES)
-  .requiringRole(Role.Admin)
+  .requiringRole([Role.Admin, Role.Clerk])
   .handle<SyncInventoryToSquareRequest, SyncInventoryToSquareResponse>(
     async (data, _context, secrets, strings) => {
       const { productId } = data;

--- a/libs/firebase/maple-functions/update-calendar-event/src/lib/update-calendar-event.ts
+++ b/libs/firebase/maple-functions/update-calendar-event/src/lib/update-calendar-event.ts
@@ -4,7 +4,10 @@
  * Updates an existing calendar event.
  * Deployed to us-east4 via CI/CD pipeline.
  */
-import { createAdminFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+} from '@maple/firebase/functions';
 import { CalendarEventRepository } from '@maple/firebase/database';
 import { calendarEventValidation } from '@maple/ts/validation';
 import type {
@@ -12,7 +15,7 @@ import type {
   UpdateCalendarEventResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const updateCalendarEvent = createAdminFunction<
+export const updateCalendarEvent = createRoleFunction<
   UpdateCalendarEventRequest,
   UpdateCalendarEventResponse
 >(async (data) => {
@@ -36,4 +39,4 @@ export const updateCalendarEvent = createAdminFunction<
   const calendarEvent = await CalendarEventRepository.update(data);
 
   return { calendarEvent };
-});
+}, [Role.Admin, Role.MtTeacher, Role.Clerk, Role.LessonTeacher]);

--- a/libs/firebase/maple-functions/update-category/src/lib/update-category.ts
+++ b/libs/firebase/maple-functions/update-category/src/lib/update-category.ts
@@ -3,7 +3,11 @@
  *
  * Updates an existing category (admin only).
  */
-import { createAdminFunction, throwNotFound } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  throwNotFound,
+  Role,
+} from '@maple/firebase/functions';
 import { CategoryRepository } from '@maple/firebase/database';
 import { categoryValidation } from '@maple/ts/validation';
 import type {
@@ -11,7 +15,7 @@ import type {
   UpdateCategoryResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const updateCategory = createAdminFunction<
+export const updateCategory = createRoleFunction<
   UpdateCategoryRequest,
   UpdateCategoryResponse
 >(async (data) => {
@@ -43,4 +47,4 @@ export const updateCategory = createAdminFunction<
   const category = await CategoryRepository.update(data);
 
   return { category };
-});
+}, [Role.Admin, Role.Clerk]);

--- a/libs/firebase/maple-functions/update-music-together-section/src/lib/update-music-together-section.spec.ts
+++ b/libs/firebase/maple-functions/update-music-together-section/src/lib/update-music-together-section.spec.ts
@@ -7,7 +7,13 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@maple/firebase/functions', () => ({
-  createAdminFunction: (h: unknown) => h,
+  Role: {
+    Admin: 'admin',
+    MtTeacher: 'mt-teacher',
+    Clerk: 'clerk',
+    LessonTeacher: 'lesson-teacher',
+  },
+  createRoleFunction: (h: unknown) => h,
   throwNotFound: (entity: string, id: string) => {
     throw new Error(`${entity} not found: ${id}`);
   },

--- a/libs/firebase/maple-functions/update-music-together-section/src/lib/update-music-together-section.ts
+++ b/libs/firebase/maple-functions/update-music-together-section/src/lib/update-music-together-section.ts
@@ -4,7 +4,11 @@
  * Updates an existing section. Validates the merged record so partial edits
  * are checked against the full shape. Deployed to us-east4 via CI/CD (maple-core).
  */
-import { createAdminFunction, throwNotFound } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  throwNotFound,
+  Role,
+} from '@maple/firebase/functions';
 import { MusicTogetherSectionRepository } from '@maple/firebase/database';
 import { musicTogetherSectionValidation } from '@maple/ts/validation';
 import type {
@@ -12,7 +16,7 @@ import type {
   UpdateMusicTogetherSectionResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const updateMusicTogetherSection = createAdminFunction<
+export const updateMusicTogetherSection = createRoleFunction<
   UpdateMusicTogetherSectionRequest,
   UpdateMusicTogetherSectionResponse
 >(async (data) => {
@@ -34,4 +38,4 @@ export const updateMusicTogetherSection = createAdminFunction<
 
   const section = await MusicTogetherSectionRepository.update(data);
   return { section };
-});
+}, [Role.Admin, Role.MtTeacher]);

--- a/libs/firebase/maple-functions/update-music-together-semester/src/lib/update-music-together-semester.spec.ts
+++ b/libs/firebase/maple-functions/update-music-together-semester/src/lib/update-music-together-semester.spec.ts
@@ -7,7 +7,13 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@maple/firebase/functions', () => ({
-  createAdminFunction: (h: unknown) => h,
+  Role: {
+    Admin: 'admin',
+    MtTeacher: 'mt-teacher',
+    Clerk: 'clerk',
+    LessonTeacher: 'lesson-teacher',
+  },
+  createRoleFunction: (h: unknown) => h,
   throwNotFound: (entity: string, id: string) => {
     throw new Error(`${entity} not found: ${id}`);
   },

--- a/libs/firebase/maple-functions/update-music-together-semester/src/lib/update-music-together-semester.ts
+++ b/libs/firebase/maple-functions/update-music-together-semester/src/lib/update-music-together-semester.ts
@@ -5,7 +5,11 @@
  * are checked against the full shape. Deployed to us-east4 via CI/CD
  * (maple-core).
  */
-import { createAdminFunction, throwNotFound } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  throwNotFound,
+  Role,
+} from '@maple/firebase/functions';
 import { MusicTogetherSemesterRepository } from '@maple/firebase/database';
 import { musicTogetherSemesterValidation } from '@maple/ts/validation';
 import type {
@@ -13,7 +17,7 @@ import type {
   UpdateMusicTogetherSemesterResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const updateMusicTogetherSemester = createAdminFunction<
+export const updateMusicTogetherSemester = createRoleFunction<
   UpdateMusicTogetherSemesterRequest,
   UpdateMusicTogetherSemesterResponse
 >(async (data) => {
@@ -35,4 +39,4 @@ export const updateMusicTogetherSemester = createAdminFunction<
 
   const semester = await MusicTogetherSemesterRepository.update(data);
   return { semester };
-});
+}, [Role.Admin, Role.MtTeacher]);

--- a/libs/firebase/maple-functions/update-product/src/lib/update-product.ts
+++ b/libs/firebase/maple-functions/update-product/src/lib/update-product.ts
@@ -38,7 +38,7 @@ import type {
 export const updateProduct = Functions.endpoint
   .usingSecrets(...SQUARE_SECRET_NAMES)
   .usingStrings(...SQUARE_STRING_NAMES)
-  .requiringRole(Role.Admin)
+  .requiringRole([Role.Admin, Role.Clerk])
   .handle<UpdateProductRequest, UpdateProductResponse>(
     async (data, _context, secrets, strings) => {
       const existing = await ProductRepository.findById(data.id);

--- a/libs/firebase/maple-functions/update-registration/src/lib/update-registration.ts
+++ b/libs/firebase/maple-functions/update-registration/src/lib/update-registration.ts
@@ -6,10 +6,11 @@
  * Deployed to us-east4 via CI/CD pipeline.
  */
 import {
-  createAdminFunction,
+  createRoleFunction,
   throwInvalidArgument,
   throwNotFound,
   throwValidationError,
+  Role,
 } from '@maple/firebase/functions';
 import { RegistrationRepository } from '@maple/firebase/database';
 import { registrationValidation } from '@maple/ts/validation';
@@ -18,7 +19,7 @@ import type {
   UpdateRegistrationResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const updateRegistration = createAdminFunction<
+export const updateRegistration = createRoleFunction<
   UpdateRegistrationRequest,
   UpdateRegistrationResponse
 >(async (data) => {
@@ -45,4 +46,4 @@ export const updateRegistration = createAdminFunction<
   const registration = await RegistrationRepository.update(data);
 
   return { registration };
-});
+}, [Role.Admin, Role.Clerk]);

--- a/libs/firebase/maple-functions/upload-category-gallery-image/src/lib/upload-category-gallery-image.ts
+++ b/libs/firebase/maple-functions/upload-category-gallery-image/src/lib/upload-category-gallery-image.ts
@@ -8,9 +8,10 @@
  * Stored at `categories/{categoryId}/gallery/photo_{timestamp}.{ext}`.
  */
 import {
-  createAdminFunction,
+  createRoleFunction,
   FirebaseProject,
   throwValidationError,
+  Role,
 } from '@maple/firebase/functions';
 import { imageUploadValidation } from '@maple/ts/validation';
 import admin from 'firebase-admin';
@@ -19,7 +20,7 @@ import type {
   UploadCategoryGalleryImageResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const uploadCategoryGalleryImage = createAdminFunction<
+export const uploadCategoryGalleryImage = createRoleFunction<
   UploadCategoryGalleryImageRequest,
   UploadCategoryGalleryImageResponse
 >(async (data) => {
@@ -51,4 +52,4 @@ export const uploadCategoryGalleryImage = createAdminFunction<
     success: true,
     url: publicUrl,
   };
-});
+}, [Role.Admin, Role.Clerk]);

--- a/libs/firebase/maple-functions/upload-product-image/src/lib/upload-product-image.ts
+++ b/libs/firebase/maple-functions/upload-product-image/src/lib/upload-product-image.ts
@@ -46,7 +46,7 @@ const SQUARE_MAX_IMAGE_BYTES = 15 * 1024 * 1024;
 export const uploadProductImage = Functions.endpoint
   .usingSecrets(...SQUARE_SECRET_NAMES)
   .usingStrings(...SQUARE_STRING_NAMES)
-  .requiringRole(Role.Admin)
+  .requiringRole([Role.Admin, Role.Clerk])
   .handle<UploadProductImageRequest, UploadProductImageResponse>(
     async (data, _context, secrets, strings) => {
       const { productId, imageBase64, contentType, caption } = data;

--- a/libs/react/data/src/lib/useSyncConflictSummary.ts
+++ b/libs/react/data/src/lib/useSyncConflictSummary.ts
@@ -15,8 +15,12 @@ import type {
  * fetching the full list of conflicts.
  *
  * @see ADR-012 for sync conflict detection and resolution strategy
+ *
+ * @param enabled - Pass false to skip fetching (e.g. for non-admin roles
+ * — getSyncConflictSummary is admin-only, so fetching would just 403).
+ * The state stays 'idle' while disabled and fetches when it flips true.
  */
-export function useSyncConflictSummary() {
+export function useSyncConflictSummary(enabled = true) {
   const [summaryState, setSummaryState] = useState<
     RequestState<SyncConflictSummary>
   >({
@@ -50,10 +54,11 @@ export function useSyncConflictSummary() {
     }
   }, []);
 
-  // Fetch summary on mount
+  // Fetch summary on mount (or when enabled flips true)
   useEffect(() => {
+    if (!enabled) return;
     fetchSummary();
-  }, [fetchSummary]);
+  }, [enabled, fetchSummary]);
 
   return {
     summaryState,


### PR DESCRIPTION
Closes #615. PR 3 of 3 for the scoped-roles epic (#617). PRs 1–2 (#619, #623) are merged; based on main.

## What — enforcement lands

**46 Cloud Functions re-scoped** from admin-only / auth-only to role sets (each a one-line gate change; new `createRoleFunction` helper for legacy-style call sites):

| Group | Roles | Functions |
|---|---|---|
| Music Together mgmt | admin + `mt-teacher` | section/semester CRUD + duplicate, roster, interest, cancel/refund, reminders, MT reads |
| Store + registrations | admin + `clerk` | product/category CRUD + uploads + Square inventory sync, sales, registration view/update/cancel, class reads, waitlists |
| Music lesson **reads** | admin + `lesson-teacher` | getLessons, getStudents, getInvoices, getInstructor(s) — mutations stay admin until #616 ownership |
| Calendar + Spruce Room | all staff roles | calendar event CRUD (book-room flow), room schedule |

⚠️ **Also tightens a pre-existing gap**: ~18 read functions (`getStudents`, `getLessons`, `getClasses`, `getProducts`, `getInvoices`, MT reads…) were `createAuthenticatedFunction` — **any self-registered account could call them**, including children's PII. They now require a role. The no-role case is locked in by matrix tests.

## Client

- **`PathRoleGuard`** replaces the plain gate: resolves the current route to allowed roles via the **same map that filters the nav** (longest-prefix match, unknown routes = admin-only), so deep links outside a user's roles get the no-access screen, and page-guarding can't drift from nav visibility
- **Dashboard role-gated**: Spruce Room card for everyone; business widgets (classes/registrations/low-stock) mount only for admin+clerk; sync card + quick links admin-only — no 403 noise for scoped roles
- `useSyncConflictSummary(enabled)` — nav badge fetch skipped for non-admins

## Verification

- **Role-matrix integration spec** (`role-matrix.spec.ts`): 41 table-driven cases — the test IS the access matrix. Stephanie (mt-teacher): 5 allows / 8 denials incl. `getStudents`+`listUsers`; Nathan (clerk+lesson-teacher union): 10 allows / 9 denials incl. class-def CRUD + payouts; admin spot-checks per group; **no-role accounts denied everywhere**
- **All integration suites** run locally against real emulators (not just utility — the re-scope touches functions other suites exercise)
- Full unit suite (2,327) + Storybook interaction (400) + all 4 codebases build + app typecheck clean
- New unit tests: `createRoleFunction`, `allowedRolesForPath` (prefix/longest-match/`/`-exact/unknown-route semantics)

## After merge + deploy

1. Approve the production deploy gate
2. On `/users`: grant Stephanie `mt-teacher`; grant Nathan `clerk` + `lesson-teacher`
3. Remaining in the epic: #616 (lesson-teacher manage-own, phase 2), #620 (callable-coverage CI analyzer), #625 (first portal e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
