### PR TITLE
fix(music-together): unblock installment vault — Customers Search rejects emails CreateCustomer accepts

### DIFF
--- a/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.ts
+++ b/libs/firebase/maple-functions/create-music-together-registration/src/lib/create-music-together-registration.ts
@@ -274,6 +274,20 @@ export const createMusicTogetherRegistration = Functions.endpoint
     } catch (paymentError) {
       const detail =
         paymentError instanceof Error ? paymentError.message : 'Unknown error';
+      const squareErrorCode =
+        paymentError instanceof PaymentError
+          ? paymentError.squareErrorCode
+          : undefined;
+      // Log the real cause with context — the vault/charge sequence has three
+      // Square calls (customer upsert, card vault, stored-card charge) and the
+      // generic customer message alone can't tell them apart in prod logs.
+      console.error('MT registration payment failed', {
+        registrationId: regRef.id,
+        sectionId: data.sectionId,
+        paymentPlan: data.paymentPlan,
+        squareErrorCode,
+        detail,
+      });
       await regRef.update({
         status: 'cancelled',
         notes: `Payment failed: ${detail}`,

--- a/libs/firebase/square/src/lib/cards.service.spec.ts
+++ b/libs/firebase/square/src/lib/cards.service.spec.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SquareError } from 'square';
+import { CardsService } from './cards.service';
+import { PaymentError } from './payments.service';
+
+interface MockClient {
+  cards: {
+    create: ReturnType<typeof vi.fn>;
+    disable: ReturnType<typeof vi.fn>;
+  };
+}
+
+const baseInput = {
+  sourceId: 'cnon:card-nonce-ok',
+  customerId: 'CUST_1',
+  cardholderName: 'Casey Nguyen',
+  verificationToken: 'verf:store-token',
+  idempotencyKey: 'mtcard-reg-1',
+};
+
+describe('CardsService.createCardOnFile', () => {
+  let mockClient: MockClient;
+  let service: CardsService;
+
+  beforeEach(() => {
+    mockClient = {
+      cards: { create: vi.fn(), disable: vi.fn() },
+    };
+    service = new CardsService(mockClient as never);
+  });
+
+  it('returns the vaulted card id + last4 on success', async () => {
+    mockClient.cards.create.mockResolvedValue({
+      card: { id: 'CARD_1', last4: '1111', cardBrand: 'VISA' },
+    });
+
+    const result = await service.createCardOnFile(baseInput);
+
+    expect(result).toEqual({
+      cardId: 'CARD_1',
+      last4: '1111',
+      cardBrand: 'VISA',
+    });
+    // The verification token must be threaded to Square — real Square rejects
+    // the vault without it.
+    expect(mockClient.cards.create).toHaveBeenCalledWith(
+      expect.objectContaining({ verificationToken: 'verf:store-token' })
+    );
+  });
+
+  it('maps a thrown SquareError to a PaymentError preserving the code + detail', async () => {
+    const squareError = new SquareError({ message: 'HTTP 400' });
+    Object.defineProperty(squareError, 'errors', {
+      value: [
+        {
+          code: 'VERIFICATION_TOKEN_USED',
+          detail: 'The verification token was already used.',
+        },
+      ],
+      writable: true,
+    });
+    mockClient.cards.create.mockRejectedValue(squareError);
+
+    try {
+      await service.createCardOnFile(baseInput);
+      expect.fail('should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(PaymentError);
+      expect((error as PaymentError).squareErrorCode).toBe(
+        'VERIFICATION_TOKEN_USED'
+      );
+      // Detail flows into the message so prod logs show why the vault failed
+      // instead of a generic "Unable to process payment".
+      expect((error as PaymentError).userMessage).toContain(
+        'verification token'
+      );
+    }
+  });
+
+  it('maps a SquareError with no errors array to a PaymentError with a message', async () => {
+    mockClient.cards.create.mockRejectedValue(
+      new SquareError({ message: 'Internal server error' })
+    );
+
+    await expect(service.createCardOnFile(baseInput)).rejects.toBeInstanceOf(
+      PaymentError
+    );
+  });
+
+  it('wraps a generic thrown Error as a PaymentError', async () => {
+    mockClient.cards.create.mockRejectedValue(new Error('Network timeout'));
+
+    const err = await service
+      .createCardOnFile(baseInput)
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(PaymentError);
+    expect((err as PaymentError).squareErrorCode).toBeUndefined();
+  });
+
+  it('throws a PaymentError with the code on a 200-with-errors response', async () => {
+    mockClient.cards.create.mockResolvedValue({
+      errors: [{ code: 'INVALID_CARD', detail: 'Card is invalid.' }],
+    });
+
+    const err = await service
+      .createCardOnFile(baseInput)
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(PaymentError);
+    expect((err as PaymentError).squareErrorCode).toBe('INVALID_CARD');
+  });
+});

--- a/libs/firebase/square/src/lib/cards.service.ts
+++ b/libs/firebase/square/src/lib/cards.service.ts
@@ -7,7 +7,8 @@
  *
  * @see https://developer.squareup.com/docs/cards-api/overview
  */
-import { SquareClient, Square } from 'square';
+import { SquareClient, Square, SquareError } from 'square';
+import { PaymentError, getPaymentErrorMessage } from './payments.service';
 
 export interface CreateCardOnFileInput {
   /** Single-use nonce from the Web Payments SDK `card.tokenize()`. */
@@ -43,15 +44,25 @@ export class CardsService {
   async createCardOnFile(
     input: CreateCardOnFileInput
   ): Promise<CreateCardOnFileResult> {
-    const response = await this.client.cards.create({
-      idempotencyKey: input.idempotencyKey,
-      sourceId: input.sourceId,
-      verificationToken: input.verificationToken,
-      card: {
-        customerId: input.customerId,
-        cardholderName: input.cardholderName,
-      },
-    });
+    let response;
+    try {
+      response = await this.client.cards.create({
+        idempotencyKey: input.idempotencyKey,
+        sourceId: input.sourceId,
+        verificationToken: input.verificationToken,
+        card: {
+          customerId: input.customerId,
+          cardholderName: input.cardholderName,
+        },
+      });
+    } catch (error) {
+      // The SDK throws SquareError on HTTP-level failures (4xx/5xx) — the
+      // real-Square vault-rejection path. Preserve the Square error code +
+      // detail as a PaymentError so callers surface it (a raw throw here
+      // was previously swallowed into a generic "Unable to process payment"
+      // with no squareErrorCode, hiding why real Square rejected the vault).
+      throw toCardPaymentError(error);
+    }
 
     throwIfErrors(response.errors, 'create card');
 
@@ -85,8 +96,38 @@ function throwIfErrors(
   operation: string
 ): void {
   if (!errors || errors.length === 0) return;
-  const msg = errors
+  // 200-with-errors path (rare). Preserve the Square code so callers can
+  // discriminate; the message carries Square's detail for logs + customers.
+  const detail = errors
     .map((e) => e.detail || e.code || 'Unknown error')
     .join('; ');
-  throw new Error(`Square ${operation} error: ${msg}`);
+  throw new PaymentError(
+    `Square ${operation} error: ${detail}`,
+    errors[0]?.code
+  );
+}
+
+/**
+ * Map a thrown Cards-API error into a PaymentError that keeps Square's error
+ * code and a customer-facing message. SquareError (HTTP failures) carries the
+ * `errors[]` array; anything else falls back to a generic vault message.
+ */
+function toCardPaymentError(error: unknown): PaymentError {
+  if (error instanceof SquareError) {
+    const squareErrors = error.errors ?? [];
+    const message =
+      squareErrors.length > 0
+        ? getPaymentErrorMessage(squareErrors)
+        : error.message ||
+          'Unable to store your card. Please try a different card.';
+    return new PaymentError(message, squareErrors[0]?.code);
+  }
+  if (error instanceof PaymentError) {
+    return error;
+  }
+  const message =
+    error instanceof Error
+      ? error.message
+      : 'Unable to store your card. Please try a different card.';
+  return new PaymentError(message);
 }

--- a/libs/firebase/square/src/lib/customers.service.spec.ts
+++ b/libs/firebase/square/src/lib/customers.service.spec.ts
@@ -1,11 +1,24 @@
 import { describe, it, expect, vi } from 'vitest';
-import { SquareClient } from 'square';
+import { SquareClient, SquareError } from 'square';
 import { CustomersService } from './customers.service';
 
 function makeClient(search: unknown, create: unknown): SquareClient {
   return {
     customers: {
       search: vi.fn().mockResolvedValue(search),
+      create: vi.fn().mockResolvedValue(create),
+    },
+  } as unknown as SquareClient;
+}
+
+/** Client whose customer search rejects (real-Square email-validation path). */
+function makeSearchRejectsClient(
+  searchError: unknown,
+  create: unknown
+): SquareClient {
+  return {
+    customers: {
+      search: vi.fn().mockRejectedValue(searchError),
       create: vi.fn().mockResolvedValue(create),
     },
   } as unknown as SquareClient;
@@ -94,5 +107,38 @@ describe('CustomersService.upsertByEmail', () => {
     await expect(
       new CustomersService(client).upsertByEmail({ email: 'a@b.com' })
     ).rejects.toThrow(/create customer/);
+  });
+
+  it('falls through to create when the customer search REJECTS the email', async () => {
+    // Real Square rejects the Customers Search email filter with INVALID_VALUE
+    // for some addresses (e.g. the e2e's reserved-TLD / plus-addressed emails,
+    // and potentially a real family's plus-addressed Gmail). A search failure
+    // must not block the vault — we create instead of throwing.
+    const searchError = new SquareError({ message: 'HTTP 400' });
+    Object.defineProperty(searchError, 'errors', {
+      value: [
+        {
+          code: 'INVALID_VALUE',
+          detail: 'The provided email address is invalid.',
+          field: 'email',
+        },
+      ],
+      writable: true,
+    });
+    const client = makeSearchRejectsClient(searchError, {
+      customer: { id: 'created-after-search-failed' },
+    });
+
+    const id = await new CustomersService(client).upsertByEmail({
+      email: 'mt-e2e-installments+123@maplespruce.test',
+      name: 'Casey Nguyen',
+    });
+
+    expect(id).toBe('created-after-search-failed');
+    expect(client.customers.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAddress: 'mt-e2e-installments+123@maplespruce.test',
+      })
+    );
   });
 });

--- a/libs/firebase/square/src/lib/customers.service.ts
+++ b/libs/firebase/square/src/lib/customers.service.ts
@@ -7,7 +7,7 @@
  *
  * @see https://developer.squareup.com/docs/customers-api/what-it-does
  */
-import { SquareClient, Square } from 'square';
+import { SquareClient, Square, SquareError } from 'square';
 
 export interface UpsertCustomerInput {
   email: string;
@@ -47,13 +47,7 @@ export class CustomersService {
 
   /** Find a Square customer by exact email, or create one. Returns the ID. */
   async upsertByEmail(input: UpsertCustomerInput): Promise<string> {
-    const searchResponse = await this.client.customers.search({
-      query: {
-        filter: { emailAddress: { exact: input.email } },
-      },
-    });
-
-    const existingId = searchResponse.customers?.[0]?.id;
+    const existingId = await this.findIdByEmail(input.email);
     if (existingId) {
       return existingId;
     }
@@ -76,6 +70,40 @@ export class CustomersService {
       throw new Error('Square customer create returned no id');
     }
     return newId;
+  }
+
+  /**
+   * Look up a customer id by exact email, tolerating a search failure.
+   *
+   * The dedup search is an optimization to avoid duplicate profiles — it must
+   * never block the caller (a card vault / payment). Square's Customers
+   * *Search* endpoint validates the `emailAddress.exact` filter more strictly
+   * than CreateCustomer, and rejects some addresses with INVALID_VALUE. On any
+   * search failure we log and return null so the caller falls through to
+   * create (a possible duplicate profile is acceptable — Square customers
+   * aren't strictly deduped anyway; see the file header).
+   */
+  private async findIdByEmail(email: string): Promise<string | undefined> {
+    try {
+      const searchResponse = await this.client.customers.search({
+        query: { filter: { emailAddress: { exact: email } } },
+      });
+      return searchResponse.customers?.[0]?.id;
+    } catch (error) {
+      const detail =
+        error instanceof SquareError
+          ? (error.errors?.[0]?.detail ??
+            error.errors?.[0]?.code ??
+            error.message)
+          : error instanceof Error
+            ? error.message
+            : 'Unknown error';
+      console.warn(
+        'Square customer search failed; creating without dedup',
+        { detail }
+      );
+      return undefined;
+    }
   }
 }
 


### PR DESCRIPTION
## The bug

`mt_e2e_dev` has failed on **every** merge since the MT card-vault feature landed — the two-installment test times out at "You're registered" while both pay-in-full tests pass. It was blocking clean deploys.

## Root cause

The installment path vaults a card on file, and `customersService.upsertByEmail` does a Square Customers **Search** by email first. Square's Search endpoint validates the `emailAddress.exact` filter **more strictly than CreateCustomer** and rejects some addresses with `INVALID_VALUE` ("…refer to the Search endpoint technical reference"). That threw, cancelling the registration.

Why it hid for so long:
- The raw Square error was **swallowed** by a generic catch (`squareErrorCode: undefined`), and the e2e teardown deletes the cancelled registration's `notes`, so nothing surfaced *why*.
- **Pay-in-full never searches** (one-time nonce charge; `createPayment`'s email field is lenient), so only the vault path hit the search.
- The **Square mock doesn't validate emails**, so the mock e2e/integration always passed — only the real-Square `mt_e2e_dev` caught it, and its error was opaque.

**This is a real production bug**, not just a test artifact: any family whose email Square's Search rejects but CreateCustomer accepts (e.g. plus-addressed Gmail) was silently blocked from installments.

## Fix

- **`CustomersService.upsertByEmail`** — the dedup search is an optimization and must never block a payment. On any search failure it logs and **falls through to create** (a possible duplicate profile is acceptable — Square customers aren't strictly deduped; the file already says so). Confirmed against real Square: search rejects the email → create accepts it → vault + charge succeed.
- **`CardsService.createCardOnFile`** — map thrown `SquareError` → `PaymentError`, preserving Square's code + detail (mirrors `payments.service`; the vault path was the only one swallowing it).
- **`createMusicTogetherRegistration`** — log the real failure with context (`registrationId`, `paymentPlan`, `squareErrorCode`, `detail`) so the three-call vault sequence is diagnosable in prod instead of a generic message.

## Verification

- **Real MT Square sandbox, full `music-together-e2e` suite → 4/4 pass**, including the two-installment vault (was failing for weeks). Log shows the intended path: `Square customer search failed; creating without dedup` → registration confirmed.
- Unit: search-rejection fallback + cards `SquareError` mapping (118 tests across the square lib + MT registration pass).
- All 4 function codebases build.

## Follow-up (not in this PR)

The Square **mock** rubber-stamps emails, which is why #624 shipped green-on-mock but broken-on-real. Worth teaching the mock's `customers/search` to reject a known-bad email pattern so this class is caught below the real-Square e2e. I can file an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
