### PR TITLE
ci(auth): callable-role analyzer — every callable declares a role or is allowlisted (#620)

### DIFF
--- a/.claude/rules/firebase-functions.md
+++ b/.claude/rules/firebase-functions.md
@@ -83,6 +83,17 @@ warmup(functions, 'calculateRegistrationCost', 'createRegistration');
 
 **Don't**: schedule a recurring Cloud Scheduler ping to keep functions warm 24/7. That bills idle time when no users are visiting. Warmup should be driven by user presence on the page.
 
+## Role Gating (callable-roles analyzer)
+
+Every function exported from a codebase entry point **MUST** either declare a role (`.requiringRole([...])`, `createAdminFunction`, or `createRoleFunction`), be a Firestore/scheduled trigger, or be explicitly allowlisted as public/auth-only in `tools/check-callable-roles.ts`. This prevents a new callable shipping reachable without a role check (how the singular `getArtist`/`getStudent` were left auth-only until #620). Scoped-roles matrix: epic #617; authoritative access table: `apps/functions-integration-tests-utility/src/role-matrix.spec.ts`.
+
+```bash
+npx tsx tools/check-callable-roles.ts            # exits non-zero on any un-gated, un-allowlisted callable
+npx tsx tools/check-callable-roles.ts --report   # prints every function + its gate classification
+```
+
+CI runs this on every PR (`build-check.yml` → `callable-roles` job). To add an intentionally public or auth-only endpoint, add it to the matching allowlist in the analyzer **with a comment saying why** — that diff is the reviewable record.
+
 ## Input Validation
 
 Cloud functions that mutate entities **MUST** validate input using the shared Vest suites from `@maple/ts/validation`. Suites are declared with `staticSuite` (never `create`) so they're pure functions — no retained state across invocations, safe to call from warm cloud function containers without `.reset()`.

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -108,6 +108,36 @@ jobs:
         # integration-tests step). Other CI jobs use it via `npx tsx`.
         run: npx tsx tools/check-firestore-indexes.ts
 
+  callable-roles:
+    name: Callable Roles
+    needs: [install]
+    runs-on: ubuntu-latest
+    if: github.repository == 'Maple-and-Spruce/maple-and-spruce'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: ${{ needs.install.outputs.cache_key }}
+
+      # Every function exported from a codebase entry point must declare a role
+      # (requiringRole / createAdminFunction / createRoleFunction), be a trigger,
+      # or be explicitly allowlisted as public / auth-only. Prevents a new
+      # callable shipping reachable without a role check. See epic #617.
+      - name: Check callable roles
+        run: npx tsx tools/check-callable-roles.ts
+
   typecheck:
     name: TypeScript Check
     needs: [install]

--- a/apps/functions-integration-tests-utility/src/role-matrix.spec.ts
+++ b/apps/functions-integration-tests-utility/src/role-matrix.spec.ts
@@ -54,6 +54,8 @@ const CASES: MatrixCase[] = [
   { as: 'stephanie', functionName: 'getClasses', expect: 403 },
   { as: 'stephanie', functionName: 'getRegistrations', expect: 403 },
   { as: 'stephanie', functionName: 'getStudents', expect: 403 },
+  // getStudent (singular) was auth-only until #620; now admin + lesson-teacher.
+  { as: 'stephanie', functionName: 'getStudent', expect: 403 },
   { as: 'stephanie', functionName: 'getLessons', expect: 403 },
   { as: 'stephanie', functionName: 'listUsers', expect: 403 },
   { as: 'stephanie', functionName: 'createClass', expect: 403 },
@@ -76,6 +78,8 @@ const CASES: MatrixCase[] = [
   { as: 'nathan', functionName: 'updateClass', expect: 403 },
   { as: 'nathan', functionName: 'getTeacherPayouts', expect: 403 },
   { as: 'nathan', functionName: 'getArtists', expect: 403 },
+  // getArtist (singular) was auth-only until #620; now admin-only like getArtists.
+  { as: 'nathan', functionName: 'getArtist', expect: 403 },
   { as: 'nathan', functionName: 'listUsers', expect: 403 },
   { as: 'nathan', functionName: 'grantRole', expect: 403 },
   { as: 'nathan', functionName: 'getDiscounts', expect: 403 },

--- a/libs/firebase/maple-functions/get-artist/src/lib/get-artist.ts
+++ b/libs/firebase/maple-functions/get-artist/src/lib/get-artist.ts
@@ -3,14 +3,16 @@
  *
  * Retrieves a single artist by ID.
  */
-import { createAuthenticatedFunction, throwNotFound } from '@maple/firebase/functions';
+import { createAdminFunction, throwNotFound } from '@maple/firebase/functions';
 import { ArtistRepository } from '@maple/firebase/database';
 import type {
   GetArtistRequest,
   GetArtistResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getArtist = createAuthenticatedFunction<
+// Admin-only, matching getArtists — Artists is an Admin-group area
+// (scoped-roles matrix, epic #617). Was auth-only before the analyzer (#620).
+export const getArtist = createAdminFunction<
   GetArtistRequest,
   GetArtistResponse
 >(async (data) => {

--- a/libs/firebase/maple-functions/get-student/src/lib/get-student.ts
+++ b/libs/firebase/maple-functions/get-student/src/lib/get-student.ts
@@ -3,14 +3,21 @@
  *
  * Retrieves a single music lesson student by ID.
  */
-import { createAuthenticatedFunction, throwNotFound } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+  throwNotFound,
+} from '@maple/firebase/functions';
 import { StudentRepository } from '@maple/firebase/database';
 import type {
   GetStudentRequest,
   GetStudentResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const getStudent = createAuthenticatedFunction<
+// Admin + lesson-teacher, matching getStudents — a student record is child
+// PII and must not be readable by any signed-in user. Was auth-only before
+// the analyzer (#620) caught the singular endpoint #633 missed.
+export const getStudent = createRoleFunction<
   GetStudentRequest,
   GetStudentResponse
 >(async (data) => {
@@ -21,4 +28,4 @@ export const getStudent = createAuthenticatedFunction<
   }
 
   return { student };
-});
+}, [Role.Admin, Role.LessonTeacher]);

--- a/tools/check-callable-roles.ts
+++ b/tools/check-callable-roles.ts
@@ -1,0 +1,416 @@
+/**
+ * Static analyzer: every deployed callable declares a role, or is explicitly
+ * allowlisted as public / auth-only.
+ *
+ * Why this exists: the scoped-roles enforcement (epic #617) gates each Cloud
+ * Function with `requiringRole(...)`. The failure mode it introduces is a NEW
+ * callable that ships with no role check — silently reachable by anyone signed
+ * in, or anyone at all. That's exactly how ~18 reads were left auth-only before
+ * #633 (getStudents, etc. — children's PII). A green test suite doesn't catch
+ * it; review discipline is unreliable. This turns "did we protect the new
+ * endpoint" into a failing check.
+ *
+ * Rule: for every function EXPORTED from a codebase entry point
+ * (the four apps/functions... src/index.ts files), its definition must be one of:
+ *   - role-gated: `requiringRole(...)`, `createAdminFunction`, `createRoleFunction`
+ *       -> always allowed, no allowlist entry needed.
+ *   - trigger: `onDocumentWritten` / `onSchedule` / ... (not client-callable)
+ *       -> exempt (nothing to gate).
+ *   - auth-only: `requiringAuth()` / `createAuthenticatedFunction`
+ *       -> MUST be listed in ALLOWLIST.authOnly.
+ *   - public: `createPublicFunction`, a raw `onRequest` (webhooks/feeds), or an
+ *     ungated `Functions.endpoint...handle()`
+ *       -> MUST be listed in ALLOWLIST.public.
+ *
+ * Adding a public/auth-only endpoint is then a deliberate, reviewable diff to
+ * the allowlist below — not an invisible gap.
+ *
+ * Usage:
+ *   npx tsx tools/check-callable-roles.ts            # exits 1 on any violation
+ *   npx tsx tools/check-callable-roles.ts --report   # prints every function + classification
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as ts from 'typescript';
+
+const ROOT = path.resolve(__dirname, '..');
+const REPORT = process.argv.includes('--report');
+
+const ENTRY_POINTS = [
+  'apps/functions/src/index.ts',
+  'apps/functions-calendar/src/index.ts',
+  'apps/functions-square/src/index.ts',
+  'apps/functions-sync/src/index.ts',
+];
+
+const MAPLE_FUNCTIONS_PREFIX = '@maple/firebase/maple-functions/';
+
+// ---------------------------------------------------------------------------
+// Allowlists — the ONLY functions permitted to be reachable without a role.
+// Adding an entry here is a deliberate, reviewable decision.
+// ---------------------------------------------------------------------------
+
+/**
+ * Public endpoints: no auth at all. Customer-facing checkout/lookup, token-based
+ * flows, webhooks (signature-verified), calendar ICS feeds, and health.
+ */
+const PUBLIC_ALLOWLIST = new Set<string>([
+  // Health / infra
+  'healthCheck',
+  // Public customer-facing reads (Webflow widgets)
+  'getPublicClass',
+  'getPublicMusicTogetherSection',
+  'getPublicMusicTogetherSections',
+  'getRelatedPublicClasses',
+  'getRequiredAgreementsForClass',
+  'calculateRegistrationCost',
+  'lookupDiscount',
+  // Public customer-facing writes (checkout / interest / waitlist).
+  // NOTE: cancelRegistration / cancelMusicTogetherRegistration are role-gated
+  // (admin/clerk), NOT public — so they are intentionally absent here.
+  'createRegistration',
+  'createMusicTogetherRegistration',
+  'addMusicTogetherInterest',
+  'addToClassWaitlist',
+  'addToMusicTogetherWaitlist',
+  'createCraftClubSubscription',
+  'cancelCraftClubSubscription',
+  'requestCraftClubAccess',
+  'checkCraftClubEligibility',
+  // Token-based (magic-link / session-token) flows — auth is the signed
+  // token, not a Firebase session.
+  'getAgreementForSigning',
+  'submitSignedAgreement',
+  'requestMusicTogetherManageLink',
+  'startMusicTogetherManageSession',
+  'updateMusicTogetherPaymentMethod',
+  'requestCraftClubManageLink',
+  'startCraftClubSession',
+  'updateCraftClubPaymentMethod',
+  'getCraftClubSubscription',
+  // Webhooks (signature-verified inside the handler)
+  'squareWebhook',
+  'tallyLeadWebhook',
+  // (Etsy OAuth callbacks etsyAuthUrl/etsyAuthCallback are admin-gated, not
+  // public — they configure the shop's connection.)
+  // Calendar ICS feeds (token- or public-by-design)
+  'calendarEmbed',
+  'calendarAdhocProxy',
+  'calendarAllFeed',
+  'calendarClassesFeed',
+  'calendarEventsFeed',
+  'calendarMusicFeed',
+  'calendarMusicTogetherFeed',
+  'calendarFamilyMusicTogetherFeed',
+  'calendarHoursFeed',
+  'calendarPrivateFeed',
+  'classCatalogFeed',
+]);
+
+/**
+ * Auth-only endpoints: require a signed-in user but intentionally NO role
+ * (any authenticated user may call). Keep this list tiny.
+ */
+const AUTH_ONLY_ALLOWLIST = new Set<string>([
+  // The client uses these to discover its own access before any role exists.
+  'checkAdminStatus',
+  'getMyRoles',
+]);
+
+// ---------------------------------------------------------------------------
+// Classification
+// ---------------------------------------------------------------------------
+
+type Gate =
+  | 'role'
+  | 'auth'
+  | 'public'
+  | 'trigger'
+  | 'raw-http'
+  | 'unknown';
+
+const ROLE_FACTORIES = new Set(['createAdminFunction', 'createRoleFunction']);
+const AUTH_FACTORIES = new Set(['createAuthenticatedFunction']);
+const PUBLIC_FACTORIES = new Set(['createPublicFunction']);
+const TRIGGER_FACTORIES = new Set([
+  'onDocumentWritten',
+  'onDocumentCreated',
+  'onDocumentUpdated',
+  'onDocumentDeleted',
+  'onSchedule',
+  'onValueWritten',
+]);
+
+/**
+ * Classify a function definition by walking its builder call-chain, ignoring
+ * the handler-body argument (so a handler that merely mentions a token can't
+ * skew the result).
+ */
+function classifyInitializer(expr: ts.Expression): Gate {
+  const methods = new Set<string>();
+  let base: string | undefined;
+
+  let node: ts.Node = expr;
+  // Unwrap parentheses / as-casts
+  while (
+    ts.isParenthesizedExpression(node) ||
+    ts.isAsExpression(node) ||
+    ts.isSatisfiesExpression(node)
+  ) {
+    node = node.expression;
+  }
+
+  // Walk down the callee chain collecting method names; stop at the base.
+  for (;;) {
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      if (ts.isIdentifier(callee)) {
+        base = callee.text;
+        break;
+      }
+      if (ts.isPropertyAccessExpression(callee)) {
+        methods.add(callee.name.text);
+        node = callee.expression;
+        continue;
+      }
+      break;
+    }
+    if (ts.isPropertyAccessExpression(node)) {
+      // e.g. `Functions.endpoint` with no trailing call
+      if (ts.isIdentifier(node.expression)) {
+        base = node.expression.text;
+        break;
+      }
+      node = node.expression;
+      continue;
+    }
+    if (ts.isIdentifier(node)) {
+      base = node.text;
+      break;
+    }
+    break;
+  }
+
+  if (base && ROLE_FACTORIES.has(base)) return 'role';
+  if (base && AUTH_FACTORIES.has(base)) return 'auth';
+  if (base && PUBLIC_FACTORIES.has(base)) return 'public';
+  if (base && TRIGGER_FACTORIES.has(base)) return 'trigger';
+  if (base === 'onRequest') return 'raw-http';
+
+  // Functions.endpoint fluent chain
+  if (methods.has('requiringRole')) return 'role';
+  if (methods.has('requiringAuth')) return 'auth';
+  if (base === 'Functions' || methods.has('handle')) return 'public';
+
+  return 'unknown';
+}
+
+// ---------------------------------------------------------------------------
+// Source scanning
+// ---------------------------------------------------------------------------
+
+function parse(file: string): ts.SourceFile {
+  const text = fs.readFileSync(file, 'utf8');
+  return ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
+}
+
+/** Find `export const <name> = <init>` in a source file, return the initializer. */
+function findExportedConstInitializer(
+  sf: ts.SourceFile,
+  name: string
+): ts.Expression | undefined {
+  let found: ts.Expression | undefined;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (
+      ts.isVariableStatement(node) &&
+      node.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+    ) {
+      for (const decl of node.declarationList.declarations) {
+        if (
+          ts.isIdentifier(decl.name) &&
+          decl.name.text === name &&
+          decl.initializer
+        ) {
+          found = decl.initializer;
+          return;
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return found;
+}
+
+/** Resolve a maple-functions slug to the gate of its exported `name`. */
+function classifyReexport(slug: string, name: string): Gate {
+  const libDir = path.join(ROOT, 'libs/firebase/maple-functions', slug, 'src');
+  if (!fs.existsSync(libDir)) return 'unknown';
+  const files = walkTs(libDir).filter((f) => !/\.spec\.ts$/.test(f));
+  for (const file of files) {
+    const init = findExportedConstInitializer(parse(file), name);
+    if (init) return classifyInitializer(init);
+  }
+  return 'unknown';
+}
+
+function walkTs(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkTs(full));
+    else if (entry.name.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+interface FunctionInfo {
+  name: string;
+  gate: Gate;
+  entry: string;
+}
+
+/** Collect every function exported from an entry point, with its gate. */
+function collectFromEntry(entryRel: string): FunctionInfo[] {
+  const entryFile = path.join(ROOT, entryRel);
+  const sf = parse(entryFile);
+  const out: FunctionInfo[] = [];
+
+  const visit = (node: ts.Node): void => {
+    // Re-export: `export { a, b } from '@maple/firebase/maple-functions/slug'`
+    if (
+      ts.isExportDeclaration(node) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier) &&
+      node.moduleSpecifier.text.startsWith(MAPLE_FUNCTIONS_PREFIX) &&
+      node.exportClause &&
+      ts.isNamedExports(node.exportClause)
+    ) {
+      const slug = node.moduleSpecifier.text.slice(
+        MAPLE_FUNCTIONS_PREFIX.length
+      );
+      for (const el of node.exportClause.elements) {
+        const name = el.name.text;
+        out.push({ name, gate: classifyReexport(slug, name), entry: entryRel });
+      }
+    }
+    // Inline: `export const name = <builder>(...)`
+    if (
+      ts.isVariableStatement(node) &&
+      node.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+    ) {
+      for (const decl of node.declarationList.declarations) {
+        if (ts.isIdentifier(decl.name) && decl.initializer) {
+          out.push({
+            name: decl.name.text,
+            gate: classifyInitializer(decl.initializer),
+            entry: entryRel,
+          });
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  const all: FunctionInfo[] = [];
+  for (const entry of ENTRY_POINTS) {
+    all.push(...collectFromEntry(entry));
+  }
+  // Dedup by name (a function is exported once).
+  const byName = new Map<string, FunctionInfo>();
+  for (const fn of all) if (!byName.has(fn.name)) byName.set(fn.name, fn);
+  const functions = [...byName.values()].sort((a, b) =>
+    a.name.localeCompare(b.name)
+  );
+
+  if (REPORT) {
+    for (const fn of functions) {
+      console.log(`${fn.gate.padEnd(9)} ${fn.name}`);
+    }
+    console.log(`\n${functions.length} functions across ${ENTRY_POINTS.length} codebases`);
+  }
+
+  const violations: string[] = [];
+  const staleAllowlist: string[] = [];
+
+  const seenPublic = new Set<string>();
+  const seenAuth = new Set<string>();
+
+  for (const fn of functions) {
+    switch (fn.gate) {
+      case 'role':
+      case 'trigger':
+        break; // always fine
+      case 'auth':
+        if (!AUTH_ONLY_ALLOWLIST.has(fn.name)) {
+          violations.push(
+            `  ${fn.name} — auth-only (requiringAuth / createAuthenticatedFunction) but not in AUTH_ONLY_ALLOWLIST`
+          );
+        } else seenAuth.add(fn.name);
+        break;
+      case 'public':
+      case 'raw-http':
+        if (!PUBLIC_ALLOWLIST.has(fn.name)) {
+          violations.push(
+            `  ${fn.name} — ${fn.gate} (no role check) but not in PUBLIC_ALLOWLIST`
+          );
+        } else seenPublic.add(fn.name);
+        break;
+      case 'unknown':
+        violations.push(
+          `  ${fn.name} — could not classify its gate; declare a role or add to an allowlist`
+        );
+        break;
+    }
+  }
+
+  // Flag allowlist entries that no longer correspond to a public/auth function
+  // (renamed/removed) so the lists don't rot.
+  for (const name of PUBLIC_ALLOWLIST) {
+    if (!seenPublic.has(name)) staleAllowlist.push(`  PUBLIC_ALLOWLIST: ${name}`);
+  }
+  for (const name of AUTH_ONLY_ALLOWLIST) {
+    if (!seenAuth.has(name)) staleAllowlist.push(`  AUTH_ONLY_ALLOWLIST: ${name}`);
+  }
+
+  if (violations.length > 0) {
+    console.error(
+      `\n✖ ${violations.length} callable(s) reachable without a declared role and not allowlisted:\n`
+    );
+    console.error(violations.join('\n'));
+    console.error(
+      `\nFix: gate the function with .requiringRole([...]) (or createAdminFunction/createRoleFunction),\n` +
+        `or — if it is intentionally public / auth-only — add it to the matching allowlist in\n` +
+        `tools/check-callable-roles.ts with a comment saying why.`
+    );
+    if (staleAllowlist.length > 0) {
+      console.error(`\nAlso, stale allowlist entries (no matching function):`);
+      console.error(staleAllowlist.join('\n'));
+    }
+    process.exit(1);
+  }
+
+  if (staleAllowlist.length > 0) {
+    // Stale entries are a warning, not a hard fail — a removed function
+    // shouldn't block an unrelated PR, but surface it so the list stays clean.
+    console.warn(
+      `⚠ ${staleAllowlist.length} allowlist entr(y/ies) no longer match a function (rename/remove?):`
+    );
+    console.warn(staleAllowlist.join('\n'));
+  }
+
+  console.log(
+    `✓ All ${functions.length} exported functions are role-gated, triggers, or explicitly allowlisted.`
+  );
+}
+
+main();


### PR DESCRIPTION
Closes #620. Part of the scoped-roles epic (#617) — the CI guardrail that protects the enforcement from #633 against regression.

## What

`tools/check-callable-roles.ts` + a `callable-roles` CI job (mirrors the Firestore-index analyzer). It parses the four codebase entry points, classifies each **exported** function by walking its builder chain via the TS AST, and **fails if a client-callable function is reachable without a declared role and isn't explicitly allowlisted.**

Classification → requirement:
- **role** (`.requiringRole([...])` / `createAdminFunction` / `createRoleFunction`) → always OK
- **trigger** (`onDocumentWritten` / `onSchedule` / …) → exempt (not client-callable)
- **auth-only** (`.requiringAuth()` / `createAuthenticatedFunction`) → must be in `AUTH_ONLY_ALLOWLIST`
- **public / raw-http** (`createPublicFunction`, raw `onRequest` webhooks/feeds, ungated `Functions.endpoint.handle`) → must be in `PUBLIC_ALLOWLIST`

Adding a public/auth-only endpoint is now a deliberate, reviewable diff to an allowlist **with a comment saying why**. Stale allowlist entries (renamed/removed fns) surface as warnings.

```
npx tsx tools/check-callable-roles.ts            # exits 1 on any un-gated, un-allowlisted callable
npx tsx tools/check-callable-roles.ts --report   # prints every function + its gate
```

## It immediately found two real gaps

#633 re-scoped the plural reads but missed the **singular** endpoints, which were still `createAuthenticatedFunction` — reachable by **any signed-in user**:

- **`getStudent`** — a student record is **child PII**. Now `[Admin, LessonTeacher]`, matching `getStudents`.
- **`getArtist`** — now admin-only, matching `getArtists`.

Both are fixed in this PR (with matching denial cases added to `role-matrix.spec.ts`).

## Allowlist notes

Seeded from current reality. During seeding the analyzer also corrected my assumptions: `etsyAuthUrl`/`etsyAuthCallback` and `cancelRegistration`/`cancelMusicTogetherRegistration` are **role-gated**, not public (they're not in the list); `getCraftClubSubscription` is token-based public (resolves a `sessionToken`).

## Verification

- Analyzer green over **190 functions**; `--report` classification reviewed.
- Utility integration suite **61 pass** (incl. the 2 new getStudent/getArtist denials).
- All 4 function codebases build; tsconfig + firestore-index guardrails still pass.
- `.claude/rules/firebase-functions.md` documents the analyzer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
