### PR TITLE
feat(lessons): record Venmo/manual payments on invoices + Student.venmoUsername (#627)

### DIFF
--- a/apps/functions-integration-tests-invoice/src/invoice-functions.spec.ts
+++ b/apps/functions-integration-tests-invoice/src/invoice-functions.spec.ts
@@ -19,6 +19,8 @@ import type {
   GetInvoicesResponse,
   UpdateInvoiceRequest,
   UpdateInvoiceResponse,
+  RecordInvoicePaymentRequest,
+  RecordInvoicePaymentResponse,
   DeleteInvoiceRequest,
   DeleteInvoiceResponse,
 } from '@maple/ts/firebase/api-types';
@@ -396,6 +398,132 @@ describe('Invoice Functions', () => {
         idToken: adminUser.idToken,
       });
       expect(result.status).not.toBe(200);
+    });
+  });
+
+  describe('recordInvoicePayment (manual / Venmo)', () => {
+    async function createSentInvoice(): Promise<string> {
+      const created = await callFunction<
+        CreateInvoiceRequest,
+        CreateInvoiceResponse
+      >({
+        functionName: 'createInvoice',
+        data: sampleInvoice(privateStudentId),
+        idToken: adminUser.idToken,
+      });
+      const id = created.data!.invoice.id;
+      await callFunction<UpdateInvoiceRequest>({
+        functionName: 'updateInvoice',
+        data: { id, status: 'sent' },
+        idToken: adminUser.idToken,
+      });
+      return id;
+    }
+
+    it('records a Venmo payment: flips to paid, attributes venmo-manual + caller uid', async () => {
+      const id = await createSentInvoice();
+
+      const result = await callFunction<
+        RecordInvoicePaymentRequest,
+        RecordInvoicePaymentResponse
+      >({
+        functionName: 'recordInvoicePayment',
+        data: { id, source: 'venmo-manual', note: '@casey-nguyen' },
+        idToken: adminUser.idToken,
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.data!.invoice.status).toBe('paid');
+      expect(result.data!.invoice.paidAt).toBeTruthy();
+      expect(result.data!.invoice.paymentRecord?.source).toBe('venmo-manual');
+      expect(result.data!.invoice.paymentRecord?.note).toBe('@casey-nguyen');
+      expect(result.data!.invoice.paymentRecord?.recordedByUid).toBe(
+        adminUser.uid
+      );
+    });
+
+    it('records a cash/check (admin-manual) payment', async () => {
+      const id = await createSentInvoice();
+
+      const result = await callFunction<
+        RecordInvoicePaymentRequest,
+        RecordInvoicePaymentResponse
+      >({
+        functionName: 'recordInvoicePayment',
+        data: { id, source: 'admin-manual' },
+        idToken: adminUser.idToken,
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.data!.invoice.paymentRecord?.source).toBe('admin-manual');
+    });
+
+    it('is idempotent: recording again leaves the first attribution intact', async () => {
+      const id = await createSentInvoice();
+
+      await callFunction<RecordInvoicePaymentRequest>({
+        functionName: 'recordInvoicePayment',
+        data: { id, source: 'venmo-manual' },
+        idToken: adminUser.idToken,
+      });
+      const second = await callFunction<
+        RecordInvoicePaymentRequest,
+        RecordInvoicePaymentResponse
+      >({
+        functionName: 'recordInvoicePayment',
+        data: { id, source: 'admin-manual' },
+        idToken: adminUser.idToken,
+      });
+
+      expect(second.status).toBe(200);
+      // First (venmo) attribution wins; the second call is a no-op.
+      expect(second.data!.invoice.paymentRecord?.source).toBe('venmo-manual');
+    });
+
+    it('rejects recording a payment on a draft invoice', async () => {
+      const created = await callFunction<
+        CreateInvoiceRequest,
+        CreateInvoiceResponse
+      >({
+        functionName: 'createInvoice',
+        data: sampleInvoice(privateStudentId),
+        idToken: adminUser.idToken,
+      });
+      const result = await callFunction<RecordInvoicePaymentRequest>({
+        functionName: 'recordInvoicePayment',
+        data: { id: created.data!.invoice.id, source: 'venmo-manual' },
+        idToken: adminUser.idToken,
+      });
+      expect(result.status).not.toBe(200);
+    });
+
+    it('rejects a spoofed server-only source (square-webhook)', async () => {
+      const id = await createSentInvoice();
+      const result = await callFunction<
+        Record<string, unknown>
+      >({
+        functionName: 'recordInvoicePayment',
+        data: { id, source: 'square-webhook' },
+        idToken: adminUser.idToken,
+      });
+      expect(result.status).not.toBe(200);
+    });
+
+    it('rejects unauthenticated + non-admin callers', async () => {
+      const id = await createSentInvoice();
+
+      const unauth = await callFunction<RecordInvoicePaymentRequest>({
+        functionName: 'recordInvoicePayment',
+        data: { id, source: 'venmo-manual' },
+      });
+      expect(unauth.status).toBe(401);
+
+      const nonAdmin = await callFunction<RecordInvoicePaymentRequest>({
+        functionName: 'recordInvoicePayment',
+        data: { id, source: 'venmo-manual' },
+        idToken: nonAdminUser.idToken,
+      });
+      expect([403, 500]).toContain(nonAdmin.status);
     });
   });
 

--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -84,6 +84,7 @@ export { deleteLesson } from '@maple/firebase/maple-functions/delete-lesson';
 export { getInvoices } from '@maple/firebase/maple-functions/get-invoices';
 export { createInvoice } from '@maple/firebase/maple-functions/create-invoice';
 export { updateInvoice } from '@maple/firebase/maple-functions/update-invoice';
+export { recordInvoicePayment } from '@maple/firebase/maple-functions/record-invoice-payment';
 export { deleteInvoice } from '@maple/firebase/maple-functions/delete-invoice';
 
 // Teacher payout aggregation (Phase 4, #283)

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -98,6 +98,7 @@
     "../../libs/firebase/maple-functions/delete-invoice/**/*.ts",
     "../../libs/firebase/maple-functions/get-invoices/**/*.ts",
     "../../libs/firebase/maple-functions/update-invoice/**/*.ts",
+    "../../libs/firebase/maple-functions/record-invoice-payment/**/*.ts",
     "../../libs/firebase/maple-functions/get-teacher-payouts/**/*.ts",
     "../../libs/firebase/maple-functions/get-agreement-templates/**/*.ts",
     "../../libs/firebase/maple-functions/get-agreement-template/**/*.ts",

--- a/apps/maple-spruce/.storybook/fixtures/invoices.ts
+++ b/apps/maple-spruce/.storybook/fixtures/invoices.ts
@@ -66,6 +66,24 @@ export const mockInvoicePaidManually: Invoice = {
   updatedAt: new Date('2026-02-24T09:00:00Z'),
 };
 
+export const mockInvoicePaidViaVenmo: Invoice = {
+  id: 'inv-003-venmo',
+  studentId: 'student-001',
+  status: 'paid',
+  lineItems: [aprilTuition],
+  totalCents: 13000,
+  issuedAt: new Date('2026-02-20T09:00:00Z'),
+  paidAt: new Date('2026-02-24T09:00:00Z'),
+  paymentRecord: {
+    source: 'venmo-manual',
+    note: '@casey-nguyen',
+    recordedByUid: 'uid-katie',
+    recordedAt: new Date('2026-02-24T09:00:00Z'),
+  },
+  createdAt: new Date('2026-02-20T09:00:00Z'),
+  updatedAt: new Date('2026-02-24T09:00:00Z'),
+};
+
 export const mockInvoiceSyncError: Invoice = {
   id: 'inv-sync-error',
   studentId: 'student-001',
@@ -126,6 +144,7 @@ export const mockInvoices: Invoice[] = [
   mockInvoiceSent,
   mockInvoicePaid,
   mockInvoicePaidManually,
+  mockInvoicePaidViaVenmo,
   mockInvoiceVoid,
   mockInvoiceMultiLine,
   mockInvoiceSyncError,

--- a/apps/maple-spruce/src/app/(admin)/students/[id]/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/students/[id]/page.tsx
@@ -20,6 +20,7 @@ import type {
   CreateLessonSeriesInput,
   Invoice,
   Lesson,
+  ManualInvoicePaymentSource,
   UpdateInvoiceInput,
   UpdateLessonInput,
 } from '@maple/ts/domain';
@@ -61,6 +62,7 @@ export default function StudentDetailPage() {
     invoicesState,
     createInvoice,
     updateInvoice,
+    recordPayment,
     deleteInvoice,
   } = useInvoices({ studentId });
 
@@ -167,10 +169,13 @@ export default function StudentDetailPage() {
     }
   };
 
-  const handleInvoiceMarkPaid = async (invoice: Invoice) => {
+  const handleInvoiceRecordPayment = async (
+    invoice: Invoice,
+    source: ManualInvoicePaymentSource
+  ) => {
     setIsSubmitting(true);
     try {
-      await updateInvoice({ id: invoice.id, status: 'paid' });
+      await recordPayment({ id: invoice.id, source });
     } finally {
       setIsSubmitting(false);
     }
@@ -362,7 +367,7 @@ export default function StudentDetailPage() {
           invoicesState={invoicesState}
           onEdit={handleInvoiceEdit}
           onSend={handleInvoiceSend}
-          onMarkPaid={handleInvoiceMarkPaid}
+          onRecordPayment={handleInvoiceRecordPayment}
           onVoid={(invoice) => setInvoiceToVoid(invoice)}
           onDelete={(invoice) => setInvoiceToDelete(invoice)}
         />

--- a/docs/reference/deployed-functions.md
+++ b/docs/reference/deployed-functions.md
@@ -27,6 +27,7 @@ Core CRUD operations, auth, triggers, and admin functions. No heavy third-party 
 
 ### Music Lesson Invoices (private-pay)
 - `getInvoices`, `createInvoice`, `updateInvoice`, `deleteInvoice`
+- `recordInvoicePayment` _(records an off-Square payment against a sent invoice — `admin-manual` (cash/check) or `venmo-manual` (Venmo QR witnessed at a lesson); idempotent, admin-gated; see epic #626)_
 - `syncInvoiceToSquare` _(Firestore trigger on `invoices/{id}` — sends via Square Invoices API on draft → sent, cancels on sent → void)_
 - `squareWebhook` now additionally handles `invoice.payment_made` → flips matching invoice to `paid` with `paymentRecord.source = 'square-webhook'`
 

--- a/libs/firebase/database/src/lib/invoice.repository.ts
+++ b/libs/firebase/database/src/lib/invoice.repository.ts
@@ -16,6 +16,7 @@ import type {
   InvoiceLineItem,
   InvoicePaymentRecord,
   InvoiceStatus,
+  ManualInvoicePaymentSource,
   UpdateInvoiceInput,
 } from '@maple/ts/domain';
 import { computeInvoiceTotalCents } from '@maple/ts/domain';
@@ -34,6 +35,8 @@ function docToInvoice(
     | {
         source: InvoicePaymentRecord['source'];
         squarePaymentId?: string;
+        note?: string;
+        recordedByUid?: string;
         recordedAt: unknown;
       }
     | undefined;
@@ -50,6 +53,8 @@ function docToInvoice(
       ? {
           source: rawPaymentRecord.source,
           squarePaymentId: rawPaymentRecord.squarePaymentId,
+          note: rawPaymentRecord.note,
+          recordedByUid: rawPaymentRecord.recordedByUid,
           recordedAt: toDate(rawPaymentRecord.recordedAt),
         }
       : undefined,
@@ -272,6 +277,57 @@ export const InvoiceRepository = {
     const invoice = docToInvoice(updated);
     if (!invoice) {
       throw new Error(`Invoice ${args.id} not found after webhook update`);
+    }
+    return invoice;
+  },
+
+  /**
+   * Record an off-Square payment (cash/check = `admin-manual`, or
+   * `venmo-manual`) against a sent invoice, flipping it to paid. Idempotent
+   * — if already paid, leaves the earlier paymentRecord intact. Mirrors
+   * `markPaidBySquareWebhook` but for human-attested payments. See epic #626.
+   *
+   * `note`/`recordedByUid` are optional; undefined fields are dropped by
+   * Firestore (`ignoreUndefinedProperties`), so they never persist as null.
+   */
+  async recordManualPayment(args: {
+    id: string;
+    source: ManualInvoicePaymentSource;
+    note?: string;
+    recordedByUid?: string;
+  }): Promise<Invoice> {
+    const docRef = db.collection(COLLECTION).doc(args.id);
+    const existingSnap = await docRef.get();
+    const existing = docToInvoice(existingSnap);
+    if (!existing) {
+      throw new Error(`Invoice ${args.id} not found`);
+    }
+
+    // Idempotent: already paid → no-op return current state.
+    if (existing.status === 'paid') {
+      return existing;
+    }
+
+    const now = new Date();
+    const payload: Record<string, unknown> = {
+      status: 'paid' as InvoiceStatus,
+      paidAt: existing.paidAt ?? now,
+      issuedAt: existing.issuedAt ?? now,
+      paymentRecord: {
+        source: args.source,
+        note: args.note,
+        recordedByUid: args.recordedByUid,
+        recordedAt: now,
+      },
+      updatedAt: now,
+    };
+
+    await docRef.update(payload);
+
+    const updated = await docRef.get();
+    const invoice = docToInvoice(updated);
+    if (!invoice) {
+      throw new Error(`Invoice ${args.id} not found after payment`);
     }
     return invoice;
   },

--- a/libs/firebase/maple-functions/record-invoice-payment/project.json
+++ b/libs/firebase/maple-functions/record-invoice-payment/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-record-invoice-payment",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/record-invoice-payment/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/record-invoice-payment/src/index.ts
+++ b/libs/firebase/maple-functions/record-invoice-payment/src/index.ts
@@ -1,0 +1,1 @@
+export { recordInvoicePayment } from './lib/record-invoice-payment';

--- a/libs/firebase/maple-functions/record-invoice-payment/src/lib/record-invoice-payment.spec.ts
+++ b/libs/firebase/maple-functions/record-invoice-payment/src/lib/record-invoice-payment.spec.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Unit tests for the recordInvoicePayment cloud function handler.
+ *
+ * Mocks createAdminFunction + the throw helpers so the handler runs as a
+ * plain function, and mocks InvoiceRepository so we can assert what the
+ * handler forwards. Uses the real MANUAL_INVOICE_PAYMENT_SOURCES so the
+ * allow-list isn't re-implemented here.
+ */
+
+const mocks = vi.hoisted(() => ({
+  findById: vi.fn(),
+  recordManualPayment: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/functions', () => ({
+  createAdminFunction: <TReq, TRes>(
+    handler: (data: TReq, ctx: unknown) => Promise<TRes>
+  ) => handler,
+  throwNotFound: (entity: string, id: string) => {
+    throw new Error(`${entity} not found: ${id}`);
+  },
+  throwInvalidArgument: (message: string) => {
+    throw new Error(`invalid-argument: ${message}`);
+  },
+  throwFailedPrecondition: (message: string) => {
+    throw new Error(`failed-precondition: ${message}`);
+  },
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  InvoiceRepository: {
+    findById: mocks.findById,
+    recordManualPayment: mocks.recordManualPayment,
+  },
+}));
+
+import { recordInvoicePayment } from './record-invoice-payment';
+
+type Handler = (data: unknown, ctx?: unknown) => Promise<unknown>;
+const handler = recordInvoicePayment as unknown as Handler;
+
+const sentInvoice = {
+  id: 'inv-1',
+  studentId: 'student-1',
+  status: 'sent',
+  lineItems: [
+    {
+      id: 'l1',
+      description: 'April tuition',
+      quantity: 4,
+      unitAmountCents: 3250,
+      subtotalCents: 13000,
+    },
+  ],
+  totalCents: 13000,
+  issuedAt: new Date(),
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('recordInvoicePayment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('records a Venmo payment and stamps the caller uid', async () => {
+    mocks.findById.mockResolvedValue(sentInvoice);
+    mocks.recordManualPayment.mockResolvedValue({
+      ...sentInvoice,
+      status: 'paid',
+      paymentRecord: {
+        source: 'venmo-manual',
+        recordedByUid: 'uid-katie',
+        recordedAt: new Date(),
+      },
+    });
+
+    const result = (await handler(
+      { id: 'inv-1', source: 'venmo-manual' },
+      { uid: 'uid-katie' }
+    )) as { invoice: { status: string; paymentRecord: { source: string } } };
+
+    expect(mocks.recordManualPayment).toHaveBeenCalledWith({
+      id: 'inv-1',
+      source: 'venmo-manual',
+      note: undefined,
+      recordedByUid: 'uid-katie',
+    });
+    expect(result.invoice.paymentRecord.source).toBe('venmo-manual');
+  });
+
+  it('trims a note and forwards it', async () => {
+    mocks.findById.mockResolvedValue(sentInvoice);
+    mocks.recordManualPayment.mockResolvedValue({
+      ...sentInvoice,
+      status: 'paid',
+    });
+
+    await handler(
+      { id: 'inv-1', source: 'venmo-manual', note: '  @casey-nguyen  ' },
+      { uid: 'uid-katie' }
+    );
+
+    expect(mocks.recordManualPayment).toHaveBeenCalledWith(
+      expect.objectContaining({ note: '@casey-nguyen' })
+    );
+  });
+
+  it('records an admin-manual (cash/check) payment', async () => {
+    mocks.findById.mockResolvedValue(sentInvoice);
+    mocks.recordManualPayment.mockResolvedValue({
+      ...sentInvoice,
+      status: 'paid',
+    });
+
+    await handler({ id: 'inv-1', source: 'admin-manual' }, { uid: 'uid-nathan' });
+
+    expect(mocks.recordManualPayment).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'admin-manual' })
+    );
+  });
+
+  it('rejects a spoofed server-only source (square-webhook)', async () => {
+    await expect(
+      handler({ id: 'inv-1', source: 'square-webhook' }, { uid: 'u' })
+    ).rejects.toThrow(/invalid-argument/);
+    expect(mocks.findById).not.toHaveBeenCalled();
+  });
+
+  it('rejects the reconciliation-only source (venmo-import)', async () => {
+    await expect(
+      handler({ id: 'inv-1', source: 'venmo-import' }, { uid: 'u' })
+    ).rejects.toThrow(/invalid-argument/);
+    expect(mocks.findById).not.toHaveBeenCalled();
+  });
+
+  it('throws not-found when the invoice does not exist', async () => {
+    mocks.findById.mockResolvedValue(undefined);
+
+    await expect(
+      handler({ id: 'missing', source: 'venmo-manual' }, { uid: 'u' })
+    ).rejects.toThrow(/Invoice not found/);
+    expect(mocks.recordManualPayment).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent: already-paid invoice is returned untouched', async () => {
+    const paid = {
+      ...sentInvoice,
+      status: 'paid',
+      paymentRecord: {
+        source: 'square-webhook',
+        squarePaymentId: 'sqp-1',
+        recordedAt: new Date(),
+      },
+    };
+    mocks.findById.mockResolvedValue(paid);
+
+    const result = (await handler(
+      { id: 'inv-1', source: 'venmo-manual' },
+      { uid: 'u' }
+    )) as { invoice: { paymentRecord: { source: string } } };
+
+    // Does not overwrite the original Square attribution.
+    expect(result.invoice.paymentRecord.source).toBe('square-webhook');
+    expect(mocks.recordManualPayment).not.toHaveBeenCalled();
+  });
+
+  it('rejects recording a payment on a draft invoice', async () => {
+    mocks.findById.mockResolvedValue({ ...sentInvoice, status: 'draft' });
+
+    await expect(
+      handler({ id: 'inv-1', source: 'venmo-manual' }, { uid: 'u' })
+    ).rejects.toThrow(/failed-precondition/);
+    expect(mocks.recordManualPayment).not.toHaveBeenCalled();
+  });
+
+  it('rejects an over-long note', async () => {
+    await expect(
+      handler(
+        { id: 'inv-1', source: 'venmo-manual', note: 'x'.repeat(501) },
+        { uid: 'u' }
+      )
+    ).rejects.toThrow(/invalid-argument/);
+    expect(mocks.findById).not.toHaveBeenCalled();
+  });
+});

--- a/libs/firebase/maple-functions/record-invoice-payment/src/lib/record-invoice-payment.ts
+++ b/libs/firebase/maple-functions/record-invoice-payment/src/lib/record-invoice-payment.ts
@@ -1,0 +1,77 @@
+/**
+ * Record Invoice Payment Cloud Function
+ *
+ * Records an off-Square payment against a sent private-pay lesson invoice,
+ * flipping it to paid and attributing it to a human-recordable source:
+ *   - `admin-manual` — cash / check / other, marked paid by a human.
+ *   - `venmo-manual` — a Venmo payment witnessed at the studio (the student
+ *     scanned the business Venmo QR). Venmo Business Profiles have no
+ *     API/webhook, so the payment is attested here and later confirmed by the
+ *     statement-reconciliation tool (#630). See epic #626.
+ *
+ * The `square-webhook` path (`markPaidBySquareWebhook`) is separate; clients
+ * cannot spoof `square-webhook` or `venmo-import` — only the two manual
+ * sources are accepted here.
+ *
+ * Admin-gated today. The same callable will serve the teacher "My Day" page
+ * (#631) once lesson-teacher ownership (#616) lands — at which point the role
+ * gate widens and an ownership check is added.
+ */
+import {
+  createAdminFunction,
+  throwFailedPrecondition,
+  throwInvalidArgument,
+  throwNotFound,
+} from '@maple/firebase/functions';
+import { InvoiceRepository } from '@maple/firebase/database';
+import { MANUAL_INVOICE_PAYMENT_SOURCES } from '@maple/ts/domain';
+import type {
+  RecordInvoicePaymentRequest,
+  RecordInvoicePaymentResponse,
+} from '@maple/ts/firebase/api-types';
+
+const MAX_NOTE_LENGTH = 500;
+
+export const recordInvoicePayment = createAdminFunction<
+  RecordInvoicePaymentRequest,
+  RecordInvoicePaymentResponse
+>(async (data, context) => {
+  if (!data.id) {
+    throwInvalidArgument('Invoice id is required');
+  }
+  if (!MANUAL_INVOICE_PAYMENT_SOURCES.includes(data.source)) {
+    throwInvalidArgument(`Invalid payment source: ${data.source}`);
+  }
+  if (data.note !== undefined && data.note.length > MAX_NOTE_LENGTH) {
+    throwInvalidArgument(
+      `Payment note must be ${MAX_NOTE_LENGTH} characters or fewer`
+    );
+  }
+
+  const existing = await InvoiceRepository.findById(data.id);
+  if (!existing) {
+    throwNotFound('Invoice', data.id);
+  }
+
+  // Idempotent: already paid → return as-is (mirrors the Square webhook path,
+  // so a double-tap or retry never clobbers the original attribution).
+  if (existing.status === 'paid') {
+    return { invoice: existing };
+  }
+
+  if (existing.status !== 'sent') {
+    throwFailedPrecondition(
+      `Only sent invoices can be marked paid (invoice is ${existing.status}).`
+    );
+  }
+
+  const trimmedNote = data.note?.trim();
+  const invoice = await InvoiceRepository.recordManualPayment({
+    id: data.id,
+    source: data.source,
+    note: trimmedNote ? trimmedNote : undefined,
+    recordedByUid: context.uid,
+  });
+
+  return { invoice };
+});

--- a/libs/firebase/maple-functions/record-invoice-payment/tsconfig.json
+++ b/libs/firebase/maple-functions/record-invoice-payment/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/record-invoice-payment/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/record-invoice-payment/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/react/data/src/lib/useInvoices.ts
+++ b/libs/react/data/src/lib/useInvoices.ts
@@ -6,6 +6,7 @@ import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
 import type {
   Invoice,
   CreateInvoiceInput,
+  ManualInvoicePaymentSource,
   UpdateInvoiceInput,
   RequestState,
 } from '@maple/ts/domain';
@@ -16,6 +17,8 @@ import type {
   CreateInvoiceResponse,
   UpdateInvoiceRequest,
   UpdateInvoiceResponse,
+  RecordInvoicePaymentRequest,
+  RecordInvoicePaymentResponse,
   DeleteInvoiceRequest,
   DeleteInvoiceResponse,
 } from '@maple/ts/firebase/api-types';
@@ -128,6 +131,34 @@ export function useInvoices({
     []
   );
 
+  const recordPayment = useCallback(
+    async (input: {
+      id: string;
+      source: ManualInvoicePaymentSource;
+      note?: string;
+    }): Promise<Invoice> => {
+      const functions = getMapleFunctions();
+      const record = httpsCallable<
+        RecordInvoicePaymentRequest,
+        RecordInvoicePaymentResponse
+      >(functions, 'recordInvoicePayment');
+
+      const result = await record(input);
+      const invoice = hydrateInvoice(result.data.invoice);
+
+      setInvoicesState((prev) => {
+        if (prev.status !== 'success') return prev;
+        return {
+          ...prev,
+          data: prev.data.map((i) => (i.id === invoice.id ? invoice : i)),
+        };
+      });
+
+      return invoice;
+    },
+    []
+  );
+
   const deleteInvoice = useCallback(async (id: string): Promise<void> => {
     const functions = getMapleFunctions();
     const del = httpsCallable<DeleteInvoiceRequest, DeleteInvoiceResponse>(
@@ -153,6 +184,7 @@ export function useInvoices({
     fetchInvoices,
     createInvoice,
     updateInvoice,
+    recordPayment,
     deleteInvoice,
   };
 }

--- a/libs/react/invoices/src/lib/InvoiceList.stories.tsx
+++ b/libs/react/invoices/src/lib/InvoiceList.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { fn, expect, userEvent, waitFor, within } from 'storybook/test';
+import { fn, expect, screen, userEvent, waitFor, within } from 'storybook/test';
 import { InvoiceList } from './InvoiceList';
 import {
   mockInvoices,
@@ -7,6 +7,7 @@ import {
   mockInvoiceSent,
   mockInvoicePaid,
   mockInvoicePaidManually,
+  mockInvoicePaidViaVenmo,
   mockInvoiceVoid,
   mockInvoiceMultiLine,
   mockInvoiceSyncError,
@@ -20,7 +21,7 @@ const meta = {
   args: {
     onEdit: fn(),
     onSend: fn(),
-    onMarkPaid: fn(),
+    onRecordPayment: fn(),
     onVoid: fn(),
     onDelete: fn(),
   },
@@ -246,7 +247,35 @@ export const SendButtonCallsOnSend: Story = {
   },
 };
 
-export const MarkPaidCallsOnMarkPaid: Story = {
+export const MarkPaidMenuRecordsVenmo: Story = {
+  args: {
+    invoicesState: {
+      status: 'success',
+      data: [mockInvoiceSent],
+    } as RequestState<Invoice[]>,
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The mark-paid button opens a method menu (Venmo vs. cash/check).
+    await userEvent.click(
+      canvas.getByRole('button', { name: /mark invoice paid/i })
+    );
+    // MUI Menu portals to document.body — query via screen, not the canvas.
+    const venmoItem = await screen.findByRole('menuitem', {
+      name: /paid via venmo/i,
+    });
+    await userEvent.click(venmoItem);
+    await waitFor(() => {
+      expect(args.onRecordPayment).toHaveBeenCalledTimes(1);
+      expect(args.onRecordPayment).toHaveBeenCalledWith(
+        mockInvoiceSent,
+        'venmo-manual'
+      );
+    });
+  },
+};
+
+export const MarkPaidMenuRecordsCashOrCheck: Story = {
   args: {
     invoicesState: {
       status: 'success',
@@ -258,9 +287,16 @@ export const MarkPaidCallsOnMarkPaid: Story = {
     await userEvent.click(
       canvas.getByRole('button', { name: /mark invoice paid/i })
     );
+    const cashItem = await screen.findByRole('menuitem', {
+      name: /cash, check, or other/i,
+    });
+    await userEvent.click(cashItem);
     await waitFor(() => {
-      expect(args.onMarkPaid).toHaveBeenCalledTimes(1);
-      expect(args.onMarkPaid).toHaveBeenCalledWith(mockInvoiceSent);
+      expect(args.onRecordPayment).toHaveBeenCalledTimes(1);
+      expect(args.onRecordPayment).toHaveBeenCalledWith(
+        mockInvoiceSent,
+        'admin-manual'
+      );
     });
   },
 };
@@ -315,6 +351,24 @@ export const PaidManuallyBadge: Story = {
       expect(canvas.getByText(/marked paid manually/i)).toBeInTheDocument();
     });
     expect(canvas.queryByText(/paid via square/i)).toBeNull();
+  },
+};
+
+export const PaidViaVenmoBadge: Story = {
+  args: {
+    invoicesState: {
+      status: 'success',
+      data: [mockInvoicePaidViaVenmo],
+    } as RequestState<Invoice[]>,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(() => {
+      expect(canvas.getByText(/paid via venmo/i)).toBeInTheDocument();
+    });
+    // Neither the Square nor the plain-manual badge should appear.
+    expect(canvas.queryByText(/paid via square/i)).toBeNull();
+    expect(canvas.queryByText(/marked paid manually/i)).toBeNull();
   },
 };
 

--- a/libs/react/invoices/src/lib/InvoiceList.tsx
+++ b/libs/react/invoices/src/lib/InvoiceList.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, type ReactElement } from 'react';
 import {
   Alert,
   Box,
@@ -10,6 +11,8 @@ import {
   List,
   ListItem,
   ListItemText,
+  Menu,
+  MenuItem,
   Skeleton,
   Typography,
 } from '@mui/material';
@@ -20,10 +23,13 @@ import BlockIcon from '@mui/icons-material/Block';
 import MonetizationOnIcon from '@mui/icons-material/MonetizationOn';
 import CreditCardIcon from '@mui/icons-material/CreditCard';
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
+import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import type {
   Invoice,
+  InvoicePaymentSource,
   InvoiceStatus,
+  ManualInvoicePaymentSource,
   RequestState,
 } from '@maple/ts/domain';
 import { formatCents } from '@maple/react/lessons';
@@ -32,9 +38,31 @@ interface InvoiceListProps {
   invoicesState: RequestState<Invoice[]>;
   onEdit: (invoice: Invoice) => void;
   onSend: (invoice: Invoice) => void;
-  onMarkPaid: (invoice: Invoice) => void;
+  /** Record a payment against a sent invoice, attributed to a manual source
+   *  (Venmo witnessed at a lesson, or cash/check/other). */
+  onRecordPayment: (
+    invoice: Invoice,
+    source: ManualInvoicePaymentSource
+  ) => void;
   onVoid: (invoice: Invoice) => void;
   onDelete: (invoice: Invoice) => void;
+}
+
+/** Icon + label for the "how was this paid" chip on a paid invoice. */
+function paymentAttribution(source: InvoicePaymentSource): {
+  icon: ReactElement;
+  label: string;
+} {
+  switch (source) {
+    case 'square-webhook':
+      return { icon: <CreditCardIcon />, label: 'Paid via Square' };
+    case 'venmo-manual':
+    case 'venmo-import':
+      return { icon: <AccountBalanceWalletIcon />, label: 'Paid via Venmo' };
+    case 'admin-manual':
+    default:
+      return { icon: <PersonOutlineIcon />, label: 'Marked paid manually' };
+  }
 }
 
 const statusColor: Record<
@@ -60,14 +88,14 @@ function InvoiceRow({
   invoice,
   onEdit,
   onSend,
-  onMarkPaid,
+  onRecordPayment,
   onVoid,
   onDelete,
 }: {
   invoice: Invoice;
   onEdit: () => void;
   onSend: () => void;
-  onMarkPaid: () => void;
+  onRecordPayment: (source: ManualInvoicePaymentSource) => void;
   onVoid: () => void;
   onDelete: () => void;
 }) {
@@ -75,6 +103,14 @@ function InvoiceRow({
   const isDraft = status === 'draft';
   const isSent = status === 'sent';
   const isTerminal = status === 'paid' || status === 'void';
+
+  // Anchor for the "mark paid" method menu (Venmo vs. cash/check/other).
+  const [payMenuAnchor, setPayMenuAnchor] = useState<HTMLElement | null>(null);
+  const closePayMenu = () => setPayMenuAnchor(null);
+  const recordAndClose = (source: ManualInvoicePaymentSource) => {
+    closePayMenu();
+    onRecordPayment(source);
+  };
 
   return (
     <ListItem
@@ -98,14 +134,34 @@ function InvoiceRow({
             </IconButton>
           )}
           {isSent && (
-            <IconButton
-              onClick={onMarkPaid}
-              size="small"
-              aria-label="Mark invoice paid"
-              color="success"
-            >
-              <MonetizationOnIcon fontSize="small" />
-            </IconButton>
+            <>
+              <IconButton
+                onClick={(e) => setPayMenuAnchor(e.currentTarget)}
+                size="small"
+                aria-label="Mark invoice paid"
+                aria-haspopup="menu"
+                color="success"
+              >
+                <MonetizationOnIcon fontSize="small" />
+              </IconButton>
+              <Menu
+                anchorEl={payMenuAnchor}
+                open={!!payMenuAnchor}
+                onClose={closePayMenu}
+              >
+                <MenuItem onClick={() => recordAndClose('venmo-manual')}>
+                  <AccountBalanceWalletIcon
+                    fontSize="small"
+                    sx={{ mr: 1 }}
+                  />
+                  Paid via Venmo
+                </MenuItem>
+                <MenuItem onClick={() => recordAndClose('admin-manual')}>
+                  <PersonOutlineIcon fontSize="small" sx={{ mr: 1 }} />
+                  Cash, check, or other
+                </MenuItem>
+              </Menu>
+            </>
           )}
           {!isTerminal && (
             <IconButton
@@ -153,24 +209,22 @@ function InvoiceRow({
               color={statusColor[status]}
               variant={status === 'paid' ? 'filled' : 'outlined'}
             />
-            {status === 'paid' && invoice.paymentRecord && (
-              <Chip
-                icon={
-                  invoice.paymentRecord.source === 'square-webhook' ? (
-                    <CreditCardIcon />
-                  ) : (
-                    <PersonOutlineIcon />
-                  )
-                }
-                label={
-                  invoice.paymentRecord.source === 'square-webhook'
-                    ? 'Paid via Square'
-                    : 'Marked paid manually'
-                }
-                size="small"
-                variant="outlined"
-              />
-            )}
+            {status === 'paid' &&
+              invoice.paymentRecord &&
+              (() => {
+                const { icon, label } = paymentAttribution(
+                  invoice.paymentRecord.source
+                );
+                return (
+                  <Chip
+                    icon={icon}
+                    label={label}
+                    title={invoice.paymentRecord.note ?? undefined}
+                    size="small"
+                    variant="outlined"
+                  />
+                );
+              })()}
             {invoice.squareSyncError && (
               <Chip
                 icon={<WarningAmberIcon />}
@@ -216,7 +270,7 @@ export function InvoiceList({
   invoicesState,
   onEdit,
   onSend,
-  onMarkPaid,
+  onRecordPayment,
   onVoid,
   onDelete,
 }: InvoiceListProps) {
@@ -252,7 +306,7 @@ export function InvoiceList({
           invoice={invoice}
           onEdit={() => onEdit(invoice)}
           onSend={() => onSend(invoice)}
-          onMarkPaid={() => onMarkPaid(invoice)}
+          onRecordPayment={(source) => onRecordPayment(invoice, source)}
           onVoid={() => onVoid(invoice)}
           onDelete={() => onDelete(invoice)}
         />

--- a/libs/react/students/src/lib/StudentForm.stories.tsx
+++ b/libs/react/students/src/lib/StudentForm.stories.tsx
@@ -153,6 +153,51 @@ export const SuccessfulSubmission: Story = {
   },
 };
 
+export const VenmoUsernameStrippedOfAtOnSubmit: Story = {
+  args: {
+    open: true,
+    isSubmitting: false,
+    onSubmit: fn().mockResolvedValue(undefined),
+  },
+  play: async ({ args }) => {
+    const canvas = await waitForDialog();
+
+    await userEvent.type(
+      canvas.getByLabelText(/student name/i),
+      'Juniper Nguyen'
+    );
+    await userEvent.type(
+      canvas.getByLabelText(/primary contact name/i),
+      'Casey Nguyen'
+    );
+    await userEvent.type(
+      canvas.getByLabelText(/primary contact email/i),
+      'casey@example.com'
+    );
+    // Enter the Venmo handle WITH a leading @ — it should be stored stripped.
+    await userEvent.type(
+      canvas.getByLabelText(/venmo username/i),
+      '@casey-nguyen'
+    );
+
+    const teacherSelect = canvas.getByLabelText(/primary teacher/i);
+    await userEvent.click(teacherSelect);
+    const teacherOption = await waitFor(() =>
+      canvas.getByRole('option', { name: mockInstructor.name })
+    );
+    await userEvent.click(teacherOption);
+
+    await userEvent.click(canvas.getByRole('button', { name: /^add$/i }));
+
+    await waitFor(() => {
+      expect(args.onSubmit).toHaveBeenCalledTimes(1);
+      expect(args.onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ venmoUsername: 'casey-nguyen' })
+      );
+    });
+  },
+};
+
 export const CancelButtonClosesDialog: Story = {
   args: { open: true, isSubmitting: false },
   play: async ({ args }) => {

--- a/libs/react/students/src/lib/StudentForm.tsx
+++ b/libs/react/students/src/lib/StudentForm.tsx
@@ -81,6 +81,7 @@ export function StudentForm({
   const primaryContactPhone = useSignal('');
   const secondaryContactEmail = useSignal('');
   const secondaryContactPhone = useSignal('');
+  const venmoUsername = useSignal('');
   const notes = useSignal('');
   const status = useSignal<StudentStatus>('active');
 
@@ -108,6 +109,7 @@ export function StudentForm({
       primaryContactPhone: primaryContactPhone.value || undefined,
       secondaryContactEmail: secondaryContactEmail.value || undefined,
       secondaryContactPhone: secondaryContactPhone.value || undefined,
+      venmoUsername: venmoUsername.value || undefined,
       notes: notes.value || undefined,
       status: status.value,
     });
@@ -144,6 +146,7 @@ export function StudentForm({
         primaryContactPhone.value = student.primaryContactPhone ?? '';
         secondaryContactEmail.value = student.secondaryContactEmail ?? '';
         secondaryContactPhone.value = student.secondaryContactPhone ?? '';
+        venmoUsername.value = student.venmoUsername ?? '';
         notes.value = student.notes ?? '';
         status.value = student.status;
         showValidationErrors.value = false;
@@ -162,6 +165,7 @@ export function StudentForm({
         primaryContactPhone.value = '';
         secondaryContactEmail.value = '';
         secondaryContactPhone.value = '';
+        venmoUsername.value = '';
         notes.value = '';
         status.value = 'active';
         showValidationErrors.value = false;
@@ -199,6 +203,9 @@ export function StudentForm({
         primaryContactPhone: primaryContactPhone.value || undefined,
         secondaryContactEmail: secondaryContactEmail.value || undefined,
         secondaryContactPhone: secondaryContactPhone.value || undefined,
+        // Store without the leading @ the user may have pasted.
+        venmoUsername:
+          venmoUsername.value.trim().replace(/^@/, '') || undefined,
         notes: notes.value || undefined,
         status: status.value,
       };
@@ -406,6 +413,24 @@ export function StudentForm({
             onChange={(e) => (secondaryContactPhone.value = e.target.value)}
             error={!!getFieldError('secondaryContactPhone')}
             helperText={getFieldError('secondaryContactPhone')}
+            fullWidth
+          />
+
+          <Divider />
+
+          {/* Payment */}
+          <Typography variant="overline" color="text.secondary">
+            Payment (optional)
+          </Typography>
+          <TextField
+            label="Venmo username"
+            value={venmoUsername.value}
+            onChange={(e) => (venmoUsername.value = e.target.value)}
+            error={!!getFieldError('venmoUsername')}
+            helperText={
+              getFieldError('venmoUsername') ||
+              'Used to match Venmo lesson payments during reconciliation.'
+            }
             fullWidth
           />
 

--- a/libs/ts/domain/src/lib/invoice.ts
+++ b/libs/ts/domain/src/lib/invoice.ts
@@ -44,15 +44,47 @@ export interface InvoiceLineItem {
 
 /**
  * How the invoice became `paid`. Stamped by the server on the transition
- * into paid so the admin UI can attribute the payment to a specific event
- * (customer paid via Square vs. Katie flipped the switch manually).
+ * into paid so the admin UI can attribute the payment to a specific event:
+ *  - `square-webhook`  — the Square `invoice.payment_made` webhook fired.
+ *  - `admin-manual`    — a human marked it paid (cash / check / other).
+ *  - `venmo-manual`    — a human recorded a Venmo payment they witnessed
+ *                        (student scanned the business Venmo QR at a lesson).
+ *  - `venmo-import`    — the Venmo statement reconciliation tool matched a
+ *                        statement row to this invoice (see #630).
+ *
+ * Venmo Business Profiles have no API/webhook, so Venmo payments are attested
+ * by a human (`venmo-manual`) and later confirmed by CSV import
+ * (`venmo-import`). See epic #626.
  */
-export type InvoicePaymentSource = 'admin-manual' | 'square-webhook';
+export type InvoicePaymentSource =
+  | 'admin-manual'
+  | 'square-webhook'
+  | 'venmo-manual'
+  | 'venmo-import';
+
+/**
+ * Payment sources a human can record by hand from the UI. Excludes the
+ * server-only `square-webhook` and the reconciliation-tool-only
+ * `venmo-import`, so a client can never spoof those attributions.
+ */
+export type ManualInvoicePaymentSource = 'admin-manual' | 'venmo-manual';
+
+export const MANUAL_INVOICE_PAYMENT_SOURCES: ManualInvoicePaymentSource[] = [
+  'admin-manual',
+  'venmo-manual',
+];
 
 export interface InvoicePaymentRecord {
   source: InvoicePaymentSource;
   /** Square payment id when the payment came in via the Square webhook. */
   squarePaymentId?: string;
+  /** Free-text detail for off-Square payments — e.g. the payer's Venmo
+   *  handle or a confirmation memo. Unset for the Square webhook path. */
+  note?: string;
+  /** Firebase Auth uid of whoever recorded a manual/Venmo payment
+   *  (server-stamped). Unset for the Square webhook path. Powers the future
+   *  teacher-attestation audit trail (#631). */
+  recordedByUid?: string;
   /** When the payment was recorded (distinct from paidAt which is the
    *  invoice status transition timestamp — typically the same but the
    *  two can differ if the webhook is delayed). */

--- a/libs/ts/domain/src/lib/student.ts
+++ b/libs/ts/domain/src/lib/student.ts
@@ -97,6 +97,13 @@ export interface Student {
   primaryContactPhone?: string;
   secondaryContactEmail?: string;
   secondaryContactPhone?: string;
+  /**
+   * The payer's Venmo username (stored without the leading @), when they pay
+   * lesson invoices via Venmo. Lets the reconciliation tool (#630) match
+   * Venmo statement rows back to this student. Optional — most students pay
+   * by Square. See epic #626.
+   */
+  venmoUsername?: string;
   notes?: string;
   status: StudentStatus;
   createdAt: Date;

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -299,6 +299,8 @@ export type {
   CreateInvoiceResponse,
   UpdateInvoiceRequest,
   UpdateInvoiceResponse,
+  RecordInvoicePaymentRequest,
+  RecordInvoicePaymentResponse,
   DeleteInvoiceRequest,
   DeleteInvoiceResponse,
 } from './invoice.types';

--- a/libs/ts/firebase/api-types/src/lib/invoice.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/invoice.types.ts
@@ -10,6 +10,7 @@ import type {
   CreateInvoiceInput,
   UpdateInvoiceInput,
   InvoiceStatus,
+  ManualInvoicePaymentSource,
 } from '@maple/ts/domain';
 
 // ============================================================================
@@ -42,6 +43,27 @@ export interface CreateInvoiceResponse {
 export interface UpdateInvoiceRequest extends UpdateInvoiceInput {}
 
 export interface UpdateInvoiceResponse {
+  invoice: Invoice;
+}
+
+// ============================================================================
+// Record Invoice Payment (manual / Venmo)
+// ============================================================================
+
+/**
+ * Record an off-Square payment against a sent invoice, attributing it to a
+ * human-recordable source (cash/check = `admin-manual`, or `venmo-manual`).
+ * The Square webhook path (`markPaidBySquareWebhook`) is separate; clients
+ * cannot set `square-webhook` or `venmo-import` here.
+ */
+export interface RecordInvoicePaymentRequest {
+  id: string;
+  source: ManualInvoicePaymentSource;
+  /** Optional memo — e.g. the payer's Venmo handle or a confirmation note. */
+  note?: string;
+}
+
+export interface RecordInvoicePaymentResponse {
   invoice: Invoice;
 }
 

--- a/libs/ts/validation/src/lib/student.validation.spec.ts
+++ b/libs/ts/validation/src/lib/student.validation.spec.ts
@@ -124,6 +124,49 @@ describe('studentValidation', () => {
     });
   });
 
+  describe('venmoUsername field', () => {
+    it('passes when undefined (optional)', () => {
+      const result = studentValidation({
+        ...validStudent,
+        venmoUsername: undefined,
+      });
+      expect(result.hasErrors('venmoUsername')).toBe(false);
+    });
+
+    it('accepts a valid handle', () => {
+      const result = studentValidation({
+        ...validStudent,
+        venmoUsername: 'casey-nguyen',
+      });
+      expect(result.hasErrors('venmoUsername')).toBe(false);
+    });
+
+    it('tolerates a leading @', () => {
+      const result = studentValidation({
+        ...validStudent,
+        venmoUsername: '@casey_nguyen',
+      });
+      expect(result.hasErrors('venmoUsername')).toBe(false);
+    });
+
+    it('fails when too short', () => {
+      const result = studentValidation({
+        ...validStudent,
+        venmoUsername: 'abc',
+      });
+      expect(result.isValid()).toBe(false);
+      expect(result.getErrors('venmoUsername').length).toBeGreaterThan(0);
+    });
+
+    it('fails on illegal characters', () => {
+      const result = studentValidation({
+        ...validStudent,
+        venmoUsername: 'has spaces!',
+      });
+      expect(result.isValid()).toBe(false);
+    });
+  });
+
   describe('registeredLessonLength field', () => {
     it('passes when undefined', () => {
       const result = studentValidation({

--- a/libs/ts/validation/src/lib/student.validation.ts
+++ b/libs/ts/validation/src/lib/student.validation.ts
@@ -90,6 +90,18 @@ export const studentValidation = staticSuite(
       }
     );
 
+    test(
+      'venmoUsername',
+      'Venmo username must be 5–30 characters (letters, numbers, hyphens, underscores)',
+      () => {
+        if (data.venmoUsername) {
+          // Venmo handles are 5–30 chars of [A-Za-z0-9_-]; tolerate a leading
+          // @ the user may paste (stripped before storage in the form).
+          enforce(data.venmoUsername).matches(/^@?[A-Za-z0-9_-]{5,30}$/);
+        }
+      }
+    );
+
     test('status', 'Status is required', () => {
       enforce(data.status).isNotBlank();
     });

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -254,6 +254,9 @@
       "@maple/firebase/maple-functions/update-invoice": [
         "libs/firebase/maple-functions/update-invoice/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/record-invoice-payment": [
+        "libs/firebase/maple-functions/record-invoice-payment/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/delete-invoice": [
         "libs/firebase/maple-functions/delete-invoice/src/index.ts"
       ],


### PR DESCRIPTION
Foundational Venmo piece of the lesson-payments epic (#626). Closes #627.

## Why

Venmo Business Profiles have **no API or webhook** (Venmo's developer API has been closed to new applicants since ~2016). So a Venmo payment for a lesson can't fire into the platform the way a Square payment does. This PR adds the **human-attested** path: someone records "paid via Venmo" against the invoice, and a later CSV-reconciliation tool (#630) confirms it against the business Venmo statement. Money still lands in the business account; only the attribution is manual.

No new payment ledger — `Invoice.paymentRecord` already is the payment locus, so Venmo becomes two new `source` values and teacher-payout aggregation flows through unchanged.

## What

**Domain**
- `InvoicePaymentSource` gains `venmo-manual` + `venmo-import`.
- New `ManualInvoicePaymentSource` = the sources a client may set; server-only `square-webhook` and import-only `venmo-import` **cannot be spoofed** through the callable.
- `InvoicePaymentRecord` gains optional `note` + `recordedByUid` (server-stamped — seeds the teacher-attestation trail for #631).
- `Student.venmoUsername` (stored without the leading `@`) so #630 can match statement rows.

**Backend**
- New admin-gated `recordInvoicePayment` callable: idempotent (already-paid → no-op, preserving the original attribution), only `sent → paid`, rejects spoofed sources. Stamps the caller uid.
- `InvoiceRepository.recordManualPayment` mirrors `markPaidBySquareWebhook`.

**UI**
- The invoice "mark paid" button becomes a small method menu — **Paid via Venmo** / **Cash, check, or other**. The paid chip gains a "Paid via Venmo" state (with the note as a tooltip).
- `StudentForm` gets a Venmo username field (`@` stripped on submit).

## Verification

- **Unit**: `recordInvoicePayment` handler (8 cases — venmo/cash/idempotent/spoofed-source/not-found/draft-reject/over-long-note) + `venmoUsername` validation. ✅
- **Integration** (real emulators): record venmo + cash, idempotency preserves first attribution, draft-rejection, spoofed `square-webhook` rejected, unauth/non-admin guards. ✅
- **Storybook play**: pay-method menu wiring (venmo + cash sources), "Paid via Venmo" badge, `@`-stripped submit. ✅ (35 play tests green)
- Firestore index analyzer clean; all 4 function codebases build; `maple-spruce` typecheck passes.

## Scope / non-goals

- Admin-gated for now. The same callable will serve the teacher "My Day" page (#631) once lesson-teacher ownership (#616) lands — at which point the role gate widens and an ownership check is added.
- Not touched: web-checkout Venmo (would be plain PayPal Checkout, only if demand appears), the POS-lesson leak (#628), the reconciliation tool (#630).

## Note

Local `nx lint` for `react-invoices`/`react-students` crashes on the pre-existing story→app-fixture module-boundary issue (#570), unrelated to this change — the new stories use the same existing import pattern and the play tests run green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)