### PR TITLE
refactor(waitlist): drop redundant sold-out banner now that the page owns the heading

### DIFF
--- a/apps/webflow-components/src/RegistrationWidget.tsx
+++ b/apps/webflow-components/src/RegistrationWidget.tsx
@@ -168,11 +168,9 @@ function formatRelatedClassDate(isoString: string): string {
  */
 function SoldOutPanel({
   classId,
-  className,
   functions,
 }: {
   classId: string;
-  className: string;
   functions: ReturnType<typeof getWidgetFunctions>;
 }) {
   const [related, setRelated] = useState<PublicClass[] | null>(null);
@@ -233,16 +231,16 @@ function SoldOutPanel({
 
   return (
     <Box>
-      <Alert severity="info" sx={{ mb: 3 }}>
-        <strong>{className}</strong> is currently full — but you can join the
-        waitlist below.
-      </Alert>
-
-      {/* Waitlist signup — the primary action for a full class, so it leads. */}
+      {/*
+        Waitlist signup — the primary action for a full class, so it leads.
+        On the class page the Webflow template renders its own "Join Waitlist"
+        heading + "this class is full…" subtext (CMS conditional visibility)
+        directly above this widget, so the panel deliberately omits a full-state
+        banner and repeats none of that copy — just the first-come fine print.
+      */}
       <Box>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          Add your email and we'll let you know if a spot opens. Spots are
-          first-come, first-served — we email everyone on the list.
+          Spots are first-come, first-served — we email everyone on the list.
         </Typography>
 
         {waitlistState.status === 'success' ? (
@@ -594,7 +592,6 @@ export function RegistrationWidget({
             {state.publicClass.spotsRemaining <= 0 ? (
               <SoldOutPanel
                 classId={state.publicClass.id}
-                className={state.publicClass.name}
                 functions={functions}
               />
             ) : !squareAppId ? (


### PR DESCRIPTION
Follow-up to #635 (merged).

Once the Webflow class template renders its own **"Join Waitlist"** heading + **"This class is full — add your email below…"** subtext (via CMS conditional visibility on `spots-remaining`, done in the Designer), the widget's sold-out panel was repeating that copy one line later:

> This class is full — add your email below and we'll let you know the moment a spot opens.  ← Webflow subtext
> Stained Glass … is currently full — but you can join the waitlist below.  ← widget blue info alert (redundant)

## Change
- Remove the widget's blue `<Alert severity="info">` full-state banner.
- Trim the intro paragraph to just the first-come fine print (*"Spots are first-come, first-served — we email everyone on the list."*) so it complements the page subtext instead of echoing it.
- Drop the now-unused `className` prop from `SoldOutPanel`.

## Resulting sold-out stack
1. **Join Waitlist** (Webflow heading)
2. This class is full — add your email below and we'll let you know the moment a spot opens. (Webflow subtext)
3. `[ email ] [ Join waitlist ]`
4. Spots are first-come, first-served — we email everyone on the list.
5. — divider — Other upcoming dates

## Verification
- `apps/webflow-components` typecheck clean (verified on the pre-rebase base; cherry-picked onto current main with no conflict). CI build-check re-typechecks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)