### PR TITLE
fix(music-together): MANAGE_URL magic link → flat /music-together-manage-payment slug

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -69,7 +69,7 @@ CRAFT_CLUB_MANAGE_URL=https://mapleandsprucefolkarts.com/craft-club-manage
 
 # Music Together self-service payment-method page (Webflow); update-card magic
 # links point here. The page reads ?token= to open the manage session.
-MUSIC_TOGETHER_MANAGE_URL=https://mapleandsprucefolkarts.com/music-together/manage-payment
+MUSIC_TOGETHER_MANAGE_URL=https://mapleandsprucefolkarts.com/music-together-manage-payment
 
 # Recipient for admin alerts (e.g. "POS sale needs an attendee email"). Dev uses
 # a +dev alias so lower-environment/test alerts stay out of the production inbox

--- a/.env.prod
+++ b/.env.prod
@@ -70,7 +70,7 @@ CRAFT_CLUB_MANAGE_URL=https://mapleandsprucefolkarts.com/craft-club-manage
 
 # Music Together self-service payment-method page (Webflow); update-card magic
 # links point here. The page reads ?token= to open the manage session.
-MUSIC_TOGETHER_MANAGE_URL=https://mapleandsprucefolkarts.com/music-together/manage-payment
+MUSIC_TOGETHER_MANAGE_URL=https://mapleandsprucefolkarts.com/music-together-manage-payment
 
 # Recipient for admin alerts (e.g. "POS sale needs an attendee email").
 ADMIN_ALERT_EMAIL=katie@mapleandsprucefolkarts.com


### PR DESCRIPTION
## What

Repoint `MUSIC_TOGETHER_MANAGE_URL` (dev + prod) from the nested path
`/music-together/manage-payment` to the flat slug `/music-together-manage-payment`.

## Why

The Week-5 installment card-update email builds its magic link from this
env var. The nested path can't exist in Webflow: a top-level `/music-together`
landing page already exists, and Webflow won't let a folder named
`music-together` coexist with it. Every other MT page uses a flat slug for
exactly this reason (`/music-together-policies`, `/music-together-calendar`),
as does Craft Club's manage page (`/craft-club-manage`).

The new **Music Together Manage Payment** Webflow page lives at
`/music-together-manage-payment`; this makes the emailed link resolve to it.

## Safety

MT hasn't launched (prod Square creds still pending), so no real installment
family has been sent a magic link — changing the URL now has no live impact.
Env-only change; no code or tests reference the value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)