### PR TITLE
feat(auth): lesson-teacher manage-own ownership (phase 2, #616)

### DIFF
--- a/apps/functions-integration-tests-lesson/src/lesson-functions.spec.ts
+++ b/apps/functions-integration-tests-lesson/src/lesson-functions.spec.ts
@@ -133,6 +133,151 @@ describe('Lesson Functions', () => {
     });
   });
 
+  describe('Lesson-teacher ownership (#617 phase 2)', () => {
+    // A lesson teacher = a portal user linked to an instructor record via
+    // instructor.uid, with the lesson-teacher role. They may manage only
+    // lessons whose teacherId is their linked instructor.
+    const OWN_INSTRUCTOR_ID = 'instructor-owned-by-teacher';
+    let teacherUser: TestUser;
+    let unlinkedTeacher: TestUser;
+    let ownLessonId: string;
+    let othersLessonId: string;
+
+    beforeAll(async () => {
+      teacherUser = await createTestUser(
+        'lesson-owner@test.maple',
+        'test-password-123!'
+      );
+      unlinkedTeacher = await createTestUser(
+        'lesson-unlinked@test.maple',
+        'test-password-123!'
+      );
+      // Both hold the lesson-teacher role...
+      await setFirestoreDoc('userRoles', teacherUser.uid, {
+        roles: ['lesson-teacher'],
+      });
+      await setFirestoreDoc('userRoles', unlinkedTeacher.uid, {
+        roles: ['lesson-teacher'],
+      });
+      // ...but only teacherUser is linked to an instructor record.
+      await setFirestoreDoc('instructors', OWN_INSTRUCTOR_ID, {
+        uid: teacherUser.uid,
+        name: 'Owning Teacher',
+        email: 'owning-teacher@test.maple',
+        status: 'active',
+      });
+
+      // A lesson taught by TEACHER_ID (NOT the linked teacher) — created by admin.
+      const others = await callFunction<
+        CreateLessonRequest,
+        CreateLessonResponse
+      >({
+        functionName: 'createLesson',
+        data: {
+          studentId,
+          teacherId: TEACHER_ID,
+          scheduledAt: new Date('2026-06-01T15:00:00Z'),
+          durationMinutes: 30,
+          status: 'scheduled',
+        },
+        idToken: adminUser.idToken,
+      });
+      othersLessonId = others.data!.lesson.id;
+    });
+
+    it('lets a linked lesson teacher create a lesson they teach', async () => {
+      const result = await callFunction<
+        CreateLessonRequest,
+        CreateLessonResponse
+      >({
+        functionName: 'createLesson',
+        data: {
+          studentId,
+          teacherId: OWN_INSTRUCTOR_ID,
+          scheduledAt: new Date('2026-06-02T15:00:00Z'),
+          durationMinutes: 30,
+          status: 'scheduled',
+        },
+        idToken: teacherUser.idToken,
+      });
+      expect(result.status).toBe(200);
+      ownLessonId = result.data!.lesson.id;
+    });
+
+    it('denies creating a lesson assigned to a different teacher', async () => {
+      const result = await callFunction<CreateLessonRequest>({
+        functionName: 'createLesson',
+        data: {
+          studentId,
+          teacherId: TEACHER_ID,
+          scheduledAt: new Date('2026-06-03T15:00:00Z'),
+          durationMinutes: 30,
+          status: 'scheduled',
+        },
+        idToken: teacherUser.idToken,
+      });
+      expect(result.status).toBe(403);
+    });
+
+    it('lets a linked lesson teacher update their own lesson', async () => {
+      const result = await callFunction<
+        UpdateLessonRequest,
+        UpdateLessonResponse
+      >({
+        functionName: 'updateLesson',
+        data: { id: ownLessonId, notes: 'practiced scales' },
+        idToken: teacherUser.idToken,
+      });
+      expect(result.status).toBe(200);
+      expect(result.data?.lesson.notes).toBe('practiced scales');
+    });
+
+    it("denies updating another teacher's lesson", async () => {
+      const result = await callFunction<UpdateLessonRequest>({
+        functionName: 'updateLesson',
+        data: { id: othersLessonId, notes: 'not mine' },
+        idToken: teacherUser.idToken,
+      });
+      expect(result.status).toBe(403);
+    });
+
+    it("denies deleting another teacher's lesson", async () => {
+      const result = await callFunction<DeleteLessonRequest>({
+        functionName: 'deleteLesson',
+        data: { id: othersLessonId },
+        idToken: teacherUser.idToken,
+      });
+      expect(result.status).toBe(403);
+    });
+
+    it('denies an unlinked lesson teacher (no instructor record) entirely', async () => {
+      const result = await callFunction<CreateLessonRequest>({
+        functionName: 'createLesson',
+        data: {
+          studentId,
+          teacherId: OWN_INSTRUCTOR_ID,
+          scheduledAt: new Date('2026-06-04T15:00:00Z'),
+          durationMinutes: 30,
+          status: 'scheduled',
+        },
+        idToken: unlinkedTeacher.idToken,
+      });
+      expect(result.status).toBe(403);
+    });
+
+    it('admin can still manage any lesson', async () => {
+      const result = await callFunction<
+        UpdateLessonRequest,
+        UpdateLessonResponse
+      >({
+        functionName: 'updateLesson',
+        data: { id: ownLessonId, notes: 'admin override' },
+        idToken: adminUser.idToken,
+      });
+      expect(result.status).toBe(200);
+    });
+  });
+
   describe('Single lesson CRUD', () => {
     let lessonId: string;
 

--- a/apps/maple-spruce/src/app/(admin)/instructors/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/instructors/page.tsx
@@ -6,7 +6,7 @@ import AddIcon from '@mui/icons-material/Add';
 import type { Instructor, CreateInstructorInput } from '@maple/ts/domain';
 import { DeleteConfirmDialog } from '@maple/react/ui';
 import { InstructorList, InstructorForm } from '@maple/react/instructors';
-import { useInstructors } from '../../../hooks';
+import { useInstructors, useUsers } from '../../../hooks';
 
 export default function InstructorsPage() {
   // Instructor state from hook (fetches on mount)
@@ -16,6 +16,11 @@ export default function InstructorsPage() {
     updateInstructor,
     deleteInstructor: deleteInstructorApi,
   } = useInstructors();
+
+  // Users power the "Portal login" picker on the form (links a login to an
+  // instructor so a lesson teacher can manage their own lessons, #617).
+  const { usersState } = useUsers();
+  const users = usersState.status === 'success' ? usersState.data : undefined;
 
   // Form dialog state
   const [isFormOpen, setIsFormOpen] = useState(false);
@@ -40,14 +45,16 @@ export default function InstructorsPage() {
   }, []);
 
   const handleSubmitForm = useCallback(
-    async (data: CreateInstructorInput) => {
+    async (data: Omit<CreateInstructorInput, 'uid'> & { uid?: string | null }) => {
       setIsSubmitting(true);
 
       try {
         if (editingInstructor) {
+          // uid may be a login to link, null to unlink, or omitted (unchanged).
           await updateInstructor({ id: editingInstructor.id, ...data });
         } else {
-          await createInstructor(data);
+          // Create can't carry a null uid — coerce to "no link".
+          await createInstructor({ ...data, uid: data.uid ?? undefined });
         }
         handleCloseForm();
       } catch (error) {
@@ -117,6 +124,7 @@ export default function InstructorsPage() {
         onSubmit={handleSubmitForm}
         instructor={editingInstructor}
         isSubmitting={isSubmitting}
+        users={users}
       />
 
       <DeleteConfirmDialog

--- a/docs/reference/implementation-status.md
+++ b/docs/reference/implementation-status.md
@@ -25,6 +25,8 @@
 | Scoped roles framework (PR 1 of epic #617) | Complete | `Role` enum (admin, mt-teacher, clerk, lesson-teacher) + `userRoles/{uid}` + any-of `requiringRole([...])` + `getMyRoles`/`grantRole`/`revokeRole`; behavior-neutral — client plumbing #614, re-scoping #615 |
 | Scoped roles client plumbing (PR 2 of epic #617) | Complete | `RolesProvider`/`useRoles`/`RoleGuard` (ADR-028), role-filtered nav (`nav-groups.tsx`), `/users` scoped-role toggles, `listUsers` roles join — enforcement re-scoping is #615 |
 | Scoped roles enforcement (PR 3 of epic #617) | Complete | 46 fns re-scoped to role sets (MT→mt-teacher, store/registrations→clerk, lesson reads→lesson-teacher, calendar→all staff); auth-only reads tightened; `PathRoleGuard` route gating; role-gated dashboard; matrix integration spec (`role-matrix.spec.ts`). Phase 2 ownership = #616, analyzer = #620 |
+| Callable-role analyzer (#620) | Complete | `tools/check-callable-roles.ts` + `callable-roles` CI job; every exported callable must be role-gated / trigger / allowlisted. Caught + fixed leftover auth-only `getArtist`/`getStudent` |
+| Lesson-teacher manage-own (phase 2 of epic #617, #616) | Complete | `Instructor.uid` link + `InstructorRepository.findByUid`; `assertCanManageLesson` ownership helper; create/update/delete-lesson + create-lesson-series re-scoped to `[Admin, LessonTeacher]` with ownership checks; permission-denied→403; instructor-form "Portal login" picker |
 | Navigation (responsive) | Complete | `libs/react/layout/` (re-exported via app barrel) |
 | Storybook | Complete | `apps/maple-spruce/.storybook/` |
 | Component stories | Complete | `apps/maple-spruce/src/components/**/*.stories.tsx`, `libs/react/*/src/**/*.stories.tsx` |

--- a/libs/firebase/database/src/lib/instructor.repository.ts
+++ b/libs/firebase/database/src/lib/instructor.repository.ts
@@ -27,6 +27,8 @@ function docToInstructor(
   const data = doc.data()!;
   return {
     id: doc.id,
+    // Firestore may store null for an unlinked instructor; normalize to undefined.
+    uid: data.uid ?? undefined,
     name: data.name,
     email: data.email,
     phone: data.phone,
@@ -93,6 +95,25 @@ export const InstructorRepository = {
   },
 
   /**
+   * Find the instructor linked to a portal user (Firebase Auth UID), if any.
+   * Used to resolve a lesson-teacher caller to the instructor record whose
+   * lessons they own. Returns undefined when the user isn't linked.
+   */
+  async findByUid(uid: string): Promise<Instructor | undefined> {
+    const snapshot = await db
+      .collection(COLLECTION)
+      .where('uid', '==', uid)
+      .limit(1)
+      .get();
+
+    if (snapshot.empty) {
+      return undefined;
+    }
+
+    return docToInstructor(snapshot.docs[0]);
+  },
+
+  /**
    * Create a new instructor
    */
   async create(input: CreateInstructorInput): Promise<Instructor> {
@@ -116,7 +137,11 @@ export const InstructorRepository = {
   /**
    * Update an existing instructor
    */
-  async update(input: UpdateInstructorInput): Promise<Instructor> {
+  async update(
+    // uid accepts null so callers can unlink a portal login (writes null;
+    // docToInstructor normalizes it back to undefined on read).
+    input: Omit<UpdateInstructorInput, 'uid'> & { uid?: string | null }
+  ): Promise<Instructor> {
     const { id, ...updates } = input;
     const docRef = db.collection(COLLECTION).doc(id);
 

--- a/libs/firebase/functions/src/lib/errors.utility.ts
+++ b/libs/firebase/functions/src/lib/errors.utility.ts
@@ -83,3 +83,17 @@ export function throwValidationError(errors: Record<string, string[]>): never {
 export function throwFailedPrecondition(message: string): never {
   throw new HttpsError('failed-precondition', message);
 }
+
+/**
+ * Throw a permission-denied error — the caller is authenticated and has a
+ * role, but isn't allowed to act on this specific resource (e.g. a lesson
+ * teacher trying to manage a lesson they don't teach).
+ *
+ * @example
+ * if (!isOwner && !isAdmin) {
+ *   throwPermissionDenied('You can only manage lessons you teach.');
+ * }
+ */
+export function throwPermissionDenied(message: string): never {
+  throw new HttpsError('permission-denied', message);
+}

--- a/libs/firebase/functions/src/lib/functions.utility.spec.ts
+++ b/libs/firebase/functions/src/lib/functions.utility.spec.ts
@@ -515,6 +515,33 @@ describe('Functions.endpoint (chain + handle)', () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
+  it('maps a thrown permission-denied HttpsError to 403', async () => {
+    const handler = vi.fn(async () => {
+      throw new HttpsError('permission-denied', 'You can only manage lessons you teach.');
+    });
+    const endpoint = Functions.endpoint.handle(handler);
+
+    const res = await invoke(endpoint, makeReq({ body: { data: {} } }));
+
+    expect(res.statusCode).toBe(403);
+    expect((res.body as { error: { status: string; message: string } }).error)
+      .toMatchObject({ status: 'PERMISSION_DENIED' });
+  });
+
+  it('keeps the 400 INVALID_ARGUMENT contract for other thrown errors', async () => {
+    const handler = vi.fn(async () => {
+      throw new HttpsError('not-found', 'Lesson missing');
+    });
+    const endpoint = Functions.endpoint.handle(handler);
+
+    const res = await invoke(endpoint, makeReq({ body: { data: {} } }));
+
+    expect(res.statusCode).toBe(400);
+    expect((res.body as { error: { status: string } }).error.status).toBe(
+      'INVALID_ARGUMENT'
+    );
+  });
+
   it('validating: rejects invalid input before invoking handler', async () => {
     const handler = vi.fn();
     const validator = vi.fn(() => ({

--- a/libs/firebase/functions/src/lib/functions.utility.ts
+++ b/libs/firebase/functions/src/lib/functions.utility.ts
@@ -12,7 +12,7 @@
  * Pattern adapted from Mountain Sol Platform:
  * @see https://github.com/MountainSOLSchool/platform/blob/main/libs/firebase/functions/src/lib/utilities/functions.utility.ts
  */
-import { onRequest } from 'firebase-functions/v2/https';
+import { onRequest, HttpsError } from 'firebase-functions/v2/https';
 import {
   defineString,
   defineSecret,
@@ -575,6 +575,20 @@ class FunctionBuilder<
               error instanceof Error
                 ? error.message
                 : 'An unexpected error occurred';
+
+            // Resource-ownership failures (throwPermissionDenied) map to 403 so
+            // clients can tell "not allowed" from "bad input" — this mirrors the
+            // role-gate's 403. Everything else keeps the existing 400
+            // INVALID_ARGUMENT contract.
+            if (
+              error instanceof HttpsError &&
+              error.code === 'permission-denied'
+            ) {
+              res.status(403).json({
+                error: { message, status: 'PERMISSION_DENIED' },
+              });
+              return;
+            }
 
             // Return error in the callable protocol format so httpsCallable
             // on the client can extract the message. Without this structure,

--- a/libs/firebase/functions/src/lib/index.ts
+++ b/libs/firebase/functions/src/lib/index.ts
@@ -55,7 +55,14 @@ export {
   throwInvalidArgument,
   throwValidationError,
   throwFailedPrecondition,
+  throwPermissionDenied,
 } from './errors.utility';
+
+// Resource-ownership checks (scoped-roles phase 2)
+export {
+  instructorIdForUser,
+  assertCanManageLesson,
+} from './ownership.utility';
 
 // Environment utilities
 export {

--- a/libs/firebase/functions/src/lib/ownership.utility.spec.ts
+++ b/libs/firebase/functions/src/lib/ownership.utility.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findByUid: vi.fn(),
+  hasRole: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  InstructorRepository: { findByUid: mocks.findByUid },
+}));
+
+vi.mock('./auth.utility', () => ({
+  Role: {
+    Admin: 'admin',
+    MtTeacher: 'mt-teacher',
+    Clerk: 'clerk',
+    LessonTeacher: 'lesson-teacher',
+  },
+  hasRole: mocks.hasRole,
+}));
+
+import {
+  assertCanManageLesson,
+  instructorIdForUser,
+} from './ownership.utility';
+
+describe('instructorIdForUser', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns the linked instructor id', async () => {
+    mocks.findByUid.mockResolvedValue({ id: 'instr-1', uid: 'nathan-uid' });
+    expect(await instructorIdForUser('nathan-uid')).toBe('instr-1');
+  });
+
+  it('returns undefined for an unlinked user', async () => {
+    mocks.findByUid.mockResolvedValue(undefined);
+    expect(await instructorIdForUser('someone')).toBeUndefined();
+  });
+
+  it('returns undefined (without querying) for a missing uid', async () => {
+    expect(await instructorIdForUser(undefined)).toBeUndefined();
+    expect(mocks.findByUid).not.toHaveBeenCalled();
+  });
+});
+
+describe('assertCanManageLesson', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('admins pass unconditionally, without resolving an instructor', async () => {
+    mocks.hasRole.mockResolvedValue(true);
+    await expect(
+      assertCanManageLesson({ uid: 'admin-uid' }, 'instr-someone')
+    ).resolves.toBeUndefined();
+    expect(mocks.findByUid).not.toHaveBeenCalled();
+  });
+
+  it('a lesson teacher passes for a lesson they teach', async () => {
+    mocks.hasRole.mockResolvedValue(false);
+    mocks.findByUid.mockResolvedValue({ id: 'instr-nathan' });
+    await expect(
+      assertCanManageLesson({ uid: 'nathan-uid' }, 'instr-nathan')
+    ).resolves.toBeUndefined();
+  });
+
+  it("denies a lesson teacher for someone else's lesson", async () => {
+    mocks.hasRole.mockResolvedValue(false);
+    mocks.findByUid.mockResolvedValue({ id: 'instr-nathan' });
+    await expect(
+      assertCanManageLesson({ uid: 'nathan-uid' }, 'instr-someone-else')
+    ).rejects.toThrow(/only manage lessons you teach/i);
+  });
+
+  it('denies an unlinked caller (no instructor record)', async () => {
+    mocks.hasRole.mockResolvedValue(false);
+    mocks.findByUid.mockResolvedValue(undefined);
+    await expect(
+      assertCanManageLesson({ uid: 'unlinked-uid' }, 'instr-nathan')
+    ).rejects.toThrow(/only manage lessons you teach/i);
+  });
+
+  it('denies when the owner is undefined (e.g. create with no teacherId)', async () => {
+    mocks.hasRole.mockResolvedValue(false);
+    mocks.findByUid.mockResolvedValue({ id: 'instr-nathan' });
+    await expect(
+      assertCanManageLesson({ uid: 'nathan-uid' }, undefined)
+    ).rejects.toThrow(/only manage lessons you teach/i);
+  });
+});

--- a/libs/firebase/functions/src/lib/ownership.utility.ts
+++ b/libs/firebase/functions/src/lib/ownership.utility.ts
@@ -1,0 +1,57 @@
+/**
+ * Resource-ownership checks layered on top of role gates (scoped-roles
+ * epic #617, phase 2).
+ *
+ * Lesson teachers can READ all lessons but MUTATE only their own. The role
+ * gate (`requiringRole([Role.Admin, Role.LessonTeacher])`) admits them to a
+ * mutation function; this helper then enforces that a non-admin caller only
+ * touches lessons taught by the instructor record linked to their login.
+ *
+ * A lesson's owner is its `teacherId` (an Instructor id). A caller's identity
+ * is resolved via `InstructorRepository.findByUid` — an instructor record
+ * whose `uid` is the caller's Firebase Auth UID.
+ */
+import { InstructorRepository } from '@maple/firebase/database';
+import { hasRole, Role } from './auth.utility';
+import { throwPermissionDenied } from './errors.utility';
+import type { FunctionContext } from './functions.utility';
+
+/**
+ * The instructor id linked to a portal user, or undefined when the user
+ * isn't linked to any instructor record.
+ */
+export async function instructorIdForUser(
+  uid: string | undefined
+): Promise<string | undefined> {
+  if (!uid) return undefined;
+  const instructor = await InstructorRepository.findByUid(uid);
+  return instructor?.id;
+}
+
+/**
+ * Enforce "lesson teachers manage only their own lessons".
+ *
+ * Passes unconditionally for admins. For anyone else (a lesson-teacher, since
+ * the role gate already excludes other roles) it passes only when their linked
+ * instructor id equals `lessonTeacherId`. Throws permission-denied otherwise —
+ * including when the caller isn't linked to any instructor record.
+ *
+ * Call this AFTER `requiringRole([Role.Admin, Role.LessonTeacher])` and after
+ * loading the target lesson (use `lesson.teacherId`), or, on create, with the
+ * `teacherId` the new lesson would be assigned.
+ */
+export async function assertCanManageLesson(
+  context: FunctionContext,
+  lessonTeacherId: string | undefined
+): Promise<void> {
+  const uid = context.uid;
+  if (uid && (await hasRole(uid, Role.Admin))) return;
+
+  const myInstructorId = await instructorIdForUser(uid);
+  // A non-admin passes only when linked to the exact instructor who teaches
+  // this lesson. An unlinked caller (myInstructorId undefined) or an undefined
+  // owner never matches -> denied.
+  if (myInstructorId && myInstructorId === lessonTeacherId) return;
+
+  throwPermissionDenied('You can only manage lessons you teach.');
+}

--- a/libs/firebase/maple-functions/create-lesson-series/src/lib/create-lesson-series.ts
+++ b/libs/firebase/maple-functions/create-lesson-series/src/lib/create-lesson-series.ts
@@ -5,7 +5,11 @@
  * final list of scheduled dates (having already applied any holiday skips
  * in the preview step), so the server writes them as-is.
  */
-import { createAdminFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+  assertCanManageLesson,
+} from '@maple/firebase/functions';
 import { LessonRepository, StudentRepository } from '@maple/firebase/database';
 import { lessonSeriesValidation } from '@maple/ts/validation';
 import type {
@@ -13,10 +17,13 @@ import type {
   CreateLessonSeriesResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const createLessonSeries = createAdminFunction<
+export const createLessonSeries = createRoleFunction<
   CreateLessonSeriesRequest,
   CreateLessonSeriesResponse
->(async (data) => {
+>(async (data, context) => {
+  // A lesson teacher may only create a series they teach.
+  await assertCanManageLesson(context, data.teacherId);
+
   // Dates arrive as ISO strings over the wire; coerce each one before validation.
   const coerced = {
     ...data,
@@ -48,4 +55,4 @@ export const createLessonSeries = createAdminFunction<
   });
 
   return { lessons, seriesId };
-});
+}, [Role.Admin, Role.LessonTeacher]);

--- a/libs/firebase/maple-functions/create-lesson/src/lib/create-lesson.ts
+++ b/libs/firebase/maple-functions/create-lesson/src/lib/create-lesson.ts
@@ -1,10 +1,16 @@
 /**
  * Create Lesson Cloud Function
  *
- * Creates a single music lesson (admin only). Used for first-lesson
+ * Admin + lesson-teacher (scoped-roles epic #617). A lesson teacher may only
+ * create lessons they teach (the new lesson's teacherId must be their own
+ * instructor id); admins may create for anyone. Used for first-lesson
  * bookings; recurring series use createLessonSeries.
  */
-import { createAdminFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+  assertCanManageLesson,
+} from '@maple/firebase/functions';
 import { LessonRepository, StudentRepository } from '@maple/firebase/database';
 import { lessonValidation } from '@maple/ts/validation';
 import type {
@@ -12,10 +18,13 @@ import type {
   CreateLessonResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const createLesson = createAdminFunction<
+export const createLesson = createRoleFunction<
   CreateLessonRequest,
   CreateLessonResponse
->(async (data) => {
+>(async (data, context) => {
+  // A lesson teacher may only create a lesson assigned to themselves.
+  await assertCanManageLesson(context, data.teacherId);
+
   // Dates arrive as ISO strings over the wire; coerce before validation.
   const coerced = {
     ...data,
@@ -49,4 +58,4 @@ export const createLesson = createAdminFunction<
   });
 
   return { lesson };
-});
+}, [Role.Admin, Role.LessonTeacher]);

--- a/libs/firebase/maple-functions/delete-lesson/src/lib/delete-lesson.ts
+++ b/libs/firebase/maple-functions/delete-lesson/src/lib/delete-lesson.ts
@@ -1,26 +1,34 @@
 /**
  * Delete Lesson Cloud Function
  *
- * Hard-deletes a lesson (admin only). UI prefers cancel (updateLesson with
- * status='cancelled') to preserve history; use delete sparingly.
+ * Admin + lesson-teacher (own lessons only; scoped-roles epic #617). UI
+ * prefers cancel (updateLesson with status='cancelled') to preserve history;
+ * use delete sparingly.
  */
-import { createAdminFunction, throwNotFound } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+  assertCanManageLesson,
+  throwNotFound,
+} from '@maple/firebase/functions';
 import { LessonRepository } from '@maple/firebase/database';
 import type {
   DeleteLessonRequest,
   DeleteLessonResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const deleteLesson = createAdminFunction<
+export const deleteLesson = createRoleFunction<
   DeleteLessonRequest,
   DeleteLessonResponse
->(async (data) => {
+>(async (data, context) => {
   const existing = await LessonRepository.findById(data.id);
   if (!existing) {
     throwNotFound('Lesson', data.id);
   }
 
+  await assertCanManageLesson(context, existing.teacherId);
+
   await LessonRepository.delete(data.id);
 
   return { success: true };
-});
+}, [Role.Admin, Role.LessonTeacher]);

--- a/libs/firebase/maple-functions/update-instructor/src/lib/update-instructor.ts
+++ b/libs/firebase/maple-functions/update-instructor/src/lib/update-instructor.ts
@@ -3,7 +3,11 @@
  *
  * Updates an existing instructor (admin only).
  */
-import { createAdminFunction, throwNotFound } from '@maple/firebase/functions';
+import {
+  createAdminFunction,
+  throwNotFound,
+  throwFailedPrecondition,
+} from '@maple/firebase/functions';
 import { InstructorRepository } from '@maple/firebase/database';
 import { instructorValidation } from '@maple/ts/validation';
 import type {
@@ -21,8 +25,11 @@ export const updateInstructor = createAdminFunction<
     throwNotFound('Instructor', data.id);
   }
 
-  // Validate update data (merge with existing for full validation)
-  const merged = { ...existing, ...data };
+  // Validate update data (merge with existing for full validation). uid is a
+  // portal-login link, not a validated field, and may be null (unlink) — keep
+  // it out of the validation merge so its type doesn't leak in.
+  const { uid: _uid, ...dataForValidation } = data;
+  const merged = { ...existing, ...dataForValidation };
   const validationResult = instructorValidation(merged);
   if (!validationResult.isValid()) {
     const errors = validationResult.getErrors();
@@ -37,6 +44,19 @@ export const updateInstructor = createAdminFunction<
     const existingWithEmail = await InstructorRepository.findByEmail(data.email);
     if (existingWithEmail) {
       throw new Error(`An instructor with email ${data.email} already exists`);
+    }
+  }
+
+  // A portal login (uid) links one user to one instructor — required for the
+  // lesson-teacher "manage only your own lessons" check (#617 phase 2). Guard
+  // uniqueness: a uid already linked to a different instructor must be
+  // unlinked there first, or ownership would be ambiguous. `null` unlinks.
+  if (data.uid) {
+    const linkedElsewhere = await InstructorRepository.findByUid(data.uid);
+    if (linkedElsewhere && linkedElsewhere.id !== data.id) {
+      throwFailedPrecondition(
+        `That portal user is already linked to instructor "${linkedElsewhere.name}". Unlink them there first.`
+      );
     }
   }
 

--- a/libs/firebase/maple-functions/update-lesson/src/lib/update-lesson.ts
+++ b/libs/firebase/maple-functions/update-lesson/src/lib/update-lesson.ts
@@ -1,11 +1,18 @@
 /**
  * Update Lesson Cloud Function
  *
- * Updates an existing lesson (admin only). Used for reschedule
- * (scheduledAt), duration change, substitute teacher, status transitions
- * (scheduled ↔ cancelled; rendered is set by #282), and notes.
+ * Admin + lesson-teacher (scoped-roles epic #617). A lesson teacher may only
+ * update lessons they teach (ownership check on the lesson's teacherId);
+ * admins may update any. Used for reschedule (scheduledAt), duration change,
+ * substitute teacher, status transitions (scheduled ↔ cancelled; rendered is
+ * set by #282), and notes.
  */
-import { createAdminFunction, throwNotFound } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+  assertCanManageLesson,
+  throwNotFound,
+} from '@maple/firebase/functions';
 import { LessonRepository } from '@maple/firebase/database';
 import { lessonValidation } from '@maple/ts/validation';
 import type {
@@ -13,14 +20,17 @@ import type {
   UpdateLessonResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const updateLesson = createAdminFunction<
+export const updateLesson = createRoleFunction<
   UpdateLessonRequest,
   UpdateLessonResponse
->(async (data) => {
+>(async (data, context) => {
   const existing = await LessonRepository.findById(data.id);
   if (!existing) {
     throwNotFound('Lesson', data.id);
   }
+
+  // Ownership: a lesson teacher may only touch a lesson they currently teach.
+  await assertCanManageLesson(context, existing.teacherId);
 
   // Coerce scheduledAt if caller sent a string, but only include it in
   // the update payload when it was actually provided — spreading
@@ -48,4 +58,4 @@ export const updateLesson = createAdminFunction<
   const lesson = await LessonRepository.update(coercedUpdates);
 
   return { lesson };
-});
+}, [Role.Admin, Role.LessonTeacher]);

--- a/libs/react/data/src/lib/useInstructors.ts
+++ b/libs/react/data/src/lib/useInstructors.ts
@@ -6,7 +6,6 @@ import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
 import type {
   Instructor,
   CreateInstructorInput,
-  UpdateInstructorInput,
   RequestState,
 } from '@maple/ts/domain';
 import type {
@@ -88,7 +87,9 @@ export function useInstructors() {
   );
 
   const updateInstructor = useCallback(
-    async (input: UpdateInstructorInput): Promise<Instructor> => {
+    // UpdateInstructorRequest (not ...Input) so callers can pass uid: null to
+    // unlink a portal login (#617 phase 2).
+    async (input: UpdateInstructorRequest): Promise<Instructor> => {
       const functions = getMapleFunctions();
       const update = httpsCallable<
         UpdateInstructorRequest,

--- a/libs/react/instructors/src/lib/InstructorForm.tsx
+++ b/libs/react/instructors/src/lib/InstructorForm.tsx
@@ -35,6 +35,7 @@ import type {
   CreateInstructorInput,
   PayeeStatus,
   InstructorPayRateType,
+  AppUser,
 } from '@maple/ts/domain';
 import type {
   UploadInstructorImageRequest,
@@ -52,9 +53,17 @@ import {
 interface InstructorFormProps {
   open: boolean;
   onClose: () => void;
-  onSubmit: (data: CreateInstructorInput) => Promise<void>;
+  onSubmit: (
+    data: Omit<CreateInstructorInput, 'uid'> & { uid?: string | null }
+  ) => Promise<void>;
   instructor?: Instructor;
   isSubmitting?: boolean;
+  /**
+   * Portal users, for the optional "Portal login" picker. Provide only on the
+   * admin page (it fetches users) — the link is what lets a lesson teacher
+   * manage their own lessons (#617 phase 2). Omit to hide the picker.
+   */
+  users?: readonly AppUser[];
 }
 
 // Common specialties for autocomplete suggestions
@@ -98,6 +107,7 @@ export function InstructorForm({
   onSubmit,
   instructor,
   isSubmitting = false,
+  users,
 }: InstructorFormProps) {
   // Enable signals tracking in this component
   useSignals();
@@ -114,6 +124,9 @@ export function InstructorForm({
   const specialties = useSignal<string[]>([]);
   const payRate = useSignal<number | undefined>(undefined);
   const payRateType = useSignal<InstructorPayRateType | undefined>(undefined);
+  // Portal login link ('' = not a portal user). Only surfaced when `users`
+  // is provided.
+  const linkedUid = useSignal('');
 
   // ============================================================
   // UI STATE SIGNALS
@@ -174,6 +187,7 @@ export function InstructorForm({
         specialties.value = instructor.specialties ?? [];
         payRate.value = instructor.payRate;
         payRateType.value = instructor.payRateType;
+        linkedUid.value = instructor.uid ?? '';
         photoUrl.value = instructor.photoUrl ?? '';
 
         if (instructor.photoUrl) {
@@ -200,6 +214,7 @@ export function InstructorForm({
         specialties.value = [];
         payRate.value = undefined;
         payRateType.value = undefined;
+        linkedUid.value = '';
         photoUrl.value = '';
         imageUploadState.value = { status: 'idle' };
         pendingImageFile.value = null;
@@ -295,7 +310,7 @@ export function InstructorForm({
         }
       }
 
-      const input: CreateInstructorInput = {
+      const input: Omit<CreateInstructorInput, 'uid'> & { uid?: string | null } = {
         name: name.value,
         email: email.value,
         phone: phone.value || undefined,
@@ -306,6 +321,9 @@ export function InstructorForm({
         payRate: payRate.value,
         payRateType: payRateType.value,
         photoUrl: currentPhotoUrl || undefined,
+        // Only emit uid when the picker is in play. '' => null (unlink /
+        // not a portal user); a uid => link. undefined leaves it unchanged.
+        ...(users ? { uid: linkedUid.value || null } : {}),
       };
 
       await onSubmit(input);
@@ -506,6 +524,34 @@ export function InstructorForm({
               <FormHelperText>{getFieldError('status')}</FormHelperText>
             )}
           </FormControl>
+
+          {/* Portal login — links a user account to this instructor so a
+              lesson teacher can manage their own lessons (#617 phase 2). */}
+          {users && (
+            <FormControl fullWidth>
+              <InputLabel>Portal login (for lesson teachers)</InputLabel>
+              <Select
+                value={linkedUid.value}
+                label="Portal login (for lesson teachers)"
+                onChange={(e) => (linkedUid.value = e.target.value)}
+              >
+                <MenuItem value="">
+                  <em>Not a portal user</em>
+                </MenuItem>
+                {users.map((u) => (
+                  <MenuItem key={u.uid} value={u.uid}>
+                    {u.displayName ? `${u.displayName} · ` : ''}
+                    {u.email ?? u.uid}
+                  </MenuItem>
+                ))}
+              </Select>
+              <FormHelperText>
+                Lets this person sign in and manage the lessons they teach.
+                Leave as &ldquo;Not a portal user&rdquo; for class-only
+                instructors.
+              </FormHelperText>
+            </FormControl>
+          )}
 
           {/* Notes */}
           <TextField

--- a/libs/ts/domain/src/lib/instructor.ts
+++ b/libs/ts/domain/src/lib/instructor.ts
@@ -20,6 +20,14 @@ export type InstructorPayRateType = 'flat' | 'hourly' | 'percentage';
  * Instructor entity - implements Payee interface
  */
 export interface Instructor extends Payee {
+  /**
+   * Firebase Auth UID of the portal user who IS this instructor, when they
+   * have a login. Set only for lesson teachers who manage their own lessons
+   * in the portal (scoped-roles epic #617) — most instructors (class-only
+   * payees) have no login and leave this unset. Used to enforce
+   * "lesson teachers manage only their own lessons".
+   */
+  uid?: string;
   /** Instructor's bio for class pages (teaching-focused) */
   bio?: string;
   /** Areas of expertise (e.g., ['weaving', 'natural dyeing']) */

--- a/libs/ts/firebase/api-types/src/lib/instructor.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/instructor.types.ts
@@ -51,7 +51,15 @@ export interface CreateInstructorResponse {
 // Update Instructor
 // ============================================================================
 
-export interface UpdateInstructorRequest extends UpdateInstructorInput {}
+export interface UpdateInstructorRequest
+  extends Omit<UpdateInstructorInput, 'uid'> {
+  /**
+   * Firebase Auth UID of the portal user who IS this instructor. A non-empty
+   * string links the login (for lesson-teacher ownership, #617 phase 2);
+   * `null` unlinks; omit to leave unchanged.
+   */
+  uid?: string | null;
+}
 
 export interface UpdateInstructorResponse {
   instructor: Instructor;


### PR DESCRIPTION
Closes #616. Phase 2 of the scoped-roles epic (#617) — the last feature piece. Lesson teachers read all lessons (shipped in #633) and now **manage only their own**. This is what lets a music teacher (Nathan, the new mandolin teacher) run their own lessons in the portal without touching anyone else's.

## Model

A lesson's owner is its `teacherId` (an Instructor id). A caller is linked to an instructor via a new **`Instructor.uid`** (their Firebase Auth UID). Ownership = the caller's linked instructor id equals the lesson's `teacherId`.

## What

- **`Instructor.uid`** + `InstructorRepository.findByUid` — links a portal login to an instructor record (most instructors are class-only payees with no login; only lesson teachers get one).
- **`assertCanManageLesson`** (`ownership.utility`) — admins pass; a lesson-teacher passes only for lessons taught by their linked instructor; an unlinked caller is denied.
- **create / update / delete-lesson + create-lesson-series** re-scoped from admin-only to `[Admin, LessonTeacher]` with the ownership check (create/update guard the assigned/existing `teacherId`).
- **`updateInstructor`** sets/clears the link (`uid` string to link, `null` to unlink) with a uniqueness guard — a user can't be linked to two instructors.
- **FunctionBuilder** now maps a thrown `permission-denied` HttpsError to **HTTP 403** (mirrors the role gate); every other error keeps the existing 400 contract.
- **Admin UI**: the instructor form gains a "Portal login (for lesson teachers)" picker, fed by `useUsers`.

## Verification

- **Lesson integration suite +7 ownership tests** (real emulators): a linked teacher can create/update their own lesson; is **denied (403)** creating for a different teacher, and updating/deleting another teacher's lesson; an **unlinked** lesson-teacher is denied entirely; **admin can still manage any** lesson. 28 pass.
- Instructor integration 11 pass (link uniqueness path exercised via update-instructor).
- Unit 2,349 (incl. `ownership.utility` + the 403-mapping builder tests); Storybook 400.
- Analyzer (#620) still green — lessons remain role-gated; firestore-index analyzer picks up `findByUid` (covered). App + all 4 codebases build.

## Setup after merge + deploy

For each lesson teacher: grant the **lesson-teacher** role (/users), then on the **Instructors** page edit their instructor record and set **Portal login** to their user. Then they can sign in and manage the lessons they teach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
