### PR TITLE
feat(pos): detect + attribute Square POS lesson sales (#628, backend PR 1/2)

### DIFF
--- a/libs/firebase/database/src/index.ts
+++ b/libs/firebase/database/src/index.ts
@@ -49,6 +49,11 @@ export {
   type CatalogSyncRequest,
 } from './lib/catalog-sync-request.repository';
 export { PosSaleRequestRepository } from './lib/pos-sale-request.repository';
+export {
+  PosLessonAttributionRepository,
+  posLessonAttributionId,
+} from './lib/pos-lesson-attribution.repository';
+export { PosLessonConfigRepository } from './lib/pos-lesson-config.repository';
 
 // Phase 5: Sales & Inventory
 export {

--- a/libs/firebase/database/src/lib/invoice.repository.spec.ts
+++ b/libs/firebase/database/src/lib/invoice.repository.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('./utilities/database.config', () => ({
   db: {
@@ -545,6 +545,71 @@ describe('InvoiceRepository', () => {
           error: 'Square 500',
         })
       ).rejects.toThrow('NOT_FOUND');
+    });
+  });
+
+  describe('settleOrCreatePosLessonInvoice', () => {
+    const posArgs = {
+      studentId: 'student-1',
+      subtotalCents: 3000,
+      description: 'In-person lesson — Guitar Lesson',
+      squarePaymentId: 'PAY-1',
+      squareOrderId: 'ORDER-1',
+    };
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('settles the single open invoice whose total matches the sale', async () => {
+      vi.spyOn(InvoiceRepository, 'findAll').mockResolvedValue([
+        { id: 'inv-open', totalCents: 3000 },
+      ] as never);
+      const mark = vi
+        .spyOn(InvoiceRepository, 'markPaidByPosSale')
+        .mockResolvedValue({ id: 'inv-open', status: 'paid' } as never);
+      const create = vi.spyOn(InvoiceRepository, 'createPosPaidInvoice');
+
+      const res = await InvoiceRepository.settleOrCreatePosLessonInvoice(posArgs);
+
+      expect(mark).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'inv-open', squarePaymentId: 'PAY-1' })
+      );
+      expect(create).not.toHaveBeenCalled();
+      expect(res.settledExisting).toBe(true);
+    });
+
+    it('creates a paid invoice when no open invoice matches the amount', async () => {
+      vi.spyOn(InvoiceRepository, 'findAll').mockResolvedValue([
+        { id: 'inv-open', totalCents: 9999 },
+      ] as never);
+      const mark = vi.spyOn(InvoiceRepository, 'markPaidByPosSale');
+      const create = vi
+        .spyOn(InvoiceRepository, 'createPosPaidInvoice')
+        .mockResolvedValue({ id: 'inv-new', status: 'paid' } as never);
+
+      const res = await InvoiceRepository.settleOrCreatePosLessonInvoice(posArgs);
+
+      expect(mark).not.toHaveBeenCalled();
+      expect(create).toHaveBeenCalledWith(expect.objectContaining(posArgs));
+      expect(res.settledExisting).toBe(false);
+    });
+
+    it('creates (does not settle) when multiple open invoices match — ambiguous', async () => {
+      vi.spyOn(InvoiceRepository, 'findAll').mockResolvedValue([
+        { id: 'inv-a', totalCents: 3000 },
+        { id: 'inv-b', totalCents: 3000 },
+      ] as never);
+      const mark = vi.spyOn(InvoiceRepository, 'markPaidByPosSale');
+      const create = vi
+        .spyOn(InvoiceRepository, 'createPosPaidInvoice')
+        .mockResolvedValue({ id: 'inv-new' } as never);
+
+      const res = await InvoiceRepository.settleOrCreatePosLessonInvoice(posArgs);
+
+      expect(mark).not.toHaveBeenCalled();
+      expect(create).toHaveBeenCalled();
+      expect(res.settledExisting).toBe(false);
     });
   });
 });

--- a/libs/firebase/database/src/lib/invoice.repository.ts
+++ b/libs/firebase/database/src/lib/invoice.repository.ts
@@ -333,6 +333,128 @@ export const InvoiceRepository = {
   },
 
   /**
+   * Flip an invoice to paid from an in-person Square POS lesson sale (#628),
+   * attributing it to `square-pos`. Idempotent — already-paid invoices keep
+   * their earlier paymentRecord.
+   */
+  async markPaidByPosSale(args: {
+    id: string;
+    squarePaymentId: string;
+    squareOrderId: string;
+    recordedByUid?: string;
+  }): Promise<Invoice> {
+    const docRef = db.collection(COLLECTION).doc(args.id);
+    const existing = docToInvoice(await docRef.get());
+    if (!existing) {
+      throw new Error(`Invoice ${args.id} not found`);
+    }
+    if (existing.status === 'paid') {
+      return existing;
+    }
+    const now = new Date();
+    await docRef.update({
+      status: 'paid' as InvoiceStatus,
+      paidAt: existing.paidAt ?? now,
+      issuedAt: existing.issuedAt ?? now,
+      squareOrderId: existing.squareOrderId ?? args.squareOrderId,
+      paymentRecord: {
+        source: 'square-pos' as const,
+        squarePaymentId: args.squarePaymentId,
+        recordedByUid: args.recordedByUid,
+        recordedAt: now,
+      },
+      updatedAt: now,
+    });
+    const invoice = docToInvoice(await docRef.get());
+    if (!invoice) {
+      throw new Error(`Invoice ${args.id} not found after POS payment`);
+    }
+    return invoice;
+  },
+
+  /**
+   * Create a fully-paid invoice for an in-person POS lesson sale that had no
+   * matching open invoice — so the payment still lands in records and teacher
+   * payouts. One line item, attributed to `square-pos`.
+   */
+  async createPosPaidInvoice(args: {
+    studentId: string;
+    subtotalCents: number;
+    description: string;
+    squarePaymentId: string;
+    squareOrderId: string;
+    recordedByUid?: string;
+  }): Promise<Invoice> {
+    const docRef = db.collection(COLLECTION).doc();
+    const now = new Date();
+    const lineItems = withComputedSubtotals([
+      {
+        id: 'pos-lesson',
+        description: args.description,
+        quantity: 1,
+        unitAmountCents: args.subtotalCents,
+        subtotalCents: args.subtotalCents,
+      },
+    ]);
+    const totalCents = computeInvoiceTotalCents(lineItems);
+    const data = {
+      studentId: args.studentId,
+      status: 'paid' as InvoiceStatus,
+      lineItems,
+      totalCents,
+      issuedAt: now,
+      paidAt: now,
+      squareOrderId: args.squareOrderId,
+      paymentRecord: {
+        source: 'square-pos' as const,
+        squarePaymentId: args.squarePaymentId,
+        recordedByUid: args.recordedByUid,
+        recordedAt: now,
+      },
+      createdAt: now,
+      updatedAt: now,
+    };
+    await docRef.set(data);
+    const invoice = docToInvoice(await docRef.get());
+    if (!invoice) {
+      throw new Error('POS invoice not found after create');
+    }
+    return invoice;
+  },
+
+  /**
+   * Attribute a POS lesson sale to a student: settle their single open `sent`
+   * invoice whose pre-tax total matches the sale, or create a paid invoice
+   * when there's no unambiguous match. Shared by the auto-attribution path in
+   * `processPosSale` and the manual review-queue resolver (#628).
+   */
+  async settleOrCreatePosLessonInvoice(args: {
+    studentId: string;
+    subtotalCents: number;
+    description: string;
+    squarePaymentId: string;
+    squareOrderId: string;
+    recordedByUid?: string;
+  }): Promise<{ invoice: Invoice; settledExisting: boolean }> {
+    const openMatches = (
+      await this.findAll({ studentId: args.studentId, status: 'sent' })
+    ).filter((i) => i.totalCents === args.subtotalCents);
+
+    if (openMatches.length === 1) {
+      const invoice = await this.markPaidByPosSale({
+        id: openMatches[0].id,
+        squarePaymentId: args.squarePaymentId,
+        squareOrderId: args.squareOrderId,
+        recordedByUid: args.recordedByUid,
+      });
+      return { invoice, settledExisting: true };
+    }
+
+    const invoice = await this.createPosPaidInvoice(args);
+    return { invoice, settledExisting: false };
+  },
+
+  /**
    * Persist the Square ids stamped during a successful send, and clear
    * any prior sync error.
    */

--- a/libs/firebase/database/src/lib/pos-lesson-attribution.repository.ts
+++ b/libs/firebase/database/src/lib/pos-lesson-attribution.repository.ts
@@ -1,0 +1,179 @@
+/**
+ * POS Lesson Attribution Repository
+ *
+ * Queue of in-person Square POS lesson sales that need to be tied to a
+ * student (`posLessonAttributions` collection). Written by `processPosSale`
+ * when a configured lesson catalog item is rung up; resolved either
+ * automatically (customer email → student) or by a human from the review
+ * queue (#628).
+ *
+ * Doc-id is deterministic — `${paymentId}__${catalogObjectId}` — so a Square
+ * webhook retry (which re-runs `processPosSale`) never creates a duplicate
+ * queue entry for the same line item.
+ */
+import { db, toDate } from './utilities/database.config';
+import type {
+  CreatePosLessonAttributionInput,
+  PosLessonAttribution,
+  PosLessonAttributionStatus,
+  PosLessonAttributionSummary,
+} from '@maple/ts/domain';
+
+const COLLECTION = 'posLessonAttributions';
+
+/** Deterministic id so retries are idempotent. */
+export function posLessonAttributionId(
+  paymentId: string,
+  catalogObjectId: string
+): string {
+  return `${paymentId}__${catalogObjectId}`;
+}
+
+function docToAttribution(
+  doc: FirebaseFirestore.DocumentSnapshot
+): PosLessonAttribution | undefined {
+  if (!doc.exists) return undefined;
+  const data = doc.data()!;
+  return {
+    id: doc.id,
+    squarePaymentId: data.squarePaymentId,
+    squareOrderId: data.squareOrderId,
+    catalogObjectId: data.catalogObjectId,
+    itemName: data.itemName,
+    quantity: data.quantity ?? 1,
+    subtotalCents: data.subtotalCents ?? 0,
+    amountPaidCents: data.amountPaidCents ?? 0,
+    occurredAt: toDate(data.occurredAt),
+    squareReceiptUrl: data.squareReceiptUrl,
+    squareCustomerId: data.squareCustomerId,
+    customerEmail: data.customerEmail,
+    customerName: data.customerName,
+    status: data.status,
+    studentId: data.studentId,
+    invoiceId: data.invoiceId,
+    attributedBy: data.attributedBy,
+    attributedAt: data.attributedAt ? toDate(data.attributedAt) : undefined,
+    notes: data.notes,
+    createdAt: toDate(data.createdAt),
+    updatedAt: toDate(data.updatedAt),
+  };
+}
+
+export const PosLessonAttributionRepository = {
+  /**
+   * List attributions, optionally by status. Sorted newest-first in memory so
+   * a status filter needs no composite index (volume is low).
+   */
+  async findAll(filters: { status?: PosLessonAttributionStatus } = {}): Promise<
+    PosLessonAttribution[]
+  > {
+    let query: FirebaseFirestore.Query = db.collection(COLLECTION);
+    if (filters.status) {
+      query = query.where('status', '==', filters.status);
+    }
+    const snapshot = await query.get();
+    return snapshot.docs
+      .map((doc) => docToAttribution(doc))
+      .filter((a): a is PosLessonAttribution => a !== undefined)
+      .sort((a, b) => b.occurredAt.getTime() - a.occurredAt.getTime());
+  },
+
+  async findById(id: string): Promise<PosLessonAttribution | undefined> {
+    const doc = await db.collection(COLLECTION).doc(id).get();
+    return docToAttribution(doc);
+  },
+
+  /**
+   * Capture a POS lesson sale. Idempotent on the deterministic id — a retried
+   * webhook returns the existing record rather than duplicating it. Optionally
+   * created already-`attributed` when the caller resolved a student inline
+   * (the auto-attribution path).
+   */
+  async capture(
+    input: CreatePosLessonAttributionInput,
+    attribution?: {
+      status: Extract<PosLessonAttributionStatus, 'pending' | 'attributed'>;
+      studentId?: string;
+      invoiceId?: string;
+      attributedBy?: string;
+    }
+  ): Promise<PosLessonAttribution> {
+    const id = posLessonAttributionId(
+      input.squarePaymentId,
+      input.catalogObjectId
+    );
+    const docRef = db.collection(COLLECTION).doc(id);
+    const existing = await docRef.get();
+    if (existing.exists) {
+      return docToAttribution(existing)!;
+    }
+
+    const now = new Date();
+    const status = attribution?.status ?? 'pending';
+    const data = {
+      ...input,
+      occurredAt: input.occurredAt,
+      status,
+      studentId: attribution?.studentId,
+      invoiceId: attribution?.invoiceId,
+      attributedBy: attribution?.attributedBy,
+      attributedAt: status === 'attributed' ? now : undefined,
+      createdAt: now,
+      updatedAt: now,
+    };
+    await docRef.set(data);
+    return docToAttribution(await docRef.get())!;
+  },
+
+  /** Mark an attribution resolved to a student + invoice (manual path, PR 2). */
+  async attribute(args: {
+    id: string;
+    studentId: string;
+    invoiceId: string;
+    attributedBy: string;
+  }): Promise<PosLessonAttribution> {
+    const docRef = db.collection(COLLECTION).doc(args.id);
+    await docRef.update({
+      status: 'attributed' as PosLessonAttributionStatus,
+      studentId: args.studentId,
+      invoiceId: args.invoiceId,
+      attributedBy: args.attributedBy,
+      attributedAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const updated = docToAttribution(await docRef.get());
+    if (!updated) throw new Error(`Attribution ${args.id} not found after update`);
+    return updated;
+  },
+
+  /** Dismiss an attribution (e.g. refunded, or not actually a lesson). */
+  async dismiss(args: {
+    id: string;
+    dismissedBy: string;
+    notes?: string;
+  }): Promise<PosLessonAttribution> {
+    const docRef = db.collection(COLLECTION).doc(args.id);
+    const updates: Record<string, unknown> = {
+      status: 'dismissed' as PosLessonAttributionStatus,
+      attributedBy: args.dismissedBy,
+      attributedAt: new Date(),
+      updatedAt: new Date(),
+    };
+    if (args.notes !== undefined) updates.notes = args.notes;
+    await docRef.update(updates);
+    const updated = docToAttribution(await docRef.get());
+    if (!updated) throw new Error(`Attribution ${args.id} not found after update`);
+    return updated;
+  },
+
+  async getSummary(): Promise<PosLessonAttributionSummary> {
+    const all = await this.findAll();
+    const summary: PosLessonAttributionSummary = {
+      pending: 0,
+      attributed: 0,
+      dismissed: 0,
+    };
+    for (const a of all) summary[a.status]++;
+    return summary;
+  },
+};

--- a/libs/firebase/database/src/lib/pos-lesson-config.repository.ts
+++ b/libs/firebase/database/src/lib/pos-lesson-config.repository.ts
@@ -1,0 +1,51 @@
+/**
+ * POS Lesson Config Repository
+ *
+ * Single config doc (`appConfig/posLessons`) holding the Square catalog
+ * object (variation) ids that count as music lessons at the POS. Read by
+ * `processPosSale` to route lesson line items to attribution (#628); managed
+ * from the admin app (PR 2).
+ */
+import { db, toDate } from './utilities/database.config';
+import type { PosLessonConfig } from '@maple/ts/domain';
+
+const CONFIG_COLLECTION = 'appConfig';
+const CONFIG_DOC = 'posLessons';
+
+function docRef() {
+  return db.collection(CONFIG_COLLECTION).doc(CONFIG_DOC);
+}
+
+export const PosLessonConfigRepository = {
+  async get(): Promise<PosLessonConfig> {
+    const doc = await docRef().get();
+    if (!doc.exists) {
+      return { lessonCatalogObjectIds: [] };
+    }
+    const data = doc.data()!;
+    return {
+      lessonCatalogObjectIds: data.lessonCatalogObjectIds ?? [],
+      updatedAt: data.updatedAt ? toDate(data.updatedAt) : undefined,
+      updatedByUid: data.updatedByUid,
+    };
+  },
+
+  async getLessonCatalogObjectIds(): Promise<string[]> {
+    return (await this.get()).lessonCatalogObjectIds;
+  },
+
+  async setLessonCatalogObjectIds(
+    lessonCatalogObjectIds: string[],
+    updatedByUid?: string
+  ): Promise<PosLessonConfig> {
+    await docRef().set(
+      {
+        lessonCatalogObjectIds,
+        updatedAt: new Date(),
+        updatedByUid: updatedByUid ?? null,
+      },
+      { merge: true }
+    );
+    return this.get();
+  },
+};

--- a/libs/firebase/database/src/lib/student.repository.ts
+++ b/libs/firebase/database/src/lib/student.repository.ts
@@ -75,6 +75,23 @@ export const StudentRepository = {
     return docToStudent(doc);
   },
 
+  /**
+   * Find students whose primary contact email matches (case-insensitive on the
+   * caller's part — pass an already-normalized email). Returns an array
+   * because siblings share a parent/guardian email; callers auto-attribute
+   * only when exactly one student matches and route ambiguous (0 or >1) cases
+   * to human review. See #628.
+   */
+  async findByPrimaryContactEmail(email: string): Promise<Student[]> {
+    const snapshot = await db
+      .collection(COLLECTION)
+      .where('primaryContactEmail', '==', email)
+      .get();
+    return snapshot.docs
+      .map((doc) => docToStudent(doc))
+      .filter((s): s is Student => s !== undefined);
+  },
+
   async create(input: CreateStudentInput): Promise<Student> {
     const docRef = db.collection(COLLECTION).doc();
     const now = new Date();

--- a/libs/firebase/maple-functions/process-pos-sale/src/lib/process-pos-sale.spec.ts
+++ b/libs/firebase/maple-functions/process-pos-sale/src/lib/process-pos-sale.spec.ts
@@ -20,6 +20,15 @@ const mocks = vi.hoisted(() => ({
   createRegistration: vi.fn(),
   // ClassRepository
   findBySquareVariationId: vi.fn(),
+  // PosLessonConfigRepository
+  getLessonCatalogObjectIds: vi.fn(),
+  // PosLessonAttributionRepository
+  attrFindById: vi.fn(),
+  attrCapture: vi.fn(),
+  // StudentRepository
+  findByPrimaryContactEmail: vi.fn(),
+  // InvoiceRepository
+  settleOrCreatePosLessonInvoice: vi.fn(),
   // Square services
   getPayment: vi.fn(),
   getOrder: vi.fn(),
@@ -56,6 +65,21 @@ vi.mock('@maple/firebase/database', () => ({
   ClassRepository: {
     findBySquareVariationId: mocks.findBySquareVariationId,
   },
+  PosLessonConfigRepository: {
+    getLessonCatalogObjectIds: mocks.getLessonCatalogObjectIds,
+  },
+  PosLessonAttributionRepository: {
+    findById: mocks.attrFindById,
+    capture: mocks.attrCapture,
+  },
+  StudentRepository: {
+    findByPrimaryContactEmail: mocks.findByPrimaryContactEmail,
+  },
+  InvoiceRepository: {
+    settleOrCreatePosLessonInvoice: mocks.settleOrCreatePosLessonInvoice,
+  },
+  posLessonAttributionId: (paymentId: string, catalogObjectId: string) =>
+    `${paymentId}__${catalogObjectId}`,
 }));
 
 vi.mock('@maple/firebase/square', () => ({
@@ -118,6 +142,16 @@ beforeEach(() => {
     priceCents: 4500,
   });
   mocks.createRegistration.mockResolvedValue({ id: 'reg-new' });
+  // Lesson defaults: no configured lesson items → lesson path never fires for
+  // the class/registration tests above.
+  mocks.getLessonCatalogObjectIds.mockResolvedValue([]);
+  mocks.attrFindById.mockResolvedValue(undefined);
+  mocks.attrCapture.mockResolvedValue({ id: 'attr-1' });
+  mocks.findByPrimaryContactEmail.mockResolvedValue([]);
+  mocks.settleOrCreatePosLessonInvoice.mockResolvedValue({
+    invoice: { id: 'inv-pos-1' },
+    settledExisting: false,
+  });
 });
 
 describe('processPosSale — early exits', () => {
@@ -335,6 +369,149 @@ describe('processPosSale — registration creation', () => {
 
     expect(mocks.findBySquareVariationId).not.toHaveBeenCalled();
     expect(mocks.createRegistration).not.toHaveBeenCalled();
+    expect(mocks.markProcessed).toHaveBeenCalledWith('PAY-1');
+  });
+});
+
+describe('processPosSale — lesson attribution', () => {
+  const lessonLine = {
+    catalogObjectId: 'VAR_LESSON',
+    name: 'Guitar Lesson',
+    quantity: 1,
+    basePriceCents: 3000,
+    grossSalesCents: 3000,
+    totalTaxCents: 0,
+    totalCents: 3000,
+  };
+
+  beforeEach(() => {
+    // Configure VAR_LESSON as a lesson item; it is NOT a class.
+    mocks.getLessonCatalogObjectIds.mockResolvedValue(['VAR_LESSON']);
+    mocks.findBySquareVariationId.mockResolvedValue(undefined);
+    mocks.getPayment.mockResolvedValue({
+      paymentId: 'PAY-1',
+      status: 'COMPLETED',
+      orderId: 'ORDER-1',
+      customerId: 'cust-1',
+      receiptUrl: 'https://squareup.com/receipt/pos',
+      createdAt: '2026-07-17T15:00:00Z',
+    });
+    mocks.getOrder.mockResolvedValue({
+      orderId: 'ORDER-1',
+      lineItems: [lessonLine],
+    });
+    mocks.getCustomer.mockResolvedValue({
+      emailAddress: 'parent@example.com',
+      givenName: 'Casey',
+      familyName: 'Nguyen',
+    });
+  });
+
+  it('auto-attributes when the customer email maps to exactly one student', async () => {
+    mocks.findByPrimaryContactEmail.mockResolvedValue([{ id: 'student-1' }]);
+    mocks.settleOrCreatePosLessonInvoice.mockResolvedValue({
+      invoice: { id: 'inv-9' },
+      settledExisting: true,
+    });
+
+    await handler(makeEvent({ orderId: 'ORDER-1' }));
+
+    expect(mocks.settleOrCreatePosLessonInvoice).toHaveBeenCalledWith(
+      expect.objectContaining({
+        studentId: 'student-1',
+        subtotalCents: 3000,
+        squarePaymentId: 'PAY-1',
+        squareOrderId: 'ORDER-1',
+      })
+    );
+    expect(mocks.attrCapture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        catalogObjectId: 'VAR_LESSON',
+        itemName: 'Guitar Lesson',
+        subtotalCents: 3000,
+        amountPaidCents: 3000,
+        customerEmail: 'parent@example.com',
+      }),
+      expect.objectContaining({
+        status: 'attributed',
+        studentId: 'student-1',
+        invoiceId: 'inv-9',
+        attributedBy: 'auto',
+      })
+    );
+    expect(mocks.mailAdd).not.toHaveBeenCalled();
+    expect(mocks.createRegistration).not.toHaveBeenCalled();
+    expect(mocks.markProcessed).toHaveBeenCalledWith('PAY-1');
+  });
+
+  it('queues (pending) + emails when the email matches no student', async () => {
+    mocks.findByPrimaryContactEmail.mockResolvedValue([]);
+
+    await handler(makeEvent({ orderId: 'ORDER-1' }));
+
+    expect(mocks.settleOrCreatePosLessonInvoice).not.toHaveBeenCalled();
+    expect(mocks.attrCapture).toHaveBeenCalledTimes(1);
+    // Second arg (attribution) omitted → captured as pending.
+    expect(mocks.attrCapture.mock.calls[0][1]).toBeUndefined();
+    expect(mocks.mailAdd).toHaveBeenCalledTimes(1);
+    expect(mocks.mailAdd.mock.calls[0][0].message.subject).toMatch(
+      /needs attribution/i
+    );
+    expect(mocks.markProcessed).toHaveBeenCalledWith('PAY-1');
+  });
+
+  it('queues (does not auto-attribute) when siblings share the parent email', async () => {
+    mocks.findByPrimaryContactEmail.mockResolvedValue([
+      { id: 'student-a' },
+      { id: 'student-b' },
+    ]);
+
+    await handler(makeEvent({ orderId: 'ORDER-1' }));
+
+    expect(mocks.settleOrCreatePosLessonInvoice).not.toHaveBeenCalled();
+    expect(mocks.attrCapture.mock.calls[0][1]).toBeUndefined();
+    expect(mocks.mailAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it('queues when the sale carried no customer email', async () => {
+    mocks.getPayment.mockResolvedValue({
+      paymentId: 'PAY-1',
+      status: 'COMPLETED',
+      orderId: 'ORDER-1',
+      customerId: undefined,
+      createdAt: '2026-07-17T15:00:00Z',
+    });
+
+    await handler(makeEvent({ orderId: 'ORDER-1' }));
+
+    expect(mocks.findByPrimaryContactEmail).not.toHaveBeenCalled();
+    expect(mocks.settleOrCreatePosLessonInvoice).not.toHaveBeenCalled();
+    expect(mocks.attrCapture.mock.calls[0][1]).toBeUndefined();
+    expect(mocks.mailAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it('is idempotent — skips a line item already captured', async () => {
+    mocks.attrFindById.mockResolvedValue({ id: 'PAY-1__VAR_LESSON' });
+
+    await handler(makeEvent({ orderId: 'ORDER-1' }));
+
+    expect(mocks.attrCapture).not.toHaveBeenCalled();
+    expect(mocks.settleOrCreatePosLessonInvoice).not.toHaveBeenCalled();
+    expect(mocks.mailAdd).not.toHaveBeenCalled();
+    expect(mocks.markProcessed).toHaveBeenCalledWith('PAY-1');
+  });
+
+  it('ignores a line item that is neither a class nor a configured lesson', async () => {
+    mocks.getOrder.mockResolvedValue({
+      orderId: 'ORDER-1',
+      lineItems: [{ catalogObjectId: 'VAR_RETAIL', name: 'A mug', quantity: 1 }],
+    });
+
+    await handler(makeEvent({ orderId: 'ORDER-1' }));
+
+    expect(mocks.attrCapture).not.toHaveBeenCalled();
+    expect(mocks.createRegistration).not.toHaveBeenCalled();
+    expect(mocks.mailAdd).not.toHaveBeenCalled();
     expect(mocks.markProcessed).toHaveBeenCalledWith('PAY-1');
   });
 });

--- a/libs/firebase/maple-functions/process-pos-sale/src/lib/process-pos-sale.ts
+++ b/libs/firebase/maple-functions/process-pos-sale/src/lib/process-pos-sale.ts
@@ -18,7 +18,10 @@
  *     and orders already turned into a registration (squareOrderId).
  *  5. For each order line item that maps to a class variation, create a
  *     `source:'pos'` registration. When the sale carried no customer email,
- *     queue an admin alert so staff can collect it.
+ *     queue an admin alert so staff can collect it. A line item that matches a
+ *     configured lesson catalog item is instead attributed to a student —
+ *     automatically when the customer email maps to exactly one student, else
+ *     captured in the POS-lesson review queue for a human (#628).
  *
  * Creating the registration fires PR B's `syncClassInventoryToSquare`, which
  * reconciles remaining POS stock — nothing extra to do here for inventory.
@@ -28,8 +31,13 @@ import { defineSecret, defineString } from 'firebase-functions/params';
 import {
   getDb,
   ClassRepository,
+  InvoiceRepository,
+  PosLessonAttributionRepository,
+  PosLessonConfigRepository,
   PosSaleRequestRepository,
   RegistrationRepository,
+  StudentRepository,
+  posLessonAttributionId,
 } from '@maple/firebase/database';
 import {
   Square,
@@ -144,16 +152,125 @@ export const processPosSale = onDocumentWritten(
 
       const taxRatePercent = square.taxRatePercent;
 
-      // 5. Create one registration per line item that maps to a class. Line
-      // items that don't map (retail products, misc POS items) are ignored.
+      // Configured lesson catalog items (e.g. a "Guitar Lesson" POS button).
+      // Lessons aren't sold as a per-student catalog item, so a lesson line
+      // needs human/auto attribution rather than a class registration (#628).
+      const lessonCatalogIds = new Set(
+        await PosLessonConfigRepository.getLessonCatalogObjectIds()
+      );
+
+      // 5. Walk the line items. A class variation → a `source:'pos'`
+      // registration. A configured lesson item → attribute to a student
+      // (auto by customer email, else a review-queue entry). Everything else
+      // (retail products, misc POS items) is ignored.
       let created = 0;
+      let lessonsAttributed = 0;
+      let lessonsPending = 0;
       for (const lineItem of order.lineItems) {
         if (!lineItem.catalogObjectId) continue;
 
         const classEntity = await ClassRepository.findBySquareVariationId(
           lineItem.catalogObjectId
         );
-        if (!classEntity) continue;
+        if (!classEntity) {
+          // Not a class. If it's a configured lesson item, capture/attribute
+          // it; otherwise it's retail/misc and we ignore it.
+          if (!lessonCatalogIds.has(lineItem.catalogObjectId)) continue;
+
+          const attrId = posLessonAttributionId(
+            paymentId,
+            lineItem.catalogObjectId
+          );
+          if (await PosLessonAttributionRepository.findById(attrId)) {
+            // Already captured on a prior run — idempotent.
+            continue;
+          }
+
+          const lessonQty =
+            Number.isFinite(lineItem.quantity) && lineItem.quantity > 0
+              ? Math.round(lineItem.quantity)
+              : 1;
+          const lessonSubtotalCents =
+            lineItem.grossSalesCents ??
+            (lineItem.basePriceCents ?? 0) * lessonQty;
+          const lessonAmountPaidCents =
+            lineItem.totalCents ??
+            lessonSubtotalCents + (lineItem.totalTaxCents ?? 0);
+          const itemName = lineItem.name ?? 'Music lesson';
+          const occurredAt = payment.createdAt
+            ? new Date(payment.createdAt)
+            : new Date();
+
+          const captureInput = {
+            squarePaymentId: paymentId,
+            squareOrderId: orderId,
+            catalogObjectId: lineItem.catalogObjectId,
+            itemName,
+            quantity: lessonQty,
+            subtotalCents: lessonSubtotalCents,
+            amountPaidCents: lessonAmountPaidCents,
+            occurredAt,
+            squareReceiptUrl: payment.receiptUrl,
+            squareCustomerId: customerId,
+            customerEmail,
+            customerName,
+          };
+
+          // Auto-attribute only when the customer email maps to EXACTLY one
+          // student — siblings share a parent email, so 0 or >1 matches are
+          // ambiguous and go to human review.
+          let didAttribute = false;
+          if (customerEmail) {
+            const matches =
+              await StudentRepository.findByPrimaryContactEmail(customerEmail);
+            if (matches.length === 1) {
+              const { invoice } =
+                await InvoiceRepository.settleOrCreatePosLessonInvoice({
+                  studentId: matches[0].id,
+                  subtotalCents: lessonSubtotalCents,
+                  description: `In-person lesson — ${itemName}`,
+                  squarePaymentId: paymentId,
+                  squareOrderId: orderId,
+                  // Auto path — no human uid.
+                });
+              await PosLessonAttributionRepository.capture(captureInput, {
+                status: 'attributed',
+                studentId: matches[0].id,
+                invoiceId: invoice.id,
+                attributedBy: 'auto',
+              });
+              didAttribute = true;
+              lessonsAttributed++;
+            }
+          }
+
+          if (!didAttribute) {
+            await PosLessonAttributionRepository.capture(captureInput);
+            lessonsPending++;
+            // Alert staff that an in-person lesson sale needs a student.
+            await db.collection('mail').add({
+              to: adminAlertEmail.value(),
+              message: {
+                subject: `POS lesson sale needs attribution — ${itemName}`,
+                text: [
+                  'An in-person POS lesson sale could not be matched to a student automatically.',
+                  '',
+                  `Item: ${itemName}`,
+                  `Amount paid: ${formatCurrency(lessonAmountPaidCents)}`,
+                  customerEmail ? `Customer email: ${customerEmail}` : 'No customer email on the sale',
+                  `Square order: ${orderId}`,
+                  `Square payment: ${paymentId}`,
+                  payment.receiptUrl ? `Receipt: ${payment.receiptUrl}` : '',
+                  '',
+                  'Open the POS lesson review queue in the admin app to pick the student.',
+                ]
+                  .filter((line) => line !== '')
+                  .join('\n'),
+              },
+            });
+          }
+          continue;
+        }
 
         const quantity =
           Number.isFinite(lineItem.quantity) && lineItem.quantity > 0
@@ -238,7 +355,9 @@ export const processPosSale = onDocumentWritten(
       }
 
       console.log(
-        `[process-pos-sale] payment=${paymentId} order=${orderId} created=${created} registration(s)`
+        `[process-pos-sale] payment=${paymentId} order=${orderId} ` +
+          `created=${created} registration(s) ` +
+          `lessons(attributed=${lessonsAttributed}, pending=${lessonsPending})`
       );
 
       await PosSaleRequestRepository.markProcessed(paymentId);

--- a/libs/ts/domain/src/index.ts
+++ b/libs/ts/domain/src/index.ts
@@ -22,6 +22,8 @@ export * from './lib/schedule-format';
 export * from './lib/class-category';
 export * from './lib/registration';
 export * from './lib/pos-sale-request';
+export * from './lib/pos-lesson-attribution';
+export * from './lib/pos-lesson-config';
 export * from './lib/discount';
 export * from './lib/tax';
 export * from './lib/class-waitlist';

--- a/libs/ts/domain/src/lib/invoice.ts
+++ b/libs/ts/domain/src/lib/invoice.ts
@@ -51,6 +51,9 @@ export interface InvoiceLineItem {
  *                        (student scanned the business Venmo QR at a lesson).
  *  - `venmo-import`    — the Venmo statement reconciliation tool matched a
  *                        statement row to this invoice (see #630).
+ *  - `square-pos`      — an in-person Square POS lesson sale was attributed to
+ *                        this invoice (auto by customer email, or by a human
+ *                        from the review queue). See #628.
  *
  * Venmo Business Profiles have no API/webhook, so Venmo payments are attested
  * by a human (`venmo-manual`) and later confirmed by CSV import
@@ -60,7 +63,8 @@ export type InvoicePaymentSource =
   | 'admin-manual'
   | 'square-webhook'
   | 'venmo-manual'
-  | 'venmo-import';
+  | 'venmo-import'
+  | 'square-pos';
 
 /**
  * Payment sources a human can record by hand from the UI. Excludes the

--- a/libs/ts/domain/src/lib/pos-lesson-attribution.ts
+++ b/libs/ts/domain/src/lib/pos-lesson-attribution.ts
@@ -1,0 +1,87 @@
+/**
+ * POS Lesson Attribution domain types
+ *
+ * When a music lesson is rung up on the Square POS (a configured lesson
+ * catalog item, e.g. "Guitar Lesson"), `processPosSale` can't tell which
+ * student it was — lessons, unlike classes, are not sold as a per-student
+ * catalog item. This record captures that in-person lesson sale so it never
+ * silently disappears (the leak #628 closes):
+ *
+ *  - Auto-attributed when the Square customer's email maps to exactly one
+ *    known student (status `attributed`, `attributedBy: 'auto'`).
+ *  - Otherwise recorded `pending` for a human to resolve from the review
+ *    queue (PR 2), picking the student.
+ *
+ * On attribution the matching open invoice is settled (`square-pos`), or a
+ * paid invoice is created — so lesson payments and teacher payouts stay
+ * consistent regardless of how the money came in. See epic #626.
+ */
+
+export type PosLessonAttributionStatus = 'pending' | 'attributed' | 'dismissed';
+
+export const POS_LESSON_ATTRIBUTION_STATUSES: PosLessonAttributionStatus[] = [
+  'pending',
+  'attributed',
+  'dismissed',
+];
+
+export interface PosLessonAttribution {
+  id: string;
+  /** Square payment id of the POS sale. */
+  squarePaymentId: string;
+  /** Square order id the line item belongs to. */
+  squareOrderId: string;
+  /** Square catalog object (variation) id of the lesson line item. */
+  catalogObjectId: string;
+  /** Line item name as it appeared on the Square order (e.g. "Guitar Lesson"). */
+  itemName: string;
+  quantity: number;
+  /** Pre-tax subtotal Square recorded for the line, in cents — used to match
+   *  an open invoice (invoice totals are pre-tax). */
+  subtotalCents: number;
+  /** Total the customer actually paid for the line (incl. tax), in cents —
+   *  shown in the queue for reference. */
+  amountPaidCents: number;
+  /** When the POS sale happened (Square payment createdAt). */
+  occurredAt: Date;
+  squareReceiptUrl?: string;
+  squareCustomerId?: string;
+  customerEmail?: string;
+  customerName?: string;
+
+  status: PosLessonAttributionStatus;
+  /** Set once attributed (auto or manual). */
+  studentId?: string;
+  /** Invoice settled or created on attribution. */
+  invoiceId?: string;
+  /** `'auto'` when matched by customer email, else the resolver's uid. */
+  attributedBy?: string;
+  attributedAt?: Date;
+  notes?: string;
+
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** Fields the POS processor supplies when first capturing a sale. */
+export type CreatePosLessonAttributionInput = Pick<
+  PosLessonAttribution,
+  | 'squarePaymentId'
+  | 'squareOrderId'
+  | 'catalogObjectId'
+  | 'itemName'
+  | 'quantity'
+  | 'subtotalCents'
+  | 'amountPaidCents'
+  | 'occurredAt'
+  | 'squareReceiptUrl'
+  | 'squareCustomerId'
+  | 'customerEmail'
+  | 'customerName'
+>;
+
+export interface PosLessonAttributionSummary {
+  pending: number;
+  attributed: number;
+  dismissed: number;
+}

--- a/libs/ts/domain/src/lib/pos-lesson-config.ts
+++ b/libs/ts/domain/src/lib/pos-lesson-config.ts
@@ -1,0 +1,17 @@
+/**
+ * POS Lesson Config domain type
+ *
+ * Which Square catalog items count as "a music lesson" when rung up at the
+ * POS. Lessons are not synced to the Square catalog per-student the way
+ * classes are (they're scheduled events, not sellable items), so the studio
+ * rings up a generic lesson item (e.g. a "Guitar Lesson" button). This config
+ * holds the catalog object (variation) ids of those items; `processPosSale`
+ * routes a line item whose catalogObjectId is in the set to lesson
+ * attribution (#628). Managed from the admin app (PR 2).
+ */
+export interface PosLessonConfig {
+  /** Square catalog object (variation) ids that represent music lessons. */
+  lessonCatalogObjectIds: string[];
+  updatedAt?: Date;
+  updatedByUid?: string;
+}


### PR DESCRIPTION
Part of #628 (epic #626). **Backend PR 1 of 2** — detection + attribution logic + repos. PR 2 adds the review-queue admin UI, manual attribute/dismiss callables, and the lesson-catalog config manager.

## The leak this closes

A lesson rung up on the Square POS (e.g. a "Guitar Lesson" catalog item) produced **no platform record**: `processPosSale` walks POS order line items, maps each to a class, and creates a `source:'pos'` registration — but a lesson line item matches no class, so it was silently skipped (`process-pos-sale.ts` line ~156). The money existed only in Square.

## What this does (per your #628 decisions)

**Detect** — `PosLessonConfig` (`appConfig/posLessons`) holds the Square catalog object ids that count as lessons. `processPosSale` reads it and routes a matching line item to attribution instead of ignoring it.

**Attribute**
- **Auto** when the Square customer email maps to **exactly one** student. Siblings share a parent/guardian email, so 0 or >1 matches are ambiguous → human review (never a wrong guess).
- On attribution: **settle** the student's single open `sent` invoice whose pre-tax total matches the sale, **else create** a paid invoice — new `InvoicePaymentSource` `'square-pos'`. Everything stays in the invoice model, so teacher-payout aggregation flows through unchanged.
- **No auto-match** → capture a `pending` `PosLessonAttribution` + email `ADMIN_ALERT_EMAIL`, for resolution from the review queue (PR 2).
- **Idempotent** on a deterministic id `${paymentId}__${catalogObjectId}` — a Square webhook retry never double-captures.

## New surface

- Domain: `PosLessonAttribution` (+ statuses/summary), `PosLessonConfig`, `InvoicePaymentSource += 'square-pos'`.
- Repos: `PosLessonAttributionRepository` (capture/attribute/dismiss/findAll/getSummary), `PosLessonConfigRepository`, `StudentRepository.findByPrimaryContactEmail`, `InvoiceRepository.{markPaidByPosSale, createPosPaidInvoice, settleOrCreatePosLessonInvoice}`.
- `processPosSale` lesson branch.

## Verification

- **Unit** `processPosSale`: auto-attribute, no-match queue+email, sibling ambiguity → queue, no-email → queue, idempotent skip, non-lesson ignored — plus every existing class-registration case still green (18 tests). ✅
- **Unit** `settleOrCreatePosLessonInvoice`: settle-one / create-when-none / create-when-ambiguous decision logic. ✅
- Index analyzer clean (single-field wheres + in-memory sort — no new composite indexes); all 4 function codebases build; 611 database+domain unit tests green.

## On integration coverage

PR 1 has **no new callable** (detection runs inside the `processPosSale` trigger), and there's no existing POS integration harness. The orchestration is thoroughly unit-tested. **PR 2 introduces the `attributePosLessonSale` callable, which is the natural integration entry point** — its emulator integration test exercises `settleOrCreatePosLessonInvoice` / the attribution repo end-to-end there.

## Operational note

Detection is inert until the lesson catalog ids are configured (`appConfig/posLessons`). PR 2 ships the admin UI to manage them; until then the config can be seeded directly. Nothing regresses in the meantime — class POS registrations behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)