### PR TITLE
fix(security): override adm-zip to >=0.6.0 (GHSA-xcpc-8h2w-3j85)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,7 @@ overrides:
   http-proxy-middleware@>=3.0.4 <3.0.7: '>=3.0.7'
   piscina@<4.9.3: '>=4.9.3'
   '@xhmikosr/decompress@>=11.0.0 <11.1.3': '>=11.1.3'
+  adm-zip: '>=0.6.0'
   websocket-driver@<0.7.5: '>=0.7.5'
   qs@>=6.11.1 <=6.15.1: '>=6.15.2'
   joi@<18.2.1: '>=18.2.1'
@@ -4765,13 +4766,9 @@ packages:
     resolution: {integrity: sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==}
     engines: {node: '>= 10.0.0'}
 
-  adm-zip@0.5.10:
-    resolution: {integrity: sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==}
-    engines: {node: '>=6.0'}
-
-  adm-zip@0.5.17:
-    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
-    engines: {node: '>=12.0'}
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -13337,7 +13334,7 @@ snapshots:
       '@module-federation/managers': 0.20.0
       '@module-federation/sdk': 0.20.0
       '@module-federation/third-party-dts-extractor': 0.20.0
-      adm-zip: 0.5.17
+      adm-zip: 0.6.0
       ansi-colors: 4.1.3
       axios: 1.16.0
       chalk: 3.0.0
@@ -13362,7 +13359,7 @@ snapshots:
       '@module-federation/managers': 2.3.2(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/sdk': 2.3.2(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/third-party-dts-extractor': 2.3.2
-      adm-zip: 0.5.10
+      adm-zip: 0.6.0
       ansi-colors: 4.1.3
       isomorphic-ws: 5.0.0(ws@8.21.0)
       node-schedule: 2.1.1
@@ -16241,9 +16238,7 @@ snapshots:
 
   address@1.2.2: {}
 
-  adm-zip@0.5.10: {}
-
-  adm-zip@0.5.17: {}
+  adm-zip@0.6.0: {}
 
   agent-base@6.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -149,6 +149,11 @@ overrides:
   # (patched in 11.1.3). Transitive dep of @swc/cli > @xhmikosr/bin-wrapper >
   # @xhmikosr/downloader > @xhmikosr/decompress. Added 2026-07-06.
   '@xhmikosr/decompress@>=11.0.0 <11.1.3': '>=11.1.3'
+  # GHSA-xcpc-8h2w-3j85: adm-zip crafted ZIP triggers 4GB memory allocation
+  # DoS (patched in 0.6.0, current latest). Dev-only transitive dep of
+  # @nx/next > @nx/react > @nx/module-federation > @module-federation/*
+  # > @module-federation/dts-plugin and @webflow/webflow-cli. Added 2026-07-17.
+  adm-zip: '>=0.6.0'
   # GHSA-xv26-6w52-cph6 (critical): websocket-driver message corruption via
   # abuse of protocol length headers, plus resource-limit bypass via message
   # compression. Both patched in 0.7.5. Transitive dep of firebase &


### PR DESCRIPTION
## What

Adds a range-scoped `overrides:` entry in `pnpm-workspace.yaml` bumping `adm-zip` to `>=0.6.0`, clearing the **high** advisory that fails the `Security Audit` CI job (`pnpm audit --audit-level=high`).

## Why

`adm-zip <0.6.0` lets a crafted ZIP trigger a 4GB memory-allocation DoS — [GHSA-xcpc-8h2w-3j85](https://github.com/advisories/GHSA-xcpc-8h2w-3j85). Patched in `0.6.0` (current `latest`, published 2026-07-10).

It is a **dev-only** transitive dep, pulled two ways by module-federation's `dts-plugin`:
- `@nx/next > @nx/react > @nx/module-federation > @module-federation/*` (was 0.5.10)
- `@webflow/webflow-cli > @module-federation/enhanced` (was 0.5.17)

Not in any Cloud Function or app runtime path.

## Verification

- `pnpm install` regenerated the lockfile; `adm-zip` now resolves to `0.6.0` at every path (`pnpm why adm-zip`).
- `pnpm audit --audit-level=high` → **exit 0** (remaining 5 are 3 low / 2 moderate, below the CI gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)