### PR TITLE
test(square-mock): reject reserved-TLD emails on Customers Search (catch the #634 class)

### DIFF
--- a/apps/functions-integration-tests-music-together/src/create-music-together-registration.spec.ts
+++ b/apps/functions-integration-tests-music-together/src/create-music-together-registration.spec.ts
@@ -158,6 +158,37 @@ describe('createMusicTogetherRegistration', () => {
     expect(String(charges[0].idempotencyKey)).toMatch(/^mt-charge-/);
   });
 
+  it('installments: an email Square Customers Search rejects still succeeds via the create fallback', async () => {
+    // Real Square's Customers Search rejects reserved-TLD emails (the mock now
+    // mirrors this). upsertByEmail must treat that search failure as "not
+    // found" and create the customer anyway (#634) — otherwise the whole
+    // installment registration fails. This is the class of bug the real-Square
+    // e2e caught but the mock previously hid.
+    const result = await callFunction<
+      CreateMusicTogetherRegistrationRequest,
+      CreateMusicTogetherRegistrationResponse
+    >({
+      functionName: 'createMusicTogetherRegistration',
+      data: family({
+        email: 'search-rejected@maplespruce.test',
+        paymentPlan: 'installments',
+        cardOnFileAuth: true,
+        cardVerificationToken: 'verf:store-token',
+      }),
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data?.status).toBe('confirmed');
+
+    const reg = await getFirestoreDoc(
+      'musicTogetherRegistrations',
+      result.data!.registrationId
+    );
+    // The customer was created despite the search rejection.
+    expect(String(reg?.squareCustomerId)).toMatch(/^mock-customer-/);
+    expect(String(reg?.squareCardId)).toMatch(/^ccof:mock-card-/);
+  });
+
   it('full pay: charges the sibling-discounted total for a 2-child family', async () => {
     const result = await callFunction<
       CreateMusicTogetherRegistrationRequest,

--- a/libs/firebase/square-test-mock-server/src/lib/routes/square.ts
+++ b/libs/firebase/square-test-mock-server/src/lib/routes/square.ts
@@ -423,10 +423,58 @@ function registerMockControlRoutes(server: SquareMockServer): void {
  * Craft Club routes: Square customers, cards on file, and subscriptions.
  * Split out to keep `registerSquareRoutes` readable.
  */
+/**
+ * Reserved / non-deliverable TLDs (RFC 2606 + RFC 6761) that real Square's
+ * Customers Search rejects as invalid email. CreateCustomer is more lenient.
+ */
+const SEARCH_REJECTED_TLDS = new Set(['test', 'example', 'invalid', 'localhost']);
+
+/** True if real Square's Customers Search would reject this email filter. */
+function isSearchRejectedEmail(email: string): boolean {
+  const domain = email.split('@')[1];
+  if (!domain) return false;
+  const tld = domain.split('.').pop()?.toLowerCase();
+  return !!tld && SEARCH_REJECTED_TLDS.has(tld);
+}
+
+/** Pull the email out of a Customers Search body's exact/fuzzy filter. */
+function extractSearchEmail(body: unknown): string | undefined {
+  const filter = (
+    body as {
+      query?: { filter?: { email_address?: { exact?: string; fuzzy?: string } } };
+    }
+  )?.query?.filter?.email_address;
+  return filter?.exact ?? filter?.fuzzy;
+}
+
 function registerCraftClubRoutes(server: SquareMockServer): void {
   // Search customers by email (upsert lookup). Default: none found → caller
   // proceeds to create. Returns an empty list so each test starts clean.
-  server.post('/v2/customers/search', () => {
+  //
+  // Real Square's Customers Search validates the email filter MORE strictly
+  // than CreateCustomer and rejects some addresses with INVALID_VALUE — e.g.
+  // reserved/undeliverable TLDs (.test/.example/.invalid/.localhost). The mock
+  // mirrors that so integration tests catch the class of bug where a customer
+  // upsert doesn't tolerate a search failure (fixed in #634: fall through to
+  // create). Real customer emails (deliverable domains) still return empty.
+  server.post('/v2/customers/search', (req) => {
+    const email = extractSearchEmail(req.body);
+    if (email && isSearchRejectedEmail(email)) {
+      return {
+        status: 400,
+        body: {
+          errors: [
+            {
+              category: 'INVALID_REQUEST_ERROR',
+              code: 'INVALID_VALUE',
+              detail:
+                'The provided email address is invalid. For more information, please refer to the Search endpoint technical reference.',
+              field: 'email',
+            },
+          ],
+        },
+      };
+    }
     return { status: 200, body: { customers: [] } };
   });
 


### PR DESCRIPTION
Follow-up to the MT installment incident (#634). Closes the test-harness gap that let it through.

## Why

The installment vault bug was invisible to the Square **mock**: real Square's Customers *Search* rejects some emails with `INVALID_VALUE` that CreateCustomer accepts, but the mock rubber-stamped every search (`{ customers: [] }`), so mock-backed integration tests passed while real Square failed. Only the real-Square e2e (`mt_e2e_dev`) caught it — after weeks of red merges.

## What

Mirrors the #624 precedent (the mock was taught to enforce the `verification_token` contract for the same reason):

- **`POST /v2/customers/search`** now returns the real `INVALID_VALUE` error for **reserved / non-deliverable TLDs** (`.test` / `.example` / `.invalid` / `.localhost`) — exactly what real Square rejected (the e2e used `@maplespruce.test`). Deliverable domains (the `.com` emails **every** existing suite uses) still return empty, so no existing test changes behavior.
- **New integration case** (`create-music-together-registration.spec.ts`) registers an installment plan with a reserved-TLD email and asserts it still **confirms** (customer created via `upsertByEmail`'s search-failure fallback). Reverting the #634 fallback now fails this test in the **fast integration layer**, not just the real-Square e2e.

## Verification

- MT integration **65 pass** (incl. the new case); square integration **43 pass**; square unit **7 pass**; mock lib lints clean.
- Confirmed isolation: no other suite uses a reserved-TLD customer email, so the mock's new rejection only affects the opt-in test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
