### PR TITLE
chore(deps): upgrade Square SDK 43 → 45

### DIFF
--- a/libs/firebase/square/src/lib/inventory.service.ts
+++ b/libs/firebase/square/src/lib/inventory.service.ts
@@ -149,7 +149,12 @@ export class InventoryService {
           type: 'ADJUSTMENT',
           adjustment: {
             catalogObjectId: input.squareVariationId,
-            locationId: input.locationId,
+            // Square 45 split the former single `locationId` into
+            // from/toLocationId. This is a same-location state change
+            // (NONE→IN_STOCK to receive, IN_STOCK→SOLD to remove), so both
+            // sides reference the same location.
+            fromLocationId: input.locationId,
+            toLocationId: input.locationId,
             quantity: String(Math.abs(input.quantityChange)),
             fromState: input.quantityChange > 0 ? 'NONE' : 'IN_STOCK',
             toState: input.quantityChange > 0 ? 'IN_STOCK' : 'SOLD',

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "signature_pad": "^5.1.3",
-    "square": "^43.2.1",
+    "square": "^45.0.1",
     "vest": "^5.4.6",
     "webflow-api": "^3.3.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,8 +117,8 @@ importers:
         specifier: ^5.1.3
         version: 5.1.3
       square:
-        specifier: ^43.2.1
-        version: 43.2.1(encoding@0.1.13)
+        specifier: ^45.0.1
+        version: 45.0.1(encoding@0.1.13)
       vest:
         specifier: ^5.4.6
         version: 5.4.6
@@ -324,8 +324,6 @@ importers:
       react-dom:
         specifier: 19.0.0
         version: 19.0.0(react@19.0.0)
-
-  apps/maple-spruce-e2e: {}
 
 packages:
 
@@ -10030,8 +10028,8 @@ packages:
     resolution: {integrity: sha512-75b/UWbXl6xk1cG0jEWeWTRHAbDseF78kdPa3N4Cm57KMkDwOS2qGSLfooyqMDmFEKhQAfTA0WSiMkw40hQ/2A==}
     engines: {node: '>=14.17.0'}
 
-  square@43.2.1:
-    resolution: {integrity: sha512-cSQyA+8CeGakip9wCiA/5otHjz+7V339tAPdDBtBvmSKVkWkdELVPoDMTn4sH/B+OX3hAqQMmxcfjR/DbGZLqA==}
+  square@45.0.1:
+    resolution: {integrity: sha512-o/pee+2jzAXnAecjUftY78oYIEJDyrvqq9FsJNszkX68ZGvn+JUldLBEqT6+a8f3L9HLhqyq8n8s0M7pctbTog==}
     engines: {node: '>=18.0.0'}
 
   ssri@13.0.1:
@@ -14110,9 +14108,9 @@ snapshots:
 
   '@napi-rs/wasm-runtime@1.0.7':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.2
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -14223,7 +14221,7 @@ snapshots:
       '@nx/js': 23.1.0(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@swc/core@1.15.21(@swc/helpers@0.5.19))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.21(@swc/helpers@0.5.19)))(@swc/core@1.15.21(@swc/helpers@0.5.19))(nx@23.1.0(@swc-node/register@1.11.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@swc/core@1.15.21(@swc/helpers@0.5.19))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.21(@swc/helpers@0.5.19)))
       '@phenomnomnominal/tsquery': 6.2.0(typescript@6.0.3)
       detect-port: 2.1.0
-      semver: 7.7.4
+      semver: 7.8.4
       tree-kill: 1.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -16122,7 +16120,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.58.2
       debug: 4.4.3(supports-color@7.2.0)
       minimatch: 10.2.5
-      semver: 7.7.4
+      semver: 7.8.4
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -17663,7 +17661,7 @@ snapshots:
       postcss-modules-scope: 3.2.1(postcss@8.5.15)
       postcss-modules-values: 4.0.0(postcss@8.5.15)
       postcss-value-parser: 4.2.0
-      semver: 7.7.4
+      semver: 7.8.4
     optionalDependencies:
       '@rspack/core': 1.7.11(@swc/helpers@0.5.19)
       webpack: 5.106.2(@swc/core@1.15.21(@swc/helpers@0.5.19))(esbuild@0.28.1)
@@ -18828,7 +18826,7 @@ snapshots:
       minimatch: 3.1.5
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.7.4
+      semver: 7.8.4
       tapable: 2.3.2
       typescript: 6.0.3
       webpack: 5.105.4(@swc/core@1.15.21(@swc/helpers@0.5.19))(esbuild@0.28.1)
@@ -18845,7 +18843,7 @@ snapshots:
       minimatch: 3.1.5
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.7.4
+      semver: 7.8.4
       tapable: 2.3.2
       typescript: 6.0.3
       webpack: 5.106.2(@swc/core@1.15.21(@swc/helpers@0.5.19))(esbuild@0.28.1)
@@ -21285,7 +21283,7 @@ snapshots:
       cosmiconfig: 9.0.1(typescript@6.0.3)
       jiti: 2.6.1
       postcss: 8.5.10
-      semver: 7.7.4
+      semver: 7.8.4
     optionalDependencies:
       '@rspack/core': 1.7.11(@swc/helpers@0.5.19)
       webpack: 5.105.4(@swc/core@1.15.21(@swc/helpers@0.5.19))(esbuild@0.28.1)
@@ -21297,7 +21295,7 @@ snapshots:
       cosmiconfig: 9.0.1(typescript@6.0.3)
       jiti: 2.6.1
       postcss: 8.5.15
-      semver: 7.7.4
+      semver: 7.8.4
     optionalDependencies:
       '@rspack/core': 1.7.11(@swc/helpers@0.5.19)
       webpack: 5.106.2(@swc/core@1.15.21(@swc/helpers@0.5.19))(esbuild@0.28.1)
@@ -22542,7 +22540,7 @@ snapshots:
       - debug
       - supports-color
 
-  square@43.2.1(encoding@0.1.13):
+  square@45.0.1(encoding@0.1.13):
     dependencies:
       form-data: 4.0.6
       form-data-encoder: 4.1.0
@@ -23058,7 +23056,7 @@ snapshots:
       chalk: 4.1.2
       enhanced-resolve: 5.20.1
       micromatch: 4.0.8
-      semver: 7.7.4
+      semver: 7.8.4
       source-map: 0.7.6
       typescript: 6.0.3
       webpack: 5.106.2(@swc/core@1.15.21(@swc/helpers@0.5.19))(esbuild@0.28.1)


### PR DESCRIPTION
Fifth in the dependency sweep. Two majors on the Square TypeScript SDK (`square` 43 → 45). The API surface we use (`SquareClient`, catalog, customers, inventory, orders, invoices, payments, oauth, subscriptions) is otherwise unchanged; **one** breaking change needed a fix.

## Breaking change
- Square 45 split `InventoryAdjustment.locationId` into `fromLocationId` / `toLocationId`. `adjustQuantity` performs a **same-location** state change (`NONE→IN_STOCK` to receive, `IN_STOCK→SOLD` to remove), so both sides now reference the same location.

## Verification
- `tsc --noEmit` clean on all 4 function codebases
- ESLint 0 errors
- 206 unit spec files / 2372 tests (incl. 103 in the Square lib)
- **Square integration suite** (real emulators + mock server): 6 files / 43 tests — exercises customers, card-on-file vaulting, Craft Club subscription lifecycle, and installments

Sweep: pnpm/esbuild (#646 ✅) · Nx 23 (#649 ✅) · MUI 7 (#650) · Node 22 (#651) · **Square 45** · firebase-admin 14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)