### PR TITLE
fix(payments): surface + measure Square SDK init failures (Safari/ITP)

### DIFF
--- a/libs/react/registrations/src/index.ts
+++ b/libs/react/registrations/src/index.ts
@@ -8,4 +8,5 @@ export { SquareCardForm } from './lib/SquareCardForm';
 export type {
   CardTokenizeResult,
   SquareBillingContact,
+  SquareInitErrorInfo,
 } from './lib/SquareCardForm';

--- a/libs/react/registrations/src/lib/SquareCardForm.spec.tsx
+++ b/libs/react/registrations/src/lib/SquareCardForm.spec.tsx
@@ -1,7 +1,12 @@
 // @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, waitFor } from '@testing-library/react';
-import { SquareCardForm, type CardTokenizeResult } from './SquareCardForm';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import {
+  SquareCardForm,
+  type CardTokenizeResult,
+  type SquareInitErrorInfo,
+} from './SquareCardForm';
 
 /**
  * Guards the Square SDK environment-selection contract that the Webflow
@@ -159,5 +164,94 @@ describe('SquareCardForm buyer verification (card on file)', () => {
     const result = await tokenize!();
     expect(result).toEqual({ nonce: 'cnon:card-nonce', verificationToken: undefined });
     expect(verifyBuyer).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Locks the observability + fallback contract added after a Safari/ITP field
+ * report: Square's `InitializationTimeoutError` ("Web Payments SDK was unable to
+ * be initialized in time") used to be swallowed into an Alert with no telemetry.
+ * It must now console.error, GA-beacon, invoke `onInitError`, and show an
+ * actionable message — while ordinary init errors keep their raw message.
+ */
+describe('SquareCardForm init failure telemetry', () => {
+  afterEach(() => {
+    delete (window as { gtag?: unknown }).gtag;
+  });
+
+  it('reports InitializationTimeoutError via console, gtag, onInitError, and an actionable message', async () => {
+    const consoleSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const gtag = vi.fn();
+    (window as unknown as { gtag: unknown }).gtag = gtag;
+    (window as unknown as { Square: unknown }).Square = {
+      payments: vi.fn().mockRejectedValue({
+        name: 'Error',
+        type: 'InitializationTimeoutError',
+        message: 'Web Payments SDK was unable to be initialized in time',
+      }),
+    };
+    const onInitError = vi.fn();
+
+    render(
+      <SquareCardForm
+        applicationId="sq0idp-xyz789"
+        locationId="LOC1"
+        totalCents={25200}
+        onInitError={onInitError}
+        onTokenizeRef={noop}
+      />
+    );
+
+    await waitFor(() => expect(onInitError).toHaveBeenCalled());
+
+    const info = onInitError.mock.calls[0][0] as SquareInitErrorInfo;
+    expect(info.isInitTimeout).toBe(true);
+    expect(info.errorType).toBe('InitializationTimeoutError');
+    expect(info.applicationId).toBe('sq0idp-xyz789');
+
+    expect(gtag).toHaveBeenCalledWith(
+      'event',
+      'payment_init_failed',
+      expect.objectContaining({ is_init_timeout: true, square_env: 'prod' })
+    );
+    expect(consoleSpy).toHaveBeenCalled();
+
+    // Actionable fallback, not the raw SDK string.
+    await screen.findByText(/secure payment form/i);
+    expect(
+      screen.queryByText(/unable to be initialized/i)
+    ).not.toBeInTheDocument();
+
+    consoleSpy.mockRestore();
+  });
+
+  it('keeps the raw message (no ITP guidance) for a non-timeout init error', async () => {
+    const consoleSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    (window as unknown as { Square: unknown }).Square = {
+      payments: vi.fn().mockRejectedValue(new Error('Square location is invalid')),
+    };
+    const onInitError = vi.fn();
+
+    render(
+      <SquareCardForm
+        applicationId="sq0idp-xyz789"
+        locationId="LOC1"
+        totalCents={25200}
+        onInitError={onInitError}
+        onTokenizeRef={noop}
+      />
+    );
+
+    await waitFor(() => expect(onInitError).toHaveBeenCalled());
+
+    const info = onInitError.mock.calls[0][0] as SquareInitErrorInfo;
+    expect(info.isInitTimeout).toBe(false);
+    await screen.findByText(/Square location is invalid/i);
+
+    consoleSpy.mockRestore();
   });
 });

--- a/libs/react/registrations/src/lib/SquareCardForm.tsx
+++ b/libs/react/registrations/src/lib/SquareCardForm.tsx
@@ -75,6 +75,19 @@ interface SquareTokenizeResult {
   errors?: Array<{ message: string }>;
 }
 
+/**
+ * Shape of an error thrown by the Square Web Payments SDK (`PaymentsError`).
+ * `type` is the machine-readable discriminator — notably
+ * `'InitializationTimeoutError'` ("Web Payments SDK was unable to be
+ * initialized in time"), which is the failure Safari's cross-site tracking
+ * prevention (ITP) provokes when it blocks Square's bootstrap iframe.
+ */
+interface SquarePaymentsError {
+  name?: string;
+  message?: string;
+  type?: string;
+}
+
 /** Billing contact passed to `verifyBuyer` for STORE-intent SCA. */
 export interface SquareBillingContact {
   givenName?: string;
@@ -101,6 +114,53 @@ declare global {
         locationId: string
       ) => Promise<SquarePayments>;
     };
+    /** GA4, present on the Webflow public pages. Used to beacon init failures. */
+    gtag?: (...args: unknown[]) => void;
+    /** WebKit-only; its presence signals Safari/iOS — the ITP-affected browsers. */
+    ApplePaySession?: unknown;
+  }
+}
+
+/**
+ * Structured detail about a payment-form initialization failure. Emitted to the
+ * console, beaconed to GA, and passed to any `onInitError` consumer so we can
+ * measure real-world incidence (previously the error was swallowed into an
+ * Alert with no telemetry).
+ */
+export interface SquareInitErrorInfo {
+  /** Square error `type` when present (e.g. `'InitializationTimeoutError'`). */
+  errorType?: string;
+  errorName?: string;
+  message: string;
+  /** True when the failure is Square's init/bootstrap timeout (the Safari/ITP class). */
+  isInitTimeout: boolean;
+  applicationId: string;
+  locationId: string;
+  env?: string;
+  /** Present ⇒ WebKit/Safari, the browser family affected by ITP cross-site blocking. */
+  hasApplePaySession: boolean;
+  userAgent: string;
+}
+
+/**
+ * Report a payment-form init failure to the console and (when available) GA.
+ * Telemetry must never throw back into the payment flow, so the beacon is
+ * fully guarded.
+ */
+function reportPaymentInitFailure(info: SquareInitErrorInfo): void {
+  // Surface for anyone watching the console — this used to be swallowed.
+  console.error('[SquareCardForm] payment form failed to initialize', info);
+  try {
+    window.gtag?.('event', 'payment_init_failed', {
+      error_type: info.errorType ?? info.errorName ?? 'unknown',
+      is_init_timeout: info.isInitTimeout,
+      square_env:
+        info.env ??
+        (info.applicationId.startsWith('sandbox-') ? 'sandbox' : 'prod'),
+      is_safari: info.hasApplePaySession,
+    });
+  } catch {
+    // Never let a telemetry failure break the form.
   }
 }
 
@@ -115,6 +175,13 @@ interface SquareCardFormProps {
   showDigitalWallets?: boolean;
   /** Called when the form is ready to tokenize */
   onReady?: () => void;
+  /**
+   * Called when the Square SDK fails to initialize the card form (e.g. Safari
+   * ITP blocking the bootstrap iframe → `InitializationTimeoutError`). Receives
+   * structured detail for telemetry / custom fallback UI. The component already
+   * console.errors + GA-beacons on its own; this is an extra hook for consumers.
+   */
+  onInitError?: (info: SquareInitErrorInfo) => void;
   /** Ref function to expose tokenize to parent */
   onTokenizeRef: (tokenize: () => Promise<CardTokenizeResult>) => void;
   /**
@@ -192,6 +259,7 @@ export function SquareCardForm({
   totalCents,
   showDigitalWallets = false,
   onReady,
+  onInitError,
   onTokenizeRef,
   verifyBuyerForStore = false,
   billingContact,
@@ -212,6 +280,8 @@ export function SquareCardForm({
   const paymentRequestRef = useRef<SquarePaymentRequest | null>(null);
   const onDigitalWalletTokenRef = useRef(onDigitalWalletToken);
   onDigitalWalletTokenRef.current = onDigitalWalletToken;
+  const onInitErrorRef = useRef(onInitError);
+  onInitErrorRef.current = onInitError;
   // Kept in refs so changing them doesn't re-init the SDK, and so the tokenize
   // closure always reads the latest values (billing contact fills in as the
   // family types).
@@ -476,14 +546,42 @@ export function SquareCardForm({
 
       onReady?.();
     } catch (err) {
+      const sqErr = err as SquarePaymentsError;
       const message =
         err instanceof Error
           ? err.message
-          : 'Failed to initialize payment form';
-      setError(message);
+          : sqErr?.message ?? 'Failed to initialize payment form';
+      // Square's bootstrap-timeout — the Safari/ITP class — reports itself with
+      // `type: 'InitializationTimeoutError'`; fall back to a message match for
+      // safety if the type is ever absent.
+      const isInitTimeout =
+        sqErr?.type === 'InitializationTimeoutError' ||
+        /unable to be initialized/i.test(message);
+
+      const info: SquareInitErrorInfo = {
+        errorType: sqErr?.type,
+        errorName: err instanceof Error ? err.name : sqErr?.name,
+        message,
+        isInitTimeout,
+        applicationId,
+        locationId,
+        env,
+        hasApplePaySession:
+          typeof window !== 'undefined' &&
+          typeof window.ApplePaySession !== 'undefined',
+        userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : '',
+      };
+      reportPaymentInitFailure(info);
+      onInitErrorRef.current?.(info);
+
+      setError(
+        isInitTimeout
+          ? "We couldn't load the secure payment form. Please refresh the page and try again — if it keeps happening, open this page in a private browsing window or a different browser."
+          : message
+      );
       setIsLoading(false);
     }
-  }, [applicationId, locationId, totalCents, showDigitalWallets, onReady, onTokenizeRef, maxWidth]);
+  }, [applicationId, locationId, env, totalCents, showDigitalWallets, onReady, onTokenizeRef, maxWidth]);
 
   // Initialize payments once SDK is ready AND we have a valid amount
   useEffect(() => {


### PR DESCRIPTION
## Why

Field report: the class registration widget (`/classes/...`) failed to load the payment form in **Safari** with **"Web Payments SDK was unable to be initialized in time"** (`InitializationTimeoutError`) — while it worked in **Chrome**, **Firefox**, a **Safari private window**, and the **Music Together widget** (which runs the Square *sandbox* SDK).

### Diagnosis (via live browser + console repro)
- Not a code regression — nothing had shipped since July 12.
- `payments()` resolves, but `payments.card()` rejects with `type: "InitializationTimeoutError"`. It's Square's **bootstrap-iframe timeout**.
- Root cause is **Safari's Prevent Cross-Site Tracking (ITP)** blocking the *production* SDK's cross-site storage/handshake in an *established* profile. Clean state (private window, Firefox, first-time visitor) is unaffected; the sandbox SDK skips the heavy fraud iframe, which is why MT worked.
- So it's **environmental**, and most real customers are fine — **but** `SquareCardForm` was swallowing the error into an Alert with **zero telemetry**, so we had no way to know if/when real customers hit it.

## What this does (scope: *measure first*)
- **Stops swallowing the error** — `console.error`s structured detail and beacons a `payment_init_failed` GA event (guarded; no-op without `gtag`, e.g. admin app / tests) with error type, init-timeout flag, Square env, and a Safari signal.
- **Adds `onInitError(info)`** prop + exported `SquareInitErrorInfo` type for consumers that want custom fallback UI.
- **Actionable message** for the init-timeout class ("refresh… try a private window or another browser") instead of the cryptic SDK string; non-timeout init errors keep their raw message.

No happy-path behavior change.

## Testing
- `SquareCardForm.spec.tsx`: new cases for the **timeout** branch (console + gtag beacon + `onInitError` + actionable message) and the **non-timeout** branch (raw message preserved). All 8 tests pass.
- Lint clean; introduces **zero** new type errors (the 4 pre-existing spec tsc errors are unchanged).

## Follow-ups (not in this PR)
Once GA shows real incidence, decide on heavier mitigation (auto-recovery retry and/or a Square hosted Payment Link fallback). Deferred pending data — see conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)