### PR TITLE
feat(tools): Venmo statement reconciliation (#630)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,7 @@ apps/registration-test-harness/dist/
 .nx/polygraph
 .nx/self-healing
 .nx/migrate-runs
+
+# Local ops-tool reports (contain student/payment PII) — reconcile-venmo,
+# reconcile-mailerlite-attendees, etc.
+evidence/

--- a/tools/reconcile-venmo-core.spec.ts
+++ b/tools/reconcile-venmo-core.spec.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseAmountToCents,
+  normalizeIdentity,
+  splitCsvLine,
+  parseVenmoCsv,
+  resolveStudent,
+  matchStatement,
+  type InvoiceLite,
+  type LessonLite,
+  type StudentLite,
+  type VenmoRow,
+} from './reconcile-venmo-core';
+
+describe('parseAmountToCents', () => {
+  it('parses "+ $40.00" as 4000', () => {
+    expect(parseAmountToCents('+ $40.00')).toBe(4000);
+  });
+  it('parses a plain "$132" as 13200', () => {
+    expect(parseAmountToCents('$132')).toBe(13200);
+  });
+  it('parses negative (outgoing) amounts', () => {
+    expect(parseAmountToCents('- $5.00')).toBe(-500);
+  });
+  it('handles thousands separators', () => {
+    expect(parseAmountToCents('$1,234.56')).toBe(123456);
+  });
+  it('returns 0 on empty/garbage', () => {
+    expect(parseAmountToCents('')).toBe(0);
+    expect(parseAmountToCents('N/A')).toBe(0);
+  });
+});
+
+describe('normalizeIdentity', () => {
+  it('strips a leading @, lowercases, collapses whitespace', () => {
+    expect(normalizeIdentity('@Casey-Nguyen')).toBe('casey-nguyen');
+    expect(normalizeIdentity('  Casey   Nguyen ')).toBe('casey nguyen');
+  });
+});
+
+describe('splitCsvLine', () => {
+  it('honors quoted fields containing commas', () => {
+    expect(splitCsvLine('a,"b, still b",c')).toEqual(['a', 'b, still b', 'c']);
+  });
+  it('handles escaped double quotes', () => {
+    expect(splitCsvLine('"she said ""hi""",x')).toEqual(['she said "hi"', 'x']);
+  });
+});
+
+const VENMO_CSV = `Account Statement - (@Maple-Spruce)
+Account Activity
+
+,ID,Datetime,Type,Status,Note,From,To,Amount (total)
+,,,,,,,,
+,1001,2026-07-03T10:00:00,Payment,Complete,Guitar lesson,casey-nguyen,Maple-Spruce,+ $40.00
+,1002,2026-07-05T14:00:00,Payment,Complete,July lessons,Dana Lopez,Maple-Spruce,+ $132.00
+,1003,2026-07-06T09:00:00,Payment,Complete,thanks,unknown-person,Maple-Spruce,+ $50.00
+,1004,2026-07-07T09:00:00,Standard Transfer,Complete,,Maple-Spruce,Bank,- $200.00
+,1005,2026-07-08T09:00:00,Payment,Complete,refund,Maple-Spruce,someone,- $40.00
+,,,,,,,,In-progress balance
+`;
+
+describe('parseVenmoCsv', () => {
+  it('finds the header past the preamble and keeps only incoming payments', () => {
+    const { rows, headerFound, skipped } = parseVenmoCsv(VENMO_CSV);
+    expect(headerFound).toBe(true);
+    // 1001, 1002, 1003 are incoming payments; the transfer + outgoing refund
+    // are skipped.
+    expect(rows.map((r) => r.amountCents)).toEqual([4000, 13200, 5000]);
+    expect(rows[0].from).toBe('casey-nguyen');
+    expect(rows[0].note).toBe('Guitar lesson');
+    expect(skipped).toBeGreaterThanOrEqual(2);
+  });
+
+  it('reports headerFound=false for an unrecognizable file', () => {
+    expect(parseVenmoCsv('nothing,useful\n1,2').headerFound).toBe(false);
+  });
+});
+
+describe('resolveStudent', () => {
+  const students: StudentLite[] = [
+    { id: 's1', name: 'Juniper Nguyen', venmoUsername: 'casey-nguyen', primaryContactName: 'Casey Nguyen' },
+    { id: 's2', name: 'Dana Lopez', primaryContactName: 'Dana Lopez' },
+    { id: 's3', name: 'Sam Twin', primaryContactName: 'Pat Twin' },
+    { id: 's4', name: 'Alex Twin', primaryContactName: 'Pat Twin' },
+  ];
+
+  it('matches by Venmo handle', () => {
+    expect(resolveStudent('casey-nguyen', students).student?.id).toBe('s1');
+    expect(resolveStudent('@Casey-Nguyen', students).student?.id).toBe('s1');
+  });
+  it('falls back to contact/student name', () => {
+    expect(resolveStudent('Dana Lopez', students).student?.id).toBe('s2');
+  });
+  it('flags ambiguous when >1 student shares the payer name (siblings)', () => {
+    const r = resolveStudent('Pat Twin', students);
+    expect(r.ambiguous).toBe(true);
+    expect(r.student).toBeUndefined();
+  });
+  it('returns nothing for an unknown payer', () => {
+    expect(resolveStudent('nobody', students).student).toBeUndefined();
+  });
+});
+
+function row(overrides: Partial<VenmoRow>): VenmoRow {
+  return {
+    rowIndex: 1,
+    datetime: new Date('2026-07-03T10:00:00'),
+    type: 'Payment',
+    status: 'Complete',
+    from: 'casey-nguyen',
+    amountCents: 4000,
+    note: '',
+    ...overrides,
+  };
+}
+
+describe('matchStatement', () => {
+  const students: StudentLite[] = [
+    { id: 's1', name: 'Juniper', venmoUsername: 'casey-nguyen', primaryContactName: 'Casey Nguyen' },
+    { id: 's2', name: 'Dana Lopez', primaryContactName: 'Dana Lopez' },
+  ];
+
+  it('settles an unpaid sent invoice the teacher forgot to mark', () => {
+    const invoices: InvoiceLite[] = [
+      { id: 'inv-1', studentId: 's1', status: 'sent', totalCents: 4000 },
+    ];
+    const res = matchStatement([row({})], students, invoices, []);
+    expect(res.settle).toHaveLength(1);
+    expect(res.settle[0].invoice?.id).toBe('inv-1');
+    expect(res.confirm).toHaveLength(0);
+    expect(res.attestedNoMoney).toHaveLength(0);
+  });
+
+  it('confirms a venmo-manual attestation', () => {
+    const invoices: InvoiceLite[] = [
+      { id: 'inv-2', studentId: 's1', status: 'paid', paymentSource: 'venmo-manual', totalCents: 4000 },
+    ];
+    const res = matchStatement([row({})], students, invoices, []);
+    expect(res.confirm).toHaveLength(1);
+    expect(res.confirm[0].invoice?.id).toBe('inv-2');
+  });
+
+  it('treats an already-imported invoice as a no-op (idempotent re-run)', () => {
+    const invoices: InvoiceLite[] = [
+      { id: 'inv-3', studentId: 's1', status: 'paid', paymentSource: 'venmo-import', totalCents: 4000 },
+    ];
+    const res = matchStatement([row({})], students, invoices, []);
+    expect(res.alreadyImported).toHaveLength(1);
+    expect(res.settle).toHaveLength(0);
+    expect(res.confirm).toHaveLength(0);
+    expect(res.attestedNoMoney).toHaveLength(0);
+  });
+
+  it('reports an unknown payer', () => {
+    const res = matchStatement([row({ from: 'ghost' })], students, [], []);
+    expect(res.unmatchedRows).toHaveLength(1);
+    expect(res.unmatchedRows[0].action).toBe('unknown-payer');
+  });
+
+  it('reports a known student with no invoice at that amount', () => {
+    const invoices: InvoiceLite[] = [
+      { id: 'inv-x', studentId: 's1', status: 'sent', totalCents: 9999 },
+    ];
+    const res = matchStatement([row({})], students, invoices, []);
+    expect(res.unmatchedRows[0].action).toBe('no-amount-match');
+  });
+
+  it('flags a venmo-manual invoice with no statement row (attested, no money)', () => {
+    const invoices: InvoiceLite[] = [
+      // Attested paid, but no row for $99 exists in the statement.
+      { id: 'inv-ghost', studentId: 's2', status: 'paid', paymentSource: 'venmo-manual', totalCents: 9900 },
+    ];
+    const res = matchStatement([row({})], students, invoices, []);
+    expect(res.attestedNoMoney.map((i) => i.id)).toEqual(['inv-ghost']);
+  });
+
+  it('prefers settling a sent invoice over confirming a paid one at the same amount', () => {
+    const invoices: InvoiceLite[] = [
+      { id: 'inv-sent', studentId: 's1', status: 'sent', totalCents: 4000 },
+      { id: 'inv-paid', studentId: 's1', status: 'paid', paymentSource: 'venmo-manual', totalCents: 4000 },
+    ];
+    const res = matchStatement([row({})], students, invoices, []);
+    expect(res.settle.map((m) => m.invoice?.id)).toEqual(['inv-sent']);
+  });
+
+  it('lists lessons still scheduled in the past as never-attested', () => {
+    const lessons: LessonLite[] = [
+      { id: 'l-old', studentId: 's1', status: 'scheduled', scheduledAt: new Date('2026-06-01') },
+      { id: 'l-future', studentId: 's1', status: 'scheduled', scheduledAt: new Date('2026-09-01') },
+      { id: 'l-done', studentId: 's1', status: 'rendered', scheduledAt: new Date('2026-06-01') },
+    ];
+    const res = matchStatement([], students, [], lessons, {
+      now: new Date('2026-07-15'),
+    });
+    expect(res.neverAttestedLessons.map((l) => l.id)).toEqual(['l-old']);
+  });
+});

--- a/tools/reconcile-venmo-core.ts
+++ b/tools/reconcile-venmo-core.ts
@@ -1,0 +1,409 @@
+/**
+ * Pure matching core for the Venmo statement reconciliation tool (#630).
+ *
+ * No firebase-admin / no @maple imports — self-contained and unit-testable.
+ * The runnable script (`reconcile-venmo.ts`) does the Firestore I/O and calls
+ * these functions.
+ *
+ * Venmo Business Profiles have no API/webhook, so lesson payments are attested
+ * by a human (`venmo-manual`) and this tool reconciles those attestations
+ * against the downloaded Venmo statement CSV:
+ *   - a statement row that matches an unpaid `sent` invoice  → the teacher
+ *     forgot to mark it; SETTLE it (`venmo-import`).
+ *   - a statement row that matches a `venmo-manual` invoice   → CONFIRM the
+ *     attestation (upgrade source to `venmo-import`).
+ *   - a statement row that matches nothing                    → unknown payer
+ *     / wrong amount; report for investigation.
+ *   - a `venmo-manual` invoice with NO statement row          → attested but
+ *     the money never arrived; ALERT (the dangerous direction).
+ */
+
+export interface VenmoRow {
+  /** 1-based line number in the source CSV, for reporting. */
+  rowIndex: number;
+  datetime?: Date;
+  type: string;
+  status: string;
+  /** Payer as it appears on the statement — a Venmo @handle or a display name. */
+  from: string;
+  /** Positive = money received by the business, in cents. */
+  amountCents: number;
+  note: string;
+}
+
+export interface StudentLite {
+  id: string;
+  name: string;
+  venmoUsername?: string;
+  primaryContactName?: string;
+}
+
+export interface InvoiceLite {
+  id: string;
+  studentId: string;
+  status: string; // draft | sent | paid | void
+  totalCents: number;
+  /** paymentRecord.source when present. */
+  paymentSource?: string;
+  issuedAt?: Date;
+  createdAt?: Date;
+}
+
+export interface LessonLite {
+  id: string;
+  studentId: string;
+  status: string; // scheduled | rendered | cancelled
+  scheduledAt?: Date;
+}
+
+export type RowAction =
+  | 'settle' // sent invoice → mark paid venmo-import
+  | 'confirm' // venmo-manual invoice → upgrade to venmo-import
+  | 'already-imported' // already venmo-import — no-op (idempotent re-run)
+  | 'unknown-payer' // no student matched the "from"
+  | 'ambiguous-student' // >1 student matched — needs a human
+  | 'no-amount-match'; // student known, but no invoice at that amount
+
+export interface RowMatch {
+  row: VenmoRow;
+  student?: StudentLite;
+  invoice?: InvoiceLite;
+  action: RowAction;
+  reason: string;
+}
+
+export interface ReconcileResult {
+  settle: RowMatch[];
+  confirm: RowMatch[];
+  alreadyImported: RowMatch[];
+  unmatchedRows: RowMatch[];
+  /** venmo-manual paid invoices with no matching statement row. */
+  attestedNoMoney: InvoiceLite[];
+  /** Lessons still `scheduled` with a past date — never rendered/attested. */
+  neverAttestedLessons: LessonLite[];
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+/** Parse a Venmo amount cell ("+ $40.00", "- $5.00", "$40") to signed cents. */
+export function parseAmountToCents(raw: string): number {
+  if (!raw) return 0;
+  const negative = /-/.test(raw);
+  const digits = raw.replace(/[^0-9.]/g, '');
+  if (!digits) return 0;
+  const value = Number.parseFloat(digits);
+  if (Number.isNaN(value)) return 0;
+  const cents = Math.round(value * 100);
+  return negative ? -cents : cents;
+}
+
+/** Normalize a Venmo handle / name for comparison. */
+export function normalizeIdentity(value: string | undefined): string {
+  return (value ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/^@/, '')
+    .replace(/\s+/g, ' ');
+}
+
+/** Split one CSV line honoring double-quoted fields. */
+export function splitCsvLine(line: string): string[] {
+  const out: string[] = [];
+  let cur = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (line[i + 1] === '"') {
+          cur += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        cur += ch;
+      }
+    } else if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ',') {
+      out.push(cur);
+      cur = '';
+    } else {
+      cur += ch;
+    }
+  }
+  out.push(cur);
+  return out.map((c) => c.trim());
+}
+
+function findColumn(headers: string[], patterns: RegExp[]): number {
+  for (const pat of patterns) {
+    const idx = headers.findIndex((h) => pat.test(h));
+    if (idx !== -1) return idx;
+  }
+  return -1;
+}
+
+export interface ParsedStatement {
+  rows: VenmoRow[];
+  /** Non-payment / outgoing / incomplete rows skipped. */
+  skipped: number;
+  headerFound: boolean;
+}
+
+/**
+ * Parse a Venmo Business statement CSV. Tolerant to the preamble/summary rows
+ * Venmo includes and to column reordering (columns are found by header name).
+ * Returns only completed INCOMING payments (money received by the business).
+ */
+export function parseVenmoCsv(text: string): ParsedStatement {
+  const lines = text.split(/\r?\n/);
+  let headerIdx = -1;
+  let headers: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const cells = splitCsvLine(lines[i]);
+    const hasDate = cells.some((c) => /datetime|^date$/i.test(c));
+    const hasAmount = cells.some((c) => /amount/i.test(c));
+    if (hasDate && hasAmount) {
+      headerIdx = i;
+      headers = cells;
+      break;
+    }
+  }
+  if (headerIdx === -1) {
+    return { rows: [], skipped: 0, headerFound: false };
+  }
+
+  const col = {
+    date: findColumn(headers, [/datetime/i, /^date$/i]),
+    type: findColumn(headers, [/^type$/i]),
+    status: findColumn(headers, [/^status$/i]),
+    from: findColumn(headers, [/^from$/i]),
+    amount: findColumn(headers, [
+      /amount\s*\(total\)/i,
+      /amount\s*\(net\)/i,
+      /^amount/i,
+    ]),
+    note: findColumn(headers, [/^note$/i]),
+  };
+
+  const rows: VenmoRow[] = [];
+  let skipped = 0;
+  for (let i = headerIdx + 1; i < lines.length; i++) {
+    if (lines[i].trim() === '') continue;
+    const cells = splitCsvLine(lines[i]);
+    const at = (idx: number) => (idx >= 0 && idx < cells.length ? cells[idx] : '');
+
+    const type = at(col.type);
+    const status = at(col.status);
+    const amountCents = parseAmountToCents(at(col.amount));
+
+    // Keep only completed, incoming payments. Venmo fires many row types
+    // (transfers, fees, refunds) and outgoing charges (negative) — skip those.
+    const isPayment = /payment/i.test(type);
+    const isComplete = status === '' || /complete/i.test(status);
+    if (!isPayment || !isComplete || amountCents <= 0) {
+      // A summary/preamble row (no type, no amount) is also skipped here.
+      if (type || at(col.amount)) skipped++;
+      continue;
+    }
+
+    const dateStr = at(col.date);
+    const parsedDate = dateStr ? new Date(dateStr) : undefined;
+    rows.push({
+      rowIndex: i + 1,
+      datetime:
+        parsedDate && !Number.isNaN(parsedDate.getTime())
+          ? parsedDate
+          : undefined,
+      type,
+      status,
+      from: at(col.from),
+      amountCents,
+      note: at(col.note),
+    });
+  }
+
+  return { rows, skipped, headerFound: true };
+}
+
+// ---------------------------------------------------------------------------
+// Matching
+// ---------------------------------------------------------------------------
+
+/** Resolve the student a statement row's payer refers to, if unambiguous. */
+export function resolveStudent(
+  from: string,
+  students: StudentLite[]
+): { student?: StudentLite; ambiguous: boolean } {
+  const key = normalizeIdentity(from);
+  if (!key) return { ambiguous: false };
+
+  // 1. Exact Venmo handle match (strongest signal).
+  const byHandle = students.filter(
+    (s) => s.venmoUsername && normalizeIdentity(s.venmoUsername) === key
+  );
+  if (byHandle.length === 1) return { student: byHandle[0], ambiguous: false };
+  if (byHandle.length > 1) return { ambiguous: true };
+
+  // 2. Fall back to name match (Venmo statements often show a display name,
+  //    not the @handle). Match the payer name against the contact/student name.
+  const byName = students.filter((s) => {
+    const contact = normalizeIdentity(s.primaryContactName);
+    const name = normalizeIdentity(s.name);
+    return contact === key || name === key;
+  });
+  if (byName.length === 1) return { student: byName[0], ambiguous: false };
+  if (byName.length > 1) return { ambiguous: true };
+
+  return { ambiguous: false };
+}
+
+function dateDistance(a?: Date, b?: Date): number {
+  if (!a || !b) return Number.POSITIVE_INFINITY;
+  return Math.abs(a.getTime() - b.getTime());
+}
+
+/**
+ * Pick the best invoice for a resolved payment: an unpaid `sent` invoice at
+ * the same amount (→ settle), else a `venmo-manual` paid one (→ confirm), else
+ * an already-`venmo-import` one (→ no-op). Ties broken by date proximity to
+ * the statement row.
+ */
+function pickInvoice(
+  row: VenmoRow,
+  studentInvoices: InvoiceLite[]
+): { invoice?: InvoiceLite; action: RowAction } {
+  const sameAmount = studentInvoices.filter(
+    (i) => i.totalCents === row.amountCents
+  );
+  const closest = (list: InvoiceLite[]) =>
+    [...list].sort(
+      (a, b) =>
+        dateDistance(row.datetime, a.issuedAt ?? a.createdAt) -
+        dateDistance(row.datetime, b.issuedAt ?? b.createdAt)
+    )[0];
+
+  const sent = sameAmount.filter((i) => i.status === 'sent');
+  if (sent.length > 0) return { invoice: closest(sent), action: 'settle' };
+
+  const venmoManual = sameAmount.filter(
+    (i) => i.status === 'paid' && i.paymentSource === 'venmo-manual'
+  );
+  if (venmoManual.length > 0) {
+    return { invoice: closest(venmoManual), action: 'confirm' };
+  }
+
+  const alreadyImported = sameAmount.filter(
+    (i) => i.status === 'paid' && i.paymentSource === 'venmo-import'
+  );
+  if (alreadyImported.length > 0) {
+    return { invoice: closest(alreadyImported), action: 'already-imported' };
+  }
+
+  return { action: 'no-amount-match' };
+}
+
+export interface MatchOptions {
+  /** Treat a lesson `scheduled` before this as "never attested". Default now. */
+  now?: Date;
+}
+
+export function matchStatement(
+  rows: VenmoRow[],
+  students: StudentLite[],
+  invoices: InvoiceLite[],
+  lessons: LessonLite[],
+  options: MatchOptions = {}
+): ReconcileResult {
+  const now = options.now ?? new Date();
+  const invoicesByStudent = new Map<string, InvoiceLite[]>();
+  for (const inv of invoices) {
+    const list = invoicesByStudent.get(inv.studentId) ?? [];
+    list.push(inv);
+    invoicesByStudent.set(inv.studentId, list);
+  }
+
+  const result: ReconcileResult = {
+    settle: [],
+    confirm: [],
+    alreadyImported: [],
+    unmatchedRows: [],
+    attestedNoMoney: [],
+    neverAttestedLessons: [],
+  };
+  const matchedInvoiceIds = new Set<string>();
+
+  for (const row of rows) {
+    const { student, ambiguous } = resolveStudent(row.from, students);
+    if (ambiguous) {
+      result.unmatchedRows.push({
+        row,
+        action: 'ambiguous-student',
+        reason: `"${row.from}" matches more than one student — resolve by hand`,
+      });
+      continue;
+    }
+    if (!student) {
+      result.unmatchedRows.push({
+        row,
+        action: 'unknown-payer',
+        reason: `no student matches "${row.from}" — save their Venmo username on the student`,
+      });
+      continue;
+    }
+
+    const { invoice, action } = pickInvoice(
+      row,
+      invoicesByStudent.get(student.id) ?? []
+    );
+
+    if (action === 'no-amount-match' || !invoice) {
+      result.unmatchedRows.push({
+        row,
+        student,
+        action: 'no-amount-match',
+        reason: `${student.name}: no open/attested invoice for $${(
+          row.amountCents / 100
+        ).toFixed(2)}`,
+      });
+      continue;
+    }
+
+    matchedInvoiceIds.add(invoice.id);
+    const match: RowMatch = {
+      row,
+      student,
+      invoice,
+      action,
+      reason:
+        action === 'settle'
+          ? `${student.name}: settle sent invoice ${invoice.id}`
+          : action === 'confirm'
+            ? `${student.name}: confirm attested invoice ${invoice.id}`
+            : `${student.name}: already imported (${invoice.id})`,
+    };
+    if (action === 'settle') result.settle.push(match);
+    else if (action === 'confirm') result.confirm.push(match);
+    else result.alreadyImported.push(match);
+  }
+
+  // Reverse drift: venmo-manual attestations with no statement row backing them.
+  result.attestedNoMoney = invoices.filter(
+    (i) =>
+      i.status === 'paid' &&
+      i.paymentSource === 'venmo-manual' &&
+      !matchedInvoiceIds.has(i.id)
+  );
+
+  // Never-attested lessons: still scheduled with a past date.
+  result.neverAttestedLessons = lessons.filter(
+    (l) =>
+      l.status === 'scheduled' && l.scheduledAt && l.scheduledAt.getTime() < now.getTime()
+  );
+
+  return result;
+}

--- a/tools/reconcile-venmo.ts
+++ b/tools/reconcile-venmo.ts
@@ -1,0 +1,325 @@
+/**
+ * Venmo statement ↔ Firestore invoice reconciliation (#630).
+ *
+ * Venmo Business Profiles have no API/webhook, so in-person lesson payments are
+ * attested by a human (`venmo-manual`, PR #640). This tool takes the downloaded
+ * Venmo Business statement CSV and reconciles it against the invoices:
+ *
+ *   - SETTLE   — a statement row matches an unpaid `sent` invoice (the teacher
+ *                forgot to mark it) → mark it paid, source `venmo-import`.
+ *   - CONFIRM  — a row matches a `venmo-manual` invoice → upgrade the source to
+ *                `venmo-import` (the money really arrived).
+ *   - UNMATCHED — a row matches no student/invoice → unknown payer or wrong
+ *                amount; investigate / save the payer's Venmo username.
+ *   - ALERT    — a `venmo-manual` invoice with NO statement row → attested but
+ *                the money never arrived (revenue leak).
+ *   - Also lists lessons still `scheduled` in the past (never attested).
+ *
+ * Read-only by default; pass --apply to write the SETTLE/CONFIRM updates.
+ *
+ * Usage:
+ *   # download the statement CSV from venmo.com (Statements → export)
+ *   npx tsx tools/reconcile-venmo.ts --csv ~/Downloads/venmo-statement.csv           # dev, dry-run
+ *   npx tsx tools/reconcile-venmo.ts --csv ./venmo.csv --prod                        # prod, dry-run
+ *   npx tsx tools/reconcile-venmo.ts --csv ./venmo.csv --prod --apply                # prod, write
+ *
+ * Firestore auth is ADC — run `gcloud auth application-default login` first.
+ *
+ * NOTE: verify the CSV column names against a real export the first time. The
+ * parser finds columns by header name (Datetime / Type / Status / From /
+ * Amount / Note) and tolerates reordering, but Venmo may rename them.
+ */
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { initializeApp } from 'firebase-admin/app';
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import {
+  matchStatement,
+  parseVenmoCsv,
+  type InvoiceLite,
+  type LessonLite,
+  type ReconcileResult,
+  type RowMatch,
+  type StudentLite,
+} from './reconcile-venmo-core';
+
+const argv = process.argv.slice(2);
+const isProd = argv.includes('--prod');
+const apply = argv.includes('--apply');
+const csvPath = argValue('--csv') ?? firstPositional();
+const projectId = isProd ? 'maple-and-spruce' : 'maple-and-spruce-dev';
+
+function argValue(flag: string): string | undefined {
+  const i = argv.indexOf(flag);
+  return i !== -1 && i + 1 < argv.length ? argv[i + 1] : undefined;
+}
+function firstPositional(): string | undefined {
+  return argv.find((a) => !a.startsWith('--'));
+}
+
+if (!csvPath) {
+  console.error(
+    'Provide the Venmo statement CSV: --csv <path> (or as a positional arg).'
+  );
+  process.exit(1);
+}
+
+console.log(`Project: ${projectId}`);
+console.log(`CSV:     ${csvPath}`);
+console.log(`Mode:    ${apply ? 'APPLY (writes SETTLE/CONFIRM)' : 'DRY-RUN (read-only)'}`);
+console.log();
+
+const app = initializeApp({ projectId });
+const db = getFirestore(app);
+
+function toDate(value: unknown): Date | undefined {
+  if (value instanceof Timestamp) return value.toDate();
+  if (value instanceof Date) return value;
+  return undefined;
+}
+
+function money(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function dateStr(d: Date | undefined): string {
+  return d ? d.toISOString().slice(0, 10) : '—';
+}
+
+async function loadStudents(): Promise<StudentLite[]> {
+  const snap = await db.collection('students').get();
+  return snap.docs.map((d) => {
+    const data = d.data();
+    return {
+      id: d.id,
+      name: data.name ?? '',
+      venmoUsername: data.venmoUsername,
+      primaryContactName: data.primaryContactName,
+    };
+  });
+}
+
+async function loadInvoices(): Promise<InvoiceLite[]> {
+  const snap = await db.collection('invoices').get();
+  return snap.docs.map((d) => {
+    const data = d.data();
+    return {
+      id: d.id,
+      studentId: data.studentId,
+      status: data.status,
+      totalCents: data.totalCents ?? 0,
+      paymentSource: data.paymentRecord?.source,
+      issuedAt: toDate(data.issuedAt),
+      createdAt: toDate(data.createdAt),
+    };
+  });
+}
+
+async function loadScheduledLessons(): Promise<LessonLite[]> {
+  const snap = await db
+    .collection('lessons')
+    .where('status', '==', 'scheduled')
+    .get();
+  return snap.docs.map((d) => {
+    const data = d.data();
+    return {
+      id: d.id,
+      studentId: data.studentId,
+      status: data.status,
+      scheduledAt: toDate(data.scheduledAt),
+    };
+  });
+}
+
+function importNote(match: RowMatch): string {
+  const parts = [`Venmo import — from ${match.row.from}`];
+  if (match.row.datetime) parts.push(`on ${dateStr(match.row.datetime)}`);
+  if (match.row.note) parts.push(`(${match.row.note})`);
+  return parts.join(' ');
+}
+
+async function applySettle(match: RowMatch): Promise<void> {
+  const now = new Date();
+  await db.collection('invoices').doc(match.invoice!.id).update({
+    status: 'paid',
+    paidAt: now,
+    issuedAt: match.invoice!.issuedAt ?? now,
+    paymentRecord: {
+      source: 'venmo-import',
+      note: importNote(match),
+      recordedAt: now,
+    },
+    updatedAt: now,
+  });
+}
+
+async function applyConfirm(match: RowMatch): Promise<void> {
+  const now = new Date();
+  // Upgrade the source in place — keep the original recordedAt/recordedByUid.
+  await db.collection('invoices').doc(match.invoice!.id).update({
+    'paymentRecord.source': 'venmo-import',
+    'paymentRecord.note': importNote(match),
+    updatedAt: now,
+  });
+}
+
+function buildReport(result: ReconcileResult, studentById: Map<string, StudentLite>): string {
+  const today = new Date().toISOString().slice(0, 10);
+  const lines: string[] = [];
+  lines.push('# Venmo ↔ Invoice reconciliation');
+  lines.push('');
+  lines.push(`**Generated:** ${today}`);
+  lines.push(`**Project:** ${projectId}`);
+  lines.push(`**Mode:** ${apply ? 'APPLY' : 'DRY-RUN'}`);
+  lines.push('');
+  lines.push(`- Settle (forgot to mark paid): **${result.settle.length}**`);
+  lines.push(`- Confirm (attestation verified): **${result.confirm.length}**`);
+  lines.push(`- Already imported (no-op): ${result.alreadyImported.length}`);
+  lines.push(`- Unmatched statement rows: **${result.unmatchedRows.length}**`);
+  lines.push(`- ⚠️ Attested but no money in statement: **${result.attestedNoMoney.length}**`);
+  lines.push(`- Lessons scheduled in the past (never attested): ${result.neverAttestedLessons.length}`);
+  lines.push('');
+
+  const rowTable = (title: string, matches: RowMatch[], blurb: string) => {
+    lines.push(`## ${title}`);
+    lines.push('');
+    lines.push(blurb);
+    lines.push('');
+    if (matches.length === 0) {
+      lines.push('_None._');
+      lines.push('');
+      return;
+    }
+    lines.push('| Date | From | Amount | Student | Invoice | Note |');
+    lines.push('|---|---|---|---|---|---|');
+    for (const m of matches) {
+      lines.push(
+        `| ${dateStr(m.row.datetime)} | ${m.row.from} | ${money(m.row.amountCents)} | ${m.student?.name ?? '—'} | ${m.invoice?.id ?? '—'} | ${m.reason} |`
+      );
+    }
+    lines.push('');
+  };
+
+  rowTable(
+    '1. Settle — teacher forgot to mark paid',
+    result.settle,
+    'Statement rows matching an unpaid `sent` invoice. With `--apply` these are marked paid (`venmo-import`).'
+  );
+  rowTable(
+    '2. Confirm — attestation verified by the statement',
+    result.confirm,
+    'Rows matching a `venmo-manual` invoice. With `--apply` the source is upgraded to `venmo-import`.'
+  );
+  rowTable(
+    '3. Unmatched statement rows',
+    result.unmatchedRows,
+    'Money arrived but no invoice matched — unknown payer or wrong amount. Save the payer’s Venmo username on the student, or investigate.'
+  );
+
+  lines.push('## 4. ⚠️ Attested but no money in the statement');
+  lines.push('');
+  lines.push(
+    'Invoices marked paid via Venmo (`venmo-manual`) with **no matching row** in this statement. Either the statement window does not cover them, or the money never actually arrived — investigate.'
+  );
+  lines.push('');
+  if (result.attestedNoMoney.length === 0) {
+    lines.push('_None._');
+  } else {
+    lines.push('| Invoice | Student | Amount |');
+    lines.push('|---|---|---|');
+    for (const inv of result.attestedNoMoney) {
+      lines.push(
+        `| ${inv.id} | ${studentById.get(inv.studentId)?.name ?? inv.studentId} | ${money(inv.totalCents)} |`
+      );
+    }
+  }
+  lines.push('');
+
+  lines.push('## 5. Lessons scheduled in the past (never attested)');
+  lines.push('');
+  lines.push(
+    'Still `scheduled` with a past date — never marked rendered, so never invoiced. May need attention.'
+  );
+  lines.push('');
+  if (result.neverAttestedLessons.length === 0) {
+    lines.push('_None._');
+  } else {
+    lines.push('| Lesson | Student | Scheduled |');
+    lines.push('|---|---|---|');
+    for (const l of result.neverAttestedLessons) {
+      lines.push(
+        `| ${l.id} | ${studentById.get(l.studentId)?.name ?? l.studentId} | ${dateStr(l.scheduledAt)} |`
+      );
+    }
+  }
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+async function main(): Promise<void> {
+  const text = readFileSync(csvPath as string, 'utf8');
+  const parsed = parseVenmoCsv(text);
+  if (!parsed.headerFound) {
+    console.error(
+      'Could not find a Venmo statement header (Datetime + Amount columns) in the CSV. Is this a Venmo Business statement export?'
+    );
+    process.exit(1);
+  }
+  console.log(
+    `Parsed ${parsed.rows.length} incoming payment(s) (${parsed.skipped} non-payment/outgoing rows skipped).`
+  );
+
+  const [students, invoices, lessons] = await Promise.all([
+    loadStudents(),
+    loadInvoices(),
+    loadScheduledLessons(),
+  ]);
+  const studentById = new Map(students.map((s) => [s.id, s]));
+
+  const result = matchStatement(parsed.rows, students, invoices, lessons);
+
+  console.log();
+  console.log(`  Settle:            ${result.settle.length}`);
+  console.log(`  Confirm:           ${result.confirm.length}`);
+  console.log(`  Already imported:  ${result.alreadyImported.length}`);
+  console.log(`  Unmatched rows:    ${result.unmatchedRows.length}`);
+  console.log(`  ⚠️ Attested/no money: ${result.attestedNoMoney.length}`);
+  console.log(`  Past scheduled:    ${result.neverAttestedLessons.length}`);
+  console.log();
+
+  if (apply) {
+    let settled = 0;
+    for (const m of result.settle) {
+      await applySettle(m);
+      settled++;
+      console.log(`  SETTLED  ${m.invoice!.id} (${m.student?.name}) ${money(m.row.amountCents)}`);
+    }
+    let confirmed = 0;
+    for (const m of result.confirm) {
+      await applyConfirm(m);
+      confirmed++;
+      console.log(`  CONFIRMED ${m.invoice!.id} (${m.student?.name})`);
+    }
+    console.log(`\nApplied ${settled} settle + ${confirmed} confirm update(s).`);
+  } else {
+    console.log('Dry-run — no writes. Re-run with --apply to settle/confirm.');
+  }
+
+  const report = buildReport(result, studentById);
+  const outDir = join(process.cwd(), 'evidence');
+  mkdirSync(outDir, { recursive: true });
+  const outPath = join(
+    outDir,
+    `venmo-reconciliation-${new Date().toISOString().slice(0, 10)}.md`
+  );
+  writeFileSync(outPath, report);
+  console.log(`\nWrote ${outPath}`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });


### PR DESCRIPTION
Closes #630 (epic #626). Makes the `venmo-manual` attestations from #627 (PR #640) **verifiable**.

## Why

Venmo Business Profiles have no API/webhook, so in-person lesson payments are attested by a human (`venmo-manual`). This tool is the safety net: it takes the downloaded Venmo Business **statement CSV** and reconciles it against the invoices, catching both directions of drift.

## What it does

| Case | Meaning | `--apply` action |
|---|---|---|
| **SETTLE** | statement row ↔ an unpaid `sent` invoice | mark paid, `venmo-import` (teacher forgot to mark it) |
| **CONFIRM** | statement row ↔ a `venmo-manual` invoice | upgrade source to `venmo-import` |
| **UNMATCHED** | money arrived, no invoice matched | reported — unknown payer / wrong amount |
| **⚠️ ALERT** | `venmo-manual` invoice with **no** statement row | reported — attested but the money never arrived |
| info | lessons still `scheduled` in the past | reported — never rendered/attested |

**Read-only by default** (writes an `evidence/*.md` report); `--apply` performs the SETTLE/CONFIRM writes. `--prod` targets prod; auth is ADC. **Idempotent** — a re-run sees already-`venmo-import` invoices as no-ops.

```
gcloud auth application-default login
npx tsx tools/reconcile-venmo.ts --csv ~/Downloads/venmo-statement.csv --prod          # dry-run first
npx tsx tools/reconcile-venmo.ts --csv ~/Downloads/venmo-statement.csv --prod --apply   # then write
```

## Design

- Mirrors the committed `reconcile-mailerlite-attendees` mold (firebase-admin modular API, raw Firestore, `--prod`, evidence report).
- The **risky logic — CSV parsing + matching — is a pure, dependency-free core** (`reconcile-venmo-core.ts`) with **22 unit tests**; the runnable script does only the Firestore I/O + writes.
- Column detection is **by header name** (tolerant to Venmo reordering the statement). Payer matched by **Venmo handle first, then contact/student name**; siblings sharing a parent name are flagged **ambiguous** rather than mis-attributed.
- Gitignores `evidence/` — both this tool's and the mailerlite tool's reports contain student/payment PII.

## Verification

- **Unit** (22): amount/handle parsing, quoted-CSV splitting, header-past-preamble detection + payment/outgoing filtering, payer resolution (handle / name / ambiguous / unknown), and full match categorization (settle / confirm / already-imported / unknown / no-amount-match / attested-no-money / past-scheduled-lessons). ✅
- **Script smoke test** (dev, dry-run): parsed a realistic statement CSV correctly ("2 incoming payments, 1 outgoing skipped") and ran through to the Firestore load — the only stop was **stale local ADC** (`invalid_grant / reauth`), an env condition, not a code issue. `tsc` clean; ESLint 0 errors.
- **First real run**: verify the CSV column names against an actual Venmo export (the parser is header-name-based and tolerant, but Venmo could rename columns) and always do a `--prod` dry-run before `--apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)