### PR TITLE
fix(deps): bump firebase-functions to ^7.3.0 for firebase-admin 14 peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "date-fns": "^3.0.0",
     "firebase": "^12.11.0",
     "firebase-admin": "^14.2.0",
-    "firebase-functions": "^7.2.2",
+    "firebase-functions": "^7.3.0",
     "ical-generator": "^10.1.0",
     "next": "16.2.6",
     "pdf-lib": "^1.17.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,8 +96,8 @@ importers:
         specifier: ^14.2.0
         version: 14.2.0(encoding@0.1.13)
       firebase-functions:
-        specifier: ^7.2.2
-        version: 7.2.5(firebase-admin@14.2.0(encoding@0.1.13))
+        specifier: ^7.3.0
+        version: 7.3.0(firebase-admin@14.2.0(encoding@0.1.13))
       ical-generator:
         specifier: ^10.1.0
         version: 10.1.0(@touch4it/ical-timezones@1.9.0)(@types/node@22.20.1)(luxon@3.7.2)
@@ -4603,9 +4603,6 @@ packages:
   '@types/node@14.18.63':
     resolution: {integrity: sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==}
 
-  '@types/node@20.19.9':
-    resolution: {integrity: sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==}
-
   '@types/node@22.20.1':
     resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
@@ -6761,14 +6758,14 @@ packages:
     resolution: {integrity: sha512-zfs5PdccEgjX479bbMmz95Rqc7ttQ4LV3qkGFlPiqOaOu/suBZc3fG52Qzn2hQjiSHkBM4NP2AZV5r2NvAt0TQ==}
     engines: {node: '>=22'}
 
-  firebase-functions@7.2.5:
-    resolution: {integrity: sha512-K+pP0AknluAguLRbD96hibyXbnOgwnvd4hkExWdGrxnNCLoj8LBFj08uvJYxyvhsCgYzQumrUaHBW4lsXKSiRg==}
+  firebase-functions@7.3.0:
+    resolution: {integrity: sha512-S3JhjESOWMq13iDodwgUPWNQ3gLAu7oTLDwF7hTtisyjVanEeQzYezgW+JTfd8I0kCJQzjGPC/wHQ19IL7CgaA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:
       '@apollo/server': ^5.2.0
       '@as-integrations/express4': ^1.1.2
-      firebase-admin: ^11.10.0 || ^12.0.0 || ^13.0.0
+      firebase-admin: ^11.10.0 || ^12.0.0 || ^13.0.0 || ^14.0.0
       graphql: ^16.12.0
     peerDependenciesMeta:
       '@apollo/server':
@@ -13277,7 +13274,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 20.19.9
+      '@types/node': 22.20.1
       jest-regex-util: 30.0.1
 
   '@jest/schemas@30.0.5':
@@ -13290,7 +13287,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.19.9
+      '@types/node': 22.20.1
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -15890,7 +15887,7 @@ snapshots:
 
   '@types/bonjour@3.5.13':
     dependencies:
-      '@types/node': 20.19.9
+      '@types/node': 22.20.1
     optional: true
 
   '@types/caseless@0.12.5':
@@ -15904,7 +15901,7 @@ snapshots:
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 5.1.2
-      '@types/node': 20.19.9
+      '@types/node': 22.20.1
     optional: true
 
   '@types/connect@3.4.38':
@@ -15937,14 +15934,14 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.8':
     dependencies:
-      '@types/node': 20.19.9
+      '@types/node': 22.20.1
       '@types/qs': 6.15.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
 
   '@types/express-serve-static-core@5.1.2':
     dependencies:
-      '@types/node': 20.19.9
+      '@types/node': 22.20.1
       '@types/qs': 6.15.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -15970,7 +15967,7 @@ snapshots:
 
   '@types/http-proxy@1.17.17':
     dependencies:
-      '@types/node': 20.19.9
+      '@types/node': 22.20.1
     optional: true
 
   '@types/istanbul-lib-coverage@2.0.6': {}
@@ -15995,10 +15992,6 @@ snapshots:
   '@types/ms@2.1.0': {}
 
   '@types/node@14.18.63': {}
-
-  '@types/node@20.19.9':
-    dependencies:
-      undici-types: 6.21.0
 
   '@types/node@22.20.1':
     dependencies:
@@ -16046,11 +16039,11 @@ snapshots:
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 20.19.9
+      '@types/node': 22.20.1
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 20.19.9
+      '@types/node': 22.20.1
 
   '@types/serve-index@1.9.4':
     dependencies:
@@ -16060,18 +16053,18 @@ snapshots:
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 20.19.9
+      '@types/node': 22.20.1
       '@types/send': 0.17.6
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 20.19.9
+      '@types/node': 22.20.1
     optional: true
 
   '@types/sockjs@0.3.36':
     dependencies:
-      '@types/node': 20.19.9
+      '@types/node': 22.20.1
     optional: true
 
   '@types/tough-cookie@4.0.5':
@@ -16081,7 +16074,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 20.19.9
+      '@types/node': 22.20.1
     optional: true
 
   '@types/yargs-parser@21.0.3': {}
@@ -18691,7 +18684,7 @@ snapshots:
       - encoding
       - supports-color
 
-  firebase-functions@7.2.5(firebase-admin@14.2.0(encoding@0.1.13)):
+  firebase-functions@7.3.0(firebase-admin@14.2.0(encoding@0.1.13)):
     dependencies:
       '@types/cors': 2.8.19
       '@types/express': 4.17.25
@@ -19723,7 +19716,7 @@ snapshots:
   jest-util@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 20.19.9
+      '@types/node': 22.20.1
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -19731,13 +19724,13 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 20.19.9
+      '@types/node': 22.20.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@30.3.0:
     dependencies:
-      '@types/node': 20.19.9
+      '@types/node': 22.20.1
       '@ungap/structured-clone': 1.3.0
       jest-util: 30.3.0
       merge-stream: 2.0.0


### PR DESCRIPTION
**Unblocks the functions deploy**, which broke on the firebase-admin 14 merge (#653).

Cloud Build runs `npm install` on Nx's generated per-codebase `package.json`, and npm enforces peer deps. `firebase-functions@7.2.5` declares `firebase-admin ^11 || ^12 || ^13` and **rejects 14 with ERESOLVE**. pnpm masked this locally (`strictPeerDependencies: false`), so our builds/tests were green while the deploy failed.

`firebase-functions@7.3.0` (latest) adds `^14.0.0` to its peer range.

## Verification
- **Reproduced Cloud Build's resolution**: `npm install --dry-run` on the generated `dist/apps/functions-square/package.json` — previously ERESOLVE, now resolves 338 packages cleanly
- All 4 codebases build · `tsc` clean · ESLint 0 errors · 206 unit spec files / 2374 tests

Follow-up to the dependency sweep (#645/#646/#649/#650/#651/#652/#653).

🤖 Generated with [Claude Code](https://claude.com/claude-code)