### PR TITLE
fix(payments): self-heal corrupt cached square.js via cache-busted reload

### DIFF
--- a/libs/react/registrations/src/lib/SquareCardForm.spec.tsx
+++ b/libs/react/registrations/src/lib/SquareCardForm.spec.tsx
@@ -255,3 +255,90 @@ describe('SquareCardForm init failure telemetry', () => {
     consoleSpy.mockRestore();
   });
 });
+
+/**
+ * Locks the self-healing recovery for the corrupt-cache case a HAR confirmed:
+ * `square.js` served empty from cache (304 revalidation of a poisoned entry) →
+ * the <script> `onload` fires but `window.Square` is never defined. The loader
+ * must retry once under a cache-busting URL (a fresh cache key forced to the
+ * network) so it recovers without anyone clearing their cache.
+ */
+describe('SquareCardForm corrupt-cache SDK recovery', () => {
+  function squareScripts(): HTMLScriptElement[] {
+    return Array.from(document.head.querySelectorAll('script')).filter((s) =>
+      s.src.includes('squarecdn.com')
+    );
+  }
+
+  /** Install a working fake Square global (so init succeeds after recovery). */
+  function installWorkingSquare() {
+    const card = {
+      attach: vi.fn().mockResolvedValue(undefined),
+      tokenize: vi.fn().mockResolvedValue({ status: 'OK', token: 'cnon:x' }),
+      destroy: vi.fn().mockResolvedValue(undefined),
+    };
+    (window as unknown as { Square: unknown }).Square = {
+      payments: vi.fn().mockResolvedValue({ card: vi.fn().mockResolvedValue(card) }),
+    };
+  }
+
+  it('retries with a cache-busted URL when the first square.js load defines no window.Square', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    render(
+      <SquareCardForm
+        applicationId="sq0idp-xyz789"
+        locationId="LOC1"
+        totalCents={6000}
+        onTokenizeRef={noop}
+      />
+    );
+
+    // Plain URL injected first; window.Square still undefined (corrupt cache).
+    const first = squareScripts().at(-1)!;
+    expect(first.src).toBe(PROD_CDN);
+    expect((window as { Square?: unknown }).Square).toBeUndefined();
+
+    // Simulate the empty cached script "loading" without defining the global.
+    first.dispatchEvent(new Event('load'));
+
+    // Loader must inject a cache-busted retry under the prod CDN.
+    await waitFor(() => {
+      expect(
+        squareScripts().some((s) => s.src.startsWith(`${PROD_CDN}?_cb=`))
+      ).toBe(true);
+    });
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('recovers and initializes once the cache-busted retry defines window.Square', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const onReady = vi.fn();
+    render(
+      <SquareCardForm
+        applicationId="sq0idp-xyz789"
+        locationId="LOC1"
+        totalCents={6000}
+        onReady={onReady}
+        onTokenizeRef={noop}
+      />
+    );
+
+    // First (empty) load fires without a global.
+    squareScripts().at(-1)!.dispatchEvent(new Event('load'));
+
+    // Wait for the cache-busted retry script, then have it define window.Square.
+    await waitFor(() =>
+      expect(
+        squareScripts().some((s) => s.src.startsWith(`${PROD_CDN}?_cb=`))
+      ).toBe(true)
+    );
+    installWorkingSquare();
+    squareScripts().at(-1)!.dispatchEvent(new Event('load'));
+
+    // SDK now ready → init runs → onReady fires. No error surfaced.
+    await waitFor(() => expect(onReady).toHaveBeenCalled());
+    expect(screen.queryByText(/Failed to load payment form/i)).not.toBeInTheDocument();
+    vi.restoreAllMocks();
+  });
+});

--- a/libs/react/registrations/src/lib/SquareCardForm.tsx
+++ b/libs/react/registrations/src/lib/SquareCardForm.tsx
@@ -164,6 +164,37 @@ function reportPaymentInitFailure(info: SquareInitErrorInfo): void {
   }
 }
 
+/** Inject a `<script>`; resolve on load, reject on error. */
+function loadSquareScript(src: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error('script load error'));
+    document.head.appendChild(script);
+  });
+}
+
+/**
+ * Beacon that `square.js` loaded but didn't define `window.Square` — the
+ * corrupt/empty-cached-script case (observed on Safari: an interrupted fetch
+ * cached under the valid ETag, then re-served via 304). Emitted when we fall
+ * back to a cache-busted reload, so we can measure how often customers hit it.
+ */
+function reportSdkCacheBustRetry(isSandbox: boolean): void {
+  console.warn(
+    '[SquareCardForm] square.js loaded without defining window.Square — retrying with a cache-busted URL'
+  );
+  try {
+    window.gtag?.('event', 'payment_sdk_cache_bust_retry', {
+      square_env: isSandbox ? 'sandbox' : 'prod',
+    });
+  } catch {
+    // Never let a telemetry failure break the form.
+  }
+}
+
 interface SquareCardFormProps {
   applicationId: string;
   locationId: string;
@@ -329,7 +360,17 @@ export function SquareCardForm({
     };
   }, []);
 
-  // Load the Square SDK script
+  // Load the Square SDK script.
+  //
+  // A corrupt/empty `square.js` can get stuck in the browser cache (observed on
+  // Safari: an interrupted fetch stored under the valid ETag, then re-served
+  // indefinitely via 304 revalidation). The `<script>` fires `onload` but
+  // defines no `window.Square`, so init later throws "Square SDK not loaded".
+  // To self-heal — for us and for any customer stuck in that cache state — if
+  // the first load doesn't yield `window.Square`, we retry once with a
+  // cache-busting query param. That's a fresh cache key, so the browser is
+  // forced to the network for a clean copy, routing around the poisoned entry
+  // without anyone having to manually clear their cache.
   useEffect(() => {
     if (sdkLoadedRef.current) return;
     sdkLoadedRef.current = true;
@@ -346,15 +387,36 @@ export function SquareCardForm({
       ? 'https://sandbox.web.squarecdn.com/v1/square.js'
       : 'https://web.squarecdn.com/v1/square.js';
 
-    const script = document.createElement('script');
-    script.src = scriptUrl;
-    script.async = true;
-    script.onload = () => setSdkReady(true);
-    script.onerror = () => {
+    (async () => {
+      // First attempt: the plain URL, so normal CDN/browser caching applies
+      // (unaffected browsers pay zero overhead — this is the only load).
+      try {
+        await loadSquareScript(scriptUrl);
+      } catch {
+        // network / onerror — fall through to the cache-busted retry
+      }
+      if (window.Square) {
+        setSdkReady(true);
+        return;
+      }
+
+      // The script "loaded" but defined nothing (empty/corrupt cached body) or
+      // errored. Retry under a cache-busting key — forced to the network — which
+      // recovers the poisoned-cache case.
+      reportSdkCacheBustRetry(isSandbox);
+      try {
+        await loadSquareScript(`${scriptUrl}?_cb=${Date.now()}`);
+      } catch {
+        // handled by the window.Square check below
+      }
+      if (window.Square) {
+        setSdkReady(true);
+        return;
+      }
+
       setError('Failed to load payment form. Please refresh and try again.');
       setIsLoading(false);
-    };
-    document.head.appendChild(script);
+    })();
   }, [applicationId, locationId, env]);
 
   const initializePayments = useCallback(async () => {


### PR DESCRIPTION
## Why

Follow-up to #654. A HAR capture from the class registration widget showed a **different** failure than the ITP timeout — **"Square SDK not loaded"** (`isInitTimeout: false`, surfaced by #654's telemetry):

```
GET https://web.squarecdn.com/v1/square.js
  Request:  If-None-Match: W/"2c41f4a29744…"
  Response: 304 Not Modified   (empty body, size 0)   ← and NO main-iframe.js follows
```

**Root cause:** the browser had an **empty/corrupt `square.js` stuck in its HTTP cache** — an earlier interrupted/blocked fetch stored under the valid ETag, then re-served indefinitely via **304 revalidation**. The `<script>` fires `onload` but never defines `window.Square`, so init throws "Square SDK not loaded". Clearing cookies/site data does **not** fix it (the poison is in the *cache*, not cookies) — only emptying the browser cache does, manually.

A real customer can land in the same cache state. So the right fix is one that **routes around the poisoned entry in code**, self-healing for us and for customers on the next load after deploy — no one has to empty their cache.

## What this does

In the SDK loader: if the first `square.js` load doesn't yield `window.Square` (empty/corrupt cached body) **or** errors, retry once under a **cache-busting URL** (`?_cb=<ts>`). That's a fresh cache key the browser is forced to fetch from the network, bypassing the poisoned entry.

- **Unaffected browsers pay zero overhead** — they load the plain URL once; the retry only runs on the failure path.
- The cache-bust query is ignored by Square's CDN for content, and the SDK loads its own sub-resources (`/<version>/main-iframe.js`) independently, so there's no functional impact.
- Beacons `payment_sdk_cache_bust_retry` to GA to measure how often customers hit this.

## Testing

`SquareCardForm.spec.tsx` — new "corrupt-cache SDK recovery" cases:
1. First `square.js` load fires `onload` without defining `window.Square` → loader injects a `?_cb=` retry script.
2. Retry defines `window.Square` → SDK becomes ready, init runs, `onReady` fires, no error shown.

10/10 tests pass; lint clean; no new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)