### PR TITLE
feat(registration): Square hosted-checkout fallback — backend (PR 1 of 2)

### DIFF
--- a/apps/functions-integration-tests-registration/src/create-registration-checkout-link.spec.ts
+++ b/apps/functions-integration-tests-registration/src/create-registration-checkout-link.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Integration tests for createRegistrationCheckoutLink — the Square-hosted
+ * checkout fallback (used when the embedded Web Payments SDK can't initialize,
+ * e.g. Safari ITP).
+ *
+ * Exercises the real function against the Firestore emulator + the Square mock
+ * server (POST /v2/online-checkout/payment-links). Verifies that it:
+ *  - reserves a `pending`, source:'web' registration with the correct pricing,
+ *  - returns a Square-hosted checkout URL + the registration id + confirmation #,
+ *  - honors class capacity (rejects when full — the shared reservation guard),
+ *  - validates input.
+ *
+ * The pending -> confirmed reconciliation (processPosSale on the payment
+ * webhook) is covered by that function's unit tests; the end-to-end redirect
+ * flow is covered by the PR-2 e2e.
+ */
+import {
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  getFirestoreDoc,
+  callFunction,
+  PUBLISHED_CLASS,
+} from '@maple/firebase/integration-test-utils';
+import type {
+  CreateRegistrationCheckoutLinkRequest,
+  CreateRegistrationCheckoutLinkResponse,
+} from '@maple/ts/firebase/api-types';
+
+const CLASS_ID = 'test-checkout-link-class';
+
+const validRequest = (): CreateRegistrationCheckoutLinkRequest => ({
+  classId: CLASS_ID,
+  customerEmail: 'buyer@test.com',
+  customerName: 'Casey Buyer',
+  quantity: 1,
+});
+
+describe('createRegistrationCheckoutLink', () => {
+  beforeEach(async () => {
+    await clearFirestoreEmulator();
+    await setFirestoreDoc('classes', CLASS_ID, { ...PUBLISHED_CLASS });
+  });
+
+  afterAll(async () => {
+    await clearFirestoreEmulator();
+  });
+
+  it('reserves a pending registration and returns a hosted checkout URL', async () => {
+    const result = await callFunction<
+      CreateRegistrationCheckoutLinkRequest,
+      CreateRegistrationCheckoutLinkResponse
+    >({
+      functionName: 'createRegistrationCheckoutLink',
+      data: validRequest(),
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data?.checkoutUrl).toContain('square.link');
+    expect(result.data?.confirmationNumber).toMatch(/^MS-/);
+    const registrationId = result.data?.registrationId;
+    expect(registrationId).toBeTruthy();
+
+    // The spot is held as a pending, source:'web' registration priced with tax.
+    const reg = await getFirestoreDoc('registrations', registrationId as string);
+    expect(reg).toBeTruthy();
+    expect(reg?.status).toBe('pending');
+    expect(reg?.source).toBe('web');
+    expect(reg?.classId).toBe(CLASS_ID);
+    expect(reg?.subtotalCents).toBe(PUBLISHED_CLASS.priceCents);
+    // 4500 + 6% WV tax = 4770.
+    expect(reg?.pricePaidCents).toBe(4770);
+  });
+
+  it('rejects when the class is already full (shared capacity guard)', async () => {
+    // Capacity 1, already taken by a confirmed registration.
+    await setFirestoreDoc('classes', CLASS_ID, {
+      ...PUBLISHED_CLASS,
+      capacity: 1,
+    });
+    await setFirestoreDoc('registrations', 'existing-confirmed', {
+      classId: CLASS_ID,
+      customerEmail: 'taken@test.com',
+      customerName: 'Already Registered',
+      quantity: 1,
+      status: 'confirmed',
+      source: 'web',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const result = await callFunction<CreateRegistrationCheckoutLinkRequest>({
+      functionName: 'createRegistrationCheckoutLink',
+      data: validRequest(),
+    });
+
+    expect(result.status).not.toBe(200);
+  });
+
+  it('rejects invalid input (missing email)', async () => {
+    const result = await callFunction<
+      Partial<CreateRegistrationCheckoutLinkRequest>
+    >({
+      functionName: 'createRegistrationCheckoutLink',
+      data: { classId: CLASS_ID, customerName: 'No Email', quantity: 1 },
+    });
+
+    expect(result.status).not.toBe(200);
+  });
+});

--- a/apps/functions-square/src/index.ts
+++ b/apps/functions-square/src/index.ts
@@ -34,6 +34,7 @@ export { processPosSale } from '@maple/firebase/maple-functions/process-pos-sale
 
 // Registration operations (Square payments)
 export { createRegistration } from '@maple/firebase/maple-functions/create-registration';
+export { createRegistrationCheckoutLink } from '@maple/firebase/maple-functions/create-registration-checkout-link';
 export { cancelRegistration } from '@maple/firebase/maple-functions/cancel-registration';
 
 // Sync conflict resolution (Square catalog comparison)

--- a/apps/functions-square/tsconfig.app.json
+++ b/apps/functions-square/tsconfig.app.json
@@ -14,6 +14,7 @@
     "../../libs/firebase/maple-functions/process-catalog-sync-request/**/*.ts",
     "../../libs/firebase/maple-functions/process-pos-sale/**/*.ts",
     "../../libs/firebase/maple-functions/create-registration/**/*.ts",
+    "../../libs/firebase/maple-functions/create-registration-checkout-link/**/*.ts",
     "../../libs/firebase/maple-functions/cancel-registration/**/*.ts",
     "../../libs/firebase/maple-functions/detect-sync-conflicts/**/*.ts",
     "../../libs/firebase/maple-functions/resolve-sync-conflict/**/*.ts",

--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -204,6 +204,7 @@ export { getRequiredAgreementsForClass } from '@maple/firebase/maple-functions/g
 
 // Agreement scheduled functions
 export { expireAgreementRequests } from '@maple/firebase/maple-functions/expire-agreement-requests';
+export { releaseStaleRegistrationHolds } from '@maple/firebase/maple-functions/release-stale-registration-holds';
 
 // Registration scheduled functions
 export {

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -123,6 +123,7 @@
     "../../libs/firebase/maple-functions/submit-signed-agreement/**/*.ts",
     "../../libs/firebase/maple-functions/get-required-agreements-for-class/**/*.ts",
     "../../libs/firebase/maple-functions/expire-agreement-requests/**/*.ts",
+    "../../libs/firebase/maple-functions/release-stale-registration-holds/**/*.ts",
     "../../libs/firebase/maple-functions/send-class-reminders/**/*.ts",
     "../../libs/firebase/maple-functions/send-music-together-reminders/**/*.ts",
     "../../libs/firebase/maple-functions/list-users/**/*.ts",

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,6 +1,20 @@
 {
   "indexes": [
     {
+      "collectionGroup": "registrations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "agreementRequests",
       "queryScope": "COLLECTION",
       "fields": [

--- a/function-codebases.json
+++ b/function-codebases.json
@@ -22,6 +22,7 @@
     "firebase-maple-functions-process-catalog-sync-request": "maple-square",
     "firebase-maple-functions-process-pos-sale": "maple-square",
     "firebase-maple-functions-create-registration": "maple-square",
+    "firebase-maple-functions-create-registration-checkout-link": "maple-square",
     "firebase-maple-functions-cancel-registration": "maple-square",
     "firebase-maple-functions-detect-sync-conflicts": "maple-square",
     "firebase-maple-functions-resolve-sync-conflict": "maple-square",

--- a/libs/firebase/functions/src/lib/index.ts
+++ b/libs/firebase/functions/src/lib/index.ts
@@ -76,6 +76,14 @@ export {
 // Email utilities
 export { isE2ETestEmail } from './email.utility';
 
+// Shared class-registration reservation (card + hosted-checkout paths)
+export {
+  reserveClassRegistration,
+  validateRequiredAgreements,
+  generateConfirmationNumber,
+  type ReserveRegistrationResult,
+} from './registration-reservation.utility';
+
 // Per-family calendar subscription utilities
 export {
   FAMILY_CALENDAR_FEED_PATH_PREFIX,

--- a/libs/firebase/functions/src/lib/registration-reservation.utility.ts
+++ b/libs/firebase/functions/src/lib/registration-reservation.utility.ts
@@ -1,0 +1,342 @@
+/**
+ * Shared class-registration reservation.
+ *
+ * Both payment paths must reserve a class spot identically before taking money:
+ *  - `createRegistration` (inline Web Payments SDK card nonce, charged
+ *    synchronously), and
+ *  - `createRegistrationCheckoutLink` (Square-hosted Payment Link — the
+ *    Safari/ITP fallback — confirmed later by the `payment.updated` webhook).
+ *
+ * This helper owns the capacity-critical, shared portion of that flow:
+ *   1. validate input,
+ *   2. verify the class is open,
+ *   3. validate required agreement signatures,
+ *   4. price the order (discount + tax),
+ *   5. atomically reserve the spot by writing a `pending` registration inside
+ *      the same Firestore transaction as the capacity check (and consume a
+ *      discount usage).
+ *
+ * A `pending` registration already counts against capacity
+ * (`RegistrationRepository.countByClassId` includes `pending`), so writing it
+ * here IS the spot hold. Each caller then does its own payment step and flips
+ * the registration to `confirmed` (card flow synchronously; hosted flow via
+ * webhook). Abandoned hosted holds are released by the stale-pending reaper.
+ *
+ * Keeping this single-sourced prevents the two flows' capacity logic from
+ * diverging — divergence there would mean overbooking.
+ */
+import { FieldValue } from 'firebase-admin/firestore';
+import {
+  ClassRepository,
+  DiscountRepository,
+  RegistrationRepository,
+  AgreementTemplateRepository,
+  getDb,
+} from '@maple/firebase/database';
+import {
+  isClassRegistrationOpen,
+  applyDiscount,
+  isDiscountValid,
+  calculateTax,
+} from '@maple/ts/domain';
+import { registrationValidation } from '@maple/ts/validation';
+import type { CreateRegistrationRequest } from '@maple/ts/firebase/api-types';
+import type { AgreementTemplate, Class } from '@maple/ts/domain';
+import { randomBytes } from 'crypto';
+
+/**
+ * The subset of a registration request needed to validate, price, and reserve
+ * a spot — everything except the payment credential. The inline card flow
+ * (which additionally has a `paymentNonce`) and the hosted-checkout flow (which
+ * has none) both satisfy this shape, so both reserve through the same helper.
+ */
+export type RegistrationReservationInput = Omit<
+  CreateRegistrationRequest,
+  'paymentNonce'
+>;
+
+/**
+ * Generate a short, human-readable confirmation number.
+ * Format: MS-XXXXXX (6 uppercase alphanumeric chars, no I/O/0/1).
+ */
+export function generateConfirmationNumber(): string {
+  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+  const bytes = randomBytes(6);
+  let code = '';
+  for (let i = 0; i < 6; i++) {
+    code += chars[bytes[i] % chars.length];
+  }
+  return `MS-${code}`;
+}
+
+/**
+ * Validate that all required agreement templates have matching signature data.
+ * Shared by both payment paths — a class with required agreements must not
+ * reach checkout (inline or hosted) without them signed.
+ */
+export function validateRequiredAgreements(
+  requiredTemplates: AgreementTemplate[],
+  agreements: RegistrationReservationInput['agreements']
+): void {
+  if (requiredTemplates.length === 0) return;
+
+  if (!agreements || agreements.length === 0) {
+    throw new Error(
+      'Required agreements must be signed before checkout can complete'
+    );
+  }
+
+  const submittedIds = new Set(agreements.map((a) => a.templateId));
+  const missingTemplates = requiredTemplates.filter(
+    (t) => !submittedIds.has(t.id)
+  );
+
+  if (missingTemplates.length > 0) {
+    const names = missingTemplates.map((t) => t.name).join(', ');
+    throw new Error(
+      `The following agreements must be signed before checkout: ${names}`
+    );
+  }
+
+  for (const agreement of agreements) {
+    if (!agreement.signatureData) {
+      throw new Error('Signature is required for all agreements');
+    }
+    if (!agreement.printedName?.trim()) {
+      throw new Error('Printed name is required for all agreements');
+    }
+    if (agreement.isMinor) {
+      if (!agreement.minorName?.trim()) {
+        throw new Error("Minor's name is required");
+      }
+      if (!agreement.guardianName?.trim()) {
+        throw new Error('Parent/guardian name is required');
+      }
+      if (!agreement.guardianSignatureData) {
+        throw new Error('Parent/guardian signature is required');
+      }
+    }
+  }
+}
+
+/** Priced, reserved registration — everything both payment paths need next. */
+export interface ReserveRegistrationResult {
+  /** Firestore id of the newly-written `pending` registration (== Square referenceId). */
+  registrationId: string;
+  /** The class being registered for. */
+  classEntity: Class;
+  /** Required agreement templates for the class category (for post-reserve processing). */
+  requiredTemplates: AgreementTemplate[];
+  /** Human-readable confirmation number stamped on the registration. */
+  confirmationNumber: string;
+  /** Pre-tax, post-discount subtotal in cents. */
+  subtotalCents: number;
+  /** Tax charged in cents. */
+  taxAmountCents: number;
+  /** Grand total in cents (subtotal + tax). */
+  pricePaidCents: number;
+  /** Tax rate applied, as a percentage. */
+  taxRatePercent: number;
+  /** Normalized (uppercased) discount code actually applied, if any. */
+  discountCode?: string;
+  /** Discount amount applied in cents (0 if none). */
+  discountAmountCents: number;
+}
+
+/**
+ * Validate, price, and atomically reserve a `pending` class registration.
+ *
+ * Throws on validation failure, a closed class, missing required agreements,
+ * an invalid/expired discount, or insufficient capacity — in every case
+ * WITHOUT writing anything (the capacity check and the write share one
+ * transaction). On success the `pending` registration exists and holds the
+ * spot; the caller is responsible for taking payment and confirming it.
+ *
+ * @param data          the registration request (same shape both flows use)
+ * @param taxRatePercent the sales-tax rate (from Square config)
+ */
+export async function reserveClassRegistration(
+  data: RegistrationReservationInput,
+  taxRatePercent: number
+): Promise<ReserveRegistrationResult> {
+  // 1. Validate input
+  const validationResult = registrationValidation(data);
+  if (!validationResult.isValid()) {
+    const errors = validationResult.getErrors();
+    const errorMessages = Object.entries(errors)
+      .map(([field, msgs]) => `${field}: ${msgs.join(', ')}`)
+      .join('; ');
+    throw new Error(`Validation failed: ${errorMessages}`);
+  }
+
+  // Cross-check quantity vs. the attendees array when the client sent it, so a
+  // stale UI can't book a different number of spots than it described.
+  const additionalAttendees = data.additionalAttendees ?? [];
+  if (
+    data.additionalAttendees !== undefined &&
+    data.quantity !== 1 + additionalAttendees.length
+  ) {
+    throw new Error(
+      `Quantity (${data.quantity}) must equal 1 + additionalAttendees.length (${1 + additionalAttendees.length}).`
+    );
+  }
+
+  // 2. Verify class exists and is open for registration
+  const classEntity = await ClassRepository.findById(data.classId);
+  if (!classEntity) {
+    throw new Error(`Class not found: ${data.classId}`);
+  }
+  if (!isClassRegistrationOpen(classEntity)) {
+    throw new Error('This class is not currently open for registration');
+  }
+
+  // 3. Required agreements must be signed before checkout (inline or hosted)
+  const requiredTemplates = classEntity.categoryId
+    ? await AgreementTemplateRepository.findRequiredForCategory(
+        classEntity.categoryId
+      )
+    : [];
+  if (requiredTemplates.length > 0) {
+    validateRequiredAgreements(requiredTemplates, data.agreements);
+  }
+
+  // 4. Price the order (optional discount, then tax)
+  const originalCostCents = classEntity.priceCents * data.quantity;
+  let discountAmountCents = 0;
+  let discountCode: string | undefined;
+  let discountIdToRedeem: string | undefined;
+
+  if (data.discountCode) {
+    const discount = await DiscountRepository.findByCode(data.discountCode);
+    // The customer was shown a price that depends on this code; if it's no
+    // longer valid at submit time we must NOT silently charge full price.
+    if (!discount || !isDiscountValid(discount)) {
+      throw new Error(
+        `Discount code "${data.discountCode}" is no longer valid. Please refresh and try again.`
+      );
+    }
+    const result = applyDiscount(discount, {
+      unitPriceCents: classEntity.priceCents,
+      quantity: data.quantity,
+    });
+    if (result.discountAmountCents > 0) {
+      discountAmountCents = result.discountAmountCents;
+      discountCode = data.discountCode.toUpperCase();
+      discountIdToRedeem = discount.id;
+    }
+  }
+
+  const subtotalCents = Math.max(0, originalCostCents - discountAmountCents);
+  const { taxAmountCents, totalCents: pricePaidCents } = calculateTax(
+    subtotalCents,
+    taxRatePercent
+  );
+
+  // 5. Reserve the spot atomically (capacity check + write share one txn)
+  const db = getDb();
+  const registrationDocRef = RegistrationRepository.getDocRef();
+  const confirmationNumber = generateConfirmationNumber();
+
+  await db.runTransaction(async (transaction) => {
+    // === Reads before writes ===
+    const existingSnapshot = await transaction.get(
+      db
+        .collection('registrations')
+        .where('classId', '==', data.classId)
+        .where('status', 'in', ['pending', 'confirmed'])
+    );
+
+    const discountRef = discountIdToRedeem
+      ? DiscountRepository.getDocRef(discountIdToRedeem)
+      : undefined;
+    const discountSnap = discountRef
+      ? await transaction.get(discountRef)
+      : undefined;
+
+    // === Validation ===
+    const currentSpotsTaken = existingSnapshot.docs.reduce(
+      (sum, doc) => sum + (doc.data().quantity || 1),
+      0
+    );
+    const spotsNeeded = data.quantity;
+    if (currentSpotsTaken + spotsNeeded > classEntity.capacity) {
+      const spotsRemaining = classEntity.capacity - currentSpotsTaken;
+      throw new Error(
+        spotsRemaining <= 0
+          ? 'This class is full'
+          : `Only ${spotsRemaining} spot${spotsRemaining === 1 ? '' : 's'} remaining`
+      );
+    }
+
+    if (discountRef && discountSnap) {
+      const fresh = discountSnap.data();
+      if (!fresh || fresh.status !== 'active') {
+        throw new Error('Discount code is no longer available');
+      }
+      const expiresAt = fresh.expiresAt?.toDate?.() ?? fresh.expiresAt;
+      if (expiresAt && new Date() > new Date(expiresAt)) {
+        throw new Error('Discount code has expired');
+      }
+      const usageLimit =
+        typeof fresh.usageLimit === 'number' ? fresh.usageLimit : null;
+      const usageCount =
+        typeof fresh.usageCount === 'number' ? fresh.usageCount : 0;
+      if (usageLimit !== null && usageCount >= usageLimit) {
+        throw new Error('Discount code has reached its usage limit');
+      }
+    }
+
+    // === Writes ===
+    const now = new Date();
+    const persistedAttendees = additionalAttendees
+      .map((a) => ({
+        name: a.name?.trim() || undefined,
+        email: a.email?.trim() || undefined,
+      }))
+      .filter((a) => a.name || a.email);
+
+    transaction.set(registrationDocRef, {
+      classId: data.classId,
+      customerEmail: data.customerEmail,
+      customerName: data.customerName,
+      customerPhone: data.customerPhone || null,
+      quantity: data.quantity,
+      additionalAttendees:
+        persistedAttendees.length > 0 ? persistedAttendees : null,
+      pricePaidCents,
+      subtotalCents,
+      taxAmountCents,
+      taxRatePercent,
+      discountCode: discountCode || null,
+      discountAmountCents: discountAmountCents || null,
+      status: 'pending',
+      source: 'web',
+      notes: data.notes || null,
+      confirmationNumber,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // Consume one discount usage atomically. Per product decision usage is
+    // NOT restored on later cancellation — single-use means single-use.
+    if (discountRef) {
+      transaction.update(discountRef, {
+        usageCount: FieldValue.increment(1),
+        updatedAt: now,
+      });
+    }
+  });
+
+  return {
+    registrationId: registrationDocRef.id,
+    classEntity,
+    requiredTemplates,
+    confirmationNumber,
+    subtotalCents,
+    taxAmountCents,
+    pricePaidCents,
+    taxRatePercent,
+    discountCode,
+    discountAmountCents,
+  };
+}

--- a/libs/firebase/maple-functions/create-registration-checkout-link/project.json
+++ b/libs/firebase/maple-functions/create-registration-checkout-link/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-create-registration-checkout-link",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/create-registration-checkout-link/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/create-registration-checkout-link/src/index.ts
+++ b/libs/firebase/maple-functions/create-registration-checkout-link/src/index.ts
@@ -1,0 +1,1 @@
+export { createRegistrationCheckoutLink } from './lib/create-registration-checkout-link';

--- a/libs/firebase/maple-functions/create-registration-checkout-link/src/lib/create-registration-checkout-link.ts
+++ b/libs/firebase/maple-functions/create-registration-checkout-link/src/lib/create-registration-checkout-link.ts
@@ -1,0 +1,175 @@
+/**
+ * Create Registration Checkout Link Cloud Function
+ *
+ * Public endpoint. The Safari/ITP fallback for class registration: when the
+ * embedded Square Web Payments SDK can't initialize in the buyer's browser,
+ * the widget calls this instead of tokenizing a card. It:
+ *  1. validates + prices + atomically reserves a `pending` spot (shared
+ *     reserveClassRegistration helper — identical to the inline card flow), then
+ *  2. creates a Square-hosted Payment Link for that order and returns its URL.
+ *
+ * The buyer pays on Square's own top-level hosted page (no cross-origin iframe,
+ * so ITP is irrelevant). Payment completion is reconciled by the
+ * `payment.updated` webhook, which flips the `pending` registration to
+ * `confirmed`. Abandoned holds are released by the stale-pending reaper.
+ *
+ * Deployed to us-east4 (maple-square codebase) via CI/CD.
+ */
+import {
+  Functions,
+  reserveClassRegistration,
+} from '@maple/firebase/functions';
+import { RegistrationRepository } from '@maple/firebase/database';
+import {
+  Square,
+  SQUARE_SECRET_NAMES,
+  SQUARE_STRING_NAMES,
+} from '@maple/firebase/square';
+import type {
+  CreateRegistrationCheckoutLinkRequest,
+  CreateRegistrationCheckoutLinkResponse,
+} from '@maple/ts/firebase/api-types';
+
+/**
+ * Build the buyer's post-payment return URL. Honors the client's `returnUrl`
+ * only when its origin is in the CORS allowlist (open-redirect guard), and
+ * appends `?reg=<registrationId>` so the class page can look the registration
+ * up and show a confirmed state. Returns undefined (Square's default
+ * confirmation page) when there's no valid return URL.
+ */
+function buildRedirectUrl(
+  returnUrl: string | undefined,
+  allowedOrigins: string,
+  registrationId: string
+): string | undefined {
+  if (!returnUrl) return undefined;
+  let url: URL;
+  try {
+    url = new URL(returnUrl);
+  } catch {
+    return undefined;
+  }
+  const origins = allowedOrigins.split(',').map((o) => o.trim());
+  if (!origins.includes(url.origin)) return undefined;
+  url.searchParams.set('reg', registrationId);
+  return url.toString();
+}
+
+/**
+ * Release a reserved spot (flip pending -> cancelled) when we reserved but
+ * couldn't hand the buyer a working checkout link, so a failed fallback attempt
+ * doesn't silently hold a spot until the reaper sweeps it.
+ */
+async function releaseHold(
+  registrationId: string,
+  reason: string
+): Promise<void> {
+  try {
+    await RegistrationRepository.getDocRef(registrationId).update({
+      status: 'cancelled',
+      notes: reason,
+      updatedAt: new Date(),
+    });
+  } catch (releaseError) {
+    console.error(
+      `Failed to release hold for registration ${registrationId}:`,
+      releaseError
+    );
+  }
+}
+
+export const createRegistrationCheckoutLink = Functions.endpoint
+  .usingSecrets(...SQUARE_SECRET_NAMES)
+  .usingStrings(...SQUARE_STRING_NAMES, 'ALLOWED_ORIGINS')
+  .handle<
+    CreateRegistrationCheckoutLinkRequest,
+    CreateRegistrationCheckoutLinkResponse
+  >(async (data, _context, secrets, strings) => {
+    const square = new Square(
+      secrets as typeof secrets &
+        Record<(typeof SQUARE_SECRET_NAMES)[number], string>,
+      strings as typeof strings &
+        Record<(typeof SQUARE_STRING_NAMES)[number], string>
+    );
+
+    // Validate, price, and atomically reserve a `pending` spot (shared with the
+    // inline card flow so both paths reserve identically).
+    const {
+      registrationId,
+      classEntity,
+      confirmationNumber,
+      subtotalCents,
+      taxRatePercent,
+      discountCode,
+      discountAmountCents,
+    } = await reserveClassRegistration(data, square.taxRatePercent);
+
+    // A free class has nothing to charge — it should never reach the hosted
+    // checkout fallback (there's no card form to fail). Guard defensively and
+    // release the hold rather than create a $0 payment link.
+    if (subtotalCents <= 0) {
+      await releaseHold(
+        registrationId,
+        'Hosted checkout requested for a $0 registration'
+      );
+      throw new Error(
+        'This registration has no balance due and does not require checkout.'
+      );
+    }
+
+    const redirectUrl = buildRedirectUrl(
+      data.returnUrl,
+      strings.ALLOWED_ORIGINS,
+      registrationId
+    );
+
+    try {
+      const link = await square.checkoutService.createPaymentLink({
+        locationId: square.locationId,
+        idempotencyKey: `checkout-${registrationId}`,
+        referenceId: registrationId,
+        lineItems: [
+          {
+            name: classEntity.name,
+            quantity: data.quantity.toString(),
+            basePriceCents: classEntity.priceCents,
+          },
+        ],
+        taxes: [
+          {
+            name: 'WV Sales Tax',
+            percentage: taxRatePercent.toString(),
+            scope: 'ORDER',
+          },
+        ],
+        discounts:
+          discountAmountCents > 0
+            ? [
+                {
+                  name: discountCode || 'Discount',
+                  amountCents: discountAmountCents,
+                  scope: 'ORDER',
+                },
+              ]
+            : undefined,
+        buyerEmail: data.customerEmail,
+        redirectUrl,
+        description: `Registration for ${classEntity.name} — ${confirmationNumber}`,
+      });
+
+      return {
+        checkoutUrl: link.url,
+        registrationId,
+        confirmationNumber,
+      };
+    } catch (linkError) {
+      // Reserved the spot but couldn't create the link — release the hold.
+      await releaseHold(
+        registrationId,
+        `Checkout link creation failed: ${
+          linkError instanceof Error ? linkError.message : 'Unknown error'
+        }`
+      );
+      throw linkError;
+    }
+  });

--- a/libs/firebase/maple-functions/create-registration-checkout-link/tsconfig.json
+++ b/libs/firebase/maple-functions/create-registration-checkout-link/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "ignoreDeprecations": "6.0"
+  },
+  "files": [],
+  "include": [],
+  "references": [{ "path": "./tsconfig.lib.json" }]
+}

--- a/libs/firebase/maple-functions/create-registration-checkout-link/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/create-registration-checkout-link/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"],
+    "rootDir": "../../.."
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/create-registration/src/lib/create-registration.ts
+++ b/libs/firebase/maple-functions/create-registration/src/lib/create-registration.ts
@@ -19,10 +19,12 @@
  *
  * Deployed to us-east4 via CI/CD pipeline.
  */
-import { FieldValue } from 'firebase-admin/firestore';
-import { Functions, isE2ETestEmail } from '@maple/firebase/functions';
 import {
-  ClassRepository,
+  Functions,
+  isE2ETestEmail,
+  reserveClassRegistration,
+} from '@maple/firebase/functions';
+import {
   DiscountRepository,
   RegistrationRepository,
   AgreementTemplateRepository,
@@ -36,40 +38,14 @@ import {
   SQUARE_STRING_NAMES,
   PaymentError,
 } from '@maple/firebase/square';
-import {
-  isClassRegistrationOpen,
-  applyDiscount,
-  isDiscountValid,
-  calculateTax,
-  formatSessions,
-} from '@maple/ts/domain';
-import { registrationValidation } from '@maple/ts/validation';
+import { formatSessions } from '@maple/ts/domain';
 import type {
   CreateRegistrationRequest,
   CreateRegistrationResponse,
-  InlineAgreementSigningData,
 } from '@maple/ts/firebase/api-types';
-import type {
-  AgreementTemplate,
-  MediaReleaseChoice,
-  PercentDiscountData,
-} from '@maple/ts/domain';
+import type { MediaReleaseChoice, PercentDiscountData } from '@maple/ts/domain';
 import { getStorage } from 'firebase-admin/storage';
 import { randomBytes } from 'crypto';
-
-/**
- * Generate a short, human-readable confirmation number.
- * Format: MS-XXXXXX (6 uppercase alphanumeric chars)
- */
-function generateConfirmationNumber(): string {
-  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // No I, O, 0, 1 to avoid confusion
-  const bytes = randomBytes(6);
-  let code = '';
-  for (let i = 0; i < 6; i++) {
-    code += chars[bytes[i] % chars.length];
-  }
-  return `MS-${code}`;
-}
 
 /**
  * Generate a referral discount code shared via the confirmation email.
@@ -143,268 +119,38 @@ ${sectionHtml}
 </html>`;
 }
 
-/**
- * Validate that all required agreement templates have matching signature data.
- */
-function validateRequiredAgreements(
-  requiredTemplates: AgreementTemplate[],
-  agreements: InlineAgreementSigningData[] | undefined
-): void {
-  if (requiredTemplates.length === 0) return;
-
-  if (!agreements || agreements.length === 0) {
-    throw new Error(
-      'Required agreements must be signed before checkout can complete'
-    );
-  }
-
-  const submittedIds = new Set(agreements.map((a) => a.templateId));
-  const missingTemplates = requiredTemplates.filter(
-    (t) => !submittedIds.has(t.id)
-  );
-
-  if (missingTemplates.length > 0) {
-    const names = missingTemplates.map((t) => t.name).join(', ');
-    throw new Error(
-      `The following agreements must be signed before checkout: ${names}`
-    );
-  }
-
-  // Validate each submitted agreement has required fields
-  for (const agreement of agreements) {
-    if (!agreement.signatureData) {
-      throw new Error('Signature is required for all agreements');
-    }
-    if (!agreement.printedName?.trim()) {
-      throw new Error('Printed name is required for all agreements');
-    }
-    if (agreement.isMinor) {
-      if (!agreement.minorName?.trim()) {
-        throw new Error("Minor's name is required");
-      }
-      if (!agreement.guardianName?.trim()) {
-        throw new Error('Parent/guardian name is required');
-      }
-      if (!agreement.guardianSignatureData) {
-        throw new Error('Parent/guardian signature is required');
-      }
-    }
-  }
-}
-
 export const createRegistration = Functions.endpoint
   .usingSecrets(...SQUARE_SECRET_NAMES)
   .usingStrings(...SQUARE_STRING_NAMES, 'ALLOWED_ORIGINS')
   .handle<CreateRegistrationRequest, CreateRegistrationResponse>(
     async (data, _context, secrets, strings) => {
-      // 1. Validate input
-      const validationResult = registrationValidation(data);
-      if (!validationResult.isValid()) {
-        const errors = validationResult.getErrors();
-        const errorMessages = Object.entries(errors)
-          .map(([field, msgs]) => `${field}: ${msgs.join(', ')}`)
-          .join('; ');
-        throw new Error(`Validation failed: ${errorMessages}`);
-      }
-
-      // When the client sent the new attendees array, cross-check that
-      // `quantity === 1 + additionalAttendees.length` so a stale UI can't
-      // book a different number of spots than the attendees it described.
-      // Callers that omit the field (legacy POS / API clients) are still
-      // trusted to send a correct `quantity` directly.
       const additionalAttendees = data.additionalAttendees ?? [];
-      if (
-        data.additionalAttendees !== undefined &&
-        data.quantity !== 1 + additionalAttendees.length
-      ) {
-        throw new Error(
-          `Quantity (${data.quantity}) must equal 1 + additionalAttendees.length (${1 + additionalAttendees.length}).`
-        );
-      }
 
-      // 2. Verify class exists and is open for registration
-      const classEntity = await ClassRepository.findById(data.classId);
-      if (!classEntity) {
-        throw new Error(`Class not found: ${data.classId}`);
-      }
-
-      if (!isClassRegistrationOpen(classEntity)) {
-        throw new Error('This class is not currently open for registration');
-      }
-
-      // 2b. Check for required agreements and validate signatures before payment
-      const requiredTemplates = classEntity.categoryId
-        ? await AgreementTemplateRepository.findRequiredForCategory(
-            classEntity.categoryId
-          )
-        : [];
-
-      if (requiredTemplates.length > 0) {
-        validateRequiredAgreements(requiredTemplates, data.agreements);
-      }
-
-      // 3. Calculate cost (with optional discount)
-      const originalCostCents = classEntity.priceCents * data.quantity;
-      let discountAmountCents = 0;
-      let discountCode: string | undefined;
-      // The discount doc id (if any) is used inside the capacity transaction
-      // to atomically check + increment usageCount. Looked up here so the
-      // transaction body has it without a second findByCode roundtrip.
-      let discountIdToRedeem: string | undefined;
-
-      if (data.discountCode) {
-        const discount = await DiscountRepository.findByCode(data.discountCode);
-        // The frontend has already shown the customer a price that depends
-        // on this code. If the code isn't valid at submit time, we MUST NOT
-        // silently fall back to full price — the customer hasn't consented
-        // to that charge. Fail the registration with a clear error so the
-        // customer can refresh and retry.
-        if (!discount || !isDiscountValid(discount)) {
-          throw new Error(
-            `Discount code "${data.discountCode}" is no longer valid. Please refresh and try again.`
-          );
-        }
-        const result = applyDiscount(discount, {
-          unitPriceCents: classEntity.priceCents,
-          quantity: data.quantity,
-        });
-        // For quantity-tier codes that don't trigger at this quantity (e.g.,
-        // "second slot 50% off" with qty=1), applyDiscount returns 0. The
-        // code is structurally valid, the preview correctly showed no
-        // discount, and the customer's expected price matches the no-discount
-        // total — so this is fine. We just don't reserve a usage.
-        if (result.discountAmountCents > 0) {
-          discountAmountCents = result.discountAmountCents;
-          discountCode = data.discountCode.toUpperCase();
-          discountIdToRedeem = discount.id;
-        }
-      }
-
-      const subtotalCents = Math.max(0, originalCostCents - discountAmountCents);
-
-      // 4. Calculate sales tax
+      // Square is needed both for the tax rate (below) and to charge the card.
       const square = new Square(
         secrets as typeof secrets &
           Record<(typeof SQUARE_SECRET_NAMES)[number], string>,
         strings as typeof strings &
           Record<(typeof SQUARE_STRING_NAMES)[number], string>
       );
-      const taxRatePercent = square.taxRatePercent;
-      const { taxAmountCents, totalCents: pricePaidCents } = calculateTax(
+
+      // 1-5. Validate, price, and atomically reserve a `pending` spot. Shared
+      // with the hosted-checkout fallback so both paths reserve identically.
+      const {
+        registrationId,
+        classEntity,
+        requiredTemplates,
+        confirmationNumber,
         subtotalCents,
-        taxRatePercent
-      );
+        taxAmountCents,
+        pricePaidCents,
+        taxRatePercent,
+        discountCode,
+        discountAmountCents,
+      } = await reserveClassRegistration(data, square.taxRatePercent);
 
-      // 5. Check capacity atomically via Firestore transaction
-      //    This prevents overbooking race conditions.
       const db = getDb();
-      const registrationDocRef = RegistrationRepository.getDocRef();
-      const confirmationNumber = generateConfirmationNumber();
-
-      await db.runTransaction(async (transaction) => {
-        // === All reads must come before any writes ===
-
-        // Count existing registrations for this class (pending + confirmed)
-        const existingSnapshot = await transaction.get(
-          db
-            .collection('registrations')
-            .where('classId', '==', data.classId)
-            .where('status', 'in', ['pending', 'confirmed'])
-        );
-
-        // Re-read the discount inside the transaction so the usage check
-        // is atomic with the increment below. Single-use codes redeemed by
-        // a parallel registration will be caught here.
-        const discountRef = discountIdToRedeem
-          ? DiscountRepository.getDocRef(discountIdToRedeem)
-          : undefined;
-        const discountSnap = discountRef
-          ? await transaction.get(discountRef)
-          : undefined;
-
-        // === Validation ===
-
-        // Sum up quantities (each registration can have quantity > 1)
-        const currentSpotsTaken = existingSnapshot.docs.reduce((sum, doc) => {
-          return sum + (doc.data().quantity || 1);
-        }, 0);
-
-        const spotsNeeded = data.quantity;
-        if (currentSpotsTaken + spotsNeeded > classEntity.capacity) {
-          const spotsRemaining = classEntity.capacity - currentSpotsTaken;
-          throw new Error(
-            spotsRemaining <= 0
-              ? 'This class is full'
-              : `Only ${spotsRemaining} spot${spotsRemaining === 1 ? '' : 's'} remaining`
-          );
-        }
-
-        if (discountRef && discountSnap) {
-          const fresh = discountSnap.data();
-          if (!fresh || fresh.status !== 'active') {
-            throw new Error('Discount code is no longer available');
-          }
-          const expiresAt = fresh.expiresAt?.toDate?.() ?? fresh.expiresAt;
-          if (expiresAt && new Date() > new Date(expiresAt)) {
-            throw new Error('Discount code has expired');
-          }
-          const usageLimit =
-            typeof fresh.usageLimit === 'number' ? fresh.usageLimit : null;
-          const usageCount =
-            typeof fresh.usageCount === 'number' ? fresh.usageCount : 0;
-          if (usageLimit !== null && usageCount >= usageLimit) {
-            throw new Error(
-              'Discount code has reached its usage limit'
-            );
-          }
-        }
-
-        // === Writes ===
-
-        // Reserve the spot by creating the registration with 'pending' status
-        // inside the transaction so it's atomic with the capacity check
-        const now = new Date();
-        // Filter out empty attendee rows for storage — only keep ones the
-        // user actually filled, so admin views aren't littered with blanks.
-        const persistedAttendees = additionalAttendees
-          .map((a) => ({
-            name: a.name?.trim() || undefined,
-            email: a.email?.trim() || undefined,
-          }))
-          .filter((a) => a.name || a.email);
-
-        transaction.set(registrationDocRef, {
-          classId: data.classId,
-          customerEmail: data.customerEmail,
-          customerName: data.customerName,
-          customerPhone: data.customerPhone || null,
-          quantity: data.quantity,
-          additionalAttendees:
-            persistedAttendees.length > 0 ? persistedAttendees : null,
-          pricePaidCents,
-          subtotalCents,
-          taxAmountCents,
-          taxRatePercent,
-          discountCode: discountCode || null,
-          discountAmountCents: discountAmountCents || null,
-          status: 'pending',
-          source: 'web',
-          notes: data.notes || null,
-          confirmationNumber,
-          createdAt: now,
-          updatedAt: now,
-        });
-
-        // Atomically consume one usage of the discount. Per ADR product
-        // decision, usage is NOT restored if the registration is later
-        // cancelled — single-use means single-use.
-        if (discountRef) {
-          transaction.update(discountRef, {
-            usageCount: FieldValue.increment(1),
-            updatedAt: now,
-          });
-        }
-      });
+      const registrationDocRef = RegistrationRepository.getDocRef(registrationId);
 
       // 6. Create Square Order and process payment
       let squarePaymentId: string | undefined;

--- a/libs/firebase/maple-functions/process-pos-sale/src/lib/process-pos-sale.spec.ts
+++ b/libs/firebase/maple-functions/process-pos-sale/src/lib/process-pos-sale.spec.ts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   findById: vi.fn(),
   findBySquareOrderId: vi.fn(),
   createRegistration: vi.fn(),
+  regUpdate: vi.fn(),
   // ClassRepository
   findBySquareVariationId: vi.fn(),
   // PosLessonConfigRepository
@@ -61,6 +62,7 @@ vi.mock('@maple/firebase/database', () => ({
     findById: mocks.findById,
     findBySquareOrderId: mocks.findBySquareOrderId,
     create: mocks.createRegistration,
+    getDocRef: (id: string) => ({ id, update: mocks.regUpdate }),
   },
   ClassRepository: {
     findBySquareVariationId: mocks.findBySquareVariationId,
@@ -191,18 +193,55 @@ describe('processPosSale — early exits', () => {
 });
 
 describe('processPosSale — dedup', () => {
-  it('skips a web-originated order (referenceId maps to an existing registration)', async () => {
+  it('skips an already-confirmed web order (inline card flow) — no create, no re-update', async () => {
     mocks.getOrder.mockResolvedValue({
       orderId: 'ORDER-1',
       referenceId: 'reg-web-abc',
       lineItems: [{ catalogObjectId: 'VAR_A', quantity: 1 }],
     });
-    mocks.findById.mockResolvedValue({ id: 'reg-web-abc', source: 'web' });
+    mocks.findById.mockResolvedValue({
+      id: 'reg-web-abc',
+      source: 'web',
+      status: 'confirmed',
+    });
 
     await handler(makeEvent({ orderId: 'ORDER-1' }));
 
     expect(mocks.findById).toHaveBeenCalledWith('reg-web-abc');
     expect(mocks.createRegistration).not.toHaveBeenCalled();
+    expect(mocks.regUpdate).not.toHaveBeenCalled();
+    expect(mocks.markProcessed).toHaveBeenCalledWith('PAY-1');
+  });
+
+  it('confirms a pending hosted-checkout registration (referenceId → pending web reg)', async () => {
+    mocks.getPayment.mockResolvedValue({
+      status: 'COMPLETED',
+      orderId: 'ORDER-1',
+      receiptUrl: 'https://squareup.com/receipt/xyz',
+    });
+    mocks.getOrder.mockResolvedValue({
+      orderId: 'ORDER-1',
+      referenceId: 'reg-hosted-1',
+      lineItems: [{ catalogObjectId: 'VAR_A', quantity: 1 }],
+    });
+    mocks.findById.mockResolvedValue({
+      id: 'reg-hosted-1',
+      source: 'web',
+      status: 'pending',
+    });
+
+    await handler(makeEvent({ orderId: 'ORDER-1' }));
+
+    // Flipped pending → confirmed with the Square payment ids — NOT a new POS reg.
+    expect(mocks.createRegistration).not.toHaveBeenCalled();
+    expect(mocks.regUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'confirmed',
+        squarePaymentId: 'PAY-1',
+        squareOrderId: 'ORDER-1',
+        squareReceiptUrl: 'https://squareup.com/receipt/xyz',
+      })
+    );
     expect(mocks.markProcessed).toHaveBeenCalledWith('PAY-1');
   });
 

--- a/libs/firebase/maple-functions/process-pos-sale/src/lib/process-pos-sale.ts
+++ b/libs/firebase/maple-functions/process-pos-sale/src/lib/process-pos-sale.ts
@@ -113,13 +113,36 @@ export const processPosSale = onDocumentWritten(
       // 2. Fetch the order (line items, referenceId, customer).
       const order = await square.ordersService.getOrder(orderId);
 
-      // 3a. Web-order dedup. Web checkouts set the order's referenceId to the
-      // Firestore registration id (see create-registration). If that
-      // registration exists, this order was born on the web — the registration
-      // already exists, so do NOT create a duplicate here.
+      // 3a. Web-order reconciliation. Web checkouts set the order's referenceId
+      // to the Firestore registration id (see create-registration /
+      // createRegistrationCheckoutLink). Two web sub-cases:
+      //   - Inline card flow: the registration is already `confirmed` (payment
+      //     happened synchronously in create-registration) → nothing to do.
+      //   - Hosted-checkout fallback: the registration is still `pending` and
+      //     THIS payment is what confirms it → flip it to `confirmed` with the
+      //     Square payment ids. (A `cancelled` hold that the buyer paid anyway —
+      //     e.g. the reaper released it just before a late completion — is also
+      //     honored rather than dropping a paid registration.)
       if (order.referenceId) {
         const webReg = await RegistrationRepository.findById(order.referenceId);
         if (webReg) {
+          if (webReg.status === 'pending' || webReg.status === 'cancelled') {
+            await RegistrationRepository.getDocRef(webReg.id).update({
+              status: 'confirmed',
+              squarePaymentId: paymentId,
+              squareOrderId: orderId,
+              squareReceiptUrl: payment.receiptUrl ?? null,
+              updatedAt: new Date(),
+            });
+            console.log(
+              `[process-pos-sale] hosted-checkout payment=${paymentId} ` +
+                `confirmed registration ${webReg.id} (was ${webReg.status})`
+            );
+            // TODO(hosted-checkout PR2): queue the rich confirmation email +
+            // process inline agreements here for full parity with the inline
+            // card flow. Square already emails the buyer its own payment
+            // receipt from the hosted page in the meantime.
+          }
           await PosSaleRequestRepository.markProcessed(paymentId);
           return;
         }

--- a/libs/firebase/maple-functions/release-stale-registration-holds/project.json
+++ b/libs/firebase/maple-functions/release-stale-registration-holds/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-release-stale-registration-holds",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/release-stale-registration-holds/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/release-stale-registration-holds/src/index.ts
+++ b/libs/firebase/maple-functions/release-stale-registration-holds/src/index.ts
@@ -1,0 +1,1 @@
+export { releaseStaleRegistrationHolds } from './lib/release-stale-registration-holds';

--- a/libs/firebase/maple-functions/release-stale-registration-holds/src/lib/release-stale-registration-holds.spec.ts
+++ b/libs/firebase/maple-functions/release-stale-registration-holds/src/lib/release-stale-registration-holds.spec.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Unit tests for the stale-hold reaper. Verifies it cancels only `pending`
+ * registrations old enough and without a payment, and leaves ones mid-confirm
+ * (with a squarePaymentId) alone.
+ */
+
+const mocks = vi.hoisted(() => ({
+  onSchedule: vi.fn(),
+  get: vi.fn(),
+  batchUpdate: vi.fn(),
+  batchCommit: vi.fn(),
+  where: vi.fn(),
+}));
+
+vi.mock('firebase-functions/v2/scheduler', () => ({
+  onSchedule: vi.fn((config, handler) => {
+    mocks.onSchedule(config, handler);
+    return handler;
+  }),
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  getDb: () => {
+    const query = {
+      where: vi.fn(() => query),
+      get: mocks.get,
+    };
+    return {
+      collection: vi.fn(() => query),
+      batch: vi.fn(() => ({
+        update: mocks.batchUpdate,
+        commit: mocks.batchCommit,
+      })),
+    };
+  },
+}));
+
+import { releaseStaleRegistrationHolds } from './release-stale-registration-holds';
+
+const handler = releaseStaleRegistrationHolds as unknown as () => Promise<void>;
+
+function doc(id: string, data: Record<string, unknown>) {
+  return { ref: { id }, data: () => data };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('releaseStaleRegistrationHolds', () => {
+  it('cancels a stale pending hold with no payment', async () => {
+    mocks.get.mockResolvedValue({
+      empty: false,
+      size: 1,
+      docs: [doc('reg-1', { status: 'pending' })],
+    });
+
+    await handler();
+
+    expect(mocks.batchUpdate).toHaveBeenCalledWith(
+      { id: 'reg-1' },
+      expect.objectContaining({ status: 'cancelled' })
+    );
+    expect(mocks.batchCommit).toHaveBeenCalled();
+  });
+
+  it('leaves a pending hold that already has a squarePaymentId (confirming race)', async () => {
+    mocks.get.mockResolvedValue({
+      empty: false,
+      size: 1,
+      docs: [doc('reg-2', { status: 'pending', squarePaymentId: 'PAY-9' })],
+    });
+
+    await handler();
+
+    expect(mocks.batchUpdate).not.toHaveBeenCalled();
+    expect(mocks.batchCommit).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when there are no stale holds', async () => {
+    mocks.get.mockResolvedValue({ empty: true, size: 0, docs: [] });
+
+    await handler();
+
+    expect(mocks.batchUpdate).not.toHaveBeenCalled();
+    expect(mocks.batchCommit).not.toHaveBeenCalled();
+  });
+});

--- a/libs/firebase/maple-functions/release-stale-registration-holds/src/lib/release-stale-registration-holds.ts
+++ b/libs/firebase/maple-functions/release-stale-registration-holds/src/lib/release-stale-registration-holds.ts
@@ -1,0 +1,72 @@
+/**
+ * Release Stale Registration Holds — scheduled reaper.
+ *
+ * A hosted-checkout Payment Link reserves a class spot by writing a `pending`
+ * registration, then hands the buyer a Square-hosted checkout URL. If the buyer
+ * abandons that page, the `pending` registration would hold the spot forever
+ * (capacity counts `pending` + `confirmed`), silently shrinking availability on
+ * a near-full class.
+ *
+ * This reaper runs every 5 minutes and cancels `pending` registrations older
+ * than the hold TTL that carry no Square payment — releasing the spot. The
+ * inline card flow resolves `pending` within a single request, and POS sales
+ * are written `confirmed`, so a lingering `pending` is always an abandoned
+ * hosted-checkout hold. The `!squarePaymentId` guard avoids racing a payment
+ * that is confirming right now.
+ *
+ * Deployed to us-east4 (maple-core codebase) via CI/CD.
+ */
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+import { getDb } from '@maple/firebase/database';
+
+/**
+ * How long a `pending` hosted-checkout hold may live before it's treated as
+ * abandoned. Long enough for a real buyer to finish on Square's hosted page,
+ * short enough not to block a near-full class for long.
+ */
+const HOLD_TTL_MINUTES = 15;
+
+export const releaseStaleRegistrationHolds = onSchedule(
+  {
+    schedule: 'every 5 minutes',
+    timeZone: 'America/New_York',
+    region: 'us-east4',
+  },
+  async () => {
+    const db = getDb();
+    const now = new Date();
+    const cutoff = new Date(now.getTime() - HOLD_TTL_MINUTES * 60 * 1000);
+
+    const snapshot = await db
+      .collection('registrations')
+      .where('status', '==', 'pending')
+      .where('createdAt', '<', cutoff)
+      .get();
+
+    if (snapshot.empty) {
+      console.log('[release-stale-holds] no stale pending holds');
+      return;
+    }
+
+    const batch = db.batch();
+    let released = 0;
+    for (const doc of snapshot.docs) {
+      // Never cancel a hold that already has a payment recorded — that's a race
+      // with the confirming webhook, not an abandoned checkout.
+      if (doc.data().squarePaymentId) continue;
+      batch.update(doc.ref, {
+        status: 'cancelled',
+        notes: `Abandoned checkout — hold released after ${HOLD_TTL_MINUTES} minutes`,
+        updatedAt: now,
+      });
+      released++;
+    }
+
+    if (released > 0) {
+      await batch.commit();
+    }
+    console.log(
+      `[release-stale-holds] released ${released} of ${snapshot.size} stale pending hold(s)`
+    );
+  }
+);

--- a/libs/firebase/maple-functions/release-stale-registration-holds/tsconfig.json
+++ b/libs/firebase/maple-functions/release-stale-registration-holds/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "ignoreDeprecations": "6.0"
+  },
+  "files": [],
+  "include": [],
+  "references": [{ "path": "./tsconfig.lib.json" }]
+}

--- a/libs/firebase/maple-functions/release-stale-registration-holds/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/release-stale-registration-holds/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"],
+    "rootDir": "../../.."
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/square-test-mock-server/src/lib/routes/square.ts
+++ b/libs/firebase/square-test-mock-server/src/lib/routes/square.ts
@@ -23,9 +23,16 @@ let inventoryChangeCounter = 0;
 let customerCounter = 0;
 let cardCounter = 0;
 let subscriptionCounter = 0;
+let paymentLinkCounter = 0;
 
 /** In-memory store of created payments for get/refund lookups */
 const payments = new Map<string, Record<string, unknown>>();
+/**
+ * Orders created by the hosted-checkout Payment Link route, keyed by order id.
+ * Stored in Square WIRE shape (snake_case) so `GET /v2/orders/:id` can serve
+ * back the `reference_id` the webhook reconciliation reads.
+ */
+const createdOrders = new Map<string, Record<string, unknown>>();
 /** Craft Club: subscriptions are stored so cancel can look them up. */
 const subscriptions = new Map<string, Record<string, unknown>>();
 
@@ -126,7 +133,9 @@ export function registerSquareRoutes(server: SquareMockServer): void {
   // the order to read line items (catalog_object_id → class variation, money),
   // reference_id (web-order dedup), and customer_id (buyer).
   server.get('/v2/orders/:orderId', (req) => {
-    const order = posFixtureOrders.get(req.params['orderId']);
+    const order =
+      posFixtureOrders.get(req.params['orderId']) ??
+      createdOrders.get(req.params['orderId']);
     if (!order) {
       return {
         status: 404,
@@ -142,6 +151,61 @@ export function registerSquareRoutes(server: SquareMockServer): void {
       };
     }
     return { status: 200, body: { order } };
+  });
+
+  // Create hosted-checkout Payment Link (Safari/ITP fallback). Echoes the
+  // order back with its `reference_id` (the Firestore registration id) and
+  // stores it so `GET /v2/orders/:id` — used by the webhook reconciliation —
+  // can resolve it. Total is computed from the request line items + taxes so
+  // the amount lines up with what the card flow would have charged.
+  server.post('/v2/online-checkout/payment-links', (req) => {
+    const body = req.body as Record<string, unknown>;
+    const order = (body['order'] as Record<string, unknown>) ?? {};
+    paymentLinkCounter++;
+    const orderId = `mock-order-link-${paymentLinkCounter}`;
+    const paymentLinkId = `mock-plink-${paymentLinkCounter}`;
+
+    const lineItems = (order['line_items'] as Record<string, unknown>[]) ?? [];
+    const subtotal = lineItems.reduce((sum, li) => {
+      const qty = Number(li['quantity'] ?? 1);
+      const base =
+        (li['base_price_money'] as Record<string, unknown>)?.['amount'] ?? 0;
+      return sum + Number(base) * qty;
+    }, 0);
+    const taxes = (order['taxes'] as Record<string, unknown>[]) ?? [];
+    const taxTotal = taxes.reduce((sum, t) => {
+      const pct = Number(t['percentage'] ?? 0);
+      return sum + Math.round((subtotal * pct) / 100);
+    }, 0);
+    const total = subtotal + taxTotal;
+
+    const storedOrder = {
+      id: orderId,
+      location_id: order['location_id'] ?? 'mock-location',
+      reference_id: order['reference_id'],
+      state: 'OPEN',
+      line_items: lineItems,
+      total_money: { amount: total, currency: 'USD' },
+      total_tax_money: { amount: taxTotal, currency: 'USD' },
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+    createdOrders.set(orderId, storedOrder);
+
+    return {
+      status: 200,
+      body: {
+        payment_link: {
+          id: paymentLinkId,
+          version: 1,
+          order_id: orderId,
+          url: `https://square.link/u/${paymentLinkId}`,
+          long_url: `https://checkout.square.site/merchant/mock/checkout/${paymentLinkId}`,
+          created_at: new Date().toISOString(),
+        },
+        related_resources: { orders: [storedOrder] },
+      },
+    };
   });
 
   // Get customer. Served from POS fixtures. Returns 200 with an empty body
@@ -623,7 +687,9 @@ export function resetSquareState(): void {
   customerCounter = 0;
   cardCounter = 0;
   subscriptionCounter = 0;
+  paymentLinkCounter = 0;
   payments.clear();
+  createdOrders.clear();
   subscriptions.clear();
   posFixturePayments.clear();
   posFixtureOrders.clear();

--- a/libs/firebase/square/src/index.ts
+++ b/libs/firebase/square/src/index.ts
@@ -68,6 +68,13 @@ export {
   type InvoiceLineItemInput,
 } from './lib/invoices.service';
 
+// Checkout service (hosted Payment Links — Safari/ITP fallback)
+export {
+  CheckoutService,
+  type CreatePaymentLinkInput,
+  type CreatePaymentLinkResult,
+} from './lib/checkout.service';
+
 // Cards service (cards on file for subscription billing)
 export {
   CardsService,

--- a/libs/firebase/square/src/lib/checkout.service.spec.ts
+++ b/libs/firebase/square/src/lib/checkout.service.spec.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CheckoutService } from './checkout.service';
+import type { SquareClient } from 'square';
+
+/**
+ * Unit tests for the Square CheckoutService (hosted Payment Links). Mocks the
+ * SDK's checkout.paymentLinks.create and verifies we build the order to match
+ * the inline-card order (line items + percentage tax + discounts + referenceId),
+ * wire the redirect + buyer email, and surface ids / errors correctly.
+ */
+
+interface MockClient {
+  checkout: {
+    paymentLinks: {
+      create: ReturnType<typeof vi.fn>;
+    };
+  };
+}
+
+function makeMockClient(): MockClient {
+  return { checkout: { paymentLinks: { create: vi.fn() } } };
+}
+
+const sampleInput = () => ({
+  locationId: 'LEJBNPRGM99NV',
+  idempotencyKey: 'reg-abc123',
+  referenceId: 'reg-abc123',
+  lineItems: [{ name: 'Stained Glass — TryIt', quantity: '1', basePriceCents: 6000 }],
+  taxes: [{ name: 'WV Sales Tax', percentage: '6.0', scope: 'ORDER' as const }],
+  buyerEmail: 'buyer@example.com',
+  redirectUrl: 'https://mapleandsprucefolkarts.com/registration-confirmed',
+  description: 'Class registration — Stained Glass',
+});
+
+const okResponse = () => ({
+  paymentLink: {
+    id: 'plink_1',
+    version: 1,
+    orderId: 'order_1',
+    url: 'https://square.link/u/plink_1',
+    longUrl: 'https://checkout.square.site/merchant/x/checkout/plink_1',
+  },
+  errors: undefined,
+});
+
+describe('CheckoutService.createPaymentLink', () => {
+  let mock: MockClient;
+  let service: CheckoutService;
+
+  beforeEach(() => {
+    mock = makeMockClient();
+    service = new CheckoutService(mock as unknown as SquareClient);
+  });
+
+  it('creates a payment link and returns its id, orderId, and hosted URL', async () => {
+    mock.checkout.paymentLinks.create.mockResolvedValue(okResponse());
+
+    const result = await service.createPaymentLink(sampleInput());
+
+    expect(result).toEqual({
+      paymentLinkId: 'plink_1',
+      orderId: 'order_1',
+      url: 'https://square.link/u/plink_1',
+    });
+  });
+
+  it('builds the order with referenceId, line items, and percentage tax', async () => {
+    mock.checkout.paymentLinks.create.mockResolvedValue(okResponse());
+
+    await service.createPaymentLink(sampleInput());
+
+    const arg = mock.checkout.paymentLinks.create.mock.calls[0][0];
+    expect(arg.idempotencyKey).toBe('reg-abc123');
+    expect(arg.order.locationId).toBe('LEJBNPRGM99NV');
+    expect(arg.order.referenceId).toBe('reg-abc123');
+    expect(arg.order.lineItems[0]).toMatchObject({
+      name: 'Stained Glass — TryIt',
+      quantity: '1',
+      basePriceMoney: { amount: 6000n, currency: 'USD' },
+    });
+    expect(arg.order.taxes[0]).toMatchObject({
+      name: 'WV Sales Tax',
+      percentage: '6.0',
+      scope: 'ORDER',
+    });
+  });
+
+  it('sets the redirect URL and pre-fills the buyer email', async () => {
+    mock.checkout.paymentLinks.create.mockResolvedValue(okResponse());
+
+    await service.createPaymentLink(sampleInput());
+
+    const arg = mock.checkout.paymentLinks.create.mock.calls[0][0];
+    expect(arg.checkoutOptions.redirectUrl).toBe(
+      'https://mapleandsprucefolkarts.com/registration-confirmed'
+    );
+    expect(arg.checkoutOptions.askForShippingAddress).toBe(false);
+    expect(arg.prePopulatedData.buyerEmail).toBe('buyer@example.com');
+  });
+
+  it('maps discounts to amountMoney when present', async () => {
+    mock.checkout.paymentLinks.create.mockResolvedValue(okResponse());
+
+    await service.createPaymentLink({
+      ...sampleInput(),
+      discounts: [{ name: 'EARLYBIRD', amountCents: 1000, scope: 'ORDER' }],
+    });
+
+    const arg = mock.checkout.paymentLinks.create.mock.calls[0][0];
+    expect(arg.order.discounts[0]).toMatchObject({
+      name: 'EARLYBIRD',
+      amountMoney: { amount: 1000n, currency: 'USD' },
+      scope: 'ORDER',
+    });
+  });
+
+  it('throws when Square returns errors', async () => {
+    mock.checkout.paymentLinks.create.mockResolvedValue({
+      errors: [{ code: 'BAD_REQUEST', detail: 'Invalid location' }],
+    });
+
+    await expect(service.createPaymentLink(sampleInput())).rejects.toThrow(
+      /create payment link error: Invalid location/
+    );
+  });
+
+  it('throws when the payment link is missing id/url/orderId', async () => {
+    mock.checkout.paymentLinks.create.mockResolvedValue({
+      paymentLink: { id: 'plink_1' },
+    });
+
+    await expect(service.createPaymentLink(sampleInput())).rejects.toThrow(
+      /no id\/url\/orderId/
+    );
+  });
+});

--- a/libs/firebase/square/src/lib/checkout.service.ts
+++ b/libs/firebase/square/src/lib/checkout.service.ts
@@ -1,0 +1,134 @@
+/**
+ * Square Checkout API service — hosted Payment Links.
+ *
+ * Creates a Square-hosted checkout page (a `square.link` / `checkout.square.site`
+ * URL) that the buyer is redirected to and pays on. Because payment happens on
+ * Square's own top-level page — not in a cross-origin iframe embedded in our
+ * page — it is immune to Safari's Intelligent Tracking Prevention (ITP)
+ * blocking the embedded Web Payments SDK's storage handshake
+ * (`InitializationTimeoutError`). This is the reliable fallback for buyers whose
+ * browser privacy settings break the inline card form.
+ *
+ * The order is built identically to `OrdersService.createOrder` (same line
+ * items, tax, discounts, `referenceId`) so the hosted total matches the inline
+ * card total to the cent. Payment completion flows back via the
+ * `payment.updated` webhook (handled in square-webhook), which resolves the
+ * order's `referenceId` to our pending Registration and flips it to confirmed.
+ *
+ * @see https://developer.squareup.com/docs/checkout-api
+ * @see https://developer.squareup.com/reference/square/checkout-api/create-payment-link
+ */
+import { SquareClient, Square } from 'square';
+import type {
+  OrderLineItemInput,
+  OrderTaxInput,
+  OrderDiscountInput,
+} from './orders.service';
+
+export interface CreatePaymentLinkInput {
+  /** Square location id. */
+  locationId: string;
+  /** Idempotency key (typically the Firestore registration id). */
+  idempotencyKey: string;
+  /**
+   * External reference set on the order — the Firestore registration id. The
+   * webhook reads this back off the paid order to reconcile the registration.
+   */
+  referenceId: string;
+  /** Line items (class name × quantity). Same shape as OrdersService. */
+  lineItems: OrderLineItemInput[];
+  /** Taxes to apply (e.g. WV Sales Tax). */
+  taxes: OrderTaxInput[];
+  /** Discounts to apply. */
+  discounts?: OrderDiscountInput[];
+  /** Pre-fills the buyer's email on the hosted page. */
+  buyerEmail?: string;
+  /** Where Square sends the buyer's browser after a successful payment. */
+  redirectUrl?: string;
+  /** Short description shown on the hosted checkout page. */
+  description?: string;
+}
+
+export interface CreatePaymentLinkResult {
+  /** Square payment-link id. */
+  paymentLinkId: string;
+  /** Square order id created for the link (carries our `referenceId`). */
+  orderId: string;
+  /** Hosted checkout URL to redirect the buyer to. */
+  url: string;
+}
+
+export class CheckoutService {
+  constructor(private readonly client: SquareClient) {}
+
+  /**
+   * Create a hosted checkout Payment Link for a class registration. The order
+   * mirrors the inline card order exactly (line items + percentage tax +
+   * discounts + `referenceId`) so the buyer sees the same total.
+   */
+  async createPaymentLink(
+    input: CreatePaymentLinkInput
+  ): Promise<CreatePaymentLinkResult> {
+    const response = await this.client.checkout.paymentLinks.create({
+      idempotencyKey: input.idempotencyKey,
+      description: input.description,
+      order: {
+        locationId: input.locationId,
+        referenceId: input.referenceId,
+        lineItems: input.lineItems.map((item) => ({
+          name: item.name,
+          quantity: item.quantity,
+          basePriceMoney: {
+            amount: BigInt(item.basePriceCents),
+            currency: 'USD',
+          },
+        })),
+        taxes: input.taxes.map((tax) => ({
+          name: tax.name,
+          percentage: tax.percentage,
+          scope: tax.scope,
+        })),
+        discounts: input.discounts?.map((discount) => ({
+          name: discount.name,
+          amountMoney: {
+            amount: BigInt(discount.amountCents),
+            currency: 'USD',
+          },
+          scope: discount.scope,
+        })),
+      },
+      checkoutOptions: input.redirectUrl
+        ? { redirectUrl: input.redirectUrl, askForShippingAddress: false }
+        : { askForShippingAddress: false },
+      prePopulatedData: input.buyerEmail
+        ? { buyerEmail: input.buyerEmail }
+        : undefined,
+    });
+
+    throwIfErrors(response.errors, 'create payment link');
+
+    const link = response.paymentLink;
+    if (!link?.id || !link.url || !link.orderId) {
+      throw new Error(
+        'Square create payment link returned no id/url/orderId'
+      );
+    }
+
+    return {
+      paymentLinkId: link.id,
+      orderId: link.orderId,
+      url: link.url,
+    };
+  }
+}
+
+function throwIfErrors(
+  errors: Square.Error_[] | undefined,
+  operation: string
+): void {
+  if (!errors || errors.length === 0) return;
+  const msg = errors
+    .map((e) => e.detail || e.code || 'Unknown error')
+    .join('; ');
+  throw new Error(`Square ${operation} error: ${msg}`);
+}

--- a/libs/firebase/square/src/lib/square.utility.ts
+++ b/libs/firebase/square/src/lib/square.utility.ts
@@ -20,6 +20,7 @@ import { InventoryService } from './inventory.service';
 import { OrdersService } from './orders.service';
 import { PaymentsService } from './payments.service';
 import { InvoicesService } from './invoices.service';
+import { CheckoutService } from './checkout.service';
 import { CardsService } from './cards.service';
 import { SubscriptionsService } from './subscriptions.service';
 import { CustomersService } from './customers.service';
@@ -74,6 +75,7 @@ export class Square {
   private readonly _ordersService: OrdersService;
   private readonly _paymentsService: PaymentsService;
   private readonly _invoicesService: InvoicesService;
+  private readonly _checkoutService: CheckoutService;
   private readonly _cardsService: CardsService;
   private readonly _subscriptionsService: SubscriptionsService;
   private readonly _customersService: CustomersService;
@@ -116,6 +118,7 @@ export class Square {
     this._ordersService = new OrdersService(this.client);
     this._paymentsService = new PaymentsService(this.client);
     this._invoicesService = new InvoicesService(this.client);
+    this._checkoutService = new CheckoutService(this.client);
     this._cardsService = new CardsService(this.client);
     this._subscriptionsService = new SubscriptionsService(this.client);
     this._customersService = new CustomersService(this.client);
@@ -168,6 +171,13 @@ export class Square {
    */
   get invoicesService(): InvoicesService {
     return this._invoicesService;
+  }
+
+  /**
+   * Get the checkout service for hosted Payment Links (Safari/ITP fallback)
+   */
+  get checkoutService(): CheckoutService {
+    return this._checkoutService;
   }
 
   /**

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -276,6 +276,8 @@ export type {
   CalculateRegistrationCostResponse,
   CreateRegistrationRequest,
   CreateRegistrationResponse,
+  CreateRegistrationCheckoutLinkRequest,
+  CreateRegistrationCheckoutLinkResponse,
 } from './registration.types';
 
 // Phase 4: Music Lessons - Student types

--- a/libs/ts/firebase/api-types/src/lib/registration.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/registration.types.ts
@@ -138,3 +138,43 @@ export interface CreateRegistrationResponse {
   /** True if all agreements were signed at checkout */
   agreementsSigned?: boolean;
 }
+
+// ============================================================================
+// Create Registration Checkout Link (Public - Square-hosted checkout fallback)
+// ============================================================================
+
+/**
+ * Request for a Square-hosted checkout Payment Link. Same fields as
+ * CreateRegistrationRequest MINUS the card `paymentNonce` — the buyer pays on
+ * Square's own hosted page instead of tokenizing a card inline. This is the
+ * fallback used when the embedded Web Payments SDK can't initialize (e.g.
+ * Safari ITP blocking its cross-origin iframe).
+ */
+export interface CreateRegistrationCheckoutLinkRequest {
+  classId: string;
+  customerEmail: string;
+  customerName: string;
+  customerPhone?: string;
+  quantity: number;
+  additionalAttendees?: Attendee[];
+  discountCode?: string;
+  notes?: string;
+  agreements?: InlineAgreementSigningData[];
+  /**
+   * URL to send the buyer back to after paying on Square's hosted page —
+   * normally the class page. The server appends `?reg=<registrationId>` and
+   * only honors it when its origin is in the CORS allowlist (open-redirect
+   * guard). The returned registration is the source of truth; the param is a
+   * pointer the widget verifies by lookup, never proof of payment.
+   */
+  returnUrl?: string;
+}
+
+export interface CreateRegistrationCheckoutLinkResponse {
+  /** Square-hosted checkout URL to redirect the buyer to. */
+  checkoutUrl: string;
+  /** The reserved (pending) registration id — also the Square order referenceId. */
+  registrationId: string;
+  /** Confirmation number stamped on the reserved registration. */
+  confirmationNumber: string;
+}

--- a/tools/check-callable-roles.ts
+++ b/tools/check-callable-roles.ts
@@ -69,6 +69,9 @@ const PUBLIC_ALLOWLIST = new Set<string>([
   // NOTE: cancelRegistration / cancelMusicTogetherRegistration are role-gated
   // (admin/clerk), NOT public — so they are intentionally absent here.
   'createRegistration',
+  // Safari/ITP hosted-checkout fallback — same public self-service surface as
+  // createRegistration (reserves a spot + returns a Square-hosted checkout URL).
+  'createRegistrationCheckoutLink',
   'createMusicTogetherRegistration',
   'addMusicTogetherInterest',
   'addToClassWaitlist',

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -365,6 +365,9 @@
       "@maple/firebase/maple-functions/create-registration-checkout-link": [
         "libs/firebase/maple-functions/create-registration-checkout-link/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/release-stale-registration-holds": [
+        "libs/firebase/maple-functions/release-stale-registration-holds/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/cancel-registration": [
         "libs/firebase/maple-functions/cancel-registration/src/index.ts"
       ],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -362,6 +362,9 @@
       "@maple/firebase/maple-functions/create-registration": [
         "libs/firebase/maple-functions/create-registration/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/create-registration-checkout-link": [
+        "libs/firebase/maple-functions/create-registration-checkout-link/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/cancel-registration": [
         "libs/firebase/maple-functions/cancel-registration/src/index.ts"
       ],


### PR DESCRIPTION
## Why

When the embedded Square Web Payments SDK can't initialize in a buyer's browser — most notably **Safari with ITP / Prevent Cross-Site Tracking**, which starves the SDK's cross-origin iframe of the storage it needs (`InitializationTimeoutError`) — the inline card form is a dead end. [Deep research](../) confirmed the only durable, no-user-settings-change fix is to redirect to **Square's own hosted checkout** (a Payment Link), which pays on a top-level Square page where ITP is irrelevant.

This PR is the **backend** for that fallback. It's dormant until PR 2 wires the widget button, so it's safe to merge on its own.

## The flow

```
widget (SDK init fails)
  → createRegistrationCheckoutLink   ── reserve pending spot + create Payment Link → { checkoutUrl }
  → buyer pays on Square's hosted page
  → payment.updated webhook → processPosSale → flip pending → confirmed
  (abandoned? → reaper releases the hold after 15 min)
```

## What's here

- **`CheckoutService.createPaymentLink`** (`libs/firebase/square`, SDK 43) — builds the order identically to the card flow (line items + WV tax + discount + `referenceId`) so the hosted total matches to the cent.
- **`reserveClassRegistration`** shared helper (`@maple/firebase/functions`) — extracted from `createRegistration` (behavior-preserving) so both payment paths reserve a `pending` spot through the *same* capacity transaction. Single-sourcing prevents overbooking from divergent logic.
- **`createRegistrationCheckoutLink`** callable — validate → reserve → Payment Link → `{ checkoutUrl, registrationId, confirmationNumber }`. `returnUrl` (the class page) is honored only when its origin is in `ALLOWED_ORIGINS` (open-redirect guard); server appends `?reg=<id>`. Releases the hold if link creation fails or a $0 registration slips through.
- **`processPosSale` reconciliation** — a hosted payment already arrives here (COMPLETED `payment.updated` → enqueue → worker with the Square SDK). The `referenceId` dedup now flips a `pending` (or reaper-`cancelled`, paid-anyway) web registration to `confirmed` with the payment ids, idempotent for already-`confirmed` ones. No new webhook surface or cold-start cost.
- **`releaseStaleRegistrationHolds`** reaper (maple-core, every 5 min) — cancels `pending` holds older than **15 min** with no `squarePaymentId`, releasing the spot. Composite index declared.

## Testing

- Unit: CheckoutService (6), processPosSale reconciliation (+2, 19 total), reaper (3).
- Integration (emulator + Square mock, new `/v2/online-checkout/payment-links` route): `createRegistrationCheckoutLink` reserves a `pending` web registration priced with tax + returns a hosted URL; capacity-full rejection; input validation. **Registration suite green: 63 tests.**
- `createRegistration` refactor verified behavior-preserving (typecheck + existing suite).
- typecheck (both codebases), lint, `validate-function-tsconfigs`, firestore index analyzer (173 covered) — all green.

## Decisions (David)

- Hold TTL **15 min**; redirect to the **class page** with a `?reg=` param the widget will **verify by lookup** (webhook is source of truth — the param is a pointer, never proof of payment).

## Follow-ups (PR 2)

- Widget "Continue to secure checkout" button on `onInitError` (signal shipped in #654) + the `?reg=` confirmation UX; real-Square-sandbox e2e.
- **Parity TODOs** (marked in `processPosSale`): rich confirmation email + inline-agreement processing for the hosted flow. Square emails its own receipt meanwhile; classes with required agreements should wait for this before the fallback is enabled for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)