### PR TITLE
feat(registration): inline-agreement parity for hosted checkout

### DIFF
--- a/libs/firebase/functions/src/lib/index.ts
+++ b/libs/firebase/functions/src/lib/index.ts
@@ -83,7 +83,14 @@ export {
   validateRequiredAgreements,
   generateConfirmationNumber,
   type ReserveRegistrationResult,
+  type RegistrationReservationInput,
 } from './registration-reservation.utility';
+
+// Shared inline-agreement processing (card + hosted-checkout paths)
+export {
+  processInlineAgreements,
+  type InlineAgreementSigner,
+} from './inline-agreements.utility';
 
 // Per-family calendar subscription utilities
 export {

--- a/libs/firebase/functions/src/lib/inline-agreements.utility.spec.ts
+++ b/libs/firebase/functions/src/lib/inline-agreements.utility.spec.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Unit tests for the shared inline-agreement processor. Verifies it uploads the
+ * signature, creates the request + signed-agreement records, moves the image
+ * under the real signed-agreement id, marks the request signed, and short-
+ * circuits when there's nothing to sign.
+ */
+
+const mocks = vi.hoisted(() => ({
+  createRequest: vi.fn(),
+  createSigned: vi.fn(),
+  markSigned: vi.fn(),
+  save: vi.fn(),
+  move: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  AgreementRequestRepository: {
+    create: mocks.createRequest,
+    markSigned: mocks.markSigned,
+  },
+  SignedAgreementRepository: { create: mocks.createSigned },
+}));
+
+vi.mock('firebase-admin/storage', () => ({
+  getStorage: () => ({
+    bucket: () => ({
+      file: () => ({ save: mocks.save, move: mocks.move }),
+    }),
+  }),
+}));
+
+import { processInlineAgreements } from './inline-agreements.utility';
+
+const template = {
+  id: 'tpl-1',
+  version: 3,
+  name: 'Studio Waiver',
+  sections: [{ title: 'Risk', content: 'You agree.' }],
+} as never;
+
+const signer = { email: 'a@test.com', name: 'Ada Signer', phone: '+1304' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.createRequest.mockResolvedValue({ id: 'req-1' });
+  mocks.createSigned.mockResolvedValue({ id: 'signed-1' });
+});
+
+describe('processInlineAgreements', () => {
+  it('returns false and does nothing when there are no required templates', async () => {
+    const result = await processInlineAgreements({
+      registrationId: 'reg-1',
+      classId: 'class-1',
+      requiredTemplates: [],
+      agreements: [{ templateId: 'tpl-1' } as never],
+      signer,
+    });
+    expect(result).toBe(false);
+    expect(mocks.createRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns false when no agreements were submitted', async () => {
+    const result = await processInlineAgreements({
+      registrationId: 'reg-1',
+      classId: 'class-1',
+      requiredTemplates: [template],
+      agreements: undefined,
+      signer,
+    });
+    expect(result).toBe(false);
+    expect(mocks.createSigned).not.toHaveBeenCalled();
+  });
+
+  it('persists a signed agreement: request + signed record + file move + markSigned', async () => {
+    const result = await processInlineAgreements({
+      registrationId: 'reg-1',
+      classId: 'class-1',
+      requiredTemplates: [template],
+      agreements: [
+        {
+          templateId: 'tpl-1',
+          signatureData: 'data:image/png;base64,AAAA',
+          printedName: '  Ada Signer  ',
+        } as never,
+      ],
+      signer,
+    });
+
+    expect(result).toBe(true);
+    expect(mocks.save).toHaveBeenCalled(); // signature uploaded
+    expect(mocks.createRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        templateId: 'tpl-1',
+        registrationId: 'reg-1',
+        classId: 'class-1',
+        signerEmail: 'a@test.com',
+      })
+    );
+    expect(mocks.createSigned).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: 'req-1',
+        printedName: 'Ada Signer', // trimmed
+        signerEmail: 'a@test.com',
+      })
+    );
+    // Image moved under the real signed-agreement id, then request marked signed.
+    expect(mocks.move).toHaveBeenCalledWith(
+      'agreements/signed-1/signature.png'
+    );
+    expect(mocks.markSigned).toHaveBeenCalledWith('req-1', 'signed-1');
+  });
+
+  it('uploads a guardian signature for a minor', async () => {
+    await processInlineAgreements({
+      registrationId: 'reg-1',
+      classId: 'class-1',
+      requiredTemplates: [template],
+      agreements: [
+        {
+          templateId: 'tpl-1',
+          signatureData: 'AAAA',
+          printedName: 'Parent',
+          isMinor: true,
+          minorName: 'Kid',
+          guardianName: 'Parent',
+          guardianSignatureData: 'BBBB',
+        } as never,
+      ],
+      signer,
+    });
+
+    // Two uploads (signature + guardian), two moves under signed-1.
+    expect(mocks.save).toHaveBeenCalledTimes(2);
+    expect(mocks.move).toHaveBeenCalledWith(
+      'agreements/signed-1/guardian-signature.png'
+    );
+  });
+
+  it('ignores submitted agreements that do not match a required template', async () => {
+    const result = await processInlineAgreements({
+      registrationId: 'reg-1',
+      classId: 'class-1',
+      requiredTemplates: [template],
+      agreements: [{ templateId: 'other-tpl', signatureData: 'x' } as never],
+      signer,
+    });
+    expect(result).toBe(true); // required set was non-empty
+    expect(mocks.createSigned).not.toHaveBeenCalled();
+  });
+});

--- a/libs/firebase/functions/src/lib/inline-agreements.utility.ts
+++ b/libs/firebase/functions/src/lib/inline-agreements.utility.ts
@@ -1,0 +1,166 @@
+/**
+ * Shared inline-agreement processing.
+ *
+ * A class category can require agreements to be signed at checkout. Both
+ * payment paths collect those signatures in the widget and must persist them
+ * identically:
+ *  - `createRegistration` (inline card) processes them after payment, and
+ *  - `createRegistrationCheckoutLink` (hosted-checkout fallback) processes them
+ *    at reservation time — the signatures are captured before the buyer is
+ *    redirected to Square, so that's the only point at which they're in hand.
+ *
+ * For each signed agreement this uploads the signature image(s), creates the
+ * AgreementRequest + SignedAgreement records (the legal snapshot), moves the
+ * images under the real signed-agreement id, and marks the request signed.
+ */
+import { getStorage } from 'firebase-admin/storage';
+import { randomBytes } from 'crypto';
+import {
+  AgreementRequestRepository,
+  SignedAgreementRepository,
+} from '@maple/firebase/database';
+import type { AgreementTemplate, MediaReleaseChoice } from '@maple/ts/domain';
+import type { InlineAgreementSigningData } from '@maple/ts/firebase/api-types';
+
+/** Who signed — carried onto the agreement/request records. */
+export interface InlineAgreementSigner {
+  email: string;
+  name: string;
+  phone?: string;
+}
+
+/** Upload a base64 PNG to Firebase Storage and return the file path. */
+async function uploadSignature(
+  signedAgreementId: string,
+  filename: string,
+  base64Data: string
+): Promise<string> {
+  const bucket = getStorage().bucket();
+  const filePath = `agreements/${signedAgreementId}/${filename}`;
+  const file = bucket.file(filePath);
+
+  const raw = base64Data.includes(',') ? base64Data.split(',')[1] : base64Data;
+  const buffer = Buffer.from(raw, 'base64');
+
+  await file.save(buffer, { metadata: { contentType: 'image/png' } });
+  return filePath;
+}
+
+/** Render agreement sections into an HTML snapshot for the legal record. */
+function renderAgreementHtml(
+  templateName: string,
+  sections: Array<{ title: string; content: string }>
+): string {
+  const sectionHtml = sections
+    .map((s) => `<section><h2>${s.title}</h2><div>${s.content}</div></section>`)
+    .join('\n');
+
+  return `<!DOCTYPE html>
+<html>
+<head><title>${templateName}</title></head>
+<body>
+<h1>${templateName}</h1>
+${sectionHtml}
+</body>
+</html>`;
+}
+
+/**
+ * Persist the signatures for a registration's required agreements. Returns
+ * whether any agreements were processed (i.e. the registration is fully signed).
+ * Agreements not matching a required template are ignored.
+ *
+ * Callers should wrap this in try/catch: a failure here must not fail a paid
+ * registration — the money is taken / the spot reserved either way; a missing
+ * agreement record is a follow-up, not a checkout blocker.
+ */
+export async function processInlineAgreements(args: {
+  registrationId: string;
+  classId: string;
+  requiredTemplates: AgreementTemplate[];
+  agreements: InlineAgreementSigningData[] | undefined;
+  signer: InlineAgreementSigner;
+}): Promise<boolean> {
+  const { registrationId, classId, requiredTemplates, agreements, signer } =
+    args;
+  if (requiredTemplates.length === 0 || !agreements) return false;
+
+  const templateMap = new Map(requiredTemplates.map((t) => [t.id, t]));
+
+  for (const agreementData of agreements) {
+    const template = templateMap.get(agreementData.templateId);
+    if (!template) continue;
+
+    const tempId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    const signatureImagePath = await uploadSignature(
+      tempId,
+      'signature.png',
+      agreementData.signatureData
+    );
+
+    let guardianSignatureImagePath: string | undefined;
+    if (agreementData.isMinor && agreementData.guardianSignatureData) {
+      guardianSignatureImagePath = await uploadSignature(
+        tempId,
+        'guardian-signature.png',
+        agreementData.guardianSignatureData
+      );
+    }
+
+    const signingToken = randomBytes(32).toString('hex');
+    const request = await AgreementRequestRepository.create({
+      templateId: template.id,
+      templateVersion: template.version,
+      signerEmail: signer.email,
+      signerName: signer.name,
+      signerPhone: signer.phone,
+      deliveryMethod: 'registration',
+      registrationId,
+      classId,
+      signingToken,
+      expiresAt: new Date(), // Already signed, expiry irrelevant
+      status: 'pending', // Marked signed immediately below
+    });
+
+    const agreementHtmlSnapshot = renderAgreementHtml(
+      template.name,
+      template.sections
+    );
+
+    const signedAgreement = await SignedAgreementRepository.create({
+      requestId: request.id,
+      templateId: template.id,
+      templateVersion: template.version,
+      agreementHtmlSnapshot,
+      signerEmail: signer.email,
+      printedName: agreementData.printedName.trim(),
+      signatureImagePath,
+      mediaReleaseChoice: agreementData.mediaReleaseChoice as
+        | MediaReleaseChoice
+        | undefined,
+      isMinor: agreementData.isMinor ?? false,
+      minorName: agreementData.minorName,
+      guardianName: agreementData.guardianName,
+      guardianSignatureImagePath,
+      signedAt: new Date(),
+      ipAddress: 'inline-checkout',
+      userAgent: 'inline-checkout',
+    });
+
+    // Move the images under the real signed-agreement id.
+    const bucket = getStorage().bucket();
+    await bucket
+      .file(signatureImagePath)
+      .move(`agreements/${signedAgreement.id}/signature.png`);
+    if (guardianSignatureImagePath) {
+      await bucket
+        .file(guardianSignatureImagePath)
+        .move(`agreements/${signedAgreement.id}/guardian-signature.png`);
+    }
+
+    await AgreementRequestRepository.markSigned(request.id, signedAgreement.id);
+  }
+
+  return true;
+}

--- a/libs/firebase/maple-functions/create-registration-checkout-link/src/lib/create-registration-checkout-link.ts
+++ b/libs/firebase/maple-functions/create-registration-checkout-link/src/lib/create-registration-checkout-link.ts
@@ -18,6 +18,7 @@
 import {
   Functions,
   reserveClassRegistration,
+  processInlineAgreements,
 } from '@maple/firebase/functions';
 import { RegistrationRepository } from '@maple/firebase/database';
 import {
@@ -97,12 +98,37 @@ export const createRegistrationCheckoutLink = Functions.endpoint
     const {
       registrationId,
       classEntity,
+      requiredTemplates,
       confirmationNumber,
       subtotalCents,
       taxRatePercent,
       discountCode,
       discountAmountCents,
     } = await reserveClassRegistration(data, square.taxRatePercent);
+
+    // Persist signed agreements now — the signatures were captured in the
+    // widget before this call, and the buyer is about to leave for Square's
+    // hosted page (processPosSale, which confirms the payment later, has no
+    // access to them). Shared with the card flow so records are identical.
+    // Best-effort: a failure here must not block a buyer who already signed.
+    try {
+      await processInlineAgreements({
+        registrationId,
+        classId: data.classId,
+        requiredTemplates,
+        agreements: data.agreements,
+        signer: {
+          email: data.customerEmail,
+          name: data.customerName,
+          phone: data.customerPhone,
+        },
+      });
+    } catch (agreementError) {
+      console.error(
+        `Failed to process agreements for hosted checkout ${registrationId}:`,
+        agreementError
+      );
+    }
 
     // A free class has nothing to charge — it should never reach the hosted
     // checkout fallback (there's no card form to fail). Guard defensively and

--- a/libs/firebase/maple-functions/create-registration/src/lib/create-registration.ts
+++ b/libs/firebase/maple-functions/create-registration/src/lib/create-registration.ts
@@ -23,13 +23,13 @@ import {
   Functions,
   isE2ETestEmail,
   reserveClassRegistration,
+  processInlineAgreements,
 } from '@maple/firebase/functions';
 import {
   DiscountRepository,
   RegistrationRepository,
   AgreementTemplateRepository,
   AgreementRequestRepository,
-  SignedAgreementRepository,
   getDb,
 } from '@maple/firebase/database';
 import {
@@ -43,8 +43,7 @@ import type {
   CreateRegistrationRequest,
   CreateRegistrationResponse,
 } from '@maple/ts/firebase/api-types';
-import type { MediaReleaseChoice, PercentDiscountData } from '@maple/ts/domain';
-import { getStorage } from 'firebase-admin/storage';
+import type { PercentDiscountData } from '@maple/ts/domain';
 import { randomBytes } from 'crypto';
 
 /**
@@ -69,54 +68,6 @@ function getAppUrl(allowedOrigins: string): string {
   const origins = allowedOrigins.split(',').map((o) => o.trim());
   const httpsOrigin = origins.find((o) => o.startsWith('https://'));
   return httpsOrigin ?? origins[0] ?? 'http://localhost:3000';
-}
-
-/**
- * Upload a base64 PNG to Firebase Storage and return the file path.
- */
-async function uploadSignature(
-  signedAgreementId: string,
-  filename: string,
-  base64Data: string
-): Promise<string> {
-  const bucket = getStorage().bucket();
-  const filePath = `agreements/${signedAgreementId}/${filename}`;
-  const file = bucket.file(filePath);
-
-  const raw = base64Data.includes(',')
-    ? base64Data.split(',')[1]
-    : base64Data;
-  const buffer = Buffer.from(raw, 'base64');
-
-  await file.save(buffer, {
-    metadata: { contentType: 'image/png' },
-  });
-
-  return filePath;
-}
-
-/**
- * Render agreement sections into an HTML snapshot for the legal record.
- */
-function renderAgreementHtml(
-  templateName: string,
-  sections: Array<{ title: string; content: string }>
-): string {
-  const sectionHtml = sections
-    .map(
-      (s) =>
-        `<section><h2>${s.title}</h2><div>${s.content}</div></section>`
-    )
-    .join('\n');
-
-  return `<!DOCTYPE html>
-<html>
-<head><title>${templateName}</title></head>
-<body>
-<h1>${templateName}</h1>
-${sectionHtml}
-</body>
-</html>`;
 }
 
 export const createRegistration = Functions.endpoint
@@ -237,99 +188,21 @@ export const createRegistration = Functions.endpoint
         );
       }
 
-      // 8. Process required agreements (signed at checkout)
+      // 8. Process required agreements (signed at checkout). Shared with the
+      // hosted-checkout fallback so both paths persist signatures identically.
       let agreementsSigned = false;
       try {
-        if (requiredTemplates.length > 0 && data.agreements) {
-          const templateMap = new Map(
-            requiredTemplates.map((t) => [t.id, t])
-          );
-
-          for (const agreementData of data.agreements) {
-            const template = templateMap.get(agreementData.templateId);
-            if (!template) continue;
-
-            const tempId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-
-            // Upload signature images
-            const signatureImagePath = await uploadSignature(
-              tempId,
-              'signature.png',
-              agreementData.signatureData
-            );
-
-            let guardianSignatureImagePath: string | undefined;
-            if (agreementData.isMinor && agreementData.guardianSignatureData) {
-              guardianSignatureImagePath = await uploadSignature(
-                tempId,
-                'guardian-signature.png',
-                agreementData.guardianSignatureData
-              );
-            }
-
-            // Create agreement request (already signed)
-            const signingToken = randomBytes(32).toString('hex');
-            const request = await AgreementRequestRepository.create({
-              templateId: template.id,
-              templateVersion: template.version,
-              signerEmail: data.customerEmail,
-              signerName: data.customerName,
-              signerPhone: data.customerPhone,
-              deliveryMethod: 'registration',
-              registrationId: registrationDocRef.id,
-              classId: data.classId,
-              signingToken,
-              expiresAt: new Date(), // Already signed, expiry irrelevant
-              status: 'pending', // Will be marked signed immediately
-            });
-
-            // Create signed agreement record
-            const agreementHtmlSnapshot = renderAgreementHtml(
-              template.name,
-              template.sections
-            );
-
-            const signedAgreement = await SignedAgreementRepository.create({
-              requestId: request.id,
-              templateId: template.id,
-              templateVersion: template.version,
-              agreementHtmlSnapshot,
-              signerEmail: data.customerEmail,
-              printedName: agreementData.printedName.trim(),
-              signatureImagePath,
-              mediaReleaseChoice: agreementData.mediaReleaseChoice as
-                | MediaReleaseChoice
-                | undefined,
-              isMinor: agreementData.isMinor ?? false,
-              minorName: agreementData.minorName,
-              guardianName: agreementData.guardianName,
-              guardianSignatureImagePath,
-              signedAt: new Date(),
-              ipAddress: 'inline-checkout',
-              userAgent: 'inline-checkout',
-            });
-
-            // Rename storage files to use the actual signed agreement ID
-            const bucket = getStorage().bucket();
-            const newSignaturePath = `agreements/${signedAgreement.id}/signature.png`;
-            await bucket.file(signatureImagePath).move(newSignaturePath);
-
-            if (guardianSignatureImagePath) {
-              const newGuardianPath = `agreements/${signedAgreement.id}/guardian-signature.png`;
-              await bucket
-                .file(guardianSignatureImagePath)
-                .move(newGuardianPath);
-            }
-
-            // Mark request as signed
-            await AgreementRequestRepository.markSigned(
-              request.id,
-              signedAgreement.id
-            );
-          }
-
-          agreementsSigned = true;
-        }
+        agreementsSigned = await processInlineAgreements({
+          registrationId: registrationDocRef.id,
+          classId: data.classId,
+          requiredTemplates,
+          agreements: data.agreements,
+          signer: {
+            email: data.customerEmail,
+            name: data.customerName,
+            phone: data.customerPhone,
+          },
+        });
       } catch (requiredAgreementError) {
         // Log but don't fail — payment already processed
         console.error(


### PR DESCRIPTION
Follow-up to #661 (now merged). Closes the one compliance-critical gap it left.

## Why
#661 added the Square hosted-checkout fallback but only the inline card flow *persisted* signed agreements. reserveClassRegistration *validates* that required agreements are present, so a class with required agreements taken through the hosted fallback would confirm without storing the signed records.

## What
- Extract createRegistration's inline agreement processing (upload signature image(s) → AgreementRequest + SignedAgreement records → move images under the real signed-agreement id → mark signed) into a shared processInlineAgreements helper in @maple/firebase/functions.
- createRegistration calls it after payment (behavior-preserving).
- createRegistrationCheckoutLink calls it at reservation time — the only point where the signatures are in hand (the buyer then leaves for Square's hosted page; processPosSale, which confirms the payment, never sees them). Best-effort: a failure never blocks a buyer who already signed.

## Testing
- 5 unit tests on the helper (persist request + signed record + file move + markSigned; minor/guardian path; no-op cases; ignores non-required submissions).
- maple-square typechecks clean; lint clean; registration integration suite green (63) — createRegistration refactor behavior-preserving.

## Remaining parity delta (follow-up)
Rich confirmation email on hosted-confirm (class details, waiver link, referral code). Square emails its own payment receipt meanwhile, so this is UX not correctness; it's a larger extraction of createRegistration's email tail (not integration-covered today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)