### PR TITLE
feat(widget): hosted-checkout fallback button (PR 2 — frontend)

### DIFF
--- a/apps/webflow-components/src/RegistrationWidget.tsx
+++ b/apps/webflow-components/src/RegistrationWidget.tsx
@@ -32,6 +32,8 @@ import type {
   CalculateRegistrationCostResponse,
   CreateRegistrationRequest,
   CreateRegistrationResponse,
+  CreateRegistrationCheckoutLinkRequest,
+  CreateRegistrationCheckoutLinkResponse,
   GetRequiredAgreementsForClassRequest,
   GetRequiredAgreementsForClassResponse,
   InlineAgreementSigningData,
@@ -408,7 +410,12 @@ export function RegistrationWidget({
     // recalc + Pay submit). The page-mount fetches above can't benefit
     // from warmup — they fire too early — but these typically run 5–60s
     // later, by which point the warmup ping has spun their container up.
-    warmup(functions, 'calculateRegistrationCost', 'createRegistration');
+    warmup(
+      functions,
+      'calculateRegistrationCost',
+      'createRegistration',
+      'createRegistrationCheckoutLink'
+    );
 
     const fetchClass = async () => {
       setState({ status: 'loading' });
@@ -513,6 +520,39 @@ export function RegistrationWidget({
     [functions, state]
   );
 
+  /**
+   * Hosted-checkout fallback: when the embedded card form can't initialize
+   * (e.g. Safari ITP), reserve the spot and get a Square-hosted checkout URL to
+   * redirect to. `returnUrl` is this page so Square sends the buyer back here
+   * after paying (the server appends ?reg=<id>).
+   */
+  const handleHostedCheckout = useCallback(
+    async (data: {
+      classId: string;
+      customerEmail: string;
+      customerName: string;
+      customerPhone?: string;
+      quantity: number;
+      additionalAttendees?: CreateRegistrationRequest['additionalAttendees'];
+      discountCode?: string;
+      notes?: string;
+      agreements?: InlineAgreementSigningData[];
+    }): Promise<{ checkoutUrl: string }> => {
+      const createLink = httpsCallable<
+        CreateRegistrationCheckoutLinkRequest,
+        CreateRegistrationCheckoutLinkResponse
+      >(functions, 'createRegistrationCheckoutLink');
+
+      const result = await createLink({
+        ...data,
+        returnUrl:
+          typeof window !== 'undefined' ? window.location.href : undefined,
+      });
+      return { checkoutUrl: result.data.checkoutUrl };
+    },
+    [functions]
+  );
+
   const handleSuccess = useCallback(
     (details: {
       confirmationNumber: string;
@@ -610,6 +650,7 @@ export function RegistrationWidget({
                   requiredAgreements={state.requiredAgreements}
                   onCalculateCost={handleCalculateCost}
                   onSubmit={handleSubmit}
+                  onHostedCheckout={handleHostedCheckout}
                   onSuccess={handleSuccess}
                 />
               </Box>

--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.spec.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.spec.tsx
@@ -49,6 +49,7 @@ vi.mock('@maple/react/agreements', () => ({
 // Capture the onDigitalWalletToken callback so tests can simulate
 // Google Pay / Apple Pay token events from outside the component.
 let capturedDigitalWalletTokenCallback: ((token: string) => void) | undefined;
+let capturedInitErrorCallback: (() => void) | undefined;
 
 // Allow individual tests to override how the mocked tokenize function
 // behaves (e.g. to keep the promise pending and simulate Square's SDK
@@ -65,11 +66,13 @@ let mockTokenizeImpl: () => Promise<{
 vi.mock('./SquareCardForm', () => ({
   SquareCardForm: ({
     onReady,
+    onInitError,
     onTokenizeRef,
     onDigitalWalletToken,
     afterCardContent,
   }: {
     onReady?: () => void;
+    onInitError?: () => void;
     onTokenizeRef: (
       fn: () => Promise<{ nonce: string; verificationToken?: string }>
     ) => void;
@@ -82,7 +85,8 @@ vi.mock('./SquareCardForm', () => ({
     }, [onReady, onTokenizeRef]);
     useEffect(() => {
       capturedDigitalWalletTokenCallback = onDigitalWalletToken;
-    }, [onDigitalWalletToken]);
+      capturedInitErrorCallback = onInitError;
+    }, [onDigitalWalletToken, onInitError]);
     return <div data-testid="mock-square-form">{afterCardContent}</div>;
   },
 }));
@@ -701,5 +705,86 @@ describe('RegistrationCheckoutForm — attendee quantity recalculation', () => {
     // button label — use getAllByText since we only need to confirm
     // the value is present, not that it's unique.
     expect(screen.getAllByText(/\$86\.38/).length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('RegistrationCheckoutForm — hosted-checkout fallback', () => {
+  it('offers "Continue to secure checkout" when the card form fails to init, then calls onHostedCheckout and redirects', async () => {
+    const onHostedCheckout = vi
+      .fn()
+      .mockResolvedValue({ checkoutUrl: 'https://square.link/u/abc' });
+
+    render(
+      <RegistrationCheckoutForm
+        publicClass={mockPublicClass}
+        squareApplicationId="test-app"
+        squareLocationId="test-loc"
+        applePayCheckoutUrl="https://business.example.com/apple-pay-checkout"
+        onCalculateCost={vi.fn().mockResolvedValue(makeCostResponse(1))}
+        onSubmit={vi.fn()}
+        onHostedCheckout={onHostedCheckout}
+        onSuccess={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(capturedInitErrorCallback).toBeDefined());
+
+    fireEvent.change(screen.getByLabelText(/Full Name/), {
+      target: { value: 'Jane Doe' },
+    });
+    fireEvent.change(screen.getByLabelText(/Email Address/), {
+      target: { value: 'jane@example.com' },
+    });
+
+    // Before failure: the normal pay button is shown, not the fallback.
+    expect(screen.getByText(/Register & Pay/)).toBeInTheDocument();
+    expect(screen.queryByText(/Continue to secure checkout/)).toBeNull();
+
+    // Card form fails to initialize (e.g. Safari ITP).
+    await act(async () => {
+      capturedInitErrorCallback!();
+    });
+
+    const fallbackBtn = await screen.findByText(/Continue to secure checkout/);
+
+    await act(async () => {
+      fireEvent.click(fallbackBtn);
+    });
+
+    await waitFor(() => expect(onHostedCheckout).toHaveBeenCalledTimes(1));
+    const arg = onHostedCheckout.mock.calls[0][0];
+    expect(arg).toEqual(
+      expect.objectContaining({
+        classId: 'class-1',
+        customerEmail: 'jane@example.com',
+        customerName: 'Jane Doe',
+        quantity: 1,
+      })
+    );
+    // No card nonce on the hosted path.
+    expect(arg).not.toHaveProperty('paymentNonce');
+  });
+
+  it('does not offer the fallback when onHostedCheckout is not provided', async () => {
+    render(
+      <RegistrationCheckoutForm
+        publicClass={mockPublicClass}
+        squareApplicationId="test-app"
+        squareLocationId="test-loc"
+        applePayCheckoutUrl="https://business.example.com/apple-pay-checkout"
+        onCalculateCost={vi.fn().mockResolvedValue(makeCostResponse(1))}
+        onSubmit={vi.fn()}
+        onSuccess={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(capturedInitErrorCallback).toBeDefined());
+    await act(async () => {
+      capturedInitErrorCallback!();
+    });
+
+    // Still just the (disabled) pay button — no fallback offered.
+    expect(screen.getByText(/Register & Pay/)).toBeInTheDocument();
+    expect(screen.queryByText(/Continue to secure checkout/)).toBeNull();
   });
 });

--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
@@ -134,6 +134,23 @@ interface RegistrationCheckoutFormProps {
     paymentNonce: string;
     agreements?: InlineAgreementSigningData[];
   }) => Promise<CreateRegistrationResponse>;
+  /**
+   * Fallback when the embedded Square card form can't initialize (e.g. Safari
+   * ITP). Given the same registration data minus the card nonce, it reserves a
+   * spot and returns a Square-hosted checkout URL the form redirects to. When
+   * omitted, no fallback is offered.
+   */
+  onHostedCheckout?: (data: {
+    classId: string;
+    customerEmail: string;
+    customerName: string;
+    customerPhone?: string;
+    quantity: number;
+    additionalAttendees?: Attendee[];
+    discountCode?: string;
+    notes?: string;
+    agreements?: InlineAgreementSigningData[];
+  }) => Promise<{ checkoutUrl: string }>;
   onSuccess: (details: {
     confirmationNumber: string;
     customerName: string;
@@ -153,6 +170,7 @@ export function RegistrationCheckoutForm({
   requiredAgreements = [],
   onCalculateCost,
   onSubmit,
+  onHostedCheckout,
   onSuccess,
 }: RegistrationCheckoutFormProps) {
   useSignals();
@@ -183,6 +201,9 @@ export function RegistrationCheckoutForm({
   const isSubmitting = useSignal(false);
   const submitError = useSignal<string | null>(null);
   const isCardReady = useSignal(false);
+  // Set when the embedded Square card form fails to initialize (e.g. Safari
+  // ITP). Reveals the hosted-checkout fallback so the buyer isn't dead-ended.
+  const cardInitFailed = useSignal(false);
   const quantityWarning = useSignal<string | null>(null);
   // Gate field errors until the user has attempted a submit once — mirrors
   // the ClassForm/ArtistForm pattern so users aren't yelled at mid-typing.
@@ -480,6 +501,68 @@ export function RegistrationCheckoutForm({
     isValid,
     allAgreementsSigned,
     performSubmit,
+  ]);
+
+  /**
+   * Hosted-checkout fallback: same validation + data as handleSubmit, but
+   * instead of tokenizing a card it reserves the spot server-side and redirects
+   * the buyer to Square's hosted checkout page. Used when the embedded card
+   * form can't initialize. On success the browser navigates away, so
+   * `isSubmitting` is intentionally left set.
+   */
+  const handleHostedCheckout = useCallback(async () => {
+    if (!onHostedCheckout || isSubmitting.value) return;
+
+    showValidationErrors.value = true;
+    if (!isValid.value) return;
+    if (!allAgreementsSigned.value) return;
+
+    isSubmitting.value = true;
+    submitError.value = null;
+
+    try {
+      const agreementsData = hasRequiredAgreements
+        ? Array.from(signedAgreements.value.values())
+        : undefined;
+
+      const { checkoutUrl } = await onHostedCheckout({
+        classId: publicClass.id,
+        customerEmail: customerEmail.value.trim(),
+        customerName: customerName.value.trim(),
+        customerPhone: customerPhone.value.trim() || undefined,
+        quantity: quantity.value,
+        additionalAttendees:
+          additionalAttendeesPayload.value.length > 0
+            ? additionalAttendeesPayload.value
+            : undefined,
+        discountCode: discountCode.value.trim() || undefined,
+        notes: notes.value.trim() || undefined,
+        agreements: agreementsData,
+      });
+
+      // Hand the buyer off to Square's hosted page.
+      window.location.assign(checkoutUrl);
+    } catch (error) {
+      submitError.value = extractErrorMessage(error);
+      isSubmitting.value = false;
+    }
+  }, [
+    onHostedCheckout,
+    isSubmitting,
+    submitError,
+    showValidationErrors,
+    isValid,
+    allAgreementsSigned,
+    hasRequiredAgreements,
+    signedAgreements,
+    publicClass.id,
+    customerName,
+    customerEmail,
+    customerPhone,
+    quantity,
+    additionalAttendeesPayload,
+    discountCode,
+    notes,
   ]);
 
   // ============================================================
@@ -907,35 +990,73 @@ export function RegistrationCheckoutForm({
           totalCents={costBreakdown.value?.totalCents}
           showDigitalWallets={showDigitalWallets}
           onReady={() => (isCardReady.value = true)}
+          onInitError={() => (cardInitFailed.value = true)}
           onTokenizeRef={(fn) => {
             tokenizeRef.current = fn;
           }}
           onDigitalWalletToken={handleDigitalWalletToken}
           afterCardContent={
-            <button
-              type="button"
-              onClick={handleSubmit}
-              disabled={isButtonDisabled.value}
-              style={{
-                width: '100%',
-                padding: '14px 24px',
-                fontSize: '16px',
-                fontWeight: 600,
-                fontFamily: fonts.button,
-                color: '#D5D6C8',
-                backgroundColor: isButtonDisabled.value ? '#8a7b6e' : '#4A3728',
-                border: 'none',
-                borderRadius: '8px',
-                cursor: isButtonDisabled.value ? 'not-allowed' : 'pointer',
-                opacity: isButtonDisabled.value ? 0.7 : 1,
-                transition: 'background-color 0.2s, opacity 0.2s',
-                letterSpacing: '0.02em',
-              }}
-            >
-              {isSubmitting.value
-                ? 'Processing...'
-                : `Register & Pay ${costBreakdown.value ? `$${(costBreakdown.value.totalCents / 100).toFixed(2)}` : ''}`}
-            </button>
+            cardInitFailed.value && onHostedCheckout ? (
+              // Card form couldn't initialize (e.g. Safari ITP) — offer Square's
+              // hosted checkout instead of a dead-ended, disabled pay button.
+              <Box>
+                <Typography
+                  variant="body2"
+                  sx={{ mb: 1.5, color: 'text.secondary' }}
+                >
+                  Continue to our secure checkout page to finish your payment.
+                </Typography>
+                <button
+                  type="button"
+                  onClick={handleHostedCheckout}
+                  disabled={isSubmitting.value}
+                  style={{
+                    width: '100%',
+                    padding: '14px 24px',
+                    fontSize: '16px',
+                    fontWeight: 600,
+                    fontFamily: fonts.button,
+                    color: '#D5D6C8',
+                    backgroundColor: isSubmitting.value ? '#8a7b6e' : '#4A3728',
+                    border: 'none',
+                    borderRadius: '8px',
+                    cursor: isSubmitting.value ? 'not-allowed' : 'pointer',
+                    opacity: isSubmitting.value ? 0.7 : 1,
+                    transition: 'background-color 0.2s, opacity 0.2s',
+                    letterSpacing: '0.02em',
+                  }}
+                >
+                  {isSubmitting.value
+                    ? 'Redirecting…'
+                    : `Continue to secure checkout${costBreakdown.value ? ` — $${(costBreakdown.value.totalCents / 100).toFixed(2)}` : ''} →`}
+                </button>
+              </Box>
+            ) : (
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={isButtonDisabled.value}
+                style={{
+                  width: '100%',
+                  padding: '14px 24px',
+                  fontSize: '16px',
+                  fontWeight: 600,
+                  fontFamily: fonts.button,
+                  color: '#D5D6C8',
+                  backgroundColor: isButtonDisabled.value ? '#8a7b6e' : '#4A3728',
+                  border: 'none',
+                  borderRadius: '8px',
+                  cursor: isButtonDisabled.value ? 'not-allowed' : 'pointer',
+                  opacity: isButtonDisabled.value ? 0.7 : 1,
+                  transition: 'background-color 0.2s, opacity 0.2s',
+                  letterSpacing: '0.02em',
+                }}
+              >
+                {isSubmitting.value
+                  ? 'Processing...'
+                  : `Register & Pay ${costBreakdown.value ? `$${(costBreakdown.value.totalCents / 100).toFixed(2)}` : ''}`}
+              </button>
+            )
           }
         />
       </Box>


### PR DESCRIPTION
Frontend for the Square hosted-checkout fallback (backend shipped in #661; agreement parity in #663).

## Why
When the embedded Square card form can't initialize — most notably **Safari with ITP** — the buyer hit a dead-ended, disabled "Register & Pay" button. This wires the escape hatch: a **"Continue to secure checkout"** button that reserves the spot and redirects to Square's own hosted checkout page (where ITP is irrelevant).

## What
- **RegistrationCheckoutForm**: new optional `onHostedCheckout` prop. On `SquareCardForm`'s `onInitError` (shipped in #654), it swaps the disabled pay button for the fallback, which runs the **same validation + gathers the same data minus the card nonce** and redirects to the returned `checkoutUrl`.
- **RegistrationWidget**: wires `onHostedCheckout` to the `createRegistrationCheckoutLink` callable with `returnUrl = window.location.href` (server appends `?reg=<id>`, origin-guarded); adds it to `warmup` so the fallback is snappy.

## Testing
- Unit (react-registrations 13/13): fallback appears + calls `onHostedCheckout` with the correct data (and **no** `paymentNonce`) on init failure; not offered when `onHostedCheckout` is absent. Lint clean.

## Follow-ups
- **`?reg=` return-confirmation UX** (verify-by-lookup): needs a small **public registration-status endpoint** so the class page can confirm the payment landed before showing "You're registered" (never trusting the query param as proof). Separate PR. Until then the buyer sees Square's own confirmation page + receipt email after paying.
- **Real-Square-sandbox e2e** through the redirect flow.
- Confirmation-email parity on hosted-confirm (from #663's note).

## Gating note
The fallback is safe for classes **with** required agreements once #663 merges (agreements persist on the hosted path). Recommend merging #663 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)