### PR TITLE
feat(auth): scope lesson-teacher to own students + strip calendar-event management

### DIFF
--- a/apps/functions-integration-tests-calendar/src/calendar-event-functions.spec.ts
+++ b/apps/functions-integration-tests-calendar/src/calendar-event-functions.spec.ts
@@ -72,6 +72,70 @@ describe('Calendar Event Functions', () => {
     await clearFirestoreEmulator();
   });
 
+  describe('Lesson-teacher calendar scoping (#617): book rooms only', () => {
+    // A pure lesson teacher may book a room but not manage arbitrary calendar
+    // events (their lessons are derived). Additive on the suite's admin seed.
+    let teacher: TestUser;
+    let eventId: string;
+
+    beforeAll(async () => {
+      teacher = await createTestUser('cal-teacher@test.maple', 'test-password-123!');
+      await setFirestoreDoc('userRoles', teacher.uid, { roles: ['lesson-teacher'] });
+      const seed = await callFunction<
+        CreateCalendarEventRequest,
+        CreateCalendarEventResponse
+      >({
+        functionName: 'createCalendarEvent',
+        data: SAMPLE_EVENT,
+        idToken: adminUser.idToken,
+      });
+      eventId = seed.data!.calendarEvent.id;
+    });
+
+    it('denies creating an arbitrary (non-room) event', async () => {
+      const result = await callFunction<CreateCalendarEventRequest>({
+        functionName: 'createCalendarEvent',
+        data: SAMPLE_EVENT, // type 'jam', no room
+        idToken: teacher.idToken,
+      });
+      expect(result.status).toBe(403);
+    });
+
+    it('allows booking a room (event with a room set)', async () => {
+      const result = await callFunction<
+        CreateCalendarEventRequest,
+        CreateCalendarEventResponse
+      >({
+        functionName: 'createCalendarEvent',
+        data: {
+          ...SAMPLE_EVENT,
+          title: 'Spruce Room booking',
+          type: 'event',
+          room: 'spruce',
+        },
+        idToken: teacher.idToken,
+      });
+      expect(result.status).toBe(200);
+      expect(result.data?.calendarEvent.room).toBe('spruce');
+    });
+
+    it('denies updating and deleting any event', async () => {
+      const upd = await callFunction<UpdateCalendarEventRequest>({
+        functionName: 'updateCalendarEvent',
+        data: { id: eventId, title: 'hijacked' },
+        idToken: teacher.idToken,
+      });
+      expect(upd.status).toBe(403);
+
+      const del = await callFunction<DeleteCalendarEventRequest>({
+        functionName: 'deleteCalendarEvent',
+        data: { id: eventId },
+        idToken: teacher.idToken,
+      });
+      expect(del.status).toBe(403);
+    });
+  });
+
   describe('Auth guard', () => {
     it('should reject unauthenticated requests', async () => {
       const result = await callFunction<CreateCalendarEventRequest>({

--- a/apps/functions-integration-tests-student/src/student-functions.spec.ts
+++ b/apps/functions-integration-tests-student/src/student-functions.spec.ts
@@ -74,6 +74,130 @@ describe('Student Functions', () => {
     await clearFirestoreEmulator();
   });
 
+  describe('Lesson-teacher scoping (#617): read-own, manage-own', () => {
+    // A lesson teacher = a portal user linked to an instructor (instructor.uid)
+    // with the lesson-teacher role. They see + manage only their own students.
+    const OWN = 'instructor-owned-by-teacher';
+    const OTHER = 'instructor-someone-else';
+    let teacher: TestUser;
+    let unlinked: TestUser;
+    let ownStudentId: string;
+    let othersStudentId: string;
+
+    beforeAll(async () => {
+      // Additive on top of the suite's admin seed (no clear — sibling blocks
+      // share this emulator state). Assertions use contains / not-contains and
+      // the unlinked→0 invariant, so extra students elsewhere don't matter.
+      teacher = await createTestUser('student-owner@test.maple', 'test-password-123!');
+      unlinked = await createTestUser('student-unlinked@test.maple', 'test-password-123!');
+      await setFirestoreDoc('userRoles', teacher.uid, { roles: ['lesson-teacher'] });
+      await setFirestoreDoc('userRoles', unlinked.uid, { roles: ['lesson-teacher'] });
+      await setFirestoreDoc('instructors', OWN, {
+        uid: teacher.uid,
+        name: 'Owning Teacher',
+        email: 'owning-teacher@test.maple',
+        status: 'active',
+      });
+
+      // One student taught by the teacher, one by someone else (admin-created).
+      const own = await callFunction<CreateStudentRequest, CreateStudentResponse>({
+        functionName: 'createStudent',
+        data: { ...SAMPLE_STUDENT, name: 'My Student', primaryTeacherId: OWN },
+        idToken: adminUser.idToken,
+      });
+      ownStudentId = own.data!.student.id;
+      const other = await callFunction<CreateStudentRequest, CreateStudentResponse>({
+        functionName: 'createStudent',
+        data: { ...SAMPLE_STUDENT, name: 'Their Student', primaryTeacherId: OTHER },
+        idToken: adminUser.idToken,
+      });
+      othersStudentId = other.data!.student.id;
+    });
+
+    it('getStudents returns only the teacher’s own students', async () => {
+      const result = await callFunction<GetStudentsRequest, GetStudentsResponse>({
+        functionName: 'getStudents',
+        idToken: teacher.idToken,
+      });
+      expect(result.status).toBe(200);
+      const ids = result.data!.students.map((s) => s.id);
+      expect(ids).toContain(ownStudentId);
+      expect(ids).not.toContain(othersStudentId);
+    });
+
+    it('getStudents returns nothing for an unlinked lesson teacher', async () => {
+      const result = await callFunction<GetStudentsRequest, GetStudentsResponse>({
+        functionName: 'getStudents',
+        idToken: unlinked.idToken,
+      });
+      expect(result.status).toBe(200);
+      expect(result.data!.students).toHaveLength(0);
+    });
+
+    it('admin still sees all students', async () => {
+      const result = await callFunction<GetStudentsRequest, GetStudentsResponse>({
+        functionName: 'getStudents',
+        idToken: adminUser.idToken,
+      });
+      const ids = result.data!.students.map((s) => s.id);
+      expect(ids).toEqual(expect.arrayContaining([ownStudentId, othersStudentId]));
+    });
+
+    it('getStudent: own allowed, other denied', async () => {
+      const own = await callFunction({
+        functionName: 'getStudent',
+        data: { id: ownStudentId },
+        idToken: teacher.idToken,
+      });
+      expect(own.status).toBe(200);
+      const other = await callFunction({
+        functionName: 'getStudent',
+        data: { id: othersStudentId },
+        idToken: teacher.idToken,
+      });
+      expect(other.status).toBe(403);
+    });
+
+    it('createStudent: only for themselves', async () => {
+      const mine = await callFunction<CreateStudentRequest>({
+        functionName: 'createStudent',
+        data: { ...SAMPLE_STUDENT, name: 'New Mine', primaryTeacherId: OWN },
+        idToken: teacher.idToken,
+      });
+      expect(mine.status).toBe(200);
+      const theirs = await callFunction<CreateStudentRequest>({
+        functionName: 'createStudent',
+        data: { ...SAMPLE_STUDENT, name: 'New Theirs', primaryTeacherId: OTHER },
+        idToken: teacher.idToken,
+      });
+      expect(theirs.status).toBe(403);
+    });
+
+    it('updateStudent: own allowed, other denied', async () => {
+      const own = await callFunction<UpdateStudentRequest>({
+        functionName: 'updateStudent',
+        data: { id: ownStudentId, notes: 'progressing' },
+        idToken: teacher.idToken,
+      });
+      expect(own.status).toBe(200);
+      const other = await callFunction<UpdateStudentRequest>({
+        functionName: 'updateStudent',
+        data: { id: othersStudentId, notes: 'nope' },
+        idToken: teacher.idToken,
+      });
+      expect(other.status).toBe(403);
+    });
+
+    it('deleteStudent: another teacher’s student is denied', async () => {
+      const result = await callFunction({
+        functionName: 'deleteStudent',
+        data: { id: othersStudentId },
+        idToken: teacher.idToken,
+      });
+      expect(result.status).toBe(403);
+    });
+  });
+
   describe('Auth guard', () => {
     it('rejects unauthenticated requests', async () => {
       const result = await callFunction<CreateStudentRequest>({

--- a/apps/functions-integration-tests-utility/src/role-matrix.spec.ts
+++ b/apps/functions-integration-tests-utility/src/role-matrix.spec.ts
@@ -56,6 +56,9 @@ const CASES: MatrixCase[] = [
   { as: 'stephanie', functionName: 'getStudents', expect: 403 },
   // getStudent (singular) was auth-only until #620; now admin + lesson-teacher.
   { as: 'stephanie', functionName: 'getStudent', expect: 403 },
+  // Student mutations are now [Admin, LessonTeacher] (#617) — mt-teacher denied.
+  { as: 'stephanie', functionName: 'createStudent', expect: 403 },
+  { as: 'stephanie', functionName: 'updateStudent', expect: 403 },
   { as: 'stephanie', functionName: 'getLessons', expect: 403 },
   { as: 'stephanie', functionName: 'listUsers', expect: 403 },
   { as: 'stephanie', functionName: 'createClass', expect: 403 },

--- a/apps/maple-spruce/src/components/layout/nav-groups.tsx
+++ b/apps/maple-spruce/src/components/layout/nav-groups.tsx
@@ -169,7 +169,9 @@ function roleNavGroups(
           label: 'Events',
           href: '/events',
           icon: <CalendarMonthIcon />,
-          roles: ALL_ROLES,
+          // Not lesson-teacher: their lessons are derived, and they don't
+          // manage calendar events (they can still book a room, below).
+          roles: ['mt-teacher', 'clerk'],
         },
         {
           label: 'Spruce Room Schedule',

--- a/docs/reference/implementation-status.md
+++ b/docs/reference/implementation-status.md
@@ -28,6 +28,7 @@
 | Callable-role analyzer (#620) | Complete | `tools/check-callable-roles.ts` + `callable-roles` CI job; every exported callable must be role-gated / trigger / allowlisted. Caught + fixed leftover auth-only `getArtist`/`getStudent` |
 | Lesson-teacher manage-own (phase 2 of epic #617, #616) | Complete | `Instructor.uid` link + `InstructorRepository.findByUid`; `assertCanManageLesson` ownership helper; create/update/delete-lesson + create-lesson-series re-scoped to `[Admin, LessonTeacher]` with ownership checks; permission-denied→403; instructor-form "Portal login" picker |
 | Portal role-scoping E2E (#625) | Complete | First browser-level e2e (`apps/maple-spruce-e2e`): seeds admin + mt-teacher, signs in via login UI, asserts role-filtered nav + `/users` gate. `connectAuthEmulator` opt-in wiring; `tools/run-portal-e2e.sh` + `portal-e2e` CI job |
+| Lesson-teacher student + calendar scoping (epic #617) | Complete | `getStudents` reads-own (filter by `primaryTeacherId`); `getStudent`/create/update/delete-student → `[Admin, LessonTeacher]` + ownership; calendar events: lesson-teacher dropped from update/delete + create requires a `room` (book-room only) + Events nav hidden. `instructorScopeForUser`/`assertCanManageStudent`/`assertOwnsAsInstructor` helpers |
 | Navigation (responsive) | Complete | `libs/react/layout/` (re-exported via app barrel) |
 | Storybook | Complete | `apps/maple-spruce/.storybook/` |
 | Component stories | Complete | `apps/maple-spruce/src/components/**/*.stories.tsx`, `libs/react/*/src/**/*.stories.tsx` |

--- a/libs/firebase/functions/src/lib/index.ts
+++ b/libs/firebase/functions/src/lib/index.ts
@@ -61,7 +61,10 @@ export {
 // Resource-ownership checks (scoped-roles phase 2)
 export {
   instructorIdForUser,
+  instructorScopeForUser,
+  assertOwnsAsInstructor,
   assertCanManageLesson,
+  assertCanManageStudent,
   assertCanRecordInvoicePayment,
 } from './ownership.utility';
 

--- a/libs/firebase/functions/src/lib/ownership.utility.spec.ts
+++ b/libs/firebase/functions/src/lib/ownership.utility.spec.ts
@@ -23,8 +23,10 @@ vi.mock('./auth.utility', () => ({
 
 import {
   assertCanManageLesson,
+  assertCanManageStudent,
   assertCanRecordInvoicePayment,
   instructorIdForUser,
+  instructorScopeForUser,
 } from './ownership.utility';
 
 describe('instructorIdForUser', () => {
@@ -148,5 +150,58 @@ describe('assertCanRecordInvoicePayment', () => {
     await expect(
       assertCanRecordInvoicePayment({ uid: 'nobody' }, invoiceForLesson('les-1'))
     ).rejects.toThrow(/only record payments on your own students/i);
+  });
+});
+
+describe('assertCanManageStudent', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('admins pass unconditionally', async () => {
+    mocks.hasRole.mockResolvedValue(true);
+    await expect(
+      assertCanManageStudent({ uid: 'admin-uid' }, 'instr-someone')
+    ).resolves.toBeUndefined();
+    expect(mocks.findByUid).not.toHaveBeenCalled();
+  });
+
+  it('a lesson teacher passes for their own student', async () => {
+    mocks.hasRole.mockResolvedValue(false);
+    mocks.findByUid.mockResolvedValue({ id: 'instr-nathan' });
+    await expect(
+      assertCanManageStudent({ uid: 'nathan-uid' }, 'instr-nathan')
+    ).resolves.toBeUndefined();
+  });
+
+  it("denies another teacher's student", async () => {
+    mocks.hasRole.mockResolvedValue(false);
+    mocks.findByUid.mockResolvedValue({ id: 'instr-nathan' });
+    await expect(
+      assertCanManageStudent({ uid: 'nathan-uid' }, 'instr-other')
+    ).rejects.toThrow(/only manage your own students/i);
+  });
+});
+
+describe('instructorScopeForUser', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('admin: isAdmin true, no instructor lookup', async () => {
+    mocks.hasRole.mockResolvedValue(true);
+    const scope = await instructorScopeForUser({ uid: 'admin-uid' });
+    expect(scope).toEqual({ isAdmin: true, instructorId: undefined });
+    expect(mocks.findByUid).not.toHaveBeenCalled();
+  });
+
+  it('linked lesson teacher: their instructor id', async () => {
+    mocks.hasRole.mockResolvedValue(false);
+    mocks.findByUid.mockResolvedValue({ id: 'instr-nathan' });
+    const scope = await instructorScopeForUser({ uid: 'nathan-uid' });
+    expect(scope).toEqual({ isAdmin: false, instructorId: 'instr-nathan' });
+  });
+
+  it('unlinked non-admin: undefined instructor id', async () => {
+    mocks.hasRole.mockResolvedValue(false);
+    mocks.findByUid.mockResolvedValue(undefined);
+    const scope = await instructorScopeForUser({ uid: 'unlinked' });
+    expect(scope).toEqual({ isAdmin: false, instructorId: undefined });
   });
 });

--- a/libs/firebase/functions/src/lib/ownership.utility.ts
+++ b/libs/firebase/functions/src/lib/ownership.utility.ts
@@ -40,20 +40,67 @@ export async function instructorIdForUser(
  * loading the target lesson (use `lesson.teacherId`), or, on create, with the
  * `teacherId` the new lesson would be assigned.
  */
-export async function assertCanManageLesson(
+export async function assertOwnsAsInstructor(
   context: FunctionContext,
-  lessonTeacherId: string | undefined
+  ownerInstructorId: string | undefined,
+  message: string
 ): Promise<void> {
   const uid = context.uid;
   if (uid && (await hasRole(uid, Role.Admin))) return;
 
   const myInstructorId = await instructorIdForUser(uid);
-  // A non-admin passes only when linked to the exact instructor who teaches
-  // this lesson. An unlinked caller (myInstructorId undefined) or an undefined
+  // A non-admin passes only when linked to the exact instructor who owns the
+  // resource. An unlinked caller (myInstructorId undefined) or an undefined
   // owner never matches -> denied.
-  if (myInstructorId && myInstructorId === lessonTeacherId) return;
+  if (myInstructorId && myInstructorId === ownerInstructorId) return;
 
-  throwPermissionDenied('You can only manage lessons you teach.');
+  throwPermissionDenied(message);
+}
+
+/**
+ * Read-scope for the caller: whether they're an admin (sees everything) and,
+ * if not, the instructor id their login is linked to (scopes list reads to
+ * their own records). A non-admin who isn't linked has `instructorId:
+ * undefined` — callers should return an empty result for them.
+ */
+export async function instructorScopeForUser(
+  context: FunctionContext
+): Promise<{ isAdmin: boolean; instructorId: string | undefined }> {
+  const uid = context.uid;
+  const isAdmin = !!uid && (await hasRole(uid, Role.Admin));
+  const instructorId = isAdmin ? undefined : await instructorIdForUser(uid);
+  return { isAdmin, instructorId };
+}
+
+/**
+ * Enforce "lesson teachers manage only their own lessons" — see
+ * {@link assertOwnsAsInstructor}. `lessonTeacherId` is the lesson's teacherId.
+ */
+export async function assertCanManageLesson(
+  context: FunctionContext,
+  lessonTeacherId: string | undefined
+): Promise<void> {
+  return assertOwnsAsInstructor(
+    context,
+    lessonTeacherId,
+    'You can only manage lessons you teach.'
+  );
+}
+
+/**
+ * Enforce "lesson teachers manage only their own students". A student's owner
+ * is its `primaryTeacherId` (an Instructor id). Admins pass; a lesson-teacher
+ * passes only when it's their student.
+ */
+export async function assertCanManageStudent(
+  context: FunctionContext,
+  primaryTeacherId: string | undefined
+): Promise<void> {
+  return assertOwnsAsInstructor(
+    context,
+    primaryTeacherId,
+    'You can only manage your own students.'
+  );
 }
 
 /**

--- a/libs/firebase/maple-functions/create-calendar-event/src/lib/create-calendar-event.ts
+++ b/libs/firebase/maple-functions/create-calendar-event/src/lib/create-calendar-event.ts
@@ -7,6 +7,8 @@
 import {
   createRoleFunction,
   Role,
+  hasAnyRole,
+  throwPermissionDenied,
 } from '@maple/firebase/functions';
 import { CalendarEventRepository } from '@maple/firebase/database';
 import { calendarEventValidation } from '@maple/ts/validation';
@@ -18,7 +20,19 @@ import type {
 export const createCalendarEvent = createRoleFunction<
   CreateCalendarEventRequest,
   CreateCalendarEventResponse
->(async (data) => {
+>(async (data, context) => {
+  // Lesson teachers do NOT manage calendar events — their lessons are derived,
+  // not hand-authored — but they CAN book a room. So a caller who is ONLY a
+  // lesson teacher (not admin / MT / clerk) may only create a room booking
+  // (an event that claims a room). Everyone else may create any event.
+  const uid = context.uid;
+  const canCreateAnyEvent =
+    !!uid &&
+    (await hasAnyRole(uid, [Role.Admin, Role.MtTeacher, Role.Clerk]));
+  if (!canCreateAnyEvent && !data.room) {
+    throwPermissionDenied('Lesson teachers can only book a room.');
+  }
+
   // Validate input
   const result = calendarEventValidation(data);
   if (!result.isValid()) {

--- a/libs/firebase/maple-functions/create-student/src/lib/create-student.ts
+++ b/libs/firebase/maple-functions/create-student/src/lib/create-student.ts
@@ -3,7 +3,11 @@
  *
  * Creates a new music lesson student (admin only).
  */
-import { createAdminFunction } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+  assertCanManageStudent,
+} from '@maple/firebase/functions';
 import { StudentRepository } from '@maple/firebase/database';
 import { studentValidation } from '@maple/ts/validation';
 import type {
@@ -11,10 +15,13 @@ import type {
   CreateStudentResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const createStudent = createAdminFunction<
+export const createStudent = createRoleFunction<
   CreateStudentRequest,
   CreateStudentResponse
->(async (data) => {
+>(async (data, context) => {
+  // A lesson teacher may only create students assigned to themselves.
+  await assertCanManageStudent(context, data.primaryTeacherId);
+
   const validationResult = studentValidation(data);
   if (!validationResult.isValid()) {
     const errors = validationResult.getErrors();
@@ -27,4 +34,4 @@ export const createStudent = createAdminFunction<
   const student = await StudentRepository.create(data);
 
   return { student };
-});
+}, [Role.Admin, Role.LessonTeacher]);

--- a/libs/firebase/maple-functions/delete-calendar-event/src/lib/delete-calendar-event.ts
+++ b/libs/firebase/maple-functions/delete-calendar-event/src/lib/delete-calendar-event.ts
@@ -27,4 +27,4 @@ export const deleteCalendarEvent = createRoleFunction<
   await CalendarEventRepository.delete(data.id);
 
   return { success: true };
-}, [Role.Admin, Role.MtTeacher, Role.Clerk, Role.LessonTeacher]);
+}, [Role.Admin, Role.MtTeacher, Role.Clerk]);

--- a/libs/firebase/maple-functions/delete-student/src/lib/delete-student.ts
+++ b/libs/firebase/maple-functions/delete-student/src/lib/delete-student.ts
@@ -5,23 +5,30 @@
  * Note: Consider using updateStudent to set status to 'inactive' instead,
  * to preserve lesson and invoice history tied to the student.
  */
-import { createAdminFunction, throwNotFound } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+  throwNotFound,
+  assertCanManageStudent,
+} from '@maple/firebase/functions';
 import { StudentRepository } from '@maple/firebase/database';
 import type {
   DeleteStudentRequest,
   DeleteStudentResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const deleteStudent = createAdminFunction<
+export const deleteStudent = createRoleFunction<
   DeleteStudentRequest,
   DeleteStudentResponse
->(async (data) => {
+>(async (data, context) => {
   const existing = await StudentRepository.findById(data.id);
   if (!existing) {
     throwNotFound('Student', data.id);
   }
 
+  await assertCanManageStudent(context, existing.primaryTeacherId);
+
   await StudentRepository.delete(data.id);
 
   return { success: true };
-});
+}, [Role.Admin, Role.LessonTeacher]);

--- a/libs/firebase/maple-functions/get-student/src/lib/get-student.ts
+++ b/libs/firebase/maple-functions/get-student/src/lib/get-student.ts
@@ -7,6 +7,7 @@ import {
   createRoleFunction,
   Role,
   throwNotFound,
+  assertOwnsAsInstructor,
 } from '@maple/firebase/functions';
 import { StudentRepository } from '@maple/firebase/database';
 import type {
@@ -15,17 +16,23 @@ import type {
 } from '@maple/ts/firebase/api-types';
 
 // Admin + lesson-teacher, matching getStudents — a student record is child
-// PII and must not be readable by any signed-in user. Was auth-only before
-// the analyzer (#620) caught the singular endpoint #633 missed.
+// PII and must not be readable by any signed-in user. A lesson-teacher may
+// only read their OWN students (read-own, matching the list scoping).
 export const getStudent = createRoleFunction<
   GetStudentRequest,
   GetStudentResponse
->(async (data) => {
+>(async (data, context) => {
   const student = await StudentRepository.findById(data.id);
 
   if (!student) {
     throwNotFound('Student', data.id);
   }
+
+  await assertOwnsAsInstructor(
+    context,
+    student.primaryTeacherId,
+    'You can only view your own students.'
+  );
 
   return { student };
 }, [Role.Admin, Role.LessonTeacher]);

--- a/libs/firebase/maple-functions/get-students/src/lib/get-students.ts
+++ b/libs/firebase/maple-functions/get-students/src/lib/get-students.ts
@@ -7,6 +7,7 @@
 import {
   createRoleFunction,
   Role,
+  instructorScopeForUser,
 } from '@maple/firebase/functions';
 import { StudentRepository } from '@maple/firebase/database';
 import type {
@@ -17,10 +18,19 @@ import type {
 export const getStudents = createRoleFunction<
   GetStudentsRequest,
   GetStudentsResponse
->(async (data) => {
+>(async (data, context) => {
+  // Lesson teachers see only their own students (read-own). Admins see all.
+  const scope = await instructorScopeForUser(context);
+  let primaryTeacherId = data.primaryTeacherId;
+  if (!scope.isAdmin) {
+    // An unlinked lesson-teacher owns no students → return an empty list.
+    if (!scope.instructorId) return { students: [] };
+    primaryTeacherId = scope.instructorId;
+  }
+
   const students = await StudentRepository.findAll({
     status: data.status,
-    primaryTeacherId: data.primaryTeacherId,
+    primaryTeacherId,
     isHopeScholarship: data.isHopeScholarship,
   });
 

--- a/libs/firebase/maple-functions/update-calendar-event/src/lib/update-calendar-event.ts
+++ b/libs/firebase/maple-functions/update-calendar-event/src/lib/update-calendar-event.ts
@@ -39,4 +39,4 @@ export const updateCalendarEvent = createRoleFunction<
   const calendarEvent = await CalendarEventRepository.update(data);
 
   return { calendarEvent };
-}, [Role.Admin, Role.MtTeacher, Role.Clerk, Role.LessonTeacher]);
+}, [Role.Admin, Role.MtTeacher, Role.Clerk]);

--- a/libs/firebase/maple-functions/update-student/src/lib/update-student.ts
+++ b/libs/firebase/maple-functions/update-student/src/lib/update-student.ts
@@ -1,9 +1,14 @@
 /**
  * Update Student Cloud Function
  *
- * Updates an existing music lesson student (admin only).
+ * Admin + lesson-teacher (own students only; scoped-roles epic #617).
  */
-import { createAdminFunction, throwNotFound } from '@maple/firebase/functions';
+import {
+  createRoleFunction,
+  Role,
+  throwNotFound,
+  assertCanManageStudent,
+} from '@maple/firebase/functions';
 import { StudentRepository } from '@maple/firebase/database';
 import { studentValidation } from '@maple/ts/validation';
 import type {
@@ -11,14 +16,17 @@ import type {
   UpdateStudentResponse,
 } from '@maple/ts/firebase/api-types';
 
-export const updateStudent = createAdminFunction<
+export const updateStudent = createRoleFunction<
   UpdateStudentRequest,
   UpdateStudentResponse
->(async (data) => {
+>(async (data, context) => {
   const existing = await StudentRepository.findById(data.id);
   if (!existing) {
     throwNotFound('Student', data.id);
   }
+
+  // A lesson teacher may only touch a student they teach.
+  await assertCanManageStudent(context, existing.primaryTeacherId);
 
   // Merge with existing so partial updates still pass full validation
   const merged = { ...existing, ...data };
@@ -34,4 +42,4 @@ export const updateStudent = createAdminFunction<
   const student = await StudentRepository.update(data);
 
   return { student };
-});
+}, [Role.Admin, Role.LessonTeacher]);


### PR DESCRIPTION
Fixes two scoping gaps found while testing the lesson-teacher (mandolin teacher) role: a brand-new teacher could **see every student** (with edit/delete) and **edit/delete every calendar event**. Refines epic #617.

## Students — read-own, manage-own

A student's owner is its `primaryTeacherId` (an Instructor id):
- **`getStudents`** filters to the caller's linked instructor for non-admins (unlinked → empty list). Admins still see all.
- **`getStudent`** + **create/update/delete-student** re-scoped from admin-only to `[Admin, LessonTeacher]` with an ownership check on `primaryTeacherId`.

With the list scoped, the edit/delete icons now only appear on the teacher's *own* students — which is correct (they manage their own).

## Calendar events — book rooms only, no event management

A lesson teacher's lessons are *derived*, so they don't hand-manage calendar events — but booking the Spruce Room stays:
- **update/delete-calendar-event** drop lesson-teacher → `[Admin, MtTeacher, Clerk]`.
- **create-calendar-event** keeps all staff, but a caller who is **only** a lesson teacher may create an event **only when it claims a `room`** (a booking) — otherwise permission-denied. Book-the-Spruce-Room still works; arbitrary events don't.
- The **"Events" nav item** is hidden for lesson-teacher (Book Room + Room Schedule stay); `PathRoleGuard` gates a deep-link to `/events` automatically.

mt-teacher / clerk are unchanged (not reported).

## Under the hood

The ownership utility is generalized: `assertOwnsAsInstructor` (shared core) + `instructorScopeForUser` (read-scoping) + `assertCanManageStudent`; `assertCanManageLesson` now delegates to the shared core.

## Verification

- Unit **2458**; **student integration +7** ownership tests (26 total: read-own, own-vs-others create/update/delete, unlinked→empty, admin-sees-all); **calendar integration +3** (book-room allowed, arbitrary create denied, update/delete denied); utility/role-matrix **63**; storybook **419**.
- Callable-role + firestore-index analyzers green; all 4 codebases build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
