### PR TITLE
fix(registration): harden hosted-checkout reconciliation (review findings)

### DIFF
--- a/apps/functions-integration-tests-registration/src/create-registration-checkout-link.spec.ts
+++ b/apps/functions-integration-tests-registration/src/create-registration-checkout-link.spec.ts
@@ -71,6 +71,22 @@ describe('createRegistrationCheckoutLink', () => {
     expect(reg?.pricePaidCents).toBe(4770);
   });
 
+  it('dedups a rapid duplicate: the second call for the same buyer+class is rejected', async () => {
+    const first = await callFunction<
+      CreateRegistrationCheckoutLinkRequest,
+      CreateRegistrationCheckoutLinkResponse
+    >({ functionName: 'createRegistrationCheckoutLink', data: validRequest() });
+    expect(first.status).toBe(200);
+
+    // Same buyer + class again while the first hold is still pending — must not
+    // stack a second hold (which would self-block capacity / burn a discount).
+    const second = await callFunction<CreateRegistrationCheckoutLinkRequest>({
+      functionName: 'createRegistrationCheckoutLink',
+      data: validRequest(),
+    });
+    expect(second.status).not.toBe(200);
+  });
+
   it('rejects when the class is already full (shared capacity guard)', async () => {
     // Capacity 1, already taken by a confirmed registration.
     await setFirestoreDoc('classes', CLASS_ID, {

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -15,6 +15,24 @@
       ]
     },
     {
+      "collectionGroup": "registrations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "customerEmail",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "agreementRequests",
       "queryScope": "COLLECTION",
       "fields": [

--- a/libs/firebase/maple-functions/create-registration-checkout-link/src/lib/create-registration-checkout-link.ts
+++ b/libs/firebase/maple-functions/create-registration-checkout-link/src/lib/create-registration-checkout-link.ts
@@ -32,6 +32,14 @@ import type {
 } from '@maple/ts/firebase/api-types';
 
 /**
+ * How recently a pending hold for the same buyer + class counts as a duplicate
+ * submit (lost-response retry / back-then-resubmit) rather than a new checkout.
+ * Short so a genuine later retry isn't blocked; the reaper clears real
+ * abandonments on its own (longer) TTL.
+ */
+const DEDUP_WINDOW_MS = 2 * 60 * 1000;
+
+/**
  * Build the buyer's post-payment return URL. Honors the client's `returnUrl`
  * only when its origin is in the CORS allowlist (open-redirect guard), and
  * appends `?reg=<registrationId>` so the class page can look the registration
@@ -93,6 +101,30 @@ export const createRegistrationCheckoutLink = Functions.endpoint
         Record<(typeof SQUARE_STRING_NAMES)[number], string>
     );
 
+    // Dedup: if this buyer already has a very recent pending hold for this
+    // class, don't reserve a second spot — that would self-block capacity (the
+    // buyer's own hold reads as "full") and double-consume a single-use
+    // discount. A rapid duplicate is a lost-response retry or a back-then-
+    // resubmit; reject it clearly rather than stacking holds. The reaper clears
+    // genuinely abandoned holds within the TTL.
+    const recentHolds = (
+      await RegistrationRepository.findAll({
+        customerEmail: data.customerEmail,
+        status: 'pending',
+      })
+    ).filter(
+      (r) =>
+        r.classId === data.classId &&
+        r.createdAt &&
+        new Date(r.createdAt).getTime() >= Date.now() - DEDUP_WINDOW_MS
+    );
+    if (recentHolds.length > 0) {
+      throw new Error(
+        'A checkout for this class is already in progress. Please check your ' +
+          'email, or try again in a couple of minutes.'
+      );
+    }
+
     // Validate, price, and atomically reserve a `pending` spot (shared with the
     // inline card flow so both paths reserve identically).
     const {
@@ -106,11 +138,27 @@ export const createRegistrationCheckoutLink = Functions.endpoint
       discountAmountCents,
     } = await reserveClassRegistration(data, square.taxRatePercent);
 
+    // A free class has nothing to charge — it should never reach the hosted
+    // checkout fallback (there's no card form to fail). Guard BEFORE any
+    // agreement/storage work so a released hold leaves no orphaned records.
+    if (subtotalCents <= 0) {
+      await releaseHold(
+        registrationId,
+        'Hosted checkout requested for a $0 registration'
+      );
+      throw new Error(
+        'This registration has no balance due and does not require checkout.'
+      );
+    }
+
     // Persist signed agreements now — the signatures were captured in the
     // widget before this call, and the buyer is about to leave for Square's
     // hosted page (processPosSale, which confirms the payment later, has no
     // access to them). Shared with the card flow so records are identical.
-    // Best-effort: a failure here must not block a buyer who already signed.
+    // For a class that REQUIRES agreements this MUST succeed: otherwise a paid
+    // registration would end up with no legal signed-agreement record, so we
+    // release the hold and fail the checkout. For a class with no required
+    // agreements this is a no-op.
     try {
       await processInlineAgreements({
         registrationId,
@@ -128,19 +176,10 @@ export const createRegistrationCheckoutLink = Functions.endpoint
         `Failed to process agreements for hosted checkout ${registrationId}:`,
         agreementError
       );
-    }
-
-    // A free class has nothing to charge — it should never reach the hosted
-    // checkout fallback (there's no card form to fail). Guard defensively and
-    // release the hold rather than create a $0 payment link.
-    if (subtotalCents <= 0) {
-      await releaseHold(
-        registrationId,
-        'Hosted checkout requested for a $0 registration'
-      );
-      throw new Error(
-        'This registration has no balance due and does not require checkout.'
-      );
+      if (requiredTemplates.length > 0) {
+        await releaseHold(registrationId, 'Agreement processing failed');
+        throw agreementError;
+      }
     }
 
     const redirectUrl = buildRedirectUrl(

--- a/libs/firebase/maple-functions/process-pos-sale/src/lib/process-pos-sale.spec.ts
+++ b/libs/firebase/maple-functions/process-pos-sale/src/lib/process-pos-sale.spec.ts
@@ -18,9 +18,13 @@ const mocks = vi.hoisted(() => ({
   findById: vi.fn(),
   findBySquareOrderId: vi.fn(),
   createRegistration: vi.fn(),
-  regUpdate: vi.fn(),
+  txnUpdate: vi.fn(),
+  // Transactional re-read state for the hosted-checkout reconciliation.
+  freshReg: undefined as Record<string, unknown> | undefined,
+  countDocs: [] as Array<{ data: () => Record<string, unknown> }>,
   // ClassRepository
   findBySquareVariationId: vi.fn(),
+  classFindById: vi.fn(),
   // PosLessonConfigRepository
   getLessonCatalogObjectIds: vi.fn(),
   // PosLessonAttributionRepository
@@ -45,6 +49,10 @@ vi.mock('firebase-functions/v2/firestore', () => ({
   }),
 }));
 
+vi.mock('firebase-admin/firestore', () => ({
+  FieldValue: { delete: () => '__DELETE__' },
+}));
+
 vi.mock('firebase-functions/params', () => ({
   defineSecret: vi.fn((name: string) => ({ name, value: () => `mock-${name}` })),
   defineString: vi.fn((name: string) => ({ name, value: () => `mock-${name}` })),
@@ -52,7 +60,29 @@ vi.mock('firebase-functions/params', () => ({
 
 vi.mock('@maple/firebase/database', () => ({
   getDb: () => ({
-    collection: vi.fn(() => ({ add: mocks.mailAdd })),
+    collection: vi.fn(() => ({
+      add: mocks.mailAdd,
+      // Capacity re-count query used inside the reconciliation transaction.
+      where: () => ({ where: () => ({ __query: true }) }),
+    })),
+    runTransaction: async (
+      cb: (txn: {
+        get: (arg: unknown) => Promise<{
+          data?: () => Record<string, unknown> | undefined;
+          docs?: Array<{ data: () => Record<string, unknown> }>;
+        }>;
+        update: (ref: unknown, data: unknown) => void;
+      }) => Promise<unknown>
+    ) => {
+      const txn = {
+        get: async (arg: unknown) =>
+          arg && (arg as { __query?: boolean }).__query
+            ? { docs: mocks.countDocs }
+            : { data: () => mocks.freshReg },
+        update: mocks.txnUpdate,
+      };
+      return cb(txn);
+    },
   }),
   PosSaleRequestRepository: {
     markProcessed: mocks.markProcessed,
@@ -62,10 +92,11 @@ vi.mock('@maple/firebase/database', () => ({
     findById: mocks.findById,
     findBySquareOrderId: mocks.findBySquareOrderId,
     create: mocks.createRegistration,
-    getDocRef: (id: string) => ({ id, update: mocks.regUpdate }),
+    getDocRef: (id: string) => ({ id }),
   },
   ClassRepository: {
     findBySquareVariationId: mocks.findBySquareVariationId,
+    findById: mocks.classFindById,
   },
   PosLessonConfigRepository: {
     getLessonCatalogObjectIds: mocks.getLessonCatalogObjectIds,
@@ -154,6 +185,9 @@ beforeEach(() => {
     invoice: { id: 'inv-pos-1' },
     settledExisting: false,
   });
+  mocks.classFindById.mockResolvedValue({ id: 'class-1', capacity: 10 });
+  mocks.freshReg = undefined;
+  mocks.countDocs = [];
 });
 
 describe('processPosSale — early exits', () => {
@@ -209,7 +243,7 @@ describe('processPosSale — dedup', () => {
 
     expect(mocks.findById).toHaveBeenCalledWith('reg-web-abc');
     expect(mocks.createRegistration).not.toHaveBeenCalled();
-    expect(mocks.regUpdate).not.toHaveBeenCalled();
+    expect(mocks.txnUpdate).not.toHaveBeenCalled();
     expect(mocks.markProcessed).toHaveBeenCalledWith('PAY-1');
   });
 
@@ -228,18 +262,89 @@ describe('processPosSale — dedup', () => {
       id: 'reg-hosted-1',
       source: 'web',
       status: 'pending',
+      classId: 'class-1',
+      quantity: 1,
     });
+    // Transactional re-read still sees it pending.
+    mocks.freshReg = { status: 'pending' };
 
     await handler(makeEvent({ orderId: 'ORDER-1' }));
 
     // Flipped pending → confirmed with the Square payment ids — NOT a new POS reg.
     expect(mocks.createRegistration).not.toHaveBeenCalled();
-    expect(mocks.regUpdate).toHaveBeenCalledWith(
+    expect(mocks.txnUpdate).toHaveBeenCalledWith(
+      { id: 'reg-hosted-1' },
       expect.objectContaining({
         status: 'confirmed',
         squarePaymentId: 'PAY-1',
         squareOrderId: 'ORDER-1',
         squareReceiptUrl: 'https://squareup.com/receipt/xyz',
+      })
+    );
+    // No capacity re-check / overbook alert for a pending hold.
+    expect(mocks.classFindById).not.toHaveBeenCalled();
+    expect(mocks.mailAdd).not.toHaveBeenCalled();
+    expect(mocks.markProcessed).toHaveBeenCalledWith('PAY-1');
+  });
+
+  it('is idempotent: does not re-confirm when the transactional re-read is already confirmed', async () => {
+    mocks.getOrder.mockResolvedValue({
+      orderId: 'ORDER-1',
+      referenceId: 'reg-hosted-2',
+      lineItems: [{ catalogObjectId: 'VAR_A', quantity: 1 }],
+    });
+    // Query-time snapshot saw pending, but a prior worker run already confirmed.
+    mocks.findById.mockResolvedValue({
+      id: 'reg-hosted-2',
+      source: 'web',
+      status: 'pending',
+      classId: 'class-1',
+      quantity: 1,
+    });
+    mocks.freshReg = { status: 'confirmed', squarePaymentId: 'PAY-0' };
+
+    await handler(makeEvent({ orderId: 'ORDER-1' }));
+
+    expect(mocks.txnUpdate).not.toHaveBeenCalled();
+    expect(mocks.markProcessed).toHaveBeenCalledWith('PAY-1');
+  });
+
+  it('honors a late payment on a reaper-cancelled hold but alerts staff when it overbooks', async () => {
+    mocks.getPayment.mockResolvedValue({
+      status: 'COMPLETED',
+      orderId: 'ORDER-1',
+      receiptUrl: 'https://squareup.com/receipt/late',
+    });
+    mocks.getOrder.mockResolvedValue({
+      orderId: 'ORDER-1',
+      referenceId: 'reg-hosted-3',
+      lineItems: [{ catalogObjectId: 'VAR_A', quantity: 1 }],
+    });
+    mocks.findById.mockResolvedValue({
+      id: 'reg-hosted-3',
+      source: 'web',
+      status: 'cancelled', // reaper released the hold
+      classId: 'class-1',
+      quantity: 1,
+    });
+    mocks.freshReg = { status: 'cancelled' };
+    // Capacity 1, and the freed spot was already resold (1 taken).
+    mocks.classFindById.mockResolvedValue({ id: 'class-1', capacity: 1 });
+    mocks.countDocs = [{ data: () => ({ quantity: 1 }) }];
+
+    await handler(makeEvent({ orderId: 'ORDER-1' }));
+
+    // Still confirmed (honor the payment)...
+    expect(mocks.txnUpdate).toHaveBeenCalledWith(
+      { id: 'reg-hosted-3' },
+      expect.objectContaining({ status: 'confirmed' })
+    );
+    // ...but staff are alerted to the overbooking.
+    expect(mocks.mailAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.objectContaining({
+          subject: expect.stringMatching(/overbooked/i),
+        }),
       })
     );
     expect(mocks.markProcessed).toHaveBeenCalledWith('PAY-1');

--- a/libs/firebase/maple-functions/process-pos-sale/src/lib/process-pos-sale.spec.ts
+++ b/libs/firebase/maple-functions/process-pos-sale/src/lib/process-pos-sale.spec.ts
@@ -22,6 +22,11 @@ const mocks = vi.hoisted(() => ({
   // Transactional re-read state for the hosted-checkout reconciliation.
   freshReg: undefined as Record<string, unknown> | undefined,
   countDocs: [] as Array<{ data: () => Record<string, unknown> }>,
+  // Helpers extracted so the mock's arrow nesting stays shallow (sonarjs).
+  snap: (value: Record<string, unknown> | undefined) => ({
+    data: () => value,
+  }),
+  whereStub: () => ({ where: () => ({ __query: true }) }),
   // ClassRepository
   findBySquareVariationId: vi.fn(),
   classFindById: vi.fn(),
@@ -63,7 +68,7 @@ vi.mock('@maple/firebase/database', () => ({
     collection: vi.fn(() => ({
       add: mocks.mailAdd,
       // Capacity re-count query used inside the reconciliation transaction.
-      where: () => ({ where: () => ({ __query: true }) }),
+      where: mocks.whereStub,
     })),
     runTransaction: async (
       cb: (txn: {
@@ -78,7 +83,7 @@ vi.mock('@maple/firebase/database', () => ({
         get: async (arg: unknown) =>
           arg && (arg as { __query?: boolean }).__query
             ? { docs: mocks.countDocs }
-            : { data: () => mocks.freshReg },
+            : mocks.snap(mocks.freshReg),
         update: mocks.txnUpdate,
       };
       return cb(txn);

--- a/libs/firebase/maple-functions/process-pos-sale/src/lib/process-pos-sale.ts
+++ b/libs/firebase/maple-functions/process-pos-sale/src/lib/process-pos-sale.ts
@@ -28,6 +28,7 @@
  */
 import { onDocumentWritten } from 'firebase-functions/v2/firestore';
 import { defineSecret, defineString } from 'firebase-functions/params';
+import { FieldValue } from 'firebase-admin/firestore';
 import {
   getDb,
   ClassRepository,
@@ -61,6 +62,68 @@ const adminAlertEmail = defineString('ADMIN_ALERT_EMAIL', {
 
 function formatCurrency(cents: number): string {
   return `$${(cents / 100).toFixed(2)}`;
+}
+
+type ConfirmOutcome = 'gone' | 'already' | 'confirmed' | 'overbooked';
+
+/** Sum the `quantity` (default 1) across registration docs. */
+function sumRegistrationQuantities(
+  docs: FirebaseFirestore.QueryDocumentSnapshot[]
+): number {
+  return docs.reduce((sum, d) => sum + (Number(d.data().quantity) || 1), 0);
+}
+
+/**
+ * Confirm a hosted-checkout registration inside a transaction. Re-reads the reg
+ * (idempotent for duplicate webhook delivery) and, for a reaper-`cancelled`
+ * hold whose spot may have been resold, re-checks capacity and reports whether
+ * confirming overbooks. Extracted so the transaction body isn't deeply nested.
+ */
+async function confirmHostedRegistration(
+  txn: FirebaseFirestore.Transaction,
+  db: FirebaseFirestore.Firestore,
+  args: {
+    regRef: FirebaseFirestore.DocumentReference;
+    classId: string;
+    wasCancelled: boolean;
+    capacity: number;
+    regQty: number;
+    squarePaymentId: string;
+    squareOrderId: string;
+    squareReceiptUrl: string | null;
+  }
+): Promise<ConfirmOutcome> {
+  const fresh = await txn.get(args.regRef);
+  const data = fresh.data();
+  if (!data) return 'gone';
+  // Idempotent: a prior worker run already resolved it.
+  if (data.status === 'confirmed' || data.status === 'refunded') {
+    return 'already';
+  }
+
+  let overbooked = false;
+  if (args.wasCancelled) {
+    const countSnap = await txn.get(
+      db
+        .collection('registrations')
+        .where('classId', '==', args.classId)
+        .where('status', 'in', ['pending', 'confirmed'])
+    );
+    overbooked =
+      sumRegistrationQuantities(countSnap.docs) + args.regQty > args.capacity;
+  }
+
+  txn.update(args.regRef, {
+    status: 'confirmed',
+    squarePaymentId: args.squarePaymentId,
+    squareOrderId: args.squareOrderId,
+    squareReceiptUrl: args.squareReceiptUrl,
+    // Drop the reaper's release reason now that it's paid; the buyer's own
+    // `notes` were never touched, so they survive.
+    holdReleaseReason: FieldValue.delete(),
+    updatedAt: new Date(),
+  });
+  return overbooked ? 'overbooked' : 'confirmed';
 }
 
 export const processPosSale = onDocumentWritten(
@@ -127,21 +190,63 @@ export const processPosSale = onDocumentWritten(
         const webReg = await RegistrationRepository.findById(order.referenceId);
         if (webReg) {
           if (webReg.status === 'pending' || webReg.status === 'cancelled') {
-            await RegistrationRepository.getDocRef(webReg.id).update({
-              status: 'confirmed',
-              squarePaymentId: paymentId,
-              squareOrderId: orderId,
-              squareReceiptUrl: payment.receiptUrl ?? null,
-              updatedAt: new Date(),
-            });
+            // A `cancelled` hold means the reaper released the spot (or an admin
+            // cancelled) yet the buyer paid — honor the payment, but the freed
+            // spot may have been resold, so re-check capacity and alert staff if
+            // confirming overbooks. A `pending` hold already counts toward
+            // capacity, so no re-check is needed there. The class capacity is
+            // effectively static, so it's read outside the transaction.
+            const wasCancelled = webReg.status === 'cancelled';
+            const capacity = wasCancelled
+              ? (await ClassRepository.findById(webReg.classId))?.capacity ?? 0
+              : 0;
+            const regQty = webReg.quantity || 1;
+
+            const regRef = RegistrationRepository.getDocRef(webReg.id);
+            const outcome = await db.runTransaction((txn) =>
+              confirmHostedRegistration(txn, db, {
+                regRef,
+                classId: webReg.classId,
+                wasCancelled,
+                capacity,
+                regQty,
+                squarePaymentId: paymentId,
+                squareOrderId: orderId,
+                squareReceiptUrl: payment.receiptUrl ?? null,
+              })
+            );
+
             console.log(
               `[process-pos-sale] hosted-checkout payment=${paymentId} ` +
-                `confirmed registration ${webReg.id} (was ${webReg.status})`
+                `registration ${webReg.id} (was ${webReg.status}) → ${outcome}`
             );
-            // TODO(hosted-checkout PR2): queue the rich confirmation email +
-            // process inline agreements here for full parity with the inline
-            // card flow. Square already emails the buyer its own payment
-            // receipt from the hosted page in the meantime.
+
+            // A late payment on a resold spot: honor it, but flag for staff.
+            if (outcome === 'overbooked') {
+              await db.collection('mail').add({
+                to: adminAlertEmail.value(),
+                message: {
+                  subject: `Class overbooked — late hosted-checkout payment`,
+                  text: [
+                    'A buyer completed a hosted-checkout payment after their hold',
+                    'was released and the spot was resold. The registration was',
+                    'confirmed to honor the payment, but the class is now over',
+                    'capacity — please resolve (add capacity or refund one).',
+                    '',
+                    `Registration: ${webReg.id}`,
+                    `Class: ${webReg.classId}`,
+                    `Square payment: ${paymentId}`,
+                    `Square order: ${orderId}`,
+                    payment.receiptUrl ? `Receipt: ${payment.receiptUrl}` : '',
+                  ]
+                    .filter((line) => line !== '')
+                    .join('\n'),
+                },
+              });
+            }
+            // TODO(follow-up): rich confirmation email + inline-agreement
+            // processing for full parity with the inline card flow. Square
+            // already emails the buyer its own payment receipt meanwhile.
           }
           await PosSaleRequestRepository.markProcessed(paymentId);
           return;

--- a/libs/firebase/maple-functions/release-stale-registration-holds/src/lib/release-stale-registration-holds.spec.ts
+++ b/libs/firebase/maple-functions/release-stale-registration-holds/src/lib/release-stale-registration-holds.spec.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 /**
- * Unit tests for the stale-hold reaper. Verifies it cancels only `pending`
- * registrations old enough and without a payment, and leaves ones mid-confirm
- * (with a squarePaymentId) alone.
+ * Unit tests for the stale-hold reaper. It cancels only holds that are STILL
+ * pending and unpaid when re-read inside a transaction, so a payment that
+ * confirms the registration between the query and the write is never clobbered.
  */
 
 const mocks = vi.hoisted(() => ({
   onSchedule: vi.fn(),
   get: vi.fn(),
-  batchUpdate: vi.fn(),
-  batchCommit: vi.fn(),
-  where: vi.fn(),
+  txnUpdate: vi.fn(),
+  // Per-ref state returned by the transactional re-read (txn.get).
+  freshData: new Map<string, Record<string, unknown> | undefined>(),
 }));
 
 vi.mock('firebase-functions/v2/scheduler', () => ({
@@ -24,15 +24,28 @@ vi.mock('firebase-functions/v2/scheduler', () => ({
 vi.mock('@maple/firebase/database', () => ({
   getDb: () => {
     const query = {
-      where: vi.fn(() => query),
+      where: () => query,
+      limit: () => query,
       get: mocks.get,
     };
     return {
-      collection: vi.fn(() => query),
-      batch: vi.fn(() => ({
-        update: mocks.batchUpdate,
-        commit: mocks.batchCommit,
-      })),
+      collection: () => query,
+      runTransaction: async (
+        cb: (txn: {
+          get: (ref: { id: string }) => Promise<{
+            data: () => Record<string, unknown> | undefined;
+          }>;
+          update: (ref: unknown, data: unknown) => void;
+        }) => Promise<unknown>
+      ) => {
+        const txn = {
+          get: async (ref: { id: string }) => ({
+            data: () => mocks.freshData.get(ref.id),
+          }),
+          update: mocks.txnUpdate,
+        };
+        return cb(txn);
+      },
     };
   },
 }));
@@ -41,42 +54,69 @@ import { releaseStaleRegistrationHolds } from './release-stale-registration-hold
 
 const handler = releaseStaleRegistrationHolds as unknown as () => Promise<void>;
 
-function doc(id: string, data: Record<string, unknown>) {
-  return { ref: { id }, data: () => data };
+/** A query-result doc — only its ref matters; the handler re-reads via txn.get. */
+function queryDoc(id: string) {
+  return { ref: { id } };
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.freshData.clear();
 });
 
 describe('releaseStaleRegistrationHolds', () => {
-  it('cancels a stale pending hold with no payment', async () => {
+  it('cancels a stale pending hold that is still pending + unpaid on re-read', async () => {
     mocks.get.mockResolvedValue({
       empty: false,
       size: 1,
-      docs: [doc('reg-1', { status: 'pending' })],
+      docs: [queryDoc('reg-1')],
     });
+    mocks.freshData.set('reg-1', { status: 'pending' });
 
     await handler();
 
-    expect(mocks.batchUpdate).toHaveBeenCalledWith(
+    expect(mocks.txnUpdate).toHaveBeenCalledWith(
       { id: 'reg-1' },
       expect.objectContaining({ status: 'cancelled' })
     );
-    expect(mocks.batchCommit).toHaveBeenCalled();
+    // Reason goes in its own field, NOT notes (preserve the buyer's note).
+    const updateArg = mocks.txnUpdate.mock.calls[0][1];
+    expect(updateArg).not.toHaveProperty('notes');
+    expect(updateArg).toHaveProperty('holdReleaseReason');
   });
 
-  it('leaves a pending hold that already has a squarePaymentId (confirming race)', async () => {
+  it('does NOT cancel a hold the webhook confirmed after the query (race)', async () => {
+    // Query snapshot saw it as pending, but the transactional re-read finds it
+    // already confirmed + paid — must not clobber it.
     mocks.get.mockResolvedValue({
       empty: false,
       size: 1,
-      docs: [doc('reg-2', { status: 'pending', squarePaymentId: 'PAY-9' })],
+      docs: [queryDoc('reg-race')],
+    });
+    mocks.freshData.set('reg-race', {
+      status: 'confirmed',
+      squarePaymentId: 'PAY-1',
     });
 
     await handler();
 
-    expect(mocks.batchUpdate).not.toHaveBeenCalled();
-    expect(mocks.batchCommit).not.toHaveBeenCalled();
+    expect(mocks.txnUpdate).not.toHaveBeenCalled();
+  });
+
+  it('does NOT cancel a hold that has a squarePaymentId on re-read', async () => {
+    mocks.get.mockResolvedValue({
+      empty: false,
+      size: 1,
+      docs: [queryDoc('reg-2')],
+    });
+    mocks.freshData.set('reg-2', {
+      status: 'pending',
+      squarePaymentId: 'PAY-9',
+    });
+
+    await handler();
+
+    expect(mocks.txnUpdate).not.toHaveBeenCalled();
   });
 
   it('no-ops when there are no stale holds', async () => {
@@ -84,7 +124,6 @@ describe('releaseStaleRegistrationHolds', () => {
 
     await handler();
 
-    expect(mocks.batchUpdate).not.toHaveBeenCalled();
-    expect(mocks.batchCommit).not.toHaveBeenCalled();
+    expect(mocks.txnUpdate).not.toHaveBeenCalled();
   });
 });

--- a/libs/firebase/maple-functions/release-stale-registration-holds/src/lib/release-stale-registration-holds.spec.ts
+++ b/libs/firebase/maple-functions/release-stale-registration-holds/src/lib/release-stale-registration-holds.spec.ts
@@ -12,6 +12,11 @@ const mocks = vi.hoisted(() => ({
   txnUpdate: vi.fn(),
   // Per-ref state returned by the transactional re-read (txn.get).
   freshData: new Map<string, Record<string, unknown> | undefined>(),
+  // Wrap a value as a Firestore-snapshot-like { data() }. Defined here (not
+  // inline in the mock) to keep the mock's arrow nesting shallow.
+  snap: (value: Record<string, unknown> | undefined) => ({
+    data: () => value,
+  }),
 }));
 
 vi.mock('firebase-functions/v2/scheduler', () => ({
@@ -39,9 +44,8 @@ vi.mock('@maple/firebase/database', () => ({
         }) => Promise<unknown>
       ) => {
         const txn = {
-          get: async (ref: { id: string }) => ({
-            data: () => mocks.freshData.get(ref.id),
-          }),
+          get: async (ref: { id: string }) =>
+            mocks.snap(mocks.freshData.get(ref.id)),
           update: mocks.txnUpdate,
         };
         return cb(txn);

--- a/libs/firebase/maple-functions/release-stale-registration-holds/src/lib/release-stale-registration-holds.ts
+++ b/libs/firebase/maple-functions/release-stale-registration-holds/src/lib/release-stale-registration-holds.ts
@@ -11,8 +11,15 @@
  * than the hold TTL that carry no Square payment — releasing the spot. The
  * inline card flow resolves `pending` within a single request, and POS sales
  * are written `confirmed`, so a lingering `pending` is always an abandoned
- * hosted-checkout hold. The `!squarePaymentId` guard avoids racing a payment
- * that is confirming right now.
+ * hosted-checkout hold.
+ *
+ * Concurrency: each hold is cancelled inside a transaction that RE-READS the
+ * doc, so a payment that confirms the registration between the query and the
+ * write is never clobbered (the query snapshot is stale by the time we commit).
+ * The cancellation reason goes in a dedicated `holdReleaseReason` field, NOT
+ * `notes`, so the buyer's own note survives if a late payment later resurrects
+ * the hold (see process-pos-sale reconciliation). The query is bounded so a
+ * large backlog can't exceed Firestore's per-commit write limit.
  *
  * Deployed to us-east4 (maple-core codebase) via CI/CD.
  */
@@ -25,6 +32,37 @@ import { getDb } from '@maple/firebase/database';
  * short enough not to block a near-full class for long.
  */
 const HOLD_TTL_MINUTES = 15;
+
+/**
+ * Max holds processed per run. Bounds work (and Firestore round-trips) so a
+ * backlog can't blow up a single run; the next 5-minute run drains the rest.
+ */
+const MAX_PER_RUN = 300;
+
+/**
+ * Cancel one hold transactionally, re-reading inside the transaction so a
+ * payment that confirmed the registration after the query snapshot is never
+ * clobbered. Returns whether it actually released the hold.
+ */
+async function releaseHoldIfStale(
+  txn: FirebaseFirestore.Transaction,
+  ref: FirebaseFirestore.DocumentReference,
+  now: Date
+): Promise<boolean> {
+  const fresh = await txn.get(ref);
+  const data = fresh.data();
+  if (!data || data.status !== 'pending' || data.squarePaymentId) {
+    return false;
+  }
+  txn.update(ref, {
+    status: 'cancelled',
+    // Reason lives in its own field so the buyer's `notes` are preserved if a
+    // late payment resurrects this hold.
+    holdReleaseReason: `Abandoned checkout — hold released after ${HOLD_TTL_MINUTES} minutes`,
+    updatedAt: now,
+  });
+  return true;
+}
 
 export const releaseStaleRegistrationHolds = onSchedule(
   {
@@ -41,6 +79,7 @@ export const releaseStaleRegistrationHolds = onSchedule(
       .collection('registrations')
       .where('status', '==', 'pending')
       .where('createdAt', '<', cutoff)
+      .limit(MAX_PER_RUN)
       .get();
 
     if (snapshot.empty) {
@@ -48,23 +87,16 @@ export const releaseStaleRegistrationHolds = onSchedule(
       return;
     }
 
-    const batch = db.batch();
     let released = 0;
     for (const doc of snapshot.docs) {
-      // Never cancel a hold that already has a payment recorded — that's a race
-      // with the confirming webhook, not an abandoned checkout.
-      if (doc.data().squarePaymentId) continue;
-      batch.update(doc.ref, {
-        status: 'cancelled',
-        notes: `Abandoned checkout — hold released after ${HOLD_TTL_MINUTES} minutes`,
-        updatedAt: now,
-      });
-      released++;
+      // Cancel transactionally so we never overwrite a registration a
+      // concurrent webhook confirmed (and paid) after the query snapshot.
+      const didRelease = await db.runTransaction((txn) =>
+        releaseHoldIfStale(txn, doc.ref, now)
+      );
+      if (didRelease) released++;
     }
 
-    if (released > 0) {
-      await batch.commit();
-    }
     console.log(
       `[release-stale-holds] released ${released} of ${snapshot.size} stale pending hold(s)`
     );


### PR DESCRIPTION
Fixes the concurrency/reconciliation cluster a high-effort code review found in the merged hosted-checkout flow (#661/#663/#664). None were live yet (the Webflow widget hasn't been republished), so this lands ahead of exposure.

## 🔴 High (money / data loss)
- **Reaper clobber race (#1):** each hold is now cancelled inside a transaction that **re-reads** the doc — a payment confirming between the query snapshot and the write can no longer revert a paid registration to `cancelled`. New race test.
- **Overbooking (#2):** the `cancelled→confirmed` late-payment path re-checks capacity in the confirm txn and **emails staff an overbook alert** instead of silently over-filling; the payment is still honored. New test.

## 🟠 Medium
- **Agreements swallowed (#4):** required-agreement classes now **release the hold + fail checkout** if signatures can't be persisted — no paying without the legal record.
- **Double-submit (#3):** a dedup guard rejects a rapid duplicate hold for the same buyer+class, so a buyer's own hold can't self-block capacity / burn a single-use discount. New index + integration test.
- **Notes clobber (#6):** the reaper records its reason in `holdReleaseReason`, never the buyer's `notes`.
- **Idempotency (#2):** confirm is transactional with a status re-read — duplicate webhook delivery can't double-process.

## 🟡 Cleanup
- **Orphan agreements (#7):** `/bin/zsh` guard moved before agreement/storage work.
- **Batch >500 (#8):** reaper query is bounded + uses per-doc transactions.

## Not-yet-fixed here (tracked separately, per plan)
- **`?reg=` return UX (#5):** needs a public registration-status endpoint — its own PR.
- **Lesson auto-invoice double-bill (#9):** unrelated to this feature (from #628) — its own fix.

## Testing
Both function codebases typecheck clean; ESLint clean; firestore index analyzer OK (174 covered); unit tests **25** (reaper 4 incl. the race, process-pos-sale 21 incl. idempotency + overbook-alert); **registration integration suite 64** (incl. the new dedup case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)