### PR TITLE
fix(lessons): idempotent auto-invoice to prevent double-billing

### DIFF
--- a/libs/firebase/database/src/lib/invoice.repository.ts
+++ b/libs/firebase/database/src/lib/invoice.repository.ts
@@ -173,6 +173,67 @@ export const InvoiceRepository = {
     };
   },
 
+  /**
+   * Idempotently create the auto-invoice for a rendered lesson. Uses a
+   * deterministic doc id derived from `lessonId` plus Firestore's `create()`
+   * (which fails if the doc already exists), so an at-least-once double-fire of
+   * the `onLessonRenderedInvoice` trigger can't produce two invoices — and thus
+   * two Square hosted payment pages — for the same lesson. Returns the created
+   * invoice, or `null` when one already existed.
+   */
+  async createAutoLessonInvoice(
+    lessonId: string,
+    input: CreateInvoiceInput
+  ): Promise<Invoice | null> {
+    const docRef = db.collection(COLLECTION).doc(`auto-lesson-${lessonId}`);
+    const now = new Date();
+    const status = input.status ?? 'draft';
+    const lineItems = withComputedSubtotals(input.lineItems);
+    const totalCents = computeInvoiceTotalCents(lineItems);
+
+    const data = {
+      studentId: input.studentId,
+      status,
+      lineItems,
+      totalCents,
+      notes: input.notes,
+      issuedAt: status === 'sent' || status === 'paid' ? now : undefined,
+      paidAt: status === 'paid' ? now : undefined,
+      paymentRecord:
+        status === 'paid'
+          ? { source: 'admin-manual' as const, recordedAt: now }
+          : undefined,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    try {
+      await docRef.create(data);
+    } catch (err) {
+      // ALREADY_EXISTS (gRPC status 6) — a concurrent trigger delivery already
+      // created this lesson's invoice. Idempotent no-op.
+      const code = (err as { code?: number | string }).code;
+      if (code === 6 || code === 'already-exists') {
+        return null;
+      }
+      throw err;
+    }
+
+    return {
+      id: docRef.id,
+      studentId: data.studentId,
+      status,
+      lineItems,
+      totalCents,
+      issuedAt: data.issuedAt,
+      paidAt: data.paidAt,
+      paymentRecord: data.paymentRecord,
+      notes: data.notes,
+      createdAt: now,
+      updatedAt: now,
+    };
+  },
+
   async update(
     input: UpdateInvoiceInput,
     existing: Invoice

--- a/libs/firebase/maple-functions/on-lesson-rendered-invoice/src/lib/on-lesson-rendered-invoice.spec.ts
+++ b/libs/firebase/maple-functions/on-lesson-rendered-invoice/src/lib/on-lesson-rendered-invoice.spec.ts
@@ -23,7 +23,11 @@ vi.mock('firebase-functions/v2/firestore', () => ({
 
 vi.mock('@maple/firebase/database', () => ({
   StudentRepository: { findById: mocks.findById },
-  InvoiceRepository: { findAll: mocks.findAll, create: mocks.create },
+  InvoiceRepository: {
+    findAll: mocks.findAll,
+    create: mocks.create,
+    createAutoLessonInvoice: mocks.create,
+  },
   LessonRatesConfigRepository: { get: mocks.getRatesConfig },
 }));
 
@@ -84,7 +88,9 @@ describe('onLessonRenderedInvoice', () => {
     await handler(makeEvent('scheduled', renderedLesson));
 
     expect(mocks.create).toHaveBeenCalledTimes(1);
-    const arg = mocks.create.mock.calls[0][0];
+    // createAutoLessonInvoice(lessonId, input) — lessonId first, input second.
+    expect(mocks.create.mock.calls[0][0]).toBe('lesson-1');
+    const arg = mocks.create.mock.calls[0][1];
     expect(arg.studentId).toBe('student-1');
     expect(arg.status).toBe('sent');
     expect(arg.lineItems).toHaveLength(1);
@@ -94,6 +100,18 @@ describe('onLessonRenderedInvoice', () => {
       unitAmountCents: 4125,
       subtotalCents: 4125,
     });
+  });
+
+  it('is idempotent: skips silently when the invoice already exists (concurrent delivery)', async () => {
+    // createAutoLessonInvoice returns null when the deterministic-id create()
+    // loses the race — the trigger must not throw or double-process.
+    mocks.create.mockResolvedValue(null);
+
+    await expect(
+      handler(makeEvent('scheduled', renderedLesson))
+    ).resolves.toBeUndefined();
+
+    expect(mocks.create).toHaveBeenCalledTimes(1);
   });
 
   it('does nothing when the status was already rendered (no transition)', async () => {

--- a/libs/firebase/maple-functions/on-lesson-rendered-invoice/src/lib/on-lesson-rendered-invoice.ts
+++ b/libs/firebase/maple-functions/on-lesson-rendered-invoice/src/lib/on-lesson-rendered-invoice.ts
@@ -148,13 +148,25 @@ export const onLessonRenderedInvoice = onDocumentWritten(
         subtotalCents: rateCents,
       };
 
-      const invoice = await InvoiceRepository.create({
+      // Idempotent create: a deterministic per-lesson invoice id + Firestore
+      // create() means a concurrent double-fire of this trigger can't produce
+      // two invoices (and two Square payment pages) for one lesson. The
+      // findAll scan above is the cheap early-out; this closes the race window
+      // where two invocations both pass that scan before either has written.
+      const invoice = await InvoiceRepository.createAutoLessonInvoice(lessonId, {
         studentId: after.studentId,
         // Create as sent so syncInvoiceToSquare delivers it automatically.
         status: 'sent',
         lineItems: [lineItem],
         notes: 'Auto-invoiced when the lesson was marked rendered.',
       });
+
+      if (!invoice) {
+        console.log(
+          `[auto-invoice] lesson ${lessonId}: invoice already exists (concurrent delivery) — skipping`
+        );
+        return;
+      }
 
       console.log(
         `[auto-invoice] lesson ${lessonId}: created + sent invoice ${invoice.id} ` +


### PR DESCRIPTION
Fixes review finding #9 (surfaced by the hosted-checkout review, but unrelated to that feature — it's the lesson auto-invoice from #628/#629).

## Bug
`onLessonRenderedInvoice`'s idempotency is a read-then-create scan with no atomicity: `findAll(student invoices)` then "is this lesson already invoiced" then `create()`. Firebase gen-2 Firestore triggers deliver at-least-once, so two invocations for one lesson's scheduled→rendered edge can both pass the scan (neither sees the other's not-yet-written invoice) and both create → `syncInvoiceToSquare` emails the parent two hosted payment pages for one lesson → double bill.

## Fix
New `InvoiceRepository.createAutoLessonInvoice(lessonId, input)`: a deterministic per-lesson invoice doc id + Firestore `create()` (throws if the doc already exists), so a concurrent double-fire can't produce two invoices. Returns null when one already exists; the trigger treats that as an idempotent skip.

The existing `findAll` scan stays as the cheap early-out (and still catches a lesson already billed via a manual/combined invoice) — this closes the race window it can't cover.

## Testing
maple-core typechecks clean; ESLint clean; unit tests 34 (trigger + invoice repo), including a new concurrent-delivery idempotent-skip test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
