### PR TITLE
feat(widget): hosted-checkout return confirmation (verify by lookup)

### DIFF
--- a/apps/functions-integration-tests-registration/src/get-registration-status.spec.ts
+++ b/apps/functions-integration-tests-registration/src/get-registration-status.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Integration tests for getRegistrationStatus — the public lookup the widget
+ * uses on the hosted-checkout return (?reg=<id>) to verify a payment landed
+ * before showing a confirmation (rather than trusting the query param).
+ */
+import {
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  callFunction,
+  PUBLISHED_CLASS,
+} from '@maple/firebase/integration-test-utils';
+import type {
+  GetRegistrationStatusRequest,
+  GetRegistrationStatusResponse,
+} from '@maple/ts/firebase/api-types';
+
+const CLASS_ID = 'test-status-class';
+
+function seedReg(id: string, overrides: Record<string, unknown>) {
+  return setFirestoreDoc('registrations', id, {
+    classId: CLASS_ID,
+    customerEmail: 'buyer@test.com',
+    customerName: 'Casey Buyer',
+    quantity: 1,
+    pricePaidCents: 4770,
+    subtotalCents: 4500,
+    taxAmountCents: 270,
+    taxRatePercent: 6,
+    confirmationNumber: 'MS-TEST01',
+    source: 'web',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  });
+}
+
+describe('getRegistrationStatus', () => {
+  beforeEach(async () => {
+    await clearFirestoreEmulator();
+    await setFirestoreDoc('classes', CLASS_ID, { ...PUBLISHED_CLASS });
+  });
+
+  afterAll(async () => {
+    await clearFirestoreEmulator();
+  });
+
+  it('returns confirmation details for a confirmed registration', async () => {
+    await seedReg('reg-confirmed', { status: 'confirmed' });
+
+    const result = await callFunction<
+      GetRegistrationStatusRequest,
+      GetRegistrationStatusResponse
+    >({
+      functionName: 'getRegistrationStatus',
+      data: { registrationId: 'reg-confirmed' },
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data?.status).toBe('confirmed');
+    expect(result.data?.confirmation).toMatchObject({
+      confirmationNumber: 'MS-TEST01',
+      customerName: 'Casey Buyer',
+      customerEmail: 'buyer@test.com',
+      quantity: 1,
+      pricePaidCents: 4770,
+    });
+    expect(result.data?.confirmation?.className).toBe(PUBLISHED_CLASS.name);
+  });
+
+  it('returns status only (no PII) for a pending registration', async () => {
+    await seedReg('reg-pending', { status: 'pending' });
+
+    const result = await callFunction<
+      GetRegistrationStatusRequest,
+      GetRegistrationStatusResponse
+    >({
+      functionName: 'getRegistrationStatus',
+      data: { registrationId: 'reg-pending' },
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data?.status).toBe('pending');
+    expect(result.data?.confirmation).toBeUndefined();
+  });
+
+  it('returns not-found for an unknown registration id', async () => {
+    const result = await callFunction<
+      GetRegistrationStatusRequest,
+      GetRegistrationStatusResponse
+    >({
+      functionName: 'getRegistrationStatus',
+      data: { registrationId: 'does-not-exist' },
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data?.status).toBe('not-found');
+  });
+});

--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -109,6 +109,7 @@ export { migrateClassSessions } from '@maple/firebase/maple-functions/migrate-cl
 
 // Public class API (no auth required - for Webflow integration)
 export { getPublicClass } from '@maple/firebase/maple-functions/get-public-class';
+export { getRegistrationStatus } from '@maple/firebase/maple-functions/get-registration-status';
 export { getPublicMusicTogetherSection } from '@maple/firebase/maple-functions/get-public-music-together-section';
 export { addToMusicTogetherWaitlist } from '@maple/firebase/maple-functions/add-to-music-together-waitlist';
 export { getPublicMusicTogetherSections } from '@maple/firebase/maple-functions/get-public-music-together-sections';

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -48,6 +48,7 @@
     "../../libs/firebase/maple-functions/upload-class-gallery-image/**/*.ts",
     "../../libs/firebase/maple-functions/upload-category-gallery-image/**/*.ts",
     "../../libs/firebase/maple-functions/get-public-class/**/*.ts",
+    "../../libs/firebase/maple-functions/get-registration-status/**/*.ts",
     "../../libs/firebase/maple-functions/get-related-public-classes/**/*.ts",
     "../../libs/firebase/maple-functions/add-to-class-waitlist/**/*.ts",
     "../../libs/firebase/maple-functions/notify-waitlist-on-spot-open/**/*.ts",

--- a/apps/webflow-components/src/RegistrationWidget.tsx
+++ b/apps/webflow-components/src/RegistrationWidget.tsx
@@ -34,6 +34,8 @@ import type {
   CreateRegistrationResponse,
   CreateRegistrationCheckoutLinkRequest,
   CreateRegistrationCheckoutLinkResponse,
+  GetRegistrationStatusRequest,
+  GetRegistrationStatusResponse,
   GetRequiredAgreementsForClassRequest,
   GetRequiredAgreementsForClassResponse,
   InlineAgreementSigningData,
@@ -366,25 +368,65 @@ interface RegistrationWidgetProps {
   showDigitalWallets?: string;
 }
 
+interface ConfirmedState {
+  status: 'confirmed';
+  confirmationNumber: string;
+  customerName: string;
+  customerEmail: string;
+  className: string;
+  pricePaidCents: number;
+  quantity: number;
+  classDate: string;
+  classEndDate: string;
+  classDurationMinutes: number;
+  skillLevel: string;
+  location?: string;
+  agreementsSigned?: boolean;
+}
+
 type WidgetState =
   | { status: 'loading' }
   | { status: 'error'; message: string }
   | { status: 'ready'; publicClass: PublicClass; requiredAgreements: RequiredAgreementTemplate[] }
-  | {
-      status: 'confirmed';
-      confirmationNumber: string;
-      customerName: string;
-      customerEmail: string;
-      className: string;
-      pricePaidCents: number;
-      quantity: number;
-      classDate: string;
-      classEndDate: string;
-      classDurationMinutes: number;
-      skillLevel: string;
-      location?: string;
-      agreementsSigned?: boolean;
-    };
+  // Buyer returned from Square's hosted checkout (?reg=<id>); we're polling for
+  // the webhook to confirm. `timedOut` = still pending after the poll window.
+  | { status: 'confirming'; customerEmail?: string; timedOut: boolean }
+  | ConfirmedState;
+
+/**
+ * Build the `confirmed` widget state from a class + payment details. Shared by
+ * the inline-payment success path and the hosted-checkout return path.
+ */
+function buildConfirmedState(
+  pc: PublicClass,
+  details: {
+    confirmationNumber: string;
+    customerName: string;
+    customerEmail: string;
+    pricePaidCents: number;
+    quantity: number;
+    agreementsSigned?: boolean;
+  }
+): ConfirmedState {
+  const firstSessionIso = pc.sessions?.[0]?.dateTime ?? '';
+  const startDate = new Date(firstSessionIso);
+  const endDate = new Date(startDate.getTime() + pc.durationMinutes * 60 * 1000);
+  return {
+    status: 'confirmed',
+    confirmationNumber: details.confirmationNumber,
+    customerName: details.customerName,
+    customerEmail: details.customerEmail,
+    className: pc.name,
+    pricePaidCents: details.pricePaidCents,
+    quantity: details.quantity,
+    classDate: firstSessionIso,
+    classEndDate: endDate.toISOString(),
+    classDurationMinutes: pc.durationMinutes,
+    skillLevel: pc.skillLevel,
+    location: pc.location,
+    agreementsSigned: details.agreementsSigned,
+  };
+}
 
 export function RegistrationWidget({
   classId,
@@ -417,6 +459,60 @@ export function RegistrationWidget({
       'createRegistrationCheckoutLink'
     );
 
+    // Poll getRegistrationStatus for a returning hosted-checkout buyer. Returns
+    // true if it took over the UI (confirmed or a "confirming payment" state),
+    // false if there's nothing to show (lookup failed / not confirmed) and the
+    // normal registration form should render.
+    const showHostedCheckoutReturn = async (
+      registrationId: string,
+      publicClass: PublicClass
+    ): Promise<boolean> => {
+      const getRegistrationStatus = httpsCallable<
+        GetRegistrationStatusRequest,
+        GetRegistrationStatusResponse
+      >(functions, 'getRegistrationStatus');
+
+      const MAX_POLLS = 6;
+      const POLL_MS = 3000;
+      for (let attempt = 0; attempt <= MAX_POLLS; attempt++) {
+        let res: GetRegistrationStatusResponse;
+        try {
+          res = (await getRegistrationStatus({ registrationId })).data;
+        } catch {
+          return false; // lookup failed — fall back to the form
+        }
+
+        if (res.status === 'confirmed' && res.confirmation) {
+          setState(
+            buildConfirmedState(publicClass, {
+              confirmationNumber: res.confirmation.confirmationNumber ?? '',
+              customerName: res.confirmation.customerName,
+              customerEmail: res.confirmation.customerEmail,
+              pricePaidCents: res.confirmation.pricePaidCents,
+              quantity: res.confirmation.quantity,
+            })
+          );
+          return true;
+        }
+        if (res.status !== 'pending') {
+          // not-found / cancelled / refunded — nothing to confirm.
+          return false;
+        }
+
+        // Still pending — the webhook hasn't landed yet. Show a confirming
+        // state and poll again.
+        setState({ status: 'confirming', timedOut: false });
+        if (attempt < MAX_POLLS) {
+          await new Promise((r) => setTimeout(r, POLL_MS));
+        }
+      }
+
+      // Payment almost certainly succeeded (Square only redirects here after
+      // payment) but the webhook is lagging — reassure rather than dead-end.
+      setState({ status: 'confirming', timedOut: true });
+      return true;
+    };
+
     const fetchClass = async () => {
       setState({ status: 'loading' });
       try {
@@ -439,6 +535,20 @@ export function RegistrationWidget({
         ]);
 
         const publicClass = classResult.data.class;
+
+        // Hosted-checkout return: Square sends the buyer back with ?reg=<id>
+        // after paying. Verify the payment landed (the webhook is the source of
+        // truth — never trust the param) and show a real confirmation instead
+        // of a blank form, so a buyer who paid doesn't pay again.
+        const regId =
+          typeof window !== 'undefined'
+            ? new URLSearchParams(window.location.search).get('reg')
+            : null;
+        if (regId) {
+          const shown = await showHostedCheckoutReturn(regId, publicClass);
+          if (shown) return; // confirmed or confirming — don't render the form
+        }
+
         setState({
           status: 'ready',
           publicClass,
@@ -565,41 +675,19 @@ export function RegistrationWidget({
       if (state.status !== 'ready') return;
 
       const pc = state.publicClass;
-      const className = pc.name;
-
-      // Calculate class end time (use first session)
-      const firstSessionIso = pc.sessions?.[0]?.dateTime ?? '';
-      const startDate = new Date(firstSessionIso);
-      const endDate = new Date(
-        startDate.getTime() + pc.durationMinutes * 60 * 1000
-      );
 
       trackPurchaseClass(
         typeof window !== 'undefined' ? window : null,
         {
           classId: pc.id,
-          className,
+          className: pc.name,
           pricePaidCents: details.pricePaidCents,
           quantity: details.quantity,
           confirmationNumber: details.confirmationNumber,
         }
       );
 
-      setState({
-        status: 'confirmed',
-        confirmationNumber: details.confirmationNumber,
-        customerName: details.customerName,
-        customerEmail: details.customerEmail,
-        className,
-        pricePaidCents: details.pricePaidCents,
-        quantity: details.quantity,
-        classDate: firstSessionIso,
-        classEndDate: endDate.toISOString(),
-        classDurationMinutes: pc.durationMinutes,
-        skillLevel: pc.skillLevel,
-        location: pc.location,
-        agreementsSigned: details.agreementsSigned,
-      });
+      setState(buildConfirmedState(pc, details));
     },
     [state]
   );
@@ -624,6 +712,22 @@ export function RegistrationWidget({
           <Alert severity="error" sx={{ mb: 2 }}>
             {state.message}
           </Alert>
+        )}
+
+        {state.status === 'confirming' && (
+          <Box sx={{ textAlign: 'center', py: 6 }}>
+            {!state.timedOut && <CircularProgress sx={{ mb: 2 }} />}
+            <Typography variant="h6" sx={{ mb: 1 }}>
+              {state.timedOut
+                ? 'Payment received — you’re all set!'
+                : 'Confirming your payment…'}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {state.timedOut
+                ? 'We’re finalizing your registration. A confirmation email is on its way — no need to pay again.'
+                : 'Just a moment while we confirm your registration.'}
+            </Typography>
+          </Box>
         )}
 
         {state.status === 'ready' && (

--- a/libs/firebase/database/src/lib/registration.repository.ts
+++ b/libs/firebase/database/src/lib/registration.repository.ts
@@ -46,6 +46,7 @@ function docToRegistration(
     discountCode: data.discountCode,
     discountAmountCents: data.discountAmountCents,
     status: data.status as RegistrationStatus,
+    confirmationNumber: data.confirmationNumber,
     // Default to 'web' so registrations created before the source field
     // existed (all of which were web checkouts) read back with a usable value.
     source: (data.source as RegistrationSource | undefined) ?? 'web',

--- a/libs/firebase/maple-functions/get-registration-status/project.json
+++ b/libs/firebase/maple-functions/get-registration-status/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-get-registration-status",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/get-registration-status/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/get-registration-status/src/index.ts
+++ b/libs/firebase/maple-functions/get-registration-status/src/index.ts
@@ -1,0 +1,1 @@
+export { getRegistrationStatus } from './lib/get-registration-status';

--- a/libs/firebase/maple-functions/get-registration-status/src/lib/get-registration-status.ts
+++ b/libs/firebase/maple-functions/get-registration-status/src/lib/get-registration-status.ts
@@ -1,0 +1,59 @@
+/**
+ * Get Registration Status Cloud Function
+ *
+ * Public lookup by registration id. Used when Square redirects a buyer back to
+ * the class page (`?reg=<id>`) after a hosted checkout: the widget VERIFIES the
+ * payment actually landed (the `payment.updated` webhook is the source of
+ * truth) rather than trusting the query param, then shows a real confirmation
+ * instead of a blank form — so a buyer who paid doesn't pay again.
+ *
+ * Confirmation details (name/email/class/amount) are returned ONLY for a
+ * confirmed registration; other statuses return the status alone (no PII). The
+ * registration id is a random Firestore id, so it isn't enumerable.
+ *
+ * Deployed to us-east4 (maple-core codebase) via CI/CD.
+ */
+import { Functions } from '@maple/firebase/functions';
+import {
+  RegistrationRepository,
+  ClassRepository,
+} from '@maple/firebase/database';
+import type {
+  GetRegistrationStatusRequest,
+  GetRegistrationStatusResponse,
+} from '@maple/ts/firebase/api-types';
+
+export const getRegistrationStatus = Functions.endpoint.handle<
+  GetRegistrationStatusRequest,
+  GetRegistrationStatusResponse
+>(async (data) => {
+  if (!data.registrationId) {
+    throw new Error('Registration ID is required');
+  }
+
+  const registration = await RegistrationRepository.findById(
+    data.registrationId
+  );
+  if (!registration) {
+    return { status: 'not-found' };
+  }
+
+  if (registration.status !== 'confirmed') {
+    // Pending / cancelled / etc. — status only, no personal details.
+    return { status: registration.status };
+  }
+
+  const classEntity = await ClassRepository.findById(registration.classId);
+
+  return {
+    status: 'confirmed',
+    confirmation: {
+      confirmationNumber: registration.confirmationNumber,
+      className: classEntity?.name ?? 'your class',
+      customerName: registration.customerName,
+      customerEmail: registration.customerEmail,
+      quantity: registration.quantity,
+      pricePaidCents: registration.pricePaidCents,
+    },
+  };
+});

--- a/libs/firebase/maple-functions/get-registration-status/tsconfig.json
+++ b/libs/firebase/maple-functions/get-registration-status/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "ignoreDeprecations": "6.0"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/get-registration-status/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/get-registration-status/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"],
+    "rootDir": "../../.."
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/ts/domain/src/lib/registration.ts
+++ b/libs/ts/domain/src/lib/registration.ts
@@ -80,6 +80,8 @@ export interface Registration {
   discountAmountCents?: number;
   /** Registration status */
   status: RegistrationStatus;
+  /** Human-readable confirmation number (e.g. MS-XXXXXX) shown to the buyer. */
+  confirmationNumber?: string;
   /**
    * Channel the registration came from. Defaults to `'web'` for any record
    * predating the field — see `docToRegistration` for the back-compat read.

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -278,6 +278,8 @@ export type {
   CreateRegistrationResponse,
   CreateRegistrationCheckoutLinkRequest,
   CreateRegistrationCheckoutLinkResponse,
+  GetRegistrationStatusRequest,
+  GetRegistrationStatusResponse,
 } from './registration.types';
 
 // Phase 4: Music Lessons - Student types

--- a/libs/ts/firebase/api-types/src/lib/registration.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/registration.types.ts
@@ -178,3 +178,33 @@ export interface CreateRegistrationCheckoutLinkResponse {
   /** Confirmation number stamped on the reserved registration. */
   confirmationNumber: string;
 }
+
+// ============================================================================
+// Get Registration Status (Public - hosted-checkout return lookup)
+// ============================================================================
+
+/**
+ * Public lookup by registration id, used when Square redirects the buyer back
+ * to the class page (`?reg=<id>`) after a hosted checkout. Lets the widget
+ * VERIFY the payment landed (the webhook is the source of truth) rather than
+ * trust the query param, so a returning buyer sees a real confirmation instead
+ * of a blank form (and doesn't pay twice). Confirmation details are returned
+ * ONLY for a confirmed registration.
+ */
+export interface GetRegistrationStatusRequest {
+  registrationId: string;
+}
+
+export interface GetRegistrationStatusResponse {
+  /** 'not-found' when no such registration; otherwise the registration status. */
+  status: 'not-found' | 'pending' | 'confirmed' | 'cancelled' | 'refunded' | 'no-show';
+  /** Present only when status is 'confirmed'. */
+  confirmation?: {
+    confirmationNumber?: string;
+    className: string;
+    customerName: string;
+    customerEmail: string;
+    quantity: number;
+    pricePaidCents: number;
+  };
+}

--- a/tools/check-callable-roles.ts
+++ b/tools/check-callable-roles.ts
@@ -62,6 +62,7 @@ const PUBLIC_ALLOWLIST = new Set<string>([
   'getPublicMusicTogetherSection',
   'getPublicMusicTogetherSections',
   'getRelatedPublicClasses',
+  'getRegistrationStatus',
   'getRequiredAgreementsForClass',
   'calculateRegistrationCost',
   'lookupDiscount',

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -374,6 +374,9 @@
       "@maple/firebase/maple-functions/get-public-class": [
         "libs/firebase/maple-functions/get-public-class/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/get-registration-status": [
+        "libs/firebase/maple-functions/get-registration-status/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/get-public-music-together-section": [
         "libs/firebase/maple-functions/get-public-music-together-section/src/index.ts"
       ],


### PR DESCRIPTION
Fixes the last code-review finding (#5). After Square redirects a paid buyer back to the class page with `?reg=<id>`, the widget ignored it — the buyer saw a blank registration form and could pay a second time.

## Backend
- New **public `getRegistrationStatus`** callable (maple-core): looks a registration up by id and returns its status. Confirmation details (name / email / class / amount) are returned **only for a confirmed** registration — status-only otherwise, so no PII leaks (and the id is a random, non-enumerable Firestore id). Allowlisted in `check-callable-roles`.
- Added `confirmationNumber` to the `Registration` domain type + `docToRegistration` mapping (it was persisted but untyped).

## Widget
- On mount, if the URL has `?reg=<id>`, **verify via `getRegistrationStatus`** (the `payment.updated` webhook is the source of truth — the param is never trusted) and show the real confirmation instead of the form.
- If still `pending`, show a **"Confirming your payment…"** state and poll (~18s); on timeout, reassure ("Payment received — a confirmation email is on its way; no need to pay again") rather than dead-end.
- Extracted `buildConfirmedState` so the inline-success and hosted-return paths share one confirmation builder.

## Relationship to the other fix PRs
Independent of #666 (reconciliation) and #667 (lesson invoice) — different files, no conflicts. Together with #666, this closes every finding from the high-effort review.

## Testing
maple-core typechecks clean; ESLint clean; callable-roles OK (205 functions, `getRegistrationStatus` allowlisted); firestore index analyzer OK; **registration integration suite 66** — 3 new `getRegistrationStatus` cases (confirmed → confirmation, pending → status-only, unknown → not-found).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
