### PR TITLE
fix(widget): hide card error + empty box when hosted-checkout fallback shows

### DIFF
--- a/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
+++ b/libs/react/registrations/src/lib/RegistrationCheckoutForm.tsx
@@ -991,6 +991,10 @@ export function RegistrationCheckoutForm({
           showDigitalWallets={showDigitalWallets}
           onReady={() => (isCardReady.value = true)}
           onInitError={() => (cardInitFailed.value = true)}
+          // When we can offer the hosted-checkout fallback, hide SquareCardForm's
+          // own error alert + empty card box so the buyer sees just the
+          // "Continue to secure checkout" button, not a scary error beside it.
+          suppressInitError={!!onHostedCheckout}
           onTokenizeRef={(fn) => {
             tokenizeRef.current = fn;
           }}

--- a/libs/react/registrations/src/lib/SquareCardForm.spec.tsx
+++ b/libs/react/registrations/src/lib/SquareCardForm.spec.tsx
@@ -254,6 +254,36 @@ describe('SquareCardForm init failure telemetry', () => {
 
     consoleSpy.mockRestore();
   });
+
+  it('suppresses its own error alert when suppressInitError is set (fallback UI owns it)', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    (window as unknown as { Square: unknown }).Square = {
+      payments: vi.fn().mockRejectedValue({
+        type: 'InitializationTimeoutError',
+        message: 'Web Payments SDK was unable to be initialized in time',
+      }),
+    };
+    const onInitError = vi.fn();
+
+    render(
+      <SquareCardForm
+        applicationId="sq0idp-xyz789"
+        locationId="LOC1"
+        totalCents={25200}
+        onInitError={onInitError}
+        suppressInitError
+        onTokenizeRef={noop}
+      />
+    );
+
+    // Still reports the failure to the consumer...
+    await waitFor(() => expect(onInitError).toHaveBeenCalled());
+    // ...but renders no scary alert of its own (the fallback UI stands alone).
+    expect(screen.queryByText(/secure payment form/i)).toBeNull();
+    expect(screen.queryByText(/private browsing/i)).toBeNull();
+
+    vi.restoreAllMocks();
+  });
 });
 
 /**

--- a/libs/react/registrations/src/lib/SquareCardForm.tsx
+++ b/libs/react/registrations/src/lib/SquareCardForm.tsx
@@ -213,6 +213,14 @@ interface SquareCardFormProps {
    * console.errors + GA-beacons on its own; this is an extra hook for consumers.
    */
   onInitError?: (info: SquareInitErrorInfo) => void;
+  /**
+   * When true, an init failure does NOT render this component's own error alert
+   * or leave an empty card box behind — the consumer is expected to present its
+   * own fallback UI (via `onInitError`). Use when a hosted-checkout fallback
+   * button will replace the card form, so the buyer sees one clear path instead
+   * of a scary error next to a working button.
+   */
+  suppressInitError?: boolean;
   /** Ref function to expose tokenize to parent */
   onTokenizeRef: (tokenize: () => Promise<CardTokenizeResult>) => void;
   /**
@@ -291,6 +299,7 @@ export function SquareCardForm({
   showDigitalWallets = false,
   onReady,
   onInitError,
+  suppressInitError = false,
   onTokenizeRef,
   verifyBuyerForStore = false,
   billingContact,
@@ -300,6 +309,9 @@ export function SquareCardForm({
 }: SquareCardFormProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // Init failed while `suppressInitError` is set — hide our own card UI so the
+  // consumer's fallback (e.g. a hosted-checkout button) stands alone.
+  const [initSuppressed, setInitSuppressed] = useState(false);
   const [portalContainer, setPortalContainer] = useState<HTMLElement | null>(
     null
   );
@@ -636,14 +648,24 @@ export function SquareCardForm({
       reportPaymentInitFailure(info);
       onInitErrorRef.current?.(info);
 
-      setError(
-        isInitTimeout
-          ? "We couldn't load the secure payment form. Please refresh the page and try again — if it keeps happening, open this page in a private browsing window or a different browser."
-          : message
-      );
+      if (suppressInitError) {
+        // The consumer will show its own fallback UI. Don't render our alert,
+        // and remove the empty card box we may have created (Shadow-DOM mode)
+        // so the buyer sees one clear path, not an error beside a live button.
+        if (cardContainerRef.current) {
+          cardContainerRef.current.style.display = 'none';
+        }
+        setInitSuppressed(true);
+      } else {
+        setError(
+          isInitTimeout
+            ? "We couldn't load the secure payment form. Please refresh the page and try again — if it keeps happening, open this page in a private browsing window or a different browser."
+            : message
+        );
+      }
       setIsLoading(false);
     }
-  }, [applicationId, locationId, env, totalCents, showDigitalWallets, onReady, onTokenizeRef, maxWidth]);
+  }, [applicationId, locationId, env, totalCents, showDigitalWallets, suppressInitError, onReady, onTokenizeRef, maxWidth]);
 
   // Initialize payments once SDK is ready AND we have a valid amount
   useEffect(() => {
@@ -716,6 +738,7 @@ export function SquareCardForm({
         ref={placeholderRef}
         id="square-card-container"
         sx={{
+          display: initSuppressed ? 'none' : 'block',
           minHeight: portalContainer ? 0 : 56,
           border: isLoading || portalContainer ? 'none' : 1,
           borderColor: 'divider',


### PR DESCRIPTION
When the embedded card form can't initialize (Safari ITP) and the hosted-checkout fallback is available, the buyer saw three things at once — a scary red "couldn't load the secure payment form… try a private window" alert, an empty card box, AND the working "Continue to secure checkout" button. Confusing (screenshot from a real session). This makes the fallback stand alone.

## Change
- **SquareCardForm**: new `suppressInitError` prop. On init failure when set, it still reports via `onInitError` (+ console/GA telemetry) but renders **no error alert** and **hides its card box** — both the imperatively-created external box (Shadow-DOM / Webflow) and the React one (normal DOM).
- **RegistrationCheckoutForm**: passes `suppressInitError={!!onHostedCheckout}`, so when a fallback exists the buyer sees just "Continue to our secure checkout page to finish your payment." + the button.

## Testing
react-registrations unit tests **24** — new case: on init failure with `suppressInitError`, `onInitError` still fires but no alert renders. `nx lint` clean.

Small UX follow-up to the hosted-checkout fallback (#664).

🤖 Generated with [Claude Code](https://claude.com/claude-code)