### PR TITLE
feat(music-together): table-shaped loading skeletons on the MT management page

### DIFF
--- a/apps/maple-spruce/src/app/(admin)/music-together/InterestListDialog.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/InterestListDialog.tsx
@@ -16,7 +16,7 @@ import {
   Box,
   Stack,
   LinearProgress,
-  CircularProgress,
+  Skeleton,
   Alert,
 } from '@mui/material';
 import type { RequestState } from '@maple/ts/domain';
@@ -30,6 +30,42 @@ interface Props {
 
 const fmtDay = (d: Date) =>
   new Date(d).toLocaleDateString(undefined, { dateStyle: 'medium' });
+
+/** Table-shaped placeholder shown while the interest list loads. */
+function InterestLoadingSkeleton() {
+  const headers = [
+    'Family',
+    'Interested in',
+    'Most interested',
+    'Other days/times',
+    'Notes',
+    'Joined',
+  ];
+  return (
+    <Box sx={{ mt: 1 }}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            {headers.map((h) => (
+              <TableCell key={h}>{h}</TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {Array.from({ length: 4 }).map((_, r) => (
+            <TableRow key={r}>
+              {headers.map((h, c) => (
+                <TableCell key={h}>
+                  <Skeleton variant="text" width={c === 0 ? '80%' : '55%'} />
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+}
 
 /** Long free-text cell, or a muted em-dash when empty. */
 function NoteCell({ text }: { text?: string }) {
@@ -67,11 +103,8 @@ export function InterestListDialog({ open, onClose, interestState }: Props) {
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
       <DialogTitle>Interest list — cross-section demand</DialogTitle>
       <DialogContent>
-        {interestState.status === 'loading' && (
-          <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
-            <CircularProgress />
-          </Box>
-        )}
+        {(interestState.status === 'idle' ||
+          interestState.status === 'loading') && <InterestLoadingSkeleton />}
         {interestState.status === 'error' && (
           <Alert severity="error">{interestState.error}</Alert>
         )}

--- a/apps/maple-spruce/src/app/(admin)/music-together/RosterDialog.stories.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/RosterDialog.stories.tsx
@@ -114,8 +114,30 @@ export const Empty: Story = {
   },
 };
 
+/**
+ * While loading, a table-shaped skeleton stands in for the roster so the dialog
+ * doesn't collapse to a bare spinner — the column headers stay put and the body
+ * fills with shimmer rows. Asserts the skeleton renders and the empty/success
+ * copy is absent.
+ */
 export const Loading: Story = {
   args: { rosterState: { status: 'loading' } },
+  play: async () => {
+    const canvas = body();
+    await waitFor(() =>
+      expect(canvas.getByRole('dialog')).toBeInTheDocument()
+    );
+    // Header structure is preserved during load…
+    await expect(canvas.getByText('Parent(s)')).toBeInTheDocument();
+    // …and the skeleton placeholder is rendered (MUI Skeleton = .MuiSkeleton-root).
+    await expect(
+      document.querySelectorAll('.MuiSkeleton-root').length
+    ).toBeGreaterThan(0);
+    // Not the empty-state nor a real family row.
+    await expect(
+      canvas.queryByText(/No families enrolled yet/i)
+    ).not.toBeInTheDocument();
+  },
 };
 
 export const ErrorState: Story = {

--- a/apps/maple-spruce/src/app/(admin)/music-together/RosterDialog.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/RosterDialog.tsx
@@ -15,7 +15,7 @@ import {
   Chip,
   Typography,
   Box,
-  CircularProgress,
+  Skeleton,
   Alert,
   TextField,
 } from '@mui/material';
@@ -64,6 +64,42 @@ function downloadCsv(filename: string, csv: string) {
 }
 
 const fmtCents = (cents: number) => `$${(cents / 100).toFixed(2)}`;
+
+/** Table-shaped placeholder shown while the roster loads. */
+function RosterLoadingSkeleton({ showActions }: { showActions: boolean }) {
+  const headers = [
+    'Parent(s)',
+    'Children (DOB)',
+    'Accommodations / notes',
+    'Plan',
+    'Status',
+    ...(showActions ? ['Actions'] : []),
+  ];
+  return (
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          {headers.map((h, i) => (
+            <TableCell key={h} align={i === headers.length - 1 && showActions ? 'right' : 'left'}>
+              {h}
+            </TableCell>
+          ))}
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {Array.from({ length: 3 }).map((_, r) => (
+          <TableRow key={r}>
+            {headers.map((h, c) => (
+              <TableCell key={h}>
+                <Skeleton variant="text" width={c === 0 ? '80%' : '55%'} />
+              </TableCell>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
 
 /** Chip color for a roster row's status (past-due takes precedence). */
 function statusChipColor(
@@ -208,10 +244,9 @@ export function RosterDialog({
             {actionMessage}
           </Alert>
         )}
-        {rosterState.status === 'loading' && (
-          <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
-            <CircularProgress />
-          </Box>
+        {(rosterState.status === 'idle' ||
+          rosterState.status === 'loading') && (
+          <RosterLoadingSkeleton showActions={!!onCancelRegistration} />
         )}
         {rosterState.status === 'error' && (
           <Alert severity="error">{rosterState.error}</Alert>

--- a/apps/maple-spruce/src/app/(admin)/music-together/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/page.tsx
@@ -11,7 +11,7 @@ import {
   TableCell,
   TableBody,
   Chip,
-  CircularProgress,
+  Skeleton,
   Alert,
   IconButton,
   Tooltip,
@@ -51,6 +51,69 @@ const fmtDate = (d?: Date) =>
 const fmtDay = (d?: Date) =>
   d ? new Date(d).toLocaleDateString(undefined, { dateStyle: 'medium' }) : '—';
 const fmtPrice = (cents: number) => `$${(cents / 100).toFixed(0)}`;
+
+/**
+ * A table-shaped loading placeholder that mirrors the real table's columns so
+ * the layout doesn't shift when data arrives. Keeps the header visible and
+ * fills the body with shimmering skeleton rows.
+ */
+function TableLoadingSkeleton({
+  headers,
+  rows = 3,
+  size = 'medium',
+  mb,
+}: {
+  headers: readonly string[];
+  rows?: number;
+  size?: 'small' | 'medium';
+  mb?: number;
+}) {
+  return (
+    <Table size={size} sx={mb ? { mb } : undefined}>
+      <TableHead>
+        <TableRow>
+          {headers.map((h, i) => (
+            <TableCell key={h} align={i === headers.length - 1 ? 'right' : 'left'}>
+              {h}
+            </TableCell>
+          ))}
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {Array.from({ length: rows }).map((_, r) => (
+          <TableRow key={r}>
+            {headers.map((h, c) => (
+              <TableCell key={h}>
+                <Skeleton variant="text" width={c === 0 ? '70%' : '55%'} />
+              </TableCell>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+const SEMESTER_HEADERS = [
+  'Name',
+  'Term',
+  'Status',
+  'Dates',
+  'Weeks',
+  'Actions',
+] as const;
+
+const SECTION_HEADERS = [
+  'Name',
+  'Semester',
+  'Status',
+  'First session',
+  'Capacity',
+  'Registered',
+  'Full price',
+  'Installments',
+  'Actions',
+] as const;
 
 export default function MusicTogetherPage() {
   const {
@@ -195,10 +258,14 @@ export default function MusicTogetherPage() {
           New Semester
         </Button>
       </Box>
-      {semestersState.status === 'loading' && (
-        <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
-          <CircularProgress />
-        </Box>
+      {(semestersState.status === 'idle' ||
+        semestersState.status === 'loading') && (
+        <TableLoadingSkeleton
+          headers={SEMESTER_HEADERS}
+          size="small"
+          rows={2}
+          mb={4}
+        />
       )}
       {semestersState.status === 'error' && (
         <Alert severity="error" sx={{ mb: 2 }}>
@@ -297,10 +364,9 @@ export default function MusicTogetherPage() {
         </Alert>
       )}
 
-      {sectionsState.status === 'loading' && (
-        <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
-          <CircularProgress />
-        </Box>
+      {(sectionsState.status === 'idle' ||
+        sectionsState.status === 'loading') && (
+        <TableLoadingSkeleton headers={SECTION_HEADERS} rows={3} />
       )}
       {sectionsState.status === 'error' && (
         <Alert severity="error">{sectionsState.error}</Alert>


### PR DESCRIPTION
## What

The Music Together management page (`/music-together`) and its Roster / Interest dialogs had weak loading UX:

- **Blank flash on first paint** — the data hooks start at `status: 'idle'` and the fetch effect fires *after* the first render, but the page only rendered anything for `'loading'`. So on mount you saw an empty area, then a spinner popped in.
- **Layout-shifting spinner** — a bare centered `CircularProgress` collapsed the layout, then the real table snapped in below it.

This aligns the page with the established `LoadingSkeleton` pattern already used across the app (InvoiceList, ArtistList, InstructorList, …).

## Changes

- **`page.tsx`** — new shared `TableLoadingSkeleton` that mirrors each table's columns; used for both the **Semesters** and **Sections** tables. Header stays visible; body fills with shimmer rows. `idle` now renders the skeleton (no blank flash).
- **`RosterDialog.tsx`** — skeleton roster table while loading (respects the optional Actions column); `idle` treated as loading.
- **`InterestListDialog.tsx`** — skeleton submissions table while loading; `idle` treated as loading.
- **`RosterDialog.stories.tsx`** — the existing `Loading` story gains a `play` that asserts the skeleton renders (`.MuiSkeleton-root`), the column headers stay put, and the empty/success copy is absent.

No behavior changes beyond the loading presentation.

## Verification

- `nx typecheck maple-spruce` ✅
- `nx lint maple-spruce` ✅ (0 errors)
- RosterDialog Storybook suite: **8/8 passing**, including the new `Loading` play assertion (headless render confirms the skeleton actually renders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)