### PR TITLE
feat(my-day): getMyWeek — self-scoped weekly commitments with recurring/one-off tagging (#684)

### DIFF
--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -165,6 +165,7 @@ export { onLessonRenderedInvoice } from '@maple/firebase/maple-functions/on-less
 export { getLessonRatesConfig } from '@maple/firebase/maple-functions/get-lesson-rates-config';
 // Teacher My Day + business payment config (#631)
 export { getMyDayLessons } from '@maple/firebase/maple-functions/get-my-day-lessons';
+export { getMyWeek } from '@maple/firebase/maple-functions/get-my-week';
 export { getBusinessPaymentConfig } from '@maple/firebase/maple-functions/get-business-payment-config';
 export { updateBusinessPaymentConfig } from '@maple/firebase/maple-functions/update-business-payment-config';
 export { updateLessonRatesConfig } from '@maple/firebase/maple-functions/update-lesson-rates-config';

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -72,6 +72,7 @@
     "../../libs/firebase/maple-functions/on-lesson-rendered-invoice/**/*.ts",
     "../../libs/firebase/maple-functions/get-lesson-rates-config/**/*.ts",
     "../../libs/firebase/maple-functions/get-my-day-lessons/**/*.ts",
+    "../../libs/firebase/maple-functions/get-my-week/**/*.ts",
     "../../libs/firebase/maple-functions/get-business-payment-config/**/*.ts",
     "../../libs/firebase/maple-functions/update-business-payment-config/**/*.ts",
     "../../libs/firebase/maple-functions/update-lesson-rates-config/**/*.ts",

--- a/libs/firebase/database/src/lib/calendar-event.repository.ts
+++ b/libs/firebase/database/src/lib/calendar-event.repository.ts
@@ -19,7 +19,7 @@ const COLLECTION = 'calendarEvents';
  * Convert Firestore document to CalendarEvent
  */
 function docToCalendarEvent(
-  doc: FirebaseFirestore.DocumentSnapshot
+  doc: FirebaseFirestore.DocumentSnapshot,
 ): CalendarEvent | undefined {
   if (!doc.exists) {
     return undefined;
@@ -38,6 +38,7 @@ function docToCalendarEvent(
     public: data.public,
     room: data.room ?? null,
     sourceRef: data.sourceRef ?? null,
+    ownerInstructorId: data.ownerInstructorId ?? null,
     createdBy: data.createdBy,
     createdAt: toDate(data.createdAt),
     updatedAt: toDate(data.updatedAt),
@@ -130,7 +131,7 @@ export const CalendarEventRepository = {
   async findByRoomInRange(
     room: Room,
     rangeStart: Date,
-    rangeEnd: Date
+    rangeEnd: Date,
   ): Promise<CalendarEvent[]> {
     const lookback = new Date(rangeStart.getTime() - 24 * 60 * 60 * 1000);
 
@@ -146,6 +147,27 @@ export const CalendarEventRepository = {
       .map((doc) => docToCalendarEvent(doc))
       .filter((e): e is CalendarEvent => e !== undefined)
       .filter((e) => e.endDateTime.getTime() > rangeStart.getTime());
+  },
+
+  /**
+   * All events whose start falls in [from, to), across every room and type.
+   * Powers the teacher My Week schedule (#683). A range + orderBy on a single
+   * field (startDateTime) is served by Firestore's automatic index — no
+   * composite index is required (and a single-field entry in indexes.json is
+   * rejected at deploy), hence the analyzer opt-out.
+   */
+  async findByStartInRange(from: Date, to: Date): Promise<CalendarEvent[]> {
+    // firestore-index-analyzer-ignore: single-field range + orderBy on startDateTime; covered by the automatic index.
+    const snapshot = await db
+      .collection(COLLECTION)
+      .where('startDateTime', '>=', from)
+      .where('startDateTime', '<', to)
+      .orderBy('startDateTime', 'asc')
+      .get();
+
+    return snapshot.docs
+      .map((doc) => docToCalendarEvent(doc))
+      .filter((e): e is CalendarEvent => e !== undefined);
   },
 
   /**
@@ -190,7 +212,7 @@ export const CalendarEventRepository = {
    */
   async upsertWithId(
     id: string,
-    input: CreateCalendarEventInput
+    input: CreateCalendarEventInput,
   ): Promise<CalendarEvent> {
     const docRef = db.collection(COLLECTION).doc(id);
     const existing = await docRef.get();
@@ -241,8 +263,12 @@ export const CalendarEventRepository = {
 
     const dataWithTimestamp = {
       ...updates,
-      ...(updates.startDateTime ? { startDateTime: new Date(updates.startDateTime) } : {}),
-      ...(updates.endDateTime ? { endDateTime: new Date(updates.endDateTime) } : {}),
+      ...(updates.startDateTime
+        ? { startDateTime: new Date(updates.startDateTime) }
+        : {}),
+      ...(updates.endDateTime
+        ? { endDateTime: new Date(updates.endDateTime) }
+        : {}),
       updatedAt: new Date(),
     };
 

--- a/libs/firebase/maple-functions/get-my-week/project.json
+++ b/libs/firebase/maple-functions/get-my-week/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-get-my-week",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/get-my-week/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/get-my-week/src/index.ts
+++ b/libs/firebase/maple-functions/get-my-week/src/index.ts
@@ -1,0 +1,1 @@
+export { getMyWeek } from './lib/get-my-week';

--- a/libs/firebase/maple-functions/get-my-week/src/lib/get-my-week.spec.ts
+++ b/libs/firebase/maple-functions/get-my-week/src/lib/get-my-week.spec.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CalendarEvent } from '@maple/ts/domain';
+
+const mocks = vi.hoisted(() => ({
+  instructorIdForUser: vi.fn(),
+  findByStartInRange: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/functions', () => ({
+  Role: { Admin: 'admin', LessonTeacher: 'lesson-teacher' },
+  createRoleFunction: <TReq, TRes>(
+    handler: (data: TReq, ctx: unknown) => Promise<TRes>,
+  ) => handler,
+  instructorIdForUser: mocks.instructorIdForUser,
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  CalendarEventRepository: { findByStartInRange: mocks.findByStartInRange },
+}));
+
+import { getMyWeek, buildCommitments, startOfWeek } from './get-my-week';
+
+type Handler = (
+  data: unknown,
+  ctx?: unknown,
+) => Promise<{
+  commitments: Array<{
+    id: string;
+    ownership: string;
+    cadence: string;
+    category: string;
+  }>;
+  unlinked: boolean;
+}>;
+const handler = getMyWeek as unknown as Handler;
+
+/** Minimal CalendarEvent builder (local time, so server-local keying is stable in tests). */
+function event(
+  partial: Partial<CalendarEvent> & { id: string; startDateTime: Date },
+): CalendarEvent {
+  return {
+    description: '',
+    endDateTime: new Date(partial.startDateTime.getTime() + 30 * 60 * 1000),
+    recurrenceRule: null,
+    location: '',
+    type: 'lesson',
+    public: false,
+    room: 'spruce',
+    sourceRef: null,
+    ownerInstructorId: null,
+    createdBy: 'system',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    title: 'Music Lesson',
+    ...partial,
+  } as CalendarEvent;
+}
+
+describe('startOfWeek', () => {
+  it('returns local Sunday 00:00 for a mid-week instant', () => {
+    const wed = new Date(2026, 6, 22, 14, 30); // Wed Jul 22 2026
+    const start = startOfWeek(wed);
+    expect(start.getDay()).toBe(0);
+    expect(start.getHours()).toBe(0);
+    expect(start.getMinutes()).toBe(0);
+    expect(start.getDate()).toBe(19); // Sun Jul 19
+  });
+});
+
+describe('buildCommitments', () => {
+  const from = new Date(2026, 6, 19); // Sun Jul 19
+  const to = new Date(2026, 6, 26); // Sun Jul 26
+  const lookbackStart = new Date(from.getTime() - 28 * 24 * 60 * 60 * 1000);
+  const me = 'instr-katie';
+
+  it("tags the caller's own event as mine and a standing weekly slot as recurring", () => {
+    const events = [
+      // this week (Thu 16:00) + a prior week same slot -> recurring
+      event({
+        id: 'k-this',
+        startDateTime: new Date(2026, 6, 23, 16, 0),
+        ownerInstructorId: me,
+      }),
+      event({
+        id: 'k-prev',
+        startDateTime: new Date(2026, 6, 16, 16, 0),
+        ownerInstructorId: me,
+      }),
+    ];
+    const result = buildCommitments(events, from, to, lookbackStart, me);
+    // only the in-week event is returned
+    expect(result.map((c) => c.id)).toEqual(['k-this']);
+    expect(result[0].ownership).toBe('mine');
+    expect(result[0].cadence).toBe('recurring');
+  });
+
+  it("tags another teacher's single event as shared + one-off", () => {
+    const events = [
+      event({
+        id: 'n-once',
+        startDateTime: new Date(2026, 6, 24, 10, 0),
+        ownerInstructorId: 'instr-nathan',
+        type: 'class',
+      }),
+    ];
+    const result = buildCommitments(events, from, to, lookbackStart, me);
+    expect(result[0].ownership).toBe('shared');
+    expect(result[0].cadence).toBe('one-off');
+  });
+
+  it('recognizes a recurring shared event (weekly jam) as recurring', () => {
+    const events = [
+      event({
+        id: 'jam-this',
+        startDateTime: new Date(2026, 6, 24, 18, 0),
+        type: 'jam',
+        ownerInstructorId: null,
+      }),
+      event({
+        id: 'jam-prev',
+        startDateTime: new Date(2026, 6, 17, 18, 0),
+        type: 'jam',
+        ownerInstructorId: null,
+      }),
+    ];
+    const result = buildCommitments(events, from, to, lookbackStart, me);
+    expect(result.map((c) => c.id)).toEqual(['jam-this']);
+    expect(result[0].cadence).toBe('recurring');
+    expect(result[0].ownership).toBe('shared');
+  });
+
+  it('does not count two occurrences in the same week as recurring', () => {
+    const events = [
+      event({
+        id: 'a',
+        startDateTime: new Date(2026, 6, 23, 16, 0),
+        ownerInstructorId: me,
+      }),
+      // a make-up the same week at the same slot key would still be one week
+      event({
+        id: 'b',
+        startDateTime: new Date(2026, 6, 23, 16, 0),
+        ownerInstructorId: me,
+      }),
+    ];
+    const result = buildCommitments(events, from, to, lookbackStart, me);
+    expect(result.every((c) => c.cadence === 'one-off')).toBe(true);
+  });
+
+  it('sorts commitments by start time', () => {
+    const events = [
+      event({
+        id: 'late',
+        startDateTime: new Date(2026, 6, 24, 18, 0),
+        ownerInstructorId: me,
+      }),
+      event({
+        id: 'early',
+        startDateTime: new Date(2026, 6, 20, 9, 0),
+        ownerInstructorId: me,
+      }),
+    ];
+    const result = buildCommitments(events, from, to, lookbackStart, me);
+    expect(result.map((c) => c.id)).toEqual(['early', 'late']);
+  });
+});
+
+describe('getMyWeek handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.instructorIdForUser.mockResolvedValue('instr-katie');
+    mocks.findByStartInRange.mockResolvedValue([]);
+  });
+
+  it('returns unlinked with no commitments when the caller has no instructor', async () => {
+    mocks.instructorIdForUser.mockResolvedValue(undefined);
+    const res = await handler({}, { uid: 'admin-uid' });
+    expect(res.unlinked).toBe(true);
+    expect(res.commitments).toEqual([]);
+    expect(mocks.findByStartInRange).not.toHaveBeenCalled();
+  });
+
+  it('queries a lookback window ending at the week end', async () => {
+    await handler(
+      { from: '2026-07-19T00:00:00', to: '2026-07-26T00:00:00' },
+      { uid: 'katie-uid' },
+    );
+    const [fromArg, toArg] = mocks.findByStartInRange.mock.calls[0];
+    const from = new Date('2026-07-19T00:00:00');
+    const to = new Date('2026-07-26T00:00:00');
+    expect(toArg.getTime()).toBe(to.getTime());
+    // lookback = from - 28 days
+    expect(fromArg.getTime()).toBe(from.getTime() - 28 * 24 * 60 * 60 * 1000);
+  });
+});

--- a/libs/firebase/maple-functions/get-my-week/src/lib/get-my-week.ts
+++ b/libs/firebase/maple-functions/get-my-week/src/lib/get-my-week.ts
@@ -1,0 +1,146 @@
+/**
+ * Get My Week Cloud Function (#683 / #684)
+ *
+ * The signed-in teacher's own commitments for a week — the lessons they teach
+ * and the classes they teach — plus the shared store-wide events that affect
+ * room and context (jams, store hours, Music Together, ad-hoc bookings). One
+ * source: the CalendarEvent collection, which already aggregates every
+ * category and carries `room` + the denormalized `ownerInstructorId`.
+ *
+ * Each commitment is tagged:
+ *  - `ownership`: `mine` (owned by the caller's instructor) vs `shared`.
+ *  - `cadence`:   `recurring` vs `one-off`, inferred from a ~4-week lookback —
+ *                 the planning unit is a *typical week*, so a standing weekly
+ *                 block is what defines availability; a one-off is an exception
+ *                 to manage, never a reason a weekly slot doesn't exist.
+ *
+ * Role-gated [Admin, LessonTeacher]; scoped to the caller's linked instructor
+ * (a caller not linked to any instructor gets `unlinked: true` and no
+ * commitments — there's no "mine" to anchor the week to).
+ */
+import {
+  Role,
+  createRoleFunction,
+  instructorIdForUser,
+} from '@maple/firebase/functions';
+import { CalendarEventRepository } from '@maple/firebase/database';
+import type { CalendarEvent } from '@maple/ts/domain';
+import type {
+  GetMyWeekRequest,
+  GetMyWeekResponse,
+  MyWeekCommitment,
+} from '@maple/ts/firebase/api-types';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const LOOKBACK_WEEKS = 4;
+
+/** Server-local start-of-week (Sunday 00:00) for a given instant. */
+export function startOfWeek(d: Date): Date {
+  const start = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  start.setDate(start.getDate() - start.getDay());
+  return start;
+}
+
+/**
+ * Recurrence key: an owner's commitments repeat when they land on the same
+ * weekday + clock-time in the same category. Shared events group under
+ * 'shared' so a weekly jam is still recognized as recurring. Uses server-local
+ * weekday/clock — a heuristic; DST shifts a boundary at most twice a year and
+ * within a 4-week window that's tolerable.
+ */
+export function recurrenceKey(event: CalendarEvent): string {
+  const s = event.startDateTime;
+  const owner = event.ownerInstructorId ?? 'shared';
+  const clockMinutes = s.getHours() * 60 + s.getMinutes();
+  return `${owner}|${event.type}|${s.getDay()}|${clockMinutes}`;
+}
+
+/**
+ * Classify each target-week event as recurring/one-off using the lookback
+ * window, and tag ownership. Pure — the handler just supplies fetched events.
+ *
+ * `events` must span [lookbackStart, to); only events in [from, to) are
+ * returned as commitments. Recurring = the event's slot appears in ≥2 distinct
+ * weeks across the window (counting distinct weeks, not raw occurrences, so two
+ * make-ups in one week don't masquerade as a standing slot).
+ */
+export function buildCommitments(
+  events: CalendarEvent[],
+  from: Date,
+  to: Date,
+  lookbackStart: Date,
+  myInstructorId: string,
+): MyWeekCommitment[] {
+  // key -> set of distinct week indices it occurred in
+  const weeksByKey = new Map<string, Set<number>>();
+  for (const e of events) {
+    const weekIndex = Math.floor(
+      (e.startDateTime.getTime() - lookbackStart.getTime()) / (7 * DAY_MS),
+    );
+    const key = recurrenceKey(e);
+    const set = weeksByKey.get(key) ?? new Set<number>();
+    set.add(weekIndex);
+    weeksByKey.set(key, set);
+  }
+
+  return events
+    .filter(
+      (e) =>
+        e.startDateTime.getTime() >= from.getTime() &&
+        e.startDateTime.getTime() < to.getTime(),
+    )
+    .sort((a, b) => a.startDateTime.getTime() - b.startDateTime.getTime())
+    .map((e) => {
+      const weeks = weeksByKey.get(recurrenceKey(e));
+      return {
+        id: e.id,
+        title: e.title,
+        category: e.type,
+        startDateTime: e.startDateTime.toISOString(),
+        endDateTime: e.endDateTime.toISOString(),
+        room: e.room ?? null,
+        ownership: e.ownerInstructorId === myInstructorId ? 'mine' : 'shared',
+        cadence: (weeks?.size ?? 0) >= 2 ? 'recurring' : 'one-off',
+      };
+    });
+}
+
+export const getMyWeek = createRoleFunction<
+  GetMyWeekRequest,
+  GetMyWeekResponse
+>(
+  async (data, context) => {
+    const myInstructorId = await instructorIdForUser(context.uid);
+    if (!myInstructorId) {
+      // Not linked to any instructor (e.g. a pure admin) — no "mine" to anchor.
+      return { commitments: [], unlinked: true };
+    }
+
+    const now = new Date();
+    const from = data.from ? new Date(data.from) : startOfWeek(now);
+    const to = data.to
+      ? new Date(data.to)
+      : new Date(from.getTime() + 7 * DAY_MS);
+    const lookbackStart = new Date(
+      from.getTime() - LOOKBACK_WEEKS * 7 * DAY_MS,
+    );
+
+    // One range query over [lookbackStart, to): the target week to display plus
+    // the lookback needed to classify recurrence. Partition + classify in memory.
+    const events = await CalendarEventRepository.findByStartInRange(
+      lookbackStart,
+      to,
+    );
+
+    const commitments = buildCommitments(
+      events,
+      from,
+      to,
+      lookbackStart,
+      myInstructorId,
+    );
+
+    return { commitments, unlinked: false };
+  },
+  [Role.Admin, Role.LessonTeacher],
+);

--- a/libs/firebase/maple-functions/get-my-week/tsconfig.json
+++ b/libs/firebase/maple-functions/get-my-week/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "ignoreDeprecations": "6.0"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/get-my-week/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/get-my-week/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"],
+    "rootDir": "../../.."
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/firebase/maple-functions/on-class-write/src/lib/on-class-write.ts
+++ b/libs/firebase/maple-functions/on-class-write/src/lib/on-class-write.ts
@@ -175,6 +175,9 @@ export const onClassWrite = onDocumentWritten(
             public: true,
             room: afterClass.room ?? null,
             sourceRef,
+            // Owner = the instructor teaching it, so the class shows up on
+            // their My Week schedule (#683). Null when unassigned.
+            ownerInstructorId: afterClass.instructorId ?? null,
             createdBy: 'system',
           });
         })

--- a/libs/firebase/maple-functions/on-lesson-write/src/lib/on-lesson-write.ts
+++ b/libs/firebase/maple-functions/on-lesson-write/src/lib/on-lesson-write.ts
@@ -114,6 +114,9 @@ export const onLessonWrite = onDocumentWritten(
         // created before the room field existed (they were all Spruce).
         room: afterLesson.room ?? 'spruce',
         sourceRef: `lessons/${lessonId}`,
+        // Owner = the teacher of record, so the lesson shows up on their My
+        // Week schedule (#683). Never undefined (teacherId is required).
+        ownerInstructorId: afterLesson.teacherId ?? null,
         createdBy: 'system',
       });
 

--- a/libs/ts/domain/src/lib/calendar-event.ts
+++ b/libs/ts/domain/src/lib/calendar-event.ts
@@ -64,6 +64,14 @@ export interface CalendarEvent {
   room?: Room | null;
   /** Optional reference to originating doc, e.g. "classes/abc123". Null for ad-hoc events. */
   sourceRef: string | null;
+  /**
+   * Instructor id that "owns" this event — denormalized from the source so a
+   * teacher's own schedule is a single query (My Week / #683). Set on
+   * lesson-derived events (the lesson's `teacherId`) and class-derived events
+   * (the class's `instructorId`). Null for shared/ad-hoc events with no single
+   * owning teacher (jams, store hours, Music Together, manual bookings).
+   */
+  ownerInstructorId?: string | null;
   /** Firebase Auth UID of creator */
   createdBy: string;
   createdAt: Date;

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -339,6 +339,15 @@ export type {
   GetMyDayLessonsRequest,
   GetMyDayLessonsResponse,
 } from './my-day.types';
+
+// Phase 4: Music Lessons - Teacher My Week schedule (#683/#684)
+export type {
+  MyWeekOwnership,
+  MyWeekCadence,
+  MyWeekCommitment,
+  GetMyWeekRequest,
+  GetMyWeekResponse,
+} from './my-week.types';
 export type {
   GetBusinessPaymentConfigRequest,
   GetBusinessPaymentConfigResponse,

--- a/libs/ts/firebase/api-types/src/lib/my-week.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/my-week.types.ts
@@ -1,0 +1,55 @@
+/**
+ * Teacher "My Week" API types (#683, #684).
+ *
+ * The signed-in teacher's own commitments for a week, plus the shared
+ * store-wide events that affect room/context, assembled server-side (the
+ * client can't resolve which instructor the signed-in user is).
+ *
+ * Datetimes cross the callable boundary as ISO strings (the client hook
+ * parses them) — unlike Date fields, ISO survives JSON serialization
+ * unambiguously.
+ */
+import type { CalendarEventType, Room } from '@maple/ts/domain';
+
+/** Whether a commitment belongs to the caller or is a shared store-wide event. */
+export type MyWeekOwnership = 'mine' | 'shared';
+
+/**
+ * Whether a commitment is a standing weekly block or a one-off.
+ *
+ * A commitment is `recurring` when the same owner + category + weekday +
+ * clock-time was seen in ≥2 weeks across the lookback window (the target week
+ * plus the preceding ~4 weeks). Otherwise it's `one-off` — shown as a
+ * this-week-only annotation that never disqualifies a standing slot.
+ */
+export type MyWeekCadence = 'recurring' | 'one-off';
+
+export interface MyWeekCommitment {
+  /** The CalendarEvent id it derives from. */
+  id: string;
+  title: string;
+  category: CalendarEventType;
+  /** ISO 8601. */
+  startDateTime: string;
+  /** ISO 8601. */
+  endDateTime: string;
+  /** The room it occupies, if any. */
+  room: Room | null;
+  ownership: MyWeekOwnership;
+  cadence: MyWeekCadence;
+}
+
+export interface GetMyWeekRequest {
+  /** ISO instant for the start of the week (inclusive). Defaults to the
+   *  current week's start (server-local Sunday 00:00) when omitted. */
+  from?: string;
+  /** ISO instant for the end of the week (exclusive). Defaults to `from` + 7
+   *  days when omitted. */
+  to?: string;
+}
+
+export interface GetMyWeekResponse {
+  commitments: MyWeekCommitment[];
+  /** True when the caller isn't linked to any instructor record (no "mine"). */
+  unlinked: boolean;
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -494,6 +494,9 @@
       "@maple/firebase/maple-functions/get-my-day-lessons": [
         "libs/firebase/maple-functions/get-my-day-lessons/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/get-my-week": [
+        "libs/firebase/maple-functions/get-my-week/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/get-business-payment-config": [
         "libs/firebase/maple-functions/get-business-payment-config/src/index.ts"
       ],


### PR DESCRIPTION
Closes #684. **PR 1 of 4** of the teacher weekly-availability epic (#683) — the backend data source for the forthcoming My Day **Week** tab.

## What & why

Katie (and any lesson teacher) plans a new student's recurring slot against a *typical week*. This adds the server side that answers "what's on my week?": a self-scoped `getMyWeek` callable returning her commitments — her lessons + her classes + the shared store-wide events that affect room/context — each tagged so the UI can render a composite week and, later, find open standing slots.

## Changes

- **`getMyWeek` callable** (`libs/firebase/maple-functions/get-my-week/`) — role-gated `[Admin, LessonTeacher]`, scoped to the caller's linked instructor via `instructorIdForUser` (unlinked caller → `{ commitments: [], unlinked: true }`, mirroring `getMyDayLessons`). Registered in the `maple-core` entry point.
- **Tagging** on each commitment:
  - `ownership`: `mine` vs `shared`.
  - `cadence`: `recurring` vs `one-off`, from a ~4-week lookback keyed by `owner + category + weekday + clock-time`, counting **distinct weeks** (≥2 → recurring). So a standing weekly class/lesson reads as recurring, while a one-off jam/make-up is annotated but never disqualifies a slot.
- **Owner denormalization** — `ownerInstructorId` added to `CalendarEvent` and set on the derived events in `onLessonWrite` (lesson `teacherId`) and `onClassWrite` (class `instructorId`), written inside the existing upsert (no new write-back → no trigger self-loop). Makes "a teacher's week" a single query.
- **`CalendarEventRepository.findByStartInRange(from, to)`** — single-field `startDateTime` range, served by Firestore's automatic index (no composite; analyzer opt-out documented in place, since a single-field entry in `indexes.json` is rejected at deploy).

## Verification

- ✅ Unit — 8 new (pure `buildCommitments`/`startOfWeek` classifier + handler scoping); 47 regression on touched trigger/repo specs.
- ✅ Firestore index analyzer — 173 queries covered, no new composite required.
- ✅ All 4 function codebases build (`nx run-many -t build`).
- ✅ `validate-function-tsconfigs.sh`, Prettier, ESLint (0 errors).

Follow-ups in the stack: #685 Week tab UI · #686 custom availability blocks · #687 Openings finder. Integration coverage matches the sibling `getMyDayLessons` (unit-only); can add an emulator suite if we want it before the tab ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
