### PR TITLE
fix(auth): assert AdminGuard lock icon via own data-testid, not MUI's dev-only one

### DIFF
--- a/libs/react/auth/src/lib/AdminGuard.stories.tsx
+++ b/libs/react/auth/src/lib/AdminGuard.stories.tsx
@@ -142,8 +142,13 @@ export const NotAdminShowsOnboardingMessage: Story = {
       canvas.getByText(/a manager at Maple & Spruce will onboard you/i)
     ).toBeInTheDocument();
 
-    // Verify the lock icon is present
-    expect(canvasElement.querySelector('[data-testid="LockOutlinedIcon"]')).toBeInTheDocument();
+    // Verify the lock icon is present. We assert on our OWN explicit
+    // data-testid (set on the icon in AdminGuard.tsx), not MUI's implicit
+    // `LockOutlinedIcon` one — MUI only emits that in non-production builds,
+    // so it vanishes in Chromatic's production Storybook build.
+    expect(
+      canvasElement.querySelector('[data-testid="admin-lock-icon"]')
+    ).toBeInTheDocument();
 
     // Verify children are NOT rendered
     expect(canvas.queryByText(/Admin Dashboard/i)).not.toBeInTheDocument();

--- a/libs/react/auth/src/lib/AdminGuard.tsx
+++ b/libs/react/auth/src/lib/AdminGuard.tsx
@@ -104,6 +104,7 @@ export function AdminGuardView({
           }}
         >
           <LockOutlinedIcon
+            data-testid="admin-lock-icon"
             sx={{ fontSize: 48, color: 'text.secondary', mb: 2 }}
           />
           <Typography variant="h5" gutterBottom>


### PR DESCRIPTION
## Problem

On the pnpm-audit PR (`fix/pnpm-audit-2026-07-24`), the Chromatic PR check fails a single Storybook interaction test:

> **AdminGuard › Not Admin Shows Onboarding Message** — `Failed interaction test: expect(null).toBeInTheDocument()`

Every other lock-screen story (they assert via visible text) passes — the failure is isolated to one line.

## Root cause

`AdminGuard.stories.tsx` asserted the lock icon via:

```ts
canvasElement.querySelector('[data-testid="LockOutlinedIcon"]')
```

That `data-testid="LockOutlinedIcon"` is the **implicit** id MUI's `createSvgIcon` attaches to every icon. In `@mui/material@7.3.11` (what this repo resolves) it is emitted **only when `NODE_ENV !== 'production'`**:

```js
"data-testid": process.env.NODE_ENV !== 'production' ? `${displayName}Icon` : undefined,
```

The audit PR bumps `next` 16.2.6 → 16.2.11 (pulled in through `@storybook/nextjs-vite`), which flips Chromatic's Storybook build to production mode. The attribute disappears, `querySelector` returns `null`, and `expect(null).toBeInTheDocument()` fails. This is a latent brittleness that any production-mode Storybook build would expose — the dep bump just tripped it.

## Fix

Stop depending on MUI's dev-only attribute. Pass our **own** explicit `data-testid="admin-lock-icon"` on the icon in `AdminGuard.tsx` and assert on it. In `createSvgIcon`, caller props spread *after* the default, so ours wins and is present in every build mode.

```diff
  <LockOutlinedIcon
+   data-testid="admin-lock-icon"
    sx={{ fontSize: 48, color: 'text.secondary', mb: 2 }}
  />
```

## Verification

- Confirmed from the actual `@mui/material@7.3.11` source (fetched from npm) that the implicit test id is `NODE_ENV`-gated, and that a caller-supplied `data-testid` overrides the default.
- jsdom render of `AdminGuardView` confirms `[data-testid="admin-lock-icon"]` is present on the rendered `<svg>`.

Once merged, `fix/pnpm-audit-2026-07-24` picks this up on rebase/merge and the Chromatic check goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)