### PR TITLE
feat(music-together): cut MT Square to production (env + location)

### DIFF
--- a/.env.prod
+++ b/.env.prod
@@ -26,6 +26,14 @@ MT_SQUARE_ENV=PROD
 # MT PRODUCTION location — "Music Together with Maple & Spruce" (recovered via
 # ListLocations 2026-07-27). Sandbox was LKZXV01GJ3SZP (still in .env.dev).
 MT_SQUARE_LOCATION_ID=L9Z1HPHQP75CB
+# MT PRODUCTION application ID (browser Web Payments SDK; public by design — the
+# same value goes on the Webflow "Music Together Registration" widget's Square
+# App ID prop). No function reads this; it is recorded here because it is NOT
+# recoverable from the access token or ListLocations, and the Developer Dashboard
+# it lives in can be 2FA-locked. Losing it blocks launch. Sandbox equivalent is
+# in .env.dev. Cross-check against the token any time via:
+#   POST https://connect.squareup.com/oauth2/token/status → client_id
+MT_SQUARE_APPLICATION_ID=sq0idp-brJuAJkB48e_UEmfraDrpw
 # MT tuition is a non-taxable service (mirrors music-lesson exemption)
 MT_SALES_TAX_RATE=0.0
 

--- a/.env.prod
+++ b/.env.prod
@@ -14,18 +14,18 @@ SALES_TAX_RATE=6.0
 # route here, not to the M&S account above. See docs/reference/music-together-plan.md.
 # The MT access token is a Firebase Secret (MT_SQUARE_ACCESS_TOKEN), NOT here.
 #
-# INTERIM (pre-launch): MT's PRODUCTION Square account isn't provisioned yet, so
-# the prod project points at the MT SANDBOX account. This lets us complete real
-# sandbox charges on the real prod MT section pages for end-to-end testing while
-# reading live section data. The MT_SQUARE_ACCESS_TOKEN secret in the prod
-# project's Secret Manager must be set to the MT SANDBOX token to match.
-# ⚠️ AT LAUNCH: flip MT_SQUARE_ENV back to PROD, set MT_SQUARE_LOCATION_ID to the
-# real MT production location, and set the prod MT_SQUARE_ACCESS_TOKEN secret to
-# the live MT token — otherwise real families would be charged against sandbox.
-MT_SQUARE_ENV=LOCAL
-# MT SANDBOX location (Stephanie's MT sandbox account). Replace with the MT
-# PRODUCTION location at launch — see TODO(#510/#517).
-MT_SQUARE_LOCATION_ID=LKZXV01GJ3SZP
+# LAUNCH: MT's PRODUCTION Square account is now live. env=PROD routes the MT
+# functions (createMusicTogetherRegistration, chargeMusicTogetherInstallments,
+# cancelMusicTogetherRegistration, updateMusicTogetherPaymentMethod) to Square's
+# production host, using the prod MT_SQUARE_ACCESS_TOKEN in Secret Manager.
+# ⚠️ These MUST match the same MT prod Square application, and the Webflow
+# registration widget's squareApplicationId prop must be the matching prod app id
+# (sq0idp-…) — a sandbox app id here (client) + prod token (server) fails to
+# charge. Env=PROD deployed WITHOUT the widget swap = broken checkout.
+MT_SQUARE_ENV=PROD
+# MT PRODUCTION location — "Music Together with Maple & Spruce" (recovered via
+# ListLocations 2026-07-27). Sandbox was LKZXV01GJ3SZP (still in .env.dev).
+MT_SQUARE_LOCATION_ID=L9Z1HPHQP75CB
 # MT tuition is a non-taxable service (mirrors music-lesson exemption)
 MT_SALES_TAX_RATE=0.0
 


### PR DESCRIPTION
## What

Flips the prod Firebase project's Music Together Square routing off the interim **sandbox** config onto Stephanie's **production** MT account.

| Param | Before (interim) | After |
|---|---|---|
| `MT_SQUARE_ENV` | `LOCAL` (→ Square Sandbox host) | `PROD` |
| `MT_SQUARE_LOCATION_ID` | `LKZXV01GJ3SZP` (sandbox) | `L9Z1HPHQP75CB` (prod — "Music Together with Maple & Spruce") |
| `MT_SALES_TAX_RATE` | `0.0` | `0.0` (unchanged; MT tuition non-taxable) |

The prod `MT_SQUARE_ACCESS_TOKEN` is already set in prod Secret Manager (v4), and the location ID was recovered via `ListLocations` against that token.

## ⚠️ Do NOT merge alone — this is one leg of an atomic cutover

Four things must be true together for MT checkout to work:
1. ✅ prod `MT_SQUARE_ACCESS_TOKEN` in Secret Manager
2. ✅ `MT_SQUARE_ENV=PROD` (this PR)
3. ✅ `MT_SQUARE_LOCATION_ID` = prod (this PR)
4. ⏳ **Webflow registration widget `squareApplicationId` = prod app id (`sq0idp-…`)** — still the sandbox app id

Merging this while the widget still tokenizes with the **sandbox** app id = broken checkout: a sandbox-issued card nonce cannot be charged by the prod token. **Hold merge until the widget swap is ready**, then land + verify together.

## Deploy note

A pure `.env.prod` change may not trip CI's codebase path filter, so `functions-square` may not redeploy. At merge, confirm the `functions-square` deploy actually ran (force it if not) so the new `defineString` values are baked in. Prod deploy waits on the manual `production` env approval gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)