### PR TITLE
chore(functions): cap maxInstances=3 globally to fix Cloud Run CPU quota deploys

### DIFF
--- a/.claude/rules/firebase-functions.md
+++ b/.claude/rules/firebase-functions.md
@@ -64,6 +64,24 @@ Functions.endpoint
   .handle<Req, Res>(async (data) => { ... });
 ```
 
+### Global `maxInstances` cap (every function, every codebase)
+
+`libs/firebase/functions/src/lib/global-runtime-options.ts` calls
+`setGlobalOptions({ maxInstances: GLOBAL_MAX_INSTANCES })` (currently **3**). Each of the
+4 entry points imports it on its **first line**, before any `export { … } from` re-export.
+
+**Why:** unset `maxInstances` inherits the gen-2 backend default of **100**, and Cloud Run's
+"Total CPU allocation, per project per region" quota reserves `maxInstances × cpu` per revision.
+Rolling deploys count the new revision on top of the old, so the default-100 reservation tipped
+the region over quota and failed deploys with *"Quota exceeded for total allowable CPU per project
+per region."* This is a small-business admin portal — nothing needs to fan out to 100.
+
+**Ordering contract:** `onRequest`/`onDocumentWritten`/`onSchedule` bake global options into
+`__endpoint` at definition time, and re-exports evaluate before the entry-point body — so the
+side-effect import must stay first. Don't move it below the re-exports or convert it to a
+body-level call, or the cap silently reverts to 100. Per-function options (`withOptions({ maxInstances })`
+or a trigger's own option object) still override the global upward when a function truly needs it.
+
 ## Warmup
 
 Every function built through `Functions.endpoint.handle()` automatically accepts a warmup sentinel — clients can boot a cold instance ahead of a real call without the function author opting in.

--- a/apps/functions-calendar/src/index.ts
+++ b/apps/functions-calendar/src/index.ts
@@ -5,6 +5,9 @@
  * Separated to isolate ical-generator and timezone dependencies
  * from other functions, reducing cold start times.
  */
+// MUST be first: sets global maxInstances before any function is defined.
+// See global-runtime-options.ts for the ordering contract.
+import '@maple/firebase/functions/global-runtime-options';
 import { getApps, initializeApp } from 'firebase-admin/app';
 
 if (getApps().length === 0) {

--- a/apps/functions-square/src/index.ts
+++ b/apps/functions-square/src/index.ts
@@ -6,6 +6,9 @@
  * Separated to isolate the heavy Square SDK dependency from other functions,
  * reducing cold start times.
  */
+// MUST be first: sets global maxInstances before any function is defined.
+// See global-runtime-options.ts for the ordering contract.
+import '@maple/firebase/functions/global-runtime-options';
 import { getApps, initializeApp } from 'firebase-admin/app';
 
 if (getApps().length === 0) {

--- a/apps/functions-sync/src/index.ts
+++ b/apps/functions-sync/src/index.ts
@@ -5,6 +5,9 @@
  * Separated to isolate the Webflow API dependency from other functions,
  * reducing cold start times.
  */
+// MUST be first: sets global maxInstances before any function is defined.
+// See global-runtime-options.ts for the ordering contract.
+import '@maple/firebase/functions/global-runtime-options';
 import { getApps, initializeApp } from 'firebase-admin/app';
 
 if (getApps().length === 0) {

--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -10,6 +10,9 @@
  * - apps/functions-square/  — Square integration (square SDK)
  * - apps/functions-sync/    — Webflow sync (webflow-api)
  */
+// MUST be first: sets global maxInstances before any function is defined.
+// See global-runtime-options.ts for the ordering contract.
+import '@maple/firebase/functions/global-runtime-options';
 import { getApps, initializeApp } from 'firebase-admin/app';
 import { createPublicFunction } from '@maple/firebase/functions';
 

--- a/libs/firebase/functions/src/lib/functions.utility.ts
+++ b/libs/firebase/functions/src/lib/functions.utility.ts
@@ -46,6 +46,13 @@ export interface RuntimeOptions {
   concurrency?: number;
   /** Minimum warm instances to avoid cold starts (default: 0) */
   minInstances?: number;
+  /**
+   * Maximum instances this function may scale to. Overrides the global
+   * default set in `global-runtime-options.ts` (GLOBAL_MAX_INSTANCES).
+   * Only set this for a function that genuinely needs more fan-out than
+   * the portal-wide default.
+   */
+  maxInstances?: number;
   /** Timeout in seconds (default: 60, max: 540) */
   timeoutSeconds?: number;
 }
@@ -483,6 +490,7 @@ class FunctionBuilder<
         ...(this.options.runtime?.memory && { memory: this.options.runtime.memory }),
         ...(this.options.runtime?.concurrency && { concurrency: this.options.runtime.concurrency }),
         ...(this.options.runtime?.minInstances !== undefined && { minInstances: this.options.runtime.minInstances }),
+        ...(this.options.runtime?.maxInstances !== undefined && { maxInstances: this.options.runtime.maxInstances }),
         ...(this.options.runtime?.timeoutSeconds && { timeoutSeconds: this.options.runtime.timeoutSeconds }),
       },
       async (req: Request, res: Response) => {

--- a/libs/firebase/functions/src/lib/global-runtime-options.ts
+++ b/libs/firebase/functions/src/lib/global-runtime-options.ts
@@ -1,0 +1,51 @@
+/**
+ * Global runtime defaults for every Cloud Function in every codebase.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Cloud Run's "Total CPU allocation, per project per region" quota is a
+ * reservation ceiling computed from `maxInstances x cpu` across every
+ * revision in the region — not from live CPU usage. When `maxInstances`
+ * is left unset, gen-2 Cloud Functions inherit the backend default of
+ * **100**, so each function reserves up to 100 vCPUs. During a rolling
+ * deploy the new revision is created *before* the old one drains, so the
+ * codebase being deployed transiently counts twice — which tipped the
+ * region over the quota and failed deploys with:
+ *
+ *   "Quota exceeded for total allowable CPU per project per region."
+ *
+ * This is an internal admin portal for a small business: a handful of
+ * staff plus at most a few simultaneous public checkouts. Nothing here
+ * ever needs to fan out to 100 instances. Capping `maxInstances` globally
+ * collapses the reservation ~33x and gives deploys comfortable headroom.
+ *
+ * ORDERING CONTRACT (IMPORTANT)
+ * -----------------------------
+ * `onRequest`/`onDocumentWritten`/`onSchedule` read the global options and
+ * bake them into the function's `__endpoint` **at definition time**. A
+ * codebase entry point re-exports its function modules via
+ * `export { x } from '...'`, and those re-exports are evaluated *before*
+ * the entry point's own body runs. So this call must execute as an import
+ * side-effect that lands *before* the function modules are evaluated.
+ *
+ * That is why each entry point imports this module on its FIRST line,
+ * ahead of every `export { ... } from` re-export. Do not move it below the
+ * re-exports, and do not convert it to an exported function called from the
+ * entry-point body — either would run too late and silently leave every
+ * function at the default of 100.
+ *
+ * Per-function overrides still work: options passed to `withOptions(...)`
+ * (HTTP builder) or directly to a trigger's option object are merged *over*
+ * these globals, so a function that genuinely needs more headroom can raise
+ * its own `maxInstances`.
+ */
+import { setGlobalOptions } from 'firebase-functions/v2';
+
+/**
+ * Max concurrent instances any single function may scale to. With HTTP
+ * functions running `concurrency: 80`, three instances already absorb 240
+ * simultaneous requests — far beyond this portal's real load.
+ */
+export const GLOBAL_MAX_INSTANCES = 3;
+
+setGlobalOptions({ maxInstances: GLOBAL_MAX_INSTANCES });

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,6 +17,9 @@
     "paths": {
       "@maple/firebase/database": ["libs/firebase/database/src/index.ts"],
       "@maple/firebase/functions": ["libs/firebase/functions/src/index.ts"],
+      "@maple/firebase/functions/global-runtime-options": [
+        "libs/firebase/functions/src/lib/global-runtime-options.ts"
+      ],
       "@maple/firebase/maple-functions/admin-pause-craft-club-subscription": [
         "libs/firebase/maple-functions/admin-pause-craft-club-subscription/src/index.ts"
       ],


### PR DESCRIPTION
## Problem

`deploy_functions_dev` (and eventually prod) fails on whichever codebase spikes first with:

> Could not create or update Cloud Run service …, Container Healthcheck failed. **Quota exceeded for total allowable CPU per project per region.**

Re-running just moves the failure to a different codebase (calendar → sync → …).

## Root cause

No function sets `maxInstances`, so every function inherits the **gen-2 backend default of 100**. Cloud Run's *Total CPU allocation, per project per region* quota is a **reservation ceiling** = `maxInstances × cpu` summed across every revision — not live usage. During a rolling deploy the new revision is created **before** the old one drains, so the codebase being deployed transiently counts twice. A whole-codebase deploy (sync ~14, calendar ~9 functions) at 100 max each tips us-east4 over the ceiling. That's why some functions in a codebase succeed and others fail mid-rollout, and why re-running only relocates the failure.

## Fix

Set `setGlobalOptions({ maxInstances: 3 })` once per codebase. This is a small-business admin portal — a handful of staff plus at most a few simultaneous public checkouts. With HTTP functions at `concurrency: 80`, three instances already absorb 240 concurrent requests. The cap collapses each function's reservation ~33× and gives deploys comfortable headroom. Applies to **HTTP functions and triggers alike**.

### Wiring / ordering contract

`onRequest`/`onDocumentWritten`/`onSchedule` bake global options into the function's `__endpoint` **at definition time**, and a codebase's `export { x } from '…'` re-exports evaluate **before** the entry-point body. So the global must be set as an import **side-effect that lands before the function modules**. Each of the 4 entry points imports `@maple/firebase/functions/global-runtime-options` on its **first line**. Moving it below the re-exports (or converting it to a body-level call) would silently revert every function to 100 — documented in the module and in `.claude/rules/firebase-functions.md`.

## Verification

- ✅ `nx run-many -t build` on all 4 codebases
- ✅ Loaded each built bundle and confirmed `__endpoint.maxInstances === 3` on HTTP functions **and** Firestore triggers, across all 4 codebases (including the previously-failing `syncClassToWebflow`, `updateEtsyListing`)
- ✅ `./tools/validate-function-tsconfigs.sh` passes
- ✅ lint passes on all touched projects

The real proof is the dev deploy on merge — expect all 4 `deploy_functions_dev` jobs green.

## Notes

- Per-function `withOptions({ maxInstances })` (added to `RuntimeOptions`) or a trigger's own option object still override the global upward for anything that ever needs more fan-out.
- Optional belt-and-suspenders: the *Total CPU allocation* quota was already raised to 200,000 in dev; with this cap that headroom is no longer load-bearing. Worth confirming prod (`maple-and-spruce`) isn't relying on the old default before the next prod deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)