### PR TITLE
feat(lessons): block admin UI + lesson-dialog block selection + unattributed flagging (#689)

### DIFF
--- a/apps/maple-spruce/src/app/(admin)/lesson-blocks/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/lesson-blocks/page.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { Box, Typography, Button, Alert } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import type { CreateLessonBlockInput, LessonBlock } from '@maple/ts/domain';
+import { DeleteConfirmDialog } from '@maple/react/ui';
+import { LessonBlockForm, LessonBlockList } from '@maple/react/lessons';
+import { WEEKDAY_LONG } from '@maple/ts/domain';
+import { useLessonBlocks, useInstructors } from '../../../hooks';
+
+export default function LessonBlocksPage() {
+  const {
+    lessonBlocksState,
+    createLessonBlock,
+    updateLessonBlock,
+    deleteLessonBlock,
+  } = useLessonBlocks();
+  const { instructorsState } = useInstructors();
+  const instructors =
+    instructorsState.status === 'success' ? instructorsState.data : [];
+
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editingBlock, setEditingBlock] = useState<LessonBlock | undefined>();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [blockToDelete, setBlockToDelete] = useState<LessonBlock | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleOpenForm = useCallback((block?: LessonBlock) => {
+    setEditingBlock(block);
+    setIsFormOpen(true);
+  }, []);
+
+  const handleCloseForm = useCallback(() => {
+    setIsFormOpen(false);
+    setEditingBlock(undefined);
+  }, []);
+
+  const handleSubmitForm = useCallback(
+    async (data: CreateLessonBlockInput) => {
+      setIsSubmitting(true);
+      try {
+        if (editingBlock) {
+          // teacherId can't be reassigned — send only the editable fields.
+          await updateLessonBlock({
+            id: editingBlock.id,
+            dayOfWeek: data.dayOfWeek,
+            startMinutes: data.startMinutes,
+            endMinutes: data.endMinutes,
+            label: data.label,
+          });
+        } else {
+          await createLessonBlock(data);
+        }
+        handleCloseForm();
+      } catch (error) {
+        console.error('Failed to save lesson block:', error);
+        throw error;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [editingBlock, handleCloseForm, createLessonBlock, updateLessonBlock],
+  );
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!blockToDelete) return;
+    setIsDeleting(true);
+    try {
+      await deleteLessonBlock(blockToDelete.id);
+      setBlockToDelete(null);
+    } catch (error) {
+      console.error('Failed to delete lesson block:', error);
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [blockToDelete, deleteLessonBlock]);
+
+  return (
+    <>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mb: 1,
+        }}
+      >
+        <Typography variant="h4" component="h1">
+          Lesson Blocks
+        </Typography>
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={() => handleOpenForm()}
+        >
+          Add Block
+        </Button>
+      </Box>
+      <Typography color="text.secondary" sx={{ mb: 3 }}>
+        Weekly windows a teacher takes lessons in. Every lesson must be
+        scheduled inside one of its teacher&rsquo;s blocks.
+      </Typography>
+
+      <LessonBlockList
+        lessonBlocksState={lessonBlocksState}
+        instructors={instructors}
+        onEdit={handleOpenForm}
+        onDelete={setBlockToDelete}
+      />
+
+      <LessonBlockForm
+        open={isFormOpen}
+        onClose={handleCloseForm}
+        onSubmit={handleSubmitForm}
+        block={editingBlock}
+        instructors={instructors}
+        isSubmitting={isSubmitting}
+      />
+
+      <DeleteConfirmDialog
+        open={!!blockToDelete}
+        onClose={() => setBlockToDelete(null)}
+        onConfirm={handleConfirmDelete}
+        isDeleting={isDeleting}
+        title="Delete Lesson Block?"
+        itemName={
+          blockToDelete ? `${WEEKDAY_LONG[blockToDelete.dayOfWeek]} block` : ''
+        }
+        warningContent={
+          <Alert severity="warning">
+            Lessons already scheduled in this block stay put but will be flagged
+            as &ldquo;needs a block&rdquo; for you to reattribute. Deleting
+            cannot be undone.
+          </Alert>
+        }
+      />
+    </>
+  );
+}

--- a/apps/maple-spruce/src/app/(admin)/students/[id]/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/students/[id]/page.tsx
@@ -31,18 +31,13 @@ import {
   LessonList,
   ScheduleLessonDialog,
 } from '@maple/react/lessons';
-import {
-  InvoiceBuilderDialog,
-  InvoiceList,
-} from '@maple/react/invoices';
-import {
-  INSTRUMENT_LABELS,
-  LESSON_LENGTH_LABELS,
-} from '@maple/react/students';
+import { InvoiceBuilderDialog, InvoiceList } from '@maple/react/invoices';
+import { INSTRUMENT_LABELS, LESSON_LENGTH_LABELS } from '@maple/react/students';
 import {
   useInstructors,
   useInvoices,
   useLessons,
+  useLessonBlocks,
   useStudents,
 } from '../../../../hooks';
 
@@ -52,12 +47,8 @@ export default function StudentDetailPage() {
 
   const { studentsState } = useStudents();
   const { instructorsState } = useInstructors();
-  const {
-    lessonsState,
-    createLesson,
-    createLessonSeries,
-    updateLesson,
-  } = useLessons({ studentId });
+  const { lessonsState, createLesson, createLessonSeries, updateLesson } =
+    useLessons({ studentId });
   const {
     invoicesState,
     createInvoice,
@@ -65,6 +56,7 @@ export default function StudentDetailPage() {
     recordPayment,
     deleteInvoice,
   } = useInvoices({ studentId });
+  const { lessonBlocksState } = useLessonBlocks();
 
   const student = useMemo(() => {
     if (studentsState.status !== 'success') return undefined;
@@ -73,6 +65,9 @@ export default function StudentDetailPage() {
 
   const instructors =
     instructorsState.status === 'success' ? instructorsState.data : [];
+
+  const blocks =
+    lessonBlocksState.status === 'success' ? lessonBlocksState.data : [];
 
   const primaryTeacherName = useMemo(() => {
     if (!student) return '—';
@@ -88,15 +83,12 @@ export default function StudentDetailPage() {
   // Invoice state
   const [invoiceDialogOpen, setInvoiceDialogOpen] = useState(false);
   const [editingInvoice, setEditingInvoice] = useState<Invoice | undefined>();
-  const [invoiceToDelete, setInvoiceToDelete] = useState<Invoice | null>(
-    null
-  );
+  const [invoiceToDelete, setInvoiceToDelete] = useState<Invoice | null>(null);
   const [invoiceToVoid, setInvoiceToVoid] = useState<Invoice | null>(null);
 
   const lessons = useMemo(
-    () =>
-      lessonsState.status === 'success' ? lessonsState.data : [],
-    [lessonsState]
+    () => (lessonsState.status === 'success' ? lessonsState.data : []),
+    [lessonsState],
   );
 
   const handleCreateSingle = async (input: CreateLessonInput) => {
@@ -171,7 +163,7 @@ export default function StudentDetailPage() {
 
   const handleInvoiceRecordPayment = async (
     invoice: Invoice,
-    source: ManualInvoicePaymentSource
+    source: ManualInvoicePaymentSource,
   ) => {
     setIsSubmitting(true);
     try {
@@ -269,11 +261,7 @@ export default function StudentDetailPage() {
               ` · ${LESSON_LENGTH_LABELS[student.registeredLessonLength]}`}
             {` · Teacher: ${primaryTeacherName}`}
           </Typography>
-          <Typography
-            variant="body2"
-            color="text.secondary"
-            sx={{ mt: 0.5 }}
-          >
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
             {student.isAdultStudent ? 'Contact' : 'Parent/guardian'}:{' '}
             {student.primaryContactName} · {student.primaryContactEmail}
           </Typography>
@@ -320,6 +308,7 @@ export default function StudentDetailPage() {
         lessonsState={lessonsState}
         instructors={instructors}
         primaryTeacherId={student.primaryTeacherId}
+        blocks={blocks}
         onEdit={(lesson) => setEditLesson(lesson)}
         onCancel={(lesson) => setCancelLesson(lesson)}
         onMarkRendered={handleMarkRendered}
@@ -393,6 +382,7 @@ export default function StudentDetailPage() {
         studentId={student.id}
         defaultTeacherId={student.primaryTeacherId}
         instructors={instructors}
+        blocks={blocks}
         defaultDurationMinutes={
           student.registeredLessonLength === '45-min'
             ? 45
@@ -411,6 +401,7 @@ export default function StudentDetailPage() {
         lesson={editLesson}
         primaryTeacherId={student.primaryTeacherId}
         instructors={instructors}
+        blocks={blocks}
         onSubmit={handleEditSubmit}
         isSubmitting={isSubmitting}
       />
@@ -455,9 +446,9 @@ export default function StudentDetailPage() {
         }
         warningContent={
           <Alert severity="warning">
-            Voiding preserves the invoice for history but marks it as
-            cancelled. Use this for refunds or mistakes once an invoice has
-            been sent — drafts can be deleted outright.
+            Voiding preserves the invoice for history but marks it as cancelled.
+            Use this for refunds or mistakes once an invoice has been sent —
+            drafts can be deleted outright.
           </Alert>
         }
       />
@@ -477,8 +468,8 @@ export default function StudentDetailPage() {
         }
         warningContent={
           <Alert severity="warning">
-            Drafts can be hard-deleted. Sent or paid invoices must be
-            voided instead to preserve history.
+            Drafts can be hard-deleted. Sent or paid invoices must be voided
+            instead to preserve history.
           </Alert>
         }
       />

--- a/apps/maple-spruce/src/components/layout/nav-groups.tsx
+++ b/apps/maple-spruce/src/components/layout/nav-groups.tsx
@@ -43,7 +43,7 @@ const ALL_ROLES = ['mt-teacher', 'clerk', 'lesson-teacher'] as const;
 
 function roleNavGroups(
   pendingConflicts: number,
-  pendingPosLessons: number
+  pendingPosLessons: number,
 ): RoleNavGroup[] {
   return [
     {
@@ -138,6 +138,11 @@ function roleNavGroups(
           roles: ['lesson-teacher'],
         },
         {
+          label: 'Lesson Blocks',
+          href: '/lesson-blocks',
+          icon: <EventNoteIcon />,
+        },
+        {
           label: 'Teacher Payouts',
           href: '/payouts',
           icon: <PaymentsIcon />,
@@ -225,11 +230,11 @@ function roleNavGroups(
 export function buildNavGroups(
   roles: readonly UserRole[],
   pendingConflicts: number,
-  pendingPosLessons = 0
+  pendingPosLessons = 0,
 ): NavGroup[] {
   return filterNavGroupsByRoles(
     roleNavGroups(pendingConflicts, pendingPosLessons),
-    roles
+    roles,
   );
 }
 

--- a/apps/maple-spruce/src/hooks/index.ts
+++ b/apps/maple-spruce/src/hooks/index.ts
@@ -6,6 +6,7 @@ export {
   useInstructors,
   useStudents,
   useLessons,
+  useLessonBlocks,
   useInvoices,
   useTeacherPayouts,
   useClasses,

--- a/libs/react/data/src/index.ts
+++ b/libs/react/data/src/index.ts
@@ -26,6 +26,10 @@ export { useClassCategories } from './lib/useClassCategories';
 // Phase 4: Music Lessons
 export { useStudents } from './lib/useStudents';
 export { useLessons, type UseLessonsOptions } from './lib/useLessons';
+export {
+  useLessonBlocks,
+  type UseLessonBlocksOptions,
+} from './lib/useLessonBlocks';
 export { useInvoices, type UseInvoicesOptions } from './lib/useInvoices';
 export {
   useTeacherPayouts,
@@ -82,10 +86,7 @@ export {
 export { useFeatureFlags } from './lib/useFeatureFlags';
 
 // Phase 3c: Registration & Discounts
-export {
-  useDiscounts,
-  type UseDiscountsFilters,
-} from './lib/useDiscounts';
+export { useDiscounts, type UseDiscountsFilters } from './lib/useDiscounts';
 export {
   useRegistrations,
   type UseRegistrationsFilters,

--- a/libs/react/data/src/lib/useLessonBlocks.ts
+++ b/libs/react/data/src/lib/useLessonBlocks.ts
@@ -1,0 +1,157 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { httpsCallable } from 'firebase/functions';
+import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
+import type {
+  LessonBlock,
+  CreateLessonBlockInput,
+  UpdateLessonBlockInput,
+  RequestState,
+} from '@maple/ts/domain';
+import type {
+  GetLessonBlocksRequest,
+  GetLessonBlocksResponse,
+  CreateLessonBlockRequest,
+  CreateLessonBlockResponse,
+  UpdateLessonBlockRequest,
+  UpdateLessonBlockResponse,
+  DeleteLessonBlockRequest,
+  DeleteLessonBlockResponse,
+} from '@maple/ts/firebase/api-types';
+
+/** Coerce ISO timestamps from the callable back to Date. */
+function hydrateBlock(block: LessonBlock): LessonBlock {
+  return {
+    ...block,
+    createdAt: new Date(block.createdAt),
+    updatedAt: new Date(block.updatedAt),
+  };
+}
+
+/** Weekday-then-start ordering for stable listing. */
+function byWeekdayThenStart(a: LessonBlock, b: LessonBlock): number {
+  return a.dayOfWeek - b.dayOfWeek || a.startMinutes - b.startMinutes;
+}
+
+export interface UseLessonBlocksOptions {
+  /** Scope the fetch to one teacher; omit for all blocks. */
+  teacherId?: string;
+  /** Fetch on mount (default true). */
+  autoFetch?: boolean;
+}
+
+/**
+ * Hook for managing lesson-block CRUD (#686/#689). Blocks are the weekly
+ * constraint windows lessons must fall inside. Create/update/delete are
+ * admin-only server-side; this hook just calls the callables.
+ */
+export function useLessonBlocks(options: UseLessonBlocksOptions = {}) {
+  const { teacherId, autoFetch = true } = options;
+  const [lessonBlocksState, setLessonBlocksState] = useState<
+    RequestState<LessonBlock[]>
+  >({ status: 'idle' });
+
+  const fetchLessonBlocks = useCallback(async () => {
+    setLessonBlocksState({ status: 'loading' });
+    try {
+      const functions = getMapleFunctions();
+      const getBlocks = httpsCallable<
+        GetLessonBlocksRequest,
+        GetLessonBlocksResponse
+      >(functions, 'getLessonBlocks');
+
+      const result = await getBlocks({ teacherId });
+      setLessonBlocksState({
+        status: 'success',
+        data: result.data.blocks.map(hydrateBlock).sort(byWeekdayThenStart),
+      });
+    } catch (error) {
+      console.error('Failed to fetch lesson blocks:', error);
+      setLessonBlocksState({
+        status: 'error',
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to fetch lesson blocks',
+      });
+    }
+  }, [teacherId]);
+
+  const createLessonBlock = useCallback(
+    async (input: CreateLessonBlockInput): Promise<LessonBlock> => {
+      const functions = getMapleFunctions();
+      const create = httpsCallable<
+        CreateLessonBlockRequest,
+        CreateLessonBlockResponse
+      >(functions, 'createLessonBlock');
+
+      const result = await create(input);
+      const block = hydrateBlock(result.data.block);
+
+      setLessonBlocksState((prev) => {
+        if (prev.status !== 'success') return prev;
+        return {
+          ...prev,
+          data: [...prev.data, block].sort(byWeekdayThenStart),
+        };
+      });
+
+      return block;
+    },
+    [],
+  );
+
+  const updateLessonBlock = useCallback(
+    async (input: UpdateLessonBlockInput): Promise<LessonBlock> => {
+      const functions = getMapleFunctions();
+      const update = httpsCallable<
+        UpdateLessonBlockRequest,
+        UpdateLessonBlockResponse
+      >(functions, 'updateLessonBlock');
+
+      const result = await update(input);
+      const block = hydrateBlock(result.data.block);
+
+      setLessonBlocksState((prev) => {
+        if (prev.status !== 'success') return prev;
+        return {
+          ...prev,
+          data: prev.data
+            .map((b) => (b.id === block.id ? block : b))
+            .sort(byWeekdayThenStart),
+        };
+      });
+
+      return block;
+    },
+    [],
+  );
+
+  const deleteLessonBlock = useCallback(async (id: string): Promise<void> => {
+    const functions = getMapleFunctions();
+    const del = httpsCallable<
+      DeleteLessonBlockRequest,
+      DeleteLessonBlockResponse
+    >(functions, 'deleteLessonBlock');
+
+    await del({ id });
+
+    setLessonBlocksState((prev) => {
+      if (prev.status !== 'success') return prev;
+      return { ...prev, data: prev.data.filter((b) => b.id !== id) };
+    });
+  }, []);
+
+  useEffect(() => {
+    if (autoFetch) fetchLessonBlocks();
+  }, [autoFetch, fetchLessonBlocks]);
+
+  return {
+    lessonBlocksState,
+    fetchLessonBlocks,
+    createLessonBlock,
+    updateLessonBlock,
+    deleteLessonBlock,
+  };
+}

--- a/libs/react/lessons/src/index.ts
+++ b/libs/react/lessons/src/index.ts
@@ -1,12 +1,17 @@
 export { LessonList } from './lib/LessonList';
 export { ScheduleLessonDialog } from './lib/ScheduleLessonDialog';
 export { EditLessonDialog } from './lib/EditLessonDialog';
+export {
+  LessonBlockForm,
+  type LessonBlockFormProps,
+} from './lib/LessonBlockForm';
+export {
+  LessonBlockList,
+  type LessonBlockListProps,
+} from './lib/LessonBlockList';
 export { HopeRatesTable } from './lib/HopeRatesTable';
 export { HopeScholarshipBanner } from './lib/HopeScholarshipBanner';
-export {
-  generateWeeklyDates,
-  type SeriesCadence,
-} from './lib/series-dates';
+export { generateWeeklyDates, type SeriesCadence } from './lib/series-dates';
 export {
   HOPE_PER_LESSON_RATE_CENTS,
   HOPE_MONTHLY_EQUIVALENT_CENTS,

--- a/libs/react/lessons/src/lib/EditLessonDialog.tsx
+++ b/libs/react/lessons/src/lib/EditLessonDialog.tsx
@@ -30,10 +30,11 @@ import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFnsV3';
 import type {
   Instructor,
   Lesson,
+  LessonBlock,
   Room,
   UpdateLessonInput,
 } from '@maple/ts/domain';
-import { ROOMS, getRoomLabel } from '@maple/ts/domain';
+import { ROOMS, getRoomLabel, lessonFitsBlock } from '@maple/ts/domain';
 import { lessonValidation } from '@maple/ts/validation';
 import {
   batch,
@@ -41,6 +42,7 @@ import {
   useSignal,
   useSignals,
 } from '@maple/react/signals';
+import { formatBlockOption } from './block-format';
 
 interface EditLessonDialogProps {
   open: boolean;
@@ -48,6 +50,8 @@ interface EditLessonDialogProps {
   lesson?: Lesson;
   primaryTeacherId: string;
   instructors: Instructor[];
+  /** All blocks; filtered to the lesson's teacher for the block picker (#689). */
+  blocks: LessonBlock[];
   onSubmit: (input: UpdateLessonInput) => Promise<unknown>;
   isSubmitting?: boolean;
 }
@@ -60,6 +64,7 @@ export function EditLessonDialog({
   lesson,
   primaryTeacherId,
   instructors,
+  blocks,
   onSubmit,
   isSubmitting = false,
 }: EditLessonDialogProps) {
@@ -68,8 +73,12 @@ export function EditLessonDialog({
   const scheduledAt = useSignal<Date>(new Date());
   const durationMinutes = useSignal<30 | 45 | 60>(30);
   const teacherId = useSignal('');
+  const blockId = useSignal('');
   const room = useSignal<Room>('spruce');
   const notes = useSignal('');
+
+  const blocksForTeacher = (tid: string) =>
+    blocks.filter((b) => b.teacherId === tid);
   const showValidationErrors = useSignal(false);
   const submitError = useSignal<string | null>(null);
 
@@ -79,6 +88,7 @@ export function EditLessonDialog({
       scheduledAt.value = new Date(lesson.scheduledAt);
       durationMinutes.value = lesson.durationMinutes as 30 | 45 | 60;
       teacherId.value = lesson.teacherId;
+      blockId.value = lesson.blockId ?? '';
       room.value = lesson.room ?? 'spruce';
       notes.value = lesson.notes ?? '';
       showValidationErrors.value = false;
@@ -99,8 +109,20 @@ export function EditLessonDialog({
     });
   });
 
+  // Block attribution (#689). Unattributed ('') is allowed — a grandfathered
+  // lesson stays editable. If a block is picked, a non-fitting time is a
+  // non-blocking warning (the server enforces fit on reschedule).
+  const blockFitWarning = useComputed<string | null>(() => {
+    if (!blockId.value) return null;
+    const b = blocks.find((bl) => bl.id === blockId.value);
+    if (!b || b.teacherId !== teacherId.value) return null;
+    return lessonFitsBlock(scheduledAt.value, durationMinutes.value, b)
+      ? null
+      : `This time falls outside the block (${formatBlockOption(b)}) and will be rejected on save.`;
+  });
+
   const isValid = useComputed(() =>
-    validation.value ? validation.value.isValid() : false
+    validation.value ? validation.value.isValid() : false,
   );
 
   const errorFor = (field: string): string | null => {
@@ -121,6 +143,7 @@ export function EditLessonDialog({
         scheduledAt: scheduledAt.value,
         durationMinutes: durationMinutes.value,
         teacherId: teacherId.value,
+        blockId: blockId.value || null,
         room: room.value,
         notes: notes.value || undefined,
       };
@@ -179,7 +202,15 @@ export function EditLessonDialog({
               labelId="edit-teacher-label"
               label="Teacher"
               value={teacherId.value}
-              onChange={(e) => (teacherId.value = e.target.value)}
+              onChange={(e) => {
+                teacherId.value = e.target.value;
+                // Keep the block only if it still belongs to the new teacher.
+                const stillValid = blocks.some(
+                  (b) =>
+                    b.id === blockId.value && b.teacherId === e.target.value,
+                );
+                if (!stillValid) blockId.value = '';
+              }}
             >
               {instructors.map((i) => (
                 <MenuItem key={i.id} value={i.id}>
@@ -189,10 +220,37 @@ export function EditLessonDialog({
               ))}
             </Select>
             <FormHelperText>
-              {errorFor('teacherId') ??
-                'Change this to record a substitute.'}
+              {errorFor('teacherId') ?? 'Change this to record a substitute.'}
             </FormHelperText>
           </FormControl>
+
+          {/* Block attribution (#689). Includes an explicit "unattributed"
+              option so grandfathered lessons can stay as-is or be migrated. */}
+          <FormControl fullWidth>
+            <InputLabel id="edit-block-label">Block</InputLabel>
+            <Select
+              labelId="edit-block-label"
+              label="Block"
+              value={blockId.value}
+              onChange={(e) => (blockId.value = e.target.value)}
+            >
+              <MenuItem value="">
+                <em>Unattributed (needs a block)</em>
+              </MenuItem>
+              {blocksForTeacher(teacherId.value).map((b) => (
+                <MenuItem key={b.id} value={b.id}>
+                  {formatBlockOption(b)}
+                  {b.label ? ` — ${b.label}` : ''}
+                </MenuItem>
+              ))}
+            </Select>
+            <FormHelperText>
+              Attribute this lesson to one of the teacher’s weekly blocks.
+            </FormHelperText>
+          </FormControl>
+          {blockFitWarning.value && (
+            <Alert severity="warning">{blockFitWarning.value}</Alert>
+          )}
 
           <FormControl fullWidth error={!!errorFor('durationMinutes')}>
             <InputLabel id="edit-duration-label">Duration</InputLabel>

--- a/libs/react/lessons/src/lib/LessonBlockForm.stories.tsx
+++ b/libs/react/lessons/src/lib/LessonBlockForm.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn, expect, userEvent, waitFor, within } from 'storybook/test';
+import { LessonBlockForm } from './LessonBlockForm';
+import {
+  mockInstructor,
+  mockInstructor2,
+  mockLessonBlockTuesday,
+} from '@maple/react/storybook-fixtures';
+
+const instructors = [mockInstructor, mockInstructor2];
+
+const meta = {
+  component: LessonBlockForm,
+  title: 'Lessons/LessonBlockForm',
+  parameters: { layout: 'centered', a11y: { disable: true } },
+  args: {
+    open: true,
+    onClose: fn(),
+    onSubmit: fn().mockResolvedValue(undefined),
+    instructors,
+    isSubmitting: false,
+  },
+} satisfies Meta<typeof LessonBlockForm>;
+
+export default meta;
+type Story = StoryObj<typeof LessonBlockForm>;
+
+const body = () => within(document.body);
+
+export const Create: Story = {};
+
+export const Edit: Story = {
+  args: { block: mockLessonBlockTuesday },
+};
+
+export const Submitting: Story = {
+  args: { isSubmitting: true },
+};
+
+export const PicksTeacherAndSubmits: Story = {
+  play: async ({ args }) => {
+    const canvas = body();
+    await waitFor(() => expect(canvas.getByRole('dialog')).toBeInTheDocument());
+    const dialog = within(canvas.getByRole('dialog'));
+
+    // Choose a teacher (weekday + 3:00–6:00 PM window default).
+    await userEvent.click(dialog.getByRole('combobox', { name: /teacher/i }));
+    await userEvent.click(
+      await canvas.findByRole('option', { name: mockInstructor.name }),
+    );
+
+    await userEvent.click(dialog.getByRole('button', { name: /^add$/i }));
+
+    await waitFor(() => {
+      expect(args.onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          teacherId: mockInstructor.id,
+          dayOfWeek: 1,
+          startMinutes: 15 * 60,
+          endMinutes: 18 * 60,
+        }),
+      );
+    });
+  },
+};

--- a/libs/react/lessons/src/lib/LessonBlockForm.stories.tsx
+++ b/libs/react/lessons/src/lib/LessonBlockForm.stories.tsx
@@ -44,7 +44,7 @@ export const PicksTeacherAndSubmits: Story = {
     const dialog = within(canvas.getByRole('dialog'));
 
     // Choose a teacher (weekday + 3:00–6:00 PM window default).
-    await userEvent.click(dialog.getByRole('combobox', { name: /teacher/i }));
+    await userEvent.click(dialog.getByLabelText(/^teacher$/i));
     await userEvent.click(
       await canvas.findByRole('option', { name: mockInstructor.name }),
     );

--- a/libs/react/lessons/src/lib/LessonBlockForm.tsx
+++ b/libs/react/lessons/src/lib/LessonBlockForm.tsx
@@ -151,8 +151,9 @@ export function LessonBlockForm({
           )}
 
           <FormControl fullWidth error={!!getFieldError('teacherId')}>
-            <InputLabel>Teacher</InputLabel>
+            <InputLabel id="lbf-teacher-label">Teacher</InputLabel>
             <Select
+              labelId="lbf-teacher-label"
               value={teacherId.value}
               label="Teacher"
               disabled={isEdit}
@@ -173,8 +174,9 @@ export function LessonBlockForm({
           </FormControl>
 
           <FormControl fullWidth error={!!getFieldError('dayOfWeek')}>
-            <InputLabel>Day of week</InputLabel>
+            <InputLabel id="lbf-dow-label">Day of week</InputLabel>
             <Select
+              labelId="lbf-dow-label"
               value={dayOfWeek.value}
               label="Day of week"
               onChange={(e) => (dayOfWeek.value = Number(e.target.value))}

--- a/libs/react/lessons/src/lib/LessonBlockForm.tsx
+++ b/libs/react/lessons/src/lib/LessonBlockForm.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+/**
+ * LessonBlockForm — create/edit a weekly lesson block (#689).
+ *
+ * A block is a weekly constraint window (teacher + weekday + start/end time)
+ * that lessons must fall inside. Times are entered as shop wall-clock (ET) and
+ * stored as minutes-from-midnight. A block's teacher can't be reassigned once
+ * created (the backend omits it from updates), so the teacher select is locked
+ * when editing.
+ */
+import { useEffect } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormHelperText,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+} from '@mui/material';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFnsV3';
+import { TimePicker } from '@mui/x-date-pickers/TimePicker';
+import type {
+  CreateLessonBlockInput,
+  Instructor,
+  LessonBlock,
+} from '@maple/ts/domain';
+import { WEEKDAY_LONG } from '@maple/ts/domain';
+import { lessonBlockValidation } from '@maple/ts/validation';
+import {
+  useSignal,
+  useComputed,
+  batch,
+  useSignals,
+} from '@maple/react/signals';
+
+export interface LessonBlockFormProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (input: CreateLessonBlockInput) => Promise<void>;
+  /** Present => edit mode. */
+  block?: LessonBlock;
+  /** Teachers the block can be attributed to. */
+  instructors: Instructor[];
+  isSubmitting?: boolean;
+}
+
+/** A local Date carrying just the given wall-clock time (date part is arbitrary). */
+function minutesToDate(minutes: number): Date {
+  return new Date(2000, 0, 1, Math.floor(minutes / 60), minutes % 60);
+}
+
+/** Wall-clock minutes-from-midnight of a picked time (as entered, shop tz). */
+function dateToMinutes(d: Date | null): number | undefined {
+  if (!d || Number.isNaN(d.getTime())) return undefined;
+  return d.getHours() * 60 + d.getMinutes();
+}
+
+export function LessonBlockForm({
+  open,
+  onClose,
+  onSubmit,
+  block,
+  instructors,
+  isSubmitting = false,
+}: LessonBlockFormProps) {
+  useSignals();
+
+  const teacherId = useSignal('');
+  const dayOfWeek = useSignal<number>(1); // Monday default
+  const startTime = useSignal<Date | null>(minutesToDate(15 * 60)); // 3:00 PM
+  const endTime = useSignal<Date | null>(minutesToDate(18 * 60)); // 6:00 PM
+  const label = useSignal('');
+
+  const showValidationErrors = useSignal(false);
+  const submitError = useSignal<string | null>(null);
+
+  const isEdit = !!block;
+
+  const startMinutes = useComputed(() => dateToMinutes(startTime.value));
+  const endMinutes = useComputed(() => dateToMinutes(endTime.value));
+
+  const validation = useComputed(() =>
+    lessonBlockValidation({
+      teacherId: teacherId.value,
+      dayOfWeek: dayOfWeek.value,
+      startMinutes: startMinutes.value,
+      endMinutes: endMinutes.value,
+      label: label.value || undefined,
+    }),
+  );
+  const errors = useComputed<Record<string, string[]>>(() =>
+    showValidationErrors.value ? validation.value.getErrors() : {},
+  );
+  const isValid = useComputed(() => validation.value.isValid());
+  const getFieldError = (field: string): string | null =>
+    errors.value[field]?.[0] ?? null;
+
+  useEffect(() => {
+    if (!open) return;
+    batch(() => {
+      teacherId.value = block?.teacherId ?? '';
+      dayOfWeek.value = block?.dayOfWeek ?? 1;
+      startTime.value = minutesToDate(block?.startMinutes ?? 15 * 60);
+      endTime.value = minutesToDate(block?.endMinutes ?? 18 * 60);
+      label.value = block?.label ?? '';
+      showValidationErrors.value = false;
+      submitError.value = null;
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, block]);
+
+  const handleSubmit = async () => {
+    showValidationErrors.value = true;
+    if (!isValid.value) return;
+    submitError.value = null;
+    try {
+      await onSubmit({
+        teacherId: teacherId.value,
+        dayOfWeek: dayOfWeek.value,
+        startMinutes: startMinutes.value as number,
+        endMinutes: endMinutes.value as number,
+        label: label.value || undefined,
+      });
+      onClose();
+    } catch (error) {
+      submitError.value =
+        error instanceof Error ? error.message : 'Failed to save block';
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        {isEdit ? 'Edit Lesson Block' : 'Add Lesson Block'}
+      </DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          {submitError.value && (
+            <Alert severity="error" onClose={() => (submitError.value = null)}>
+              {submitError.value}
+            </Alert>
+          )}
+
+          <FormControl fullWidth error={!!getFieldError('teacherId')}>
+            <InputLabel>Teacher</InputLabel>
+            <Select
+              value={teacherId.value}
+              label="Teacher"
+              disabled={isEdit}
+              onChange={(e) => (teacherId.value = e.target.value)}
+            >
+              {instructors.map((i) => (
+                <MenuItem key={i.id} value={i.id}>
+                  {i.name}
+                </MenuItem>
+              ))}
+            </Select>
+            <FormHelperText>
+              {getFieldError('teacherId') ??
+                (isEdit
+                  ? 'A block’s teacher can’t be changed — delete and recreate.'
+                  : 'Who teaches during this block.')}
+            </FormHelperText>
+          </FormControl>
+
+          <FormControl fullWidth error={!!getFieldError('dayOfWeek')}>
+            <InputLabel>Day of week</InputLabel>
+            <Select
+              value={dayOfWeek.value}
+              label="Day of week"
+              onChange={(e) => (dayOfWeek.value = Number(e.target.value))}
+            >
+              {WEEKDAY_LONG.map((name, idx) => (
+                <MenuItem key={name} value={idx}>
+                  {name}
+                </MenuItem>
+              ))}
+            </Select>
+            {getFieldError('dayOfWeek') && (
+              <FormHelperText>{getFieldError('dayOfWeek')}</FormHelperText>
+            )}
+          </FormControl>
+
+          <LocalizationProvider dateAdapter={AdapterDateFns}>
+            <Box sx={{ display: 'flex', gap: 2 }}>
+              <TimePicker
+                label="Start (ET)"
+                value={startTime.value}
+                onChange={(v) => (startTime.value = v)}
+                slotProps={{ textField: { fullWidth: true } }}
+              />
+              <TimePicker
+                label="End (ET)"
+                value={endTime.value}
+                onChange={(v) => (endTime.value = v)}
+                slotProps={{
+                  textField: {
+                    fullWidth: true,
+                    error: !!getFieldError('endMinutes'),
+                    helperText: getFieldError('endMinutes') ?? undefined,
+                  },
+                }}
+              />
+            </Box>
+          </LocalizationProvider>
+
+          <TextField
+            label="Label"
+            value={label.value}
+            onChange={(e) => (label.value = e.target.value)}
+            error={!!getFieldError('label')}
+            helperText={
+              getFieldError('label') ?? 'Optional, e.g. “Tuesday afternoons”'
+            }
+            fullWidth
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={isSubmitting}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? 'Saving...' : isEdit ? 'Update' : 'Add'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/libs/react/lessons/src/lib/LessonBlockList.stories.tsx
+++ b/libs/react/lessons/src/lib/LessonBlockList.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import { LessonBlockList } from './LessonBlockList';
+import {
+  mockInstructor,
+  mockInstructor2,
+  mockLessonBlocks,
+} from '@maple/react/storybook-fixtures';
+
+const instructors = [mockInstructor, mockInstructor2];
+
+const meta = {
+  component: LessonBlockList,
+  title: 'Lessons/LessonBlockList',
+  parameters: { layout: 'padded' },
+  args: {
+    instructors,
+    onEdit: fn(),
+    onDelete: fn(),
+  },
+} satisfies Meta<typeof LessonBlockList>;
+
+export default meta;
+type Story = StoryObj<typeof LessonBlockList>;
+
+export const Populated: Story = {
+  args: {
+    lessonBlocksState: { status: 'success', data: mockLessonBlocks },
+  },
+};
+
+export const Empty: Story = {
+  args: { lessonBlocksState: { status: 'success', data: [] } },
+};
+
+export const Loading: Story = {
+  args: { lessonBlocksState: { status: 'loading' } },
+};
+
+export const ErrorState: Story = {
+  args: {
+    lessonBlocksState: { status: 'error', error: 'Could not load blocks.' },
+  },
+};

--- a/libs/react/lessons/src/lib/LessonBlockList.tsx
+++ b/libs/react/lessons/src/lib/LessonBlockList.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+/**
+ * LessonBlockList — weekly lesson blocks grouped by teacher (#689).
+ */
+import {
+  Alert,
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  IconButton,
+  Skeleton,
+  Stack,
+  Typography,
+} from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import type { Instructor, LessonBlock, RequestState } from '@maple/ts/domain';
+import { WEEKDAY_LONG } from '@maple/ts/domain';
+import { formatMinutes } from './block-format';
+
+export interface LessonBlockListProps {
+  lessonBlocksState: RequestState<LessonBlock[]>;
+  instructors: Instructor[];
+  onEdit: (block: LessonBlock) => void;
+  onDelete: (block: LessonBlock) => void;
+}
+
+export function LessonBlockList({
+  lessonBlocksState,
+  instructors,
+  onEdit,
+  onDelete,
+}: LessonBlockListProps) {
+  if (lessonBlocksState.status === 'idle') return null;
+
+  if (lessonBlocksState.status === 'loading') {
+    return (
+      <Stack spacing={2}>
+        {[1, 2, 3].map((i) => (
+          <Skeleton key={i} variant="rectangular" height={72} />
+        ))}
+      </Stack>
+    );
+  }
+
+  if (lessonBlocksState.status === 'error') {
+    return <Alert severity="error">{lessonBlocksState.error}</Alert>;
+  }
+
+  const blocks = lessonBlocksState.data;
+  if (blocks.length === 0) {
+    return (
+      <Typography color="text.secondary">
+        No lesson blocks yet. Add one so lessons can be scheduled.
+      </Typography>
+    );
+  }
+
+  const nameById = new Map(instructors.map((i) => [i.id, i.name]));
+
+  // Group by teacher, preserving the weekday/start ordering within each.
+  const byTeacher = new Map<string, LessonBlock[]>();
+  for (const b of blocks) {
+    const list = byTeacher.get(b.teacherId) ?? [];
+    list.push(b);
+    byTeacher.set(b.teacherId, list);
+  }
+
+  return (
+    <Stack spacing={3}>
+      {[...byTeacher.entries()].map(([teacherId, teacherBlocks]) => (
+        <Box key={teacherId}>
+          <Typography variant="h6" sx={{ mb: 1 }}>
+            {nameById.get(teacherId) ?? 'Unknown teacher'}
+          </Typography>
+          <Stack spacing={1}>
+            {teacherBlocks.map((block) => (
+              <Card key={block.id} variant="outlined">
+                <CardContent
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    py: 1.5,
+                    '&:last-child': { pb: 1.5 },
+                  }}
+                >
+                  <Box>
+                    <Typography>
+                      {WEEKDAY_LONG[block.dayOfWeek]}s ·{' '}
+                      {formatMinutes(block.startMinutes)}–
+                      {formatMinutes(block.endMinutes)}
+                    </Typography>
+                    {block.label && (
+                      <Chip
+                        label={block.label}
+                        size="small"
+                        sx={{ mt: 0.5 }}
+                        variant="outlined"
+                      />
+                    )}
+                  </Box>
+                  <Box>
+                    <IconButton
+                      aria-label="Edit block"
+                      onClick={() => onEdit(block)}
+                    >
+                      <EditIcon />
+                    </IconButton>
+                    <IconButton
+                      aria-label="Delete block"
+                      onClick={() => onDelete(block)}
+                    >
+                      <DeleteIcon />
+                    </IconButton>
+                  </Box>
+                </CardContent>
+              </Card>
+            ))}
+          </Stack>
+        </Box>
+      ))}
+    </Stack>
+  );
+}

--- a/libs/react/lessons/src/lib/LessonList.tsx
+++ b/libs/react/lessons/src/lib/LessonList.tsx
@@ -14,7 +14,13 @@ import {
 import EditIcon from '@mui/icons-material/Edit';
 import CancelIcon from '@mui/icons-material/Cancel';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import type { Instructor, Lesson, RequestState } from '@maple/ts/domain';
+import type {
+  Instructor,
+  Lesson,
+  LessonBlock,
+  RequestState,
+} from '@maple/ts/domain';
+import { isLessonUnattributed } from '@maple/ts/domain';
 
 interface LessonListProps {
   lessonsState: RequestState<Lesson[]>;
@@ -22,6 +28,9 @@ interface LessonListProps {
   /** For attribution — a lesson's teacher that differs from the student's
    *  primary teacher is shown as "Substitute". */
   primaryTeacherId?: string;
+  /** Teacher blocks; when provided, lessons not sitting in one of their
+   *  teacher's blocks get a "needs a block" flag (#689). */
+  blocks?: LessonBlock[];
   onEdit: (lesson: Lesson) => void;
   onCancel: (lesson: Lesson) => void;
   /**
@@ -58,6 +67,7 @@ function LessonRow({
   lesson,
   teacherName,
   isSubstitute,
+  isUnattributed,
   isPast,
   onEdit,
   onCancel,
@@ -66,6 +76,7 @@ function LessonRow({
   lesson: Lesson;
   teacherName: string;
   isSubstitute: boolean;
+  isUnattributed: boolean;
   isPast: boolean;
   onEdit: () => void;
   onCancel: () => void;
@@ -123,7 +134,12 @@ function LessonRow({
       <ListItemText
         primary={
           <Box
-            sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}
+            sx={{
+              display: 'flex',
+              gap: 1,
+              alignItems: 'center',
+              flexWrap: 'wrap',
+            }}
           >
             <Typography variant="body1" component="span">
               {formatDateTime(lesson.scheduledAt)}
@@ -148,6 +164,9 @@ function LessonRow({
                 color="info"
                 variant="outlined"
               />
+            )}
+            {isUnattributed && (
+              <Chip label="Needs a block" size="small" color="warning" />
             )}
           </Box>
         }
@@ -176,6 +195,7 @@ export function LessonList({
   lessonsState,
   instructors,
   primaryTeacherId,
+  blocks = [],
   onEdit,
   onCancel,
   onMarkRendered,
@@ -211,13 +231,15 @@ export function LessonList({
 
   const upcoming = lessons
     .filter(
-      (l) => l.status === 'scheduled' && l.scheduledAt.getTime() > now.getTime()
+      (l) =>
+        l.status === 'scheduled' && l.scheduledAt.getTime() > now.getTime(),
     )
     .sort((a, b) => a.scheduledAt.getTime() - b.scheduledAt.getTime());
 
   const past = lessons
     .filter(
-      (l) => l.scheduledAt.getTime() <= now.getTime() || l.status !== 'scheduled'
+      (l) =>
+        l.scheduledAt.getTime() <= now.getTime() || l.status !== 'scheduled',
     )
     .sort((a, b) => b.scheduledAt.getTime() - a.scheduledAt.getTime());
 
@@ -225,19 +247,19 @@ export function LessonList({
     <LessonRow
       key={lesson.id}
       lesson={lesson}
-      teacherName={
-        teacherNameById.get(lesson.teacherId) ?? 'Unassigned'
-      }
+      teacherName={teacherNameById.get(lesson.teacherId) ?? 'Unassigned'}
       isSubstitute={
-        primaryTeacherId !== undefined &&
-        lesson.teacherId !== primaryTeacherId
+        primaryTeacherId !== undefined && lesson.teacherId !== primaryTeacherId
+      }
+      isUnattributed={
+        lesson.status !== 'cancelled' &&
+        blocks.length > 0 &&
+        isLessonUnattributed(lesson, blocks)
       }
       isPast={lesson.scheduledAt.getTime() <= now.getTime()}
       onEdit={() => onEdit(lesson)}
       onCancel={() => onCancel(lesson)}
-      onMarkRendered={
-        onMarkRendered ? () => onMarkRendered(lesson) : undefined
-      }
+      onMarkRendered={onMarkRendered ? () => onMarkRendered(lesson) : undefined}
     />
   );
 

--- a/libs/react/lessons/src/lib/ScheduleLessonDialog.stories.tsx
+++ b/libs/react/lessons/src/lib/ScheduleLessonDialog.stories.tsx
@@ -5,9 +5,12 @@ import {
   mockInstructor,
   mockInstructor2,
   mockInstructorPercentage,
+  mockLessonBlock,
 } from '@maple/react/storybook-fixtures';
 
 const instructors = [mockInstructor, mockInstructor2, mockInstructorPercentage];
+// One block for the default teacher (instructor-001) so it auto-selects.
+const blocks = [mockLessonBlock];
 
 const meta = {
   component: ScheduleLessonDialog,
@@ -20,6 +23,7 @@ const meta = {
     studentId: 'student-001',
     defaultTeacherId: mockInstructor.id,
     instructors,
+    blocks,
     defaultDurationMinutes: 30,
   },
 } satisfies Meta<typeof ScheduleLessonDialog>;
@@ -32,10 +36,10 @@ const waitForDialog = async () => {
     () => {
       expect(canvas.getByRole('dialog')).toBeInTheDocument();
       expect(
-        canvas.getByRole('button', { name: /single lesson/i })
+        canvas.getByRole('button', { name: /single lesson/i }),
       ).toBeInTheDocument();
     },
-    { timeout: 3000 }
+    { timeout: 3000 },
   );
   return canvas;
 };
@@ -60,7 +64,7 @@ export const SeriesMode: Story = {
   play: async () => {
     const canvas = await waitForDialog();
     await userEvent.click(
-      canvas.getByRole('button', { name: /recurring series/i })
+      canvas.getByRole('button', { name: /recurring series/i }),
     );
     const dialog = within(canvas.getByRole('dialog'));
     await waitFor(() => {
@@ -84,7 +88,7 @@ export const SingleLessonSuccessfulSubmit: Story = {
 
     // Single mode is the default. Submit with defaults.
     await userEvent.click(
-      canvas.getByRole('button', { name: /schedule lesson/i })
+      canvas.getByRole('button', { name: /schedule lesson/i }),
     );
 
     await waitFor(() => {
@@ -97,7 +101,7 @@ export const SingleLessonSuccessfulSubmit: Story = {
           status: 'scheduled',
           // Room selector defaults to Spruce and flows into the payload.
           room: 'spruce',
-        })
+        }),
       );
     });
   },
@@ -120,7 +124,7 @@ export const SwitchToSeriesShowsPreview: Story = {
     const canvas = await waitForDialog();
 
     await userEvent.click(
-      canvas.getByRole('button', { name: /recurring series/i })
+      canvas.getByRole('button', { name: /recurring series/i }),
     );
 
     const dialog = within(canvas.getByRole('dialog'));
@@ -139,7 +143,7 @@ export const SkippingPreviewDatesReducesSubmittedCount: Story = {
 
     // Switch to series mode
     await userEvent.click(
-      canvas.getByRole('button', { name: /recurring series/i })
+      canvas.getByRole('button', { name: /recurring series/i }),
     );
 
     const dialog = within(canvas.getByRole('dialog'));
@@ -161,12 +165,13 @@ export const SkippingPreviewDatesReducesSubmittedCount: Story = {
 
     // Submit — should call createSeries with 6 dates
     await userEvent.click(
-      canvas.getByRole('button', { name: /schedule 6 lessons/i })
+      canvas.getByRole('button', { name: /schedule 6 lessons/i }),
     );
 
     await waitFor(() => {
       expect(args.onCreateSeries).toHaveBeenCalledTimes(1);
-      const arg = (args.onCreateSeries as ReturnType<typeof fn>).mock.calls[0][0];
+      const arg = (args.onCreateSeries as ReturnType<typeof fn>).mock
+        .calls[0][0];
       expect(arg.scheduledAts.length).toBe(6);
       expect(arg.studentId).toBe('student-001');
       expect(arg.teacherId).toBe(mockInstructor.id);
@@ -186,19 +191,19 @@ export const SubstituteTeacherSelection: Story = {
 
     // Pick the second instructor (non-primary)
     const option = await waitFor(() =>
-      canvas.getByRole('option', { name: new RegExp(mockInstructor2.name) })
+      canvas.getByRole('option', { name: new RegExp(mockInstructor2.name) }),
     );
     await userEvent.click(option);
 
     await userEvent.click(
-      canvas.getByRole('button', { name: /schedule lesson/i })
+      canvas.getByRole('button', { name: /schedule lesson/i }),
     );
 
     await waitFor(() => {
       expect(args.onCreateSingle).toHaveBeenCalledWith(
         expect.objectContaining({
           teacherId: mockInstructor2.id,
-        })
+        }),
       );
     });
   },

--- a/libs/react/lessons/src/lib/ScheduleLessonDialog.stories.tsx
+++ b/libs/react/lessons/src/lib/ScheduleLessonDialog.stories.tsx
@@ -6,11 +6,13 @@ import {
   mockInstructor2,
   mockInstructorPercentage,
   mockLessonBlock,
+  mockLessonBlockOtherTeacher,
 } from '@maple/react/storybook-fixtures';
 
 const instructors = [mockInstructor, mockInstructor2, mockInstructorPercentage];
-// One block for the default teacher (instructor-001) so it auto-selects.
-const blocks = [mockLessonBlock];
+// Exactly one block per selectable teacher (instructor-001 + -002) so the
+// dialog auto-selects on open and on a substitute switch.
+const blocks = [mockLessonBlock, mockLessonBlockOtherTeacher];
 
 const meta = {
   component: ScheduleLessonDialog,

--- a/libs/react/lessons/src/lib/ScheduleLessonDialog.tsx
+++ b/libs/react/lessons/src/lib/ScheduleLessonDialog.tsx
@@ -41,13 +41,11 @@ import type {
   CreateLessonInput,
   CreateLessonSeriesInput,
   Instructor,
+  LessonBlock,
   Room,
 } from '@maple/ts/domain';
-import { ROOMS, getRoomLabel } from '@maple/ts/domain';
-import {
-  lessonSeriesValidation,
-  lessonValidation,
-} from '@maple/ts/validation';
+import { ROOMS, getRoomLabel, lessonFitsBlock } from '@maple/ts/domain';
+import { lessonSeriesValidation, lessonValidation } from '@maple/ts/validation';
 import {
   batch,
   useComputed,
@@ -55,10 +53,8 @@ import {
   useSignals,
 } from '@maple/react/signals';
 import { RoomAvailability } from '@maple/react/rooms';
-import {
-  generateWeeklyDates,
-  type SeriesCadence,
-} from './series-dates';
+import { generateWeeklyDates, type SeriesCadence } from './series-dates';
+import { formatBlockOption } from './block-format';
 
 type Mode = 'single' | 'series';
 type EndType = 'count' | 'date';
@@ -71,6 +67,9 @@ interface ScheduleLessonDialogProps {
   defaultTeacherId: string;
   /** For the teacher dropdown. */
   instructors: Instructor[];
+  /** All lesson blocks; the dialog filters to the chosen teacher (#689). A
+   *  lesson must be attributed to one of its teacher's blocks. */
+  blocks: LessonBlock[];
   /** Default lesson length in minutes (30, 45, 60). */
   defaultDurationMinutes?: 30 | 45 | 60;
   onCreateSingle: (input: CreateLessonInput) => Promise<unknown>;
@@ -104,6 +103,7 @@ export function ScheduleLessonDialog({
   studentId,
   defaultTeacherId,
   instructors,
+  blocks,
   defaultDurationMinutes = 30,
   onCreateSingle,
   onCreateSeries,
@@ -111,11 +111,20 @@ export function ScheduleLessonDialog({
 }: ScheduleLessonDialogProps) {
   useSignals();
 
+  /** Blocks belonging to a teacher; auto-select when there's exactly one. */
+  const blocksForTeacher = (tid: string) =>
+    blocks.filter((b) => b.teacherId === tid);
+  const defaultBlockFor = (tid: string): string => {
+    const tb = blocksForTeacher(tid);
+    return tb.length === 1 ? tb[0].id : '';
+  };
+
   // ============================================================
   // SHARED FIELDS
   // ============================================================
   const mode = useSignal<Mode>('single');
   const teacherId = useSignal(defaultTeacherId);
+  const blockId = useSignal(defaultBlockFor(defaultTeacherId));
   const durationMinutes = useSignal<30 | 45 | 60>(defaultDurationMinutes);
   const room = useSignal<Room>('spruce');
   const notes = useSignal('');
@@ -133,7 +142,7 @@ export function ScheduleLessonDialog({
       const d = new Date();
       d.setDate(d.getDate() + 60);
       return d;
-    })()
+    })(),
   );
   /** Per-previewed-date skip flag, keyed by ISO timestamp. */
   const skipped = useSignal<Record<string, boolean>>({});
@@ -150,6 +159,7 @@ export function ScheduleLessonDialog({
     batch(() => {
       mode.value = 'single';
       teacherId.value = defaultTeacherId;
+      blockId.value = defaultBlockFor(defaultTeacherId);
       durationMinutes.value = defaultDurationMinutes;
       room.value = 'spruce';
       notes.value = '';
@@ -182,9 +192,7 @@ export function ScheduleLessonDialog({
   });
 
   const keptDates = useComputed(() =>
-    previewDates.value.filter(
-      (d) => !skipped.value[d.toISOString()]
-    )
+    previewDates.value.filter((d) => !skipped.value[d.toISOString()]),
   );
 
   // ============================================================
@@ -198,7 +206,7 @@ export function ScheduleLessonDialog({
       durationMinutes: durationMinutes.value,
       status: 'scheduled',
       notes: notes.value || undefined,
-    })
+    }),
   );
 
   const seriesVal = useComputed(() =>
@@ -208,13 +216,41 @@ export function ScheduleLessonDialog({
       durationMinutes: durationMinutes.value,
       scheduledAts: keptDates.value,
       notes: notes.value || undefined,
-    })
+    }),
   );
 
-  const isValid = useComputed(() =>
-    mode.value === 'single'
-      ? singleValidation.value.isValid()
-      : seriesVal.value.isValid()
+  // Block attribution (#689). Selecting a block is required (hard); whether the
+  // chosen time fits it is a non-blocking warning — the server enforces fit, so
+  // we guide rather than trap (mirrors the RoomAvailability warn pattern).
+  const selectedBlock = useComputed(() =>
+    blocks.find((b) => b.id === blockId.value),
+  );
+  const blockSelectionError = useComputed<string | null>(() => {
+    const b = selectedBlock.value;
+    return !b || b.teacherId !== teacherId.value
+      ? 'Select a block for this teacher.'
+      : null;
+  });
+  const blockFitWarning = useComputed<string | null>(() => {
+    const b = selectedBlock.value;
+    if (!b) return null;
+    const dates =
+      mode.value === 'single' ? [scheduledAt.value] : keptDates.value;
+    const outside = dates.filter(
+      (d) => !lessonFitsBlock(d, durationMinutes.value, b),
+    );
+    return outside.length > 0
+      ? `${outside.length} lesson time${
+          outside.length === 1 ? '' : 's'
+        } fall outside this block (${formatBlockOption(b)}) and will be rejected on save.`
+      : null;
+  });
+
+  const isValid = useComputed(
+    () =>
+      (mode.value === 'single'
+        ? singleValidation.value.isValid()
+        : seriesVal.value.isValid()) && !blockSelectionError.value,
   );
 
   const errorFor = (field: string): string | null => {
@@ -242,6 +278,7 @@ export function ScheduleLessonDialog({
         const input: CreateLessonInput = {
           studentId,
           teacherId: teacherId.value,
+          blockId: blockId.value,
           scheduledAt: scheduledAt.value,
           durationMinutes: durationMinutes.value,
           room: room.value,
@@ -253,6 +290,7 @@ export function ScheduleLessonDialog({
         const input: CreateLessonSeriesInput = {
           studentId,
           teacherId: teacherId.value,
+          blockId: blockId.value,
           durationMinutes: durationMinutes.value,
           scheduledAts: keptDates.value,
           room: room.value,
@@ -325,7 +363,7 @@ export function ScheduleLessonDialog({
                   end={
                     new Date(
                       scheduledAt.value.getTime() +
-                        durationMinutes.value * 60_000
+                        durationMinutes.value * 60_000,
                     )
                   }
                 />
@@ -408,7 +446,10 @@ export function ScheduleLessonDialog({
               labelId="teacher-label"
               label="Teacher"
               value={teacherId.value}
-              onChange={(e) => (teacherId.value = e.target.value)}
+              onChange={(e) => {
+                teacherId.value = e.target.value;
+                blockId.value = defaultBlockFor(e.target.value);
+              }}
             >
               {instructors.map((i) => (
                 <MenuItem key={i.id} value={i.id}>
@@ -422,6 +463,46 @@ export function ScheduleLessonDialog({
                 'Override for a substitute on a one-off lesson.'}
             </FormHelperText>
           </FormControl>
+
+          {/* Block attribution (#689) — a lesson must sit inside one of the
+              teacher's weekly blocks. */}
+          {blocksForTeacher(teacherId.value).length === 0 ? (
+            <Alert severity="warning">
+              This teacher has no lesson blocks yet. Create one under Lesson
+              Blocks before scheduling.
+            </Alert>
+          ) : (
+            <>
+              <FormControl
+                fullWidth
+                error={
+                  showValidationErrors.value && !!blockSelectionError.value
+                }
+              >
+                <InputLabel id="block-label">Block</InputLabel>
+                <Select
+                  labelId="block-label"
+                  label="Block"
+                  value={blockId.value}
+                  onChange={(e) => (blockId.value = e.target.value)}
+                >
+                  {blocksForTeacher(teacherId.value).map((b) => (
+                    <MenuItem key={b.id} value={b.id}>
+                      {formatBlockOption(b)}
+                      {b.label ? ` — ${b.label}` : ''}
+                    </MenuItem>
+                  ))}
+                </Select>
+                <FormHelperText>
+                  {(showValidationErrors.value && blockSelectionError.value) ||
+                    'The lesson must fall on this block’s day and inside its window.'}
+                </FormHelperText>
+              </FormControl>
+              {blockFitWarning.value && (
+                <Alert severity="warning">{blockFitWarning.value}</Alert>
+              )}
+            </>
+          )}
 
           <FormControl fullWidth error={!!errorFor('durationMinutes')}>
             <InputLabel id="duration-label">Duration</InputLabel>
@@ -546,10 +627,9 @@ export function ScheduleLessonDialog({
                   })}
                 </Box>
               )}
-              {showValidationErrors.value &&
-                errorFor('scheduledAts') && (
-                  <Alert severity="error">{errorFor('scheduledAts')}</Alert>
-                )}
+              {showValidationErrors.value && errorFor('scheduledAts') && (
+                <Alert severity="error">{errorFor('scheduledAts')}</Alert>
+              )}
             </>
           )}
         </Box>

--- a/libs/react/lessons/src/lib/block-format.ts
+++ b/libs/react/lessons/src/lib/block-format.ts
@@ -1,0 +1,18 @@
+import type { LessonBlock } from '@maple/ts/domain';
+import { WEEKDAY_LONG } from '@maple/ts/domain';
+
+/** Minutes-from-midnight → "3:00 PM". */
+export function formatMinutes(minutes: number): string {
+  const h24 = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  const period = h24 < 12 ? 'AM' : 'PM';
+  const h12 = h24 % 12 === 0 ? 12 : h24 % 12;
+  return `${h12}:${String(m).padStart(2, '0')} ${period}`;
+}
+
+/** A block as a one-line option, e.g. "Tuesdays · 3:00 PM–6:00 PM". */
+export function formatBlockOption(block: LessonBlock): string {
+  return `${WEEKDAY_LONG[block.dayOfWeek]}s · ${formatMinutes(
+    block.startMinutes,
+  )}–${formatMinutes(block.endMinutes)}`;
+}

--- a/libs/react/storybook-fixtures/src/index.ts
+++ b/libs/react/storybook-fixtures/src/index.ts
@@ -13,6 +13,7 @@ export * from './discounts';
 export * from './registrations';
 export * from './students';
 export * from './lessons';
+export * from './lesson-blocks';
 export * from './invoices';
 export * from './etsy-listings';
 export * from './teacher-payouts';

--- a/libs/react/storybook-fixtures/src/lesson-blocks.ts
+++ b/libs/react/storybook-fixtures/src/lesson-blocks.ts
@@ -1,0 +1,49 @@
+import type { LessonBlock } from '@maple/ts/domain';
+
+/**
+ * Mock lesson blocks for Storybook. Teacher ids line up with the instructor
+ * fixtures (instructor-001 / -002).
+ */
+
+const NOW = new Date('2026-05-01T10:00:00Z');
+
+/** instructor-001 · Sundays 10:00 AM–1:00 PM (fits the Sunday mock lessons). */
+export const mockLessonBlock: LessonBlock = {
+  id: 'block-001',
+  teacherId: 'instructor-001',
+  dayOfWeek: 0,
+  startMinutes: 10 * 60,
+  endMinutes: 13 * 60,
+  label: 'Sunday mornings',
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
+/** instructor-001 · Tuesdays 3:00–6:00 PM. */
+export const mockLessonBlockTuesday: LessonBlock = {
+  id: 'block-002',
+  teacherId: 'instructor-001',
+  dayOfWeek: 2,
+  startMinutes: 15 * 60,
+  endMinutes: 18 * 60,
+  label: 'Tuesday afternoons',
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
+/** instructor-002 · Thursdays 4:00–7:00 PM. */
+export const mockLessonBlockOtherTeacher: LessonBlock = {
+  id: 'block-003',
+  teacherId: 'instructor-002',
+  dayOfWeek: 4,
+  startMinutes: 16 * 60,
+  endMinutes: 19 * 60,
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
+export const mockLessonBlocks: LessonBlock[] = [
+  mockLessonBlock,
+  mockLessonBlockTuesday,
+  mockLessonBlockOtherTeacher,
+];

--- a/libs/ts/domain/src/lib/schedule-format.ts
+++ b/libs/ts/domain/src/lib/schedule-format.ts
@@ -16,8 +16,8 @@
 
 const DEFAULT_TIME_ZONE = 'America/New_York';
 
-const WEEKDAY_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-const WEEKDAY_LONG = [
+export const WEEKDAY_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+export const WEEKDAY_LONG = [
   'Sunday',
   'Monday',
   'Tuesday',


### PR DESCRIPTION
Closes #689. **PR 3 of 5** of the teacher weekly-availability epic (#683) — the UI that makes lesson scheduling compliant with the block-attribution enforcement shipped in #690.

## Why this is time-sensitive
#690 (enforcement) is merged to `main`. Until this ships, the admin lesson dialog can't attach a `blockId`, so **scheduling a lesson fails in prod**. Land this with #690's deploy.

## What's here
- **`useLessonBlocks`** hook (mirrors `useInstructors`, hydrates dates) → data + app hooks barrels.
- **`/lesson-blocks`** admin route (nav under *Music Lessons*, **admin-only**) with **`LessonBlockForm`** + **`LessonBlockList`** so Katie manages each teacher's weekly blocks (weekday + start/end via TimePicker, optional label; teacher locked on edit).
- **`ScheduleLessonDialog`**: required **block selector** (auto-selects when the teacher has exactly one), `blockId` on single + series payloads. Time-fit is a **non-blocking warning** — the server enforces fit, so we guide rather than trap (the dialog's default time is dynamic; mirrors the existing `RoomAvailability` warn pattern).
- **`EditLessonDialog`**: block selector with an explicit **"Unattributed"** option — grandfathered lessons stay editable and can be migrated onto a block.
- **`LessonList`**: **"Needs a block"** chip via `isLessonUnattributed`, wired on the student detail page (blocks passed to all three components).
- Shared `block-format` util; `WEEKDAY_SHORT/LONG` exported from `schedule-format`; `mockLessonBlock*` fixtures + stories (incl. a `LessonBlockForm` play test).

## Verification
- ✅ `maple-spruce` **typecheck** — covers all runtime component code the app imports (dialogs, list, page, hook).
- ✅ **build-storybook** — every story + the new fixtures typecheck and bundle.
- ✅ ESLint (0 errors), Prettier.
- Play-test execution runs in the Storybook UI job. (Chromatic UI checks are the free-tier snapshot checks that also fail on #688/#690 — not introduced here.)

Branched off `origin/main` (which has #690). Next: **#685** Week tab, then **#687** Openings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
