### PR TITLE
chore(functions): lower global maxInstances 3 → 1 to stop intermittent deploy quota failures

### DIFF
--- a/.claude/rules/firebase-functions.md
+++ b/.claude/rules/firebase-functions.md
@@ -67,19 +67,24 @@ Functions.endpoint
 ### Global `maxInstances` cap (every function, every codebase)
 
 `libs/firebase/functions/src/lib/global-runtime-options.ts` calls
-`setGlobalOptions({ maxInstances: GLOBAL_MAX_INSTANCES })` (currently **3**). Each of the
+`setGlobalOptions({ maxInstances: GLOBAL_MAX_INSTANCES })` (currently **1**). Each of the
 4 entry points imports it on its **first line**, before any `export { … } from` re-export.
 
 **Why:** unset `maxInstances` inherits the gen-2 backend default of **100**, and Cloud Run's
 "Total CPU allocation, per project per region" quota reserves `maxInstances × cpu` per revision.
-Rolling deploys count the new revision on top of the old, so the default-100 reservation tipped
-the region over quota and failed deploys with *"Quota exceeded for total allowable CPU per project
-per region."* This is a small-business admin portal — nothing needs to fan out to 100.
+A deploy stacks the new revision's reservation on top of the old (until GC minutes later), and
+firebase updates a whole codebase's functions concurrently — so a broad merge briefly reserves
+`2 × maxInstances × cpu` for every function in the codebase at once. At the default 100 this failed
+outright; even at 3 it intermittently tipped the region over on full-codebase redeploys (the
+maple-sync deploy, most functions + deploys last). **1** keeps both the idle baseline and that
+deploy-overlap spike minimal. `concurrency: 80` means one instance still serves 80 simultaneous
+requests, so 1 is ample for this portal. Raising the (already large) region quota was the
+alternative; capping lower is the more principled fix for a tiny app.
 
 **Ordering contract:** `onRequest`/`onDocumentWritten`/`onSchedule` bake global options into
 `__endpoint` at definition time, and re-exports evaluate before the entry-point body — so the
 side-effect import must stay first. Don't move it below the re-exports or convert it to a
-body-level call, or the cap silently reverts to 100. Per-function options (`withOptions({ maxInstances })`
+body-level call, or the cap silently reverts to the default 100. Per-function options (`withOptions({ maxInstances })`
 or a trigger's own option object) still override the global upward when a function truly needs it.
 
 ## Warmup

--- a/libs/firebase/functions/src/lib/global-runtime-options.ts
+++ b/libs/firebase/functions/src/lib/global-runtime-options.ts
@@ -17,7 +17,23 @@
  * This is an internal admin portal for a small business: a handful of
  * staff plus at most a few simultaneous public checkouts. Nothing here
  * ever needs to fan out to 100 instances. Capping `maxInstances` globally
- * collapses the reservation ~33x and gives deploys comfortable headroom.
+ * collapses the reservation and gives deploys comfortable headroom.
+ *
+ * WHY 1 (not 3)
+ * -------------
+ * The quota is hit *transiently during deploys*, not at idle. Updating a
+ * function makes a NEW revision whose reservation stacks on top of the OLD
+ * revision until Cloud Run garbage-collects it minutes later, and firebase
+ * updates every function in a codebase concurrently. A broad merge that
+ * redeploys all ~14 functions in a codebase at once therefore briefly
+ * reserves `2 x maxInstances x cpu` for the whole codebase — which at
+ * maxInstances=3 kept punching through the region's Total-CPU ceiling
+ * (repeated "Quota exceeded" failures on the maple-sync deploy, which has
+ * the most functions and deploys last). Dropping the cap to 1 shrinks both
+ * the idle baseline AND that deploy-overlap spike ~3x, so a full-codebase
+ * redeploy fits under the ceiling without raising the (already large) quota.
+ * `concurrency: 80` means a single instance still serves 80 simultaneous
+ * requests, so 1 is ample for this portal's real load.
  *
  * ORDERING CONTRACT (IMPORTANT)
  * -----------------------------
@@ -43,9 +59,10 @@ import { setGlobalOptions } from 'firebase-functions/v2';
 
 /**
  * Max concurrent instances any single function may scale to. With HTTP
- * functions running `concurrency: 80`, three instances already absorb 240
- * simultaneous requests — far beyond this portal's real load.
+ * functions running `concurrency: 80`, a single instance already absorbs 80
+ * simultaneous requests — far beyond this portal's real load. Kept at 1 so
+ * the deploy-time reservation overlap (see "WHY 1" above) stays small.
  */
-export const GLOBAL_MAX_INSTANCES = 3;
+export const GLOBAL_MAX_INSTANCES = 1;
 
 setGlobalOptions({ maxInstances: GLOBAL_MAX_INSTANCES });


### PR DESCRIPTION
## Problem

#704 capped `maxInstances` at 3 (from the default 100) and fixed the *wholesale* deploy failures — but an **intermittent** one remained. Broad merges kept failing `deploy_functions_dev` with:

> Container Healthcheck failed. **Quota exceeded for total allowable CPU per project per region.**

…always on **maple-sync** (most functions, deploys last). Small merges sail through; big ones (touching a shared lib / api-types, or a large feature) fail. That pattern is the tell.

## Root cause — deploy overlap, not idle load

At idle the region sits well under the quota. The quota is a **reservation ceiling** = `maxInstances × cpu` per revision. During a deploy:

- updating a function creates a **new** revision whose reservation **stacks on top of the old** one until Cloud Run GCs it minutes later, and
- firebase updates **all** of a codebase's functions **concurrently**.

So a full-codebase redeploy briefly reserves ~`2 × maxInstances × cpu` for every function at once. At `maxInstances=3` that transient spike intermittently punched through the region ceiling. Solo re-runs always passed because they redeploy only the few failed functions against a clean baseline — confirming it's overlap, not baseline.

## Fix

Lower the global cap **3 → 1**. This shrinks *both* the idle baseline **and** the deploy-overlap spike ~3×, so even a full-codebase redeploy fits — **without raising the (already large) region quota**, which felt like papering over a tiny app's footprint.

Safe for this portal:
- HTTP functions run `concurrency: 80`, so a single instance still serves 80 simultaneous requests — far beyond real load (a few staff + 1–4 simultaneous public checkouts).
- Triggers just process events serially (gentler on Webflow/Etsy rate limits).
- The only `minInstances` functions resolve to `min=1` in prod, which stays `≤ max=1` — no min>max conflict.

## Verification

- ✅ `nx run-many -t build` on all 4 codebases
- ✅ Loaded each built bundle: `__endpoint.maxInstances === 1` on HTTP functions **and** triggers, across all 4 codebases; `getPublicClass` shows `min ≤ max`
- ✅ `./tools/validate-function-tsconfigs.sh` + lint pass

The real proof is the next few merges going green without a sync re-run. If a worst-case redeploy ever still bites, the follow-ups are: sequential deploy batching in the workflow, or the free region-quota bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)