### PR TITLE
feat(my-day): Week tab — composite week with blocks, 30-min slots, color-coded toggles (#685)

### DIFF
--- a/apps/maple-spruce/src/app/(admin)/my-day/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/my-day/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   Alert,
   Box,
@@ -8,17 +8,39 @@ import {
   Collapse,
   Skeleton,
   Stack,
+  Tab,
+  Tabs,
   Typography,
 } from '@mui/material';
 import QrCode2Icon from '@mui/icons-material/QrCode2';
 import type { ManualInvoicePaymentSource } from '@maple/ts/domain';
-import { useMyDay } from '@maple/react/data';
+import { useMyDay, useMyWeek } from '@maple/react/data';
+import { MyWeek } from '@maple/react/lessons';
 import { MyDayLessonCard, VenmoQr } from '../../../components/my-day';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Local Sunday 00:00 for a given instant. */
+function startOfWeek(d: Date): Date {
+  const s = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  s.setDate(s.getDate() - s.getDay());
+  return s;
+}
+
+type MyDayTab = 'today' | 'week';
 
 export default function MyDayPage() {
   const { dayState, markRendered, recordPayment } = useMyDay();
   const [busy, setBusy] = useState(false);
   const [showQr, setShowQr] = useState(false);
+  const [tab, setTab] = useState<MyDayTab>('today');
+  const [weekOffset, setWeekOffset] = useState(0);
+
+  const weekStart = useMemo(
+    () => new Date(startOfWeek(new Date()).getTime() + weekOffset * 7 * DAY_MS),
+    [weekOffset],
+  );
+  const { weekState } = useMyWeek(weekStart);
 
   const handleMarkRendered = async (lessonId: string) => {
     setBusy(true);
@@ -31,7 +53,7 @@ export default function MyDayPage() {
 
   const handleRecordPayment = async (
     invoiceId: string,
-    source: ManualInvoicePaymentSource
+    source: ManualInvoicePaymentSource,
   ) => {
     setBusy(true);
     try {
@@ -69,69 +91,96 @@ export default function MyDayPage() {
           {today}
         </Typography>
       </Box>
-      <Typography color="text.secondary" sx={{ mb: 3 }}>
-        Your lessons today. Tap “Mark rendered” after a lesson (it invoices the
-        student automatically), and record a Venmo payment if they pay on the
-        spot.
-      </Typography>
 
-      {venmoHandle && (
-        <Box sx={{ mb: 3 }}>
-          <Button
-            variant="outlined"
-            startIcon={<QrCode2Icon />}
-            onClick={() => setShowQr((v) => !v)}
-          >
-            {showQr ? 'Hide' : 'Show'} Venmo QR
-          </Button>
-          <Collapse in={showQr}>
-            <Box sx={{ mt: 2 }}>
-              <VenmoQr handle={venmoHandle} />
-            </Box>
-          </Collapse>
-        </Box>
-      )}
+      <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}>
+        <Tabs
+          value={tab}
+          onChange={(_e, v: MyDayTab) => setTab(v)}
+          aria-label="My Day view"
+        >
+          <Tab value="today" label="Today" />
+          <Tab value="week" label="Week" />
+        </Tabs>
+      </Box>
 
-      {dayState.status === 'loading' && (
-        <Stack spacing={2}>
-          {[1, 2, 3].map((i) => (
-            <Skeleton key={i} variant="rectangular" height={110} />
-          ))}
-        </Stack>
-      )}
-
-      {dayState.status === 'error' && (
-        <Alert severity="error">Couldn’t load your day: {dayState.error}</Alert>
-      )}
-
-      {dayState.status === 'success' && dayState.data.unlinked && (
-        <Alert severity="info">
-          Your login isn’t linked to an instructor record yet, so there are no
-          lessons to show. Ask an admin to link your account on your instructor
-          profile.
-        </Alert>
-      )}
-
-      {dayState.status === 'success' &&
-        !dayState.data.unlinked &&
-        dayState.data.lessons.length === 0 && (
-          <Typography variant="body1" color="text.secondary">
-            No lessons scheduled today. 🎉
+      {tab === 'week' ? (
+        <MyWeek
+          weekState={weekState}
+          weekStart={weekStart}
+          onPrevWeek={() => setWeekOffset((o) => o - 1)}
+          onNextWeek={() => setWeekOffset((o) => o + 1)}
+          onThisWeek={() => setWeekOffset(0)}
+        />
+      ) : (
+        <>
+          <Typography color="text.secondary" sx={{ mb: 3 }}>
+            Your lessons today. Tap “Mark rendered” after a lesson (it invoices
+            the student automatically), and record a Venmo payment if they pay
+            on the spot.
           </Typography>
-        )}
 
-      {dayState.status === 'success' && dayState.data.lessons.length > 0 && (
-        <Stack spacing={2}>
-          {dayState.data.lessons.map((item) => (
-            <MyDayLessonCard
-              key={item.lesson.id}
-              item={item}
-              onMarkRendered={handleMarkRendered}
-              onRecordPayment={handleRecordPayment}
-              busy={busy}
-            />
-          ))}
-        </Stack>
+          {venmoHandle && (
+            <Box sx={{ mb: 3 }}>
+              <Button
+                variant="outlined"
+                startIcon={<QrCode2Icon />}
+                onClick={() => setShowQr((v) => !v)}
+              >
+                {showQr ? 'Hide' : 'Show'} Venmo QR
+              </Button>
+              <Collapse in={showQr}>
+                <Box sx={{ mt: 2 }}>
+                  <VenmoQr handle={venmoHandle} />
+                </Box>
+              </Collapse>
+            </Box>
+          )}
+
+          {dayState.status === 'loading' && (
+            <Stack spacing={2}>
+              {[1, 2, 3].map((i) => (
+                <Skeleton key={i} variant="rectangular" height={110} />
+              ))}
+            </Stack>
+          )}
+
+          {dayState.status === 'error' && (
+            <Alert severity="error">
+              Couldn’t load your day: {dayState.error}
+            </Alert>
+          )}
+
+          {dayState.status === 'success' && dayState.data.unlinked && (
+            <Alert severity="info">
+              Your login isn’t linked to an instructor record yet, so there are
+              no lessons to show. Ask an admin to link your account on your
+              instructor profile.
+            </Alert>
+          )}
+
+          {dayState.status === 'success' &&
+            !dayState.data.unlinked &&
+            dayState.data.lessons.length === 0 && (
+              <Typography variant="body1" color="text.secondary">
+                No lessons scheduled today. 🎉
+              </Typography>
+            )}
+
+          {dayState.status === 'success' &&
+            dayState.data.lessons.length > 0 && (
+              <Stack spacing={2}>
+                {dayState.data.lessons.map((item) => (
+                  <MyDayLessonCard
+                    key={item.lesson.id}
+                    item={item}
+                    onMarkRendered={handleMarkRendered}
+                    onRecordPayment={handleRecordPayment}
+                    busy={busy}
+                  />
+                ))}
+              </Stack>
+            )}
+        </>
       )}
     </>
   );

--- a/libs/firebase/maple-functions/get-my-week/src/lib/get-my-week.spec.ts
+++ b/libs/firebase/maple-functions/get-my-week/src/lib/get-my-week.spec.ts
@@ -4,6 +4,8 @@ import type { CalendarEvent } from '@maple/ts/domain';
 const mocks = vi.hoisted(() => ({
   instructorIdForUser: vi.fn(),
   findByStartInRange: vi.fn(),
+  findBlocks: vi.fn(),
+  findLessons: vi.fn(),
 }));
 
 vi.mock('@maple/firebase/functions', () => ({
@@ -16,6 +18,8 @@ vi.mock('@maple/firebase/functions', () => ({
 
 vi.mock('@maple/firebase/database', () => ({
   CalendarEventRepository: { findByStartInRange: mocks.findByStartInRange },
+  LessonBlockRepository: { findAll: mocks.findBlocks },
+  LessonRepository: { findAll: mocks.findLessons },
 }));
 
 import { getMyWeek, buildCommitments, startOfWeek } from './get-my-week';
@@ -29,7 +33,9 @@ type Handler = (
     ownership: string;
     cadence: string;
     category: string;
+    unattributed: boolean;
   }>;
+  blocks: Array<Record<string, unknown>>;
   unlinked: boolean;
 }>;
 const handler = getMyWeek as unknown as Handler;
@@ -170,14 +176,69 @@ describe('getMyWeek handler', () => {
     vi.clearAllMocks();
     mocks.instructorIdForUser.mockResolvedValue('instr-katie');
     mocks.findByStartInRange.mockResolvedValue([]);
+    mocks.findBlocks.mockResolvedValue([]);
+    mocks.findLessons.mockResolvedValue([]);
   });
 
-  it('returns unlinked with no commitments when the caller has no instructor', async () => {
+  it('returns unlinked with no commitments or blocks when the caller has no instructor', async () => {
     mocks.instructorIdForUser.mockResolvedValue(undefined);
     const res = await handler({}, { uid: 'admin-uid' });
     expect(res.unlinked).toBe(true);
     expect(res.commitments).toEqual([]);
+    expect(res.blocks).toEqual([]);
     expect(mocks.findByStartInRange).not.toHaveBeenCalled();
+  });
+
+  it('returns the teacher’s serialized blocks and flags unattributed lessons', async () => {
+    const block = {
+      id: 'blk-1',
+      teacherId: 'instr-katie',
+      dayOfWeek: 2,
+      startMinutes: 900,
+      endMinutes: 1080,
+      label: 'Tue',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    mocks.findBlocks.mockResolvedValue([block]);
+    // A lesson with no blockId -> unattributed.
+    mocks.findLessons.mockResolvedValue([
+      {
+        id: 'les-x',
+        teacherId: 'instr-katie',
+        scheduledAt: new Date('2026-07-21T20:00:00Z'),
+        durationMinutes: 30,
+        blockId: null,
+      },
+    ]);
+    mocks.findByStartInRange.mockResolvedValue([
+      {
+        id: 'lesson-les-x',
+        title: 'Music Lesson',
+        type: 'lesson',
+        startDateTime: new Date('2026-07-21T20:00:00Z'),
+        endDateTime: new Date('2026-07-21T20:30:00Z'),
+        room: 'spruce',
+        sourceRef: 'lessons/les-x',
+        ownerInstructorId: 'instr-katie',
+      },
+    ]);
+
+    const res = await handler(
+      { from: '2026-07-19T00:00:00', to: '2026-07-26T00:00:00' },
+      { uid: 'katie-uid' },
+    );
+    expect(res.blocks).toEqual([
+      {
+        id: 'blk-1',
+        teacherId: 'instr-katie',
+        dayOfWeek: 2,
+        startMinutes: 900,
+        endMinutes: 1080,
+        label: 'Tue',
+      },
+    ]);
+    expect(res.commitments[0].unattributed).toBe(true);
   });
 
   it('queries a lookback window ending at the week end', async () => {

--- a/libs/firebase/maple-functions/get-my-week/src/lib/get-my-week.ts
+++ b/libs/firebase/maple-functions/get-my-week/src/lib/get-my-week.ts
@@ -23,11 +23,17 @@ import {
   createRoleFunction,
   instructorIdForUser,
 } from '@maple/firebase/functions';
-import { CalendarEventRepository } from '@maple/firebase/database';
-import type { CalendarEvent } from '@maple/ts/domain';
+import {
+  CalendarEventRepository,
+  LessonBlockRepository,
+  LessonRepository,
+} from '@maple/firebase/database';
+import { isLessonUnattributed } from '@maple/ts/domain';
+import type { CalendarEvent, LessonBlock } from '@maple/ts/domain';
 import type {
   GetMyWeekRequest,
   GetMyWeekResponse,
+  MyWeekBlock,
   MyWeekCommitment,
 } from '@maple/ts/firebase/api-types';
 
@@ -70,6 +76,8 @@ export function buildCommitments(
   to: Date,
   lookbackStart: Date,
   myInstructorId: string,
+  /** sourceRefs ("lessons/{id}") of the caller's lessons that need a block. */
+  unattributedRefs: Set<string> = new Set(),
 ): MyWeekCommitment[] {
   // key -> set of distinct week indices it occurred in
   const weeksByKey = new Map<string, Set<number>>();
@@ -101,8 +109,24 @@ export function buildCommitments(
         room: e.room ?? null,
         ownership: e.ownerInstructorId === myInstructorId ? 'mine' : 'shared',
         cadence: (weeks?.size ?? 0) >= 2 ? 'recurring' : 'one-off',
+        unattributed:
+          e.type === 'lesson' &&
+          !!e.sourceRef &&
+          unattributedRefs.has(e.sourceRef),
       };
     });
+}
+
+/** Serialize a block for the wire (drop Date fields). */
+function toMyWeekBlock(block: LessonBlock): MyWeekBlock {
+  return {
+    id: block.id,
+    teacherId: block.teacherId,
+    dayOfWeek: block.dayOfWeek,
+    startMinutes: block.startMinutes,
+    endMinutes: block.endMinutes,
+    label: block.label,
+  };
 }
 
 export const getMyWeek = createRoleFunction<
@@ -113,7 +137,7 @@ export const getMyWeek = createRoleFunction<
     const myInstructorId = await instructorIdForUser(context.uid);
     if (!myInstructorId) {
       // Not linked to any instructor (e.g. a pure admin) — no "mine" to anchor.
-      return { commitments: [], unlinked: true };
+      return { commitments: [], blocks: [], unlinked: true };
     }
 
     const now = new Date();
@@ -125,11 +149,19 @@ export const getMyWeek = createRoleFunction<
       from.getTime() - LOOKBACK_WEEKS * 7 * DAY_MS,
     );
 
-    // One range query over [lookbackStart, to): the target week to display plus
-    // the lookback needed to classify recurrence. Partition + classify in memory.
-    const events = await CalendarEventRepository.findByStartInRange(
-      lookbackStart,
-      to,
+    // One range query over [lookbackStart, to) for recurrence classification,
+    // plus the teacher's blocks and this week's lessons to flag unattributed
+    // ones (#689).
+    const [events, blocks, lessons] = await Promise.all([
+      CalendarEventRepository.findByStartInRange(lookbackStart, to),
+      LessonBlockRepository.findAll({ teacherId: myInstructorId }),
+      LessonRepository.findAll({ teacherId: myInstructorId, from, to }),
+    ]);
+
+    const unattributedRefs = new Set(
+      lessons
+        .filter((lesson) => isLessonUnattributed(lesson, blocks))
+        .map((lesson) => `lessons/${lesson.id}`),
     );
 
     const commitments = buildCommitments(
@@ -138,9 +170,14 @@ export const getMyWeek = createRoleFunction<
       to,
       lookbackStart,
       myInstructorId,
+      unattributedRefs,
     );
 
-    return { commitments, unlinked: false };
+    return {
+      commitments,
+      blocks: blocks.map(toMyWeekBlock),
+      unlinked: false,
+    };
   },
   [Role.Admin, Role.LessonTeacher],
 );

--- a/libs/react/data/src/index.ts
+++ b/libs/react/data/src/index.ts
@@ -31,6 +31,7 @@ export {
   useLessonBlocks,
   type UseLessonBlocksOptions,
 } from './lib/useLessonBlocks';
+export { useMyWeek } from './lib/useMyWeek';
 export { useInvoices, type UseInvoicesOptions } from './lib/useInvoices';
 export {
   useTeacherPayouts,

--- a/libs/react/data/src/lib/useMyWeek.ts
+++ b/libs/react/data/src/lib/useMyWeek.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { httpsCallable } from 'firebase/functions';
+import { getMapleFunctions } from '@maple/ts/firebase/firebase-config';
+import type { RequestState } from '@maple/ts/domain';
+import type {
+  GetMyWeekRequest,
+  GetMyWeekResponse,
+} from '@maple/ts/firebase/api-types';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Hook for the teacher "My Week" tab (#685): the signed-in teacher's
+ * commitments + blocks for the week starting at `weekStart` (a local Sunday
+ * 00:00). Refetches when the week changes.
+ */
+export function useMyWeek(weekStart: Date) {
+  const [weekState, setWeekState] = useState<RequestState<GetMyWeekResponse>>({
+    status: 'idle',
+  });
+
+  const startMs = weekStart.getTime();
+
+  const fetchWeek = useCallback(async () => {
+    setWeekState({ status: 'loading' });
+    try {
+      const from = new Date(startMs).toISOString();
+      const to = new Date(startMs + 7 * DAY_MS).toISOString();
+      const fn = httpsCallable<GetMyWeekRequest, GetMyWeekResponse>(
+        getMapleFunctions(),
+        'getMyWeek',
+      );
+      const result = await fn({ from, to });
+      setWeekState({ status: 'success', data: result.data });
+    } catch (error) {
+      console.error('Failed to fetch My Week:', error);
+      setWeekState({
+        status: 'error',
+        error: error instanceof Error ? error.message : 'Failed to fetch',
+      });
+    }
+  }, [startMs]);
+
+  useEffect(() => {
+    fetchWeek();
+  }, [fetchWeek]);
+
+  return { weekState, fetchWeek };
+}

--- a/libs/react/lessons/src/index.ts
+++ b/libs/react/lessons/src/index.ts
@@ -9,6 +9,7 @@ export {
   LessonBlockList,
   type LessonBlockListProps,
 } from './lib/LessonBlockList';
+export { MyWeek, type MyWeekProps } from './lib/MyWeek';
 export { HopeRatesTable } from './lib/HopeRatesTable';
 export { HopeScholarshipBanner } from './lib/HopeScholarshipBanner';
 export { generateWeeklyDates, type SeriesCadence } from './lib/series-dates';

--- a/libs/react/lessons/src/lib/MyWeek.stories.tsx
+++ b/libs/react/lessons/src/lib/MyWeek.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn, expect, userEvent, waitFor, within } from 'storybook/test';
+import { MyWeek } from './MyWeek';
+import {
+  mockMyWeekResponse,
+  mockMyWeekStart,
+} from '@maple/react/storybook-fixtures';
+
+const meta = {
+  component: MyWeek,
+  title: 'Lessons/MyWeek',
+  parameters: { layout: 'fullscreen' },
+  // The category toggle persists to localStorage; clear it so stories don't
+  // bleed hidden-category state into each other.
+  beforeEach: () => {
+    localStorage.removeItem('myWeek.hiddenCategories');
+  },
+  args: {
+    weekStart: mockMyWeekStart,
+    onPrevWeek: fn(),
+    onNextWeek: fn(),
+    onThisWeek: fn(),
+  },
+} satisfies Meta<typeof MyWeek>;
+
+export default meta;
+type Story = StoryObj<typeof MyWeek>;
+
+export const Populated: Story = {
+  args: {
+    weekState: { status: 'success', data: mockMyWeekResponse },
+  },
+};
+
+export const Loading: Story = {
+  args: { weekState: { status: 'loading' } },
+};
+
+export const ErrorState: Story = {
+  args: { weekState: { status: 'error', error: 'Network blip.' } },
+};
+
+export const Unlinked: Story = {
+  args: {
+    weekState: {
+      status: 'success',
+      data: { commitments: [], blocks: [], unlinked: true },
+    },
+  },
+};
+
+export const StepsWeeks: Story = {
+  args: { weekState: { status: 'success', data: mockMyWeekResponse } },
+  play: async ({ args, canvas }) => {
+    await userEvent.click(canvas.getByRole('button', { name: /next week/i }));
+    await expect(args.onNextWeek).toHaveBeenCalledTimes(1);
+    await userEvent.click(
+      canvas.getByRole('button', { name: /previous week/i }),
+    );
+    await expect(args.onPrevWeek).toHaveBeenCalledTimes(1);
+  },
+};
+
+export const TogglesCategoryOff: Story = {
+  args: { weekState: { status: 'success', data: mockMyWeekResponse } },
+  play: async ({ canvas }) => {
+    const body = within(document.body);
+    // The Friday jam is visible initially.
+    await waitFor(() =>
+      expect(body.getByText(/Friday Jam/)).toBeInTheDocument(),
+    );
+    // Toggle the "Jam Session" category chip off.
+    await userEvent.click(canvas.getByRole('button', { name: /jam session/i }));
+    await waitFor(() =>
+      expect(body.queryByText(/Friday Jam/)).not.toBeInTheDocument(),
+    );
+  },
+};

--- a/libs/react/lessons/src/lib/MyWeek.tsx
+++ b/libs/react/lessons/src/lib/MyWeek.tsx
@@ -1,0 +1,388 @@
+'use client';
+
+/**
+ * MyWeek — the teacher's week at a glance (#685).
+ *
+ * Seven day columns (Sun–Sat). A teacher's weekly blocks render as containers
+ * with 30-minute slots (filled by a lesson or "open") — the view Katie uses to
+ * see where a new student fits. Commitments outside a block (classes, jams,
+ * store hours, Music Together, out-of-block/unattributed lessons) list under
+ * "Also this day". Categories are color-coded and can be toggled off; the
+ * toggle state is sticky per browser. Presentational — the page owns the data
+ * (`useMyWeek`) and week navigation.
+ */
+import { useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Chip,
+  IconButton,
+  Skeleton,
+  Stack,
+  Typography,
+} from '@mui/material';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import TodayIcon from '@mui/icons-material/Today';
+import Button from '@mui/material/Button';
+import type { CalendarEventType, RequestState } from '@maple/ts/domain';
+import {
+  DEFAULT_LESSON_TIME_ZONE,
+  WEEKDAY_LONG,
+  getCalendarEventTypeLabel,
+  minutesOfDayInZone,
+  weekdayIndexInZone,
+} from '@maple/ts/domain';
+import type {
+  GetMyWeekResponse,
+  MyWeekBlock,
+  MyWeekCommitment,
+} from '@maple/ts/firebase/api-types';
+import { formatMinutes } from './block-format';
+
+export interface MyWeekProps {
+  weekState: RequestState<GetMyWeekResponse>;
+  /** Local Sunday 00:00 of the displayed week. */
+  weekStart: Date;
+  onPrevWeek: () => void;
+  onNextWeek: () => void;
+  onThisWeek: () => void;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const SLOT_MINUTES = 30;
+const TZ = DEFAULT_LESSON_TIME_ZONE;
+const CATEGORIES: CalendarEventType[] = [
+  'lesson',
+  'class',
+  'jam',
+  'event',
+  'musictogether',
+  'hours',
+];
+const STORAGE_KEY = 'myWeek.hiddenCategories';
+
+/** Category → MUI chip color (mirrors the RoomScheduleAgenda convention). */
+const CATEGORY_COLOR: Record<
+  CalendarEventType,
+  'default' | 'primary' | 'secondary' | 'info' | 'success'
+> = {
+  lesson: 'info',
+  class: 'primary',
+  jam: 'success',
+  event: 'secondary',
+  musictogether: 'secondary',
+  hours: 'default',
+};
+
+function startMinutesOf(iso: string): number {
+  return minutesOfDayInZone(new Date(iso), TZ);
+}
+function weekdayOf(iso: string): number {
+  return weekdayIndexInZone(new Date(iso), TZ);
+}
+
+function formatWeekRange(weekStart: Date): string {
+  const end = new Date(weekStart.getTime() + 6 * DAY_MS);
+  const fmt = (d: Date) =>
+    d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  return `${fmt(weekStart)} – ${fmt(end)}`;
+}
+
+function CommitmentChip({ c }: { c: MyWeekCommitment }) {
+  const label = `${formatMinutes(startMinutesOf(c.startDateTime))} ${
+    c.unattributed ? '⚠ ' : ''
+  }${c.title}`;
+  return (
+    <Chip
+      size="small"
+      label={label}
+      color={c.unattributed ? 'warning' : CATEGORY_COLOR[c.category]}
+      // Shared store-wide events read as context (outlined); the teacher's own
+      // as solid. One-offs are faded so standing commitments stand out.
+      variant={c.ownership === 'shared' ? 'outlined' : 'filled'}
+      sx={{ opacity: c.cadence === 'one-off' ? 0.6 : 1, maxWidth: '100%' }}
+    />
+  );
+}
+
+export function MyWeek({
+  weekState,
+  weekStart,
+  onPrevWeek,
+  onNextWeek,
+  onThisWeek,
+}: MyWeekProps) {
+  const [hidden, setHidden] = useState<Set<CalendarEventType>>(new Set());
+
+  // Sticky toggle state (per browser). Read after mount to avoid SSR mismatch.
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) setHidden(new Set(JSON.parse(raw) as CalendarEventType[]));
+    } catch {
+      /* ignore malformed storage */
+    }
+  }, []);
+
+  const toggleCategory = (cat: CalendarEventType) => {
+    setHidden((prev) => {
+      const next = new Set(prev);
+      if (next.has(cat)) next.delete(cat);
+      else next.add(cat);
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify([...next]));
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  };
+
+  const header = (
+    <Stack
+      direction="row"
+      spacing={1}
+      alignItems="center"
+      flexWrap="wrap"
+      sx={{ mb: 2 }}
+    >
+      <IconButton aria-label="Previous week" onClick={onPrevWeek} size="small">
+        <ChevronLeftIcon />
+      </IconButton>
+      <Button
+        size="small"
+        startIcon={<TodayIcon />}
+        onClick={onThisWeek}
+        variant="outlined"
+      >
+        This week
+      </Button>
+      <IconButton aria-label="Next week" onClick={onNextWeek} size="small">
+        <ChevronRightIcon />
+      </IconButton>
+      <Typography variant="subtitle1" sx={{ ml: 1, fontWeight: 600 }}>
+        {formatWeekRange(weekStart)}
+      </Typography>
+    </Stack>
+  );
+
+  const toggles = (
+    <Stack direction="row" spacing={1} flexWrap="wrap" sx={{ mb: 2, gap: 1 }}>
+      {CATEGORIES.map((cat) => {
+        const on = !hidden.has(cat);
+        return (
+          <Chip
+            key={cat}
+            label={getCalendarEventTypeLabel(cat)}
+            size="small"
+            color={on ? CATEGORY_COLOR[cat] : 'default'}
+            variant={on ? 'filled' : 'outlined'}
+            onClick={() => toggleCategory(cat)}
+            aria-pressed={on}
+            sx={{ opacity: on ? 1 : 0.5 }}
+          />
+        );
+      })}
+    </Stack>
+  );
+
+  if (weekState.status === 'loading') {
+    return (
+      <Box>
+        {header}
+        <Skeleton variant="rectangular" height={320} />
+      </Box>
+    );
+  }
+  if (weekState.status === 'error') {
+    return (
+      <Box>
+        {header}
+        <Alert severity="error">
+          Couldn’t load your week: {weekState.error}
+        </Alert>
+      </Box>
+    );
+  }
+  if (weekState.status === 'idle') return header;
+
+  if (weekState.data.unlinked) {
+    return (
+      <Box>
+        {header}
+        <Alert severity="info">
+          Your login isn’t linked to an instructor record yet, so there’s no
+          schedule to show. Ask an admin to link your account on your instructor
+          profile.
+        </Alert>
+      </Box>
+    );
+  }
+
+  const { commitments, blocks } = weekState.data;
+  const visible = commitments.filter((c) => !hidden.has(c.category));
+
+  return (
+    <Box>
+      {header}
+      {toggles}
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: {
+            xs: '1fr',
+            sm: 'repeat(2, 1fr)',
+            md: 'repeat(7, minmax(0, 1fr))',
+          },
+          gap: 1,
+        }}
+      >
+        {WEEKDAY_LONG.map((dayName, dayIndex) => (
+          <DayColumn
+            key={dayName}
+            dayName={dayName}
+            date={new Date(weekStart.getTime() + dayIndex * DAY_MS)}
+            blocks={blocks.filter((b) => b.dayOfWeek === dayIndex)}
+            commitments={visible.filter(
+              (c) => weekdayOf(c.startDateTime) === dayIndex,
+            )}
+            lessonHidden={hidden.has('lesson')}
+          />
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+function DayColumn({
+  dayName,
+  date,
+  blocks,
+  commitments,
+  lessonHidden,
+}: {
+  dayName: string;
+  date: Date;
+  blocks: MyWeekBlock[];
+  commitments: MyWeekCommitment[];
+  lessonHidden: boolean;
+}) {
+  // Lessons that sit inside a block are rendered in that block's slots; every
+  // other commitment (classes, shared events, out-of-block lessons) goes to
+  // "Also this day".
+  const lessons = commitments.filter((c) => c.category === 'lesson');
+  const inSlot = (block: MyWeekBlock, slotStart: number) =>
+    lessons.find((c) => {
+      const m = startMinutesOf(c.startDateTime);
+      return m >= slotStart && m < slotStart + SLOT_MINUTES;
+    });
+
+  const placedIds = new Set<string>();
+  const blockEls = blocks.map((block) => {
+    const slots: React.ReactNode[] = [];
+    for (let m = block.startMinutes; m < block.endMinutes; m += SLOT_MINUTES) {
+      const lesson = inSlot(block, m);
+      if (lesson) placedIds.add(lesson.id);
+      slots.push(
+        <Box
+          key={m}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.5,
+            px: 0.5,
+            py: 0.25,
+            borderTop: '1px dashed',
+            borderColor: 'divider',
+            minHeight: 28,
+          }}
+        >
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ width: 56, flexShrink: 0 }}
+          >
+            {formatMinutes(m)}
+          </Typography>
+          {lesson ? (
+            <CommitmentChip c={lesson} />
+          ) : (
+            <Typography variant="caption" color="text.disabled">
+              {lessonHidden ? '—' : 'open'}
+            </Typography>
+          )}
+        </Box>,
+      );
+    }
+    return (
+      <Box
+        key={block.id}
+        sx={{
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: 1,
+          mb: 1,
+        }}
+      >
+        <Typography
+          variant="caption"
+          sx={{ display: 'block', px: 0.5, py: 0.25, fontWeight: 600 }}
+        >
+          {formatMinutes(block.startMinutes)}–{formatMinutes(block.endMinutes)}
+          {block.label ? ` · ${block.label}` : ''}
+        </Typography>
+        {slots}
+      </Box>
+    );
+  });
+
+  const alsoEls = commitments.filter(
+    (c) => !(c.category === 'lesson' && placedIds.has(c.id)),
+  );
+
+  return (
+    <Box
+      sx={{
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 1,
+        p: 0.5,
+        minHeight: 80,
+      }}
+    >
+      <Typography variant="overline" sx={{ display: 'block' }}>
+        {dayName.slice(0, 3)}{' '}
+        <Typography component="span" variant="caption" color="text.secondary">
+          {date.toLocaleDateString(undefined, {
+            month: 'numeric',
+            day: 'numeric',
+          })}
+        </Typography>
+      </Typography>
+
+      {blockEls}
+
+      {alsoEls.length > 0 && (
+        <Box sx={{ mt: blocks.length > 0 ? 1 : 0 }}>
+          {blocks.length > 0 && (
+            <Typography variant="caption" color="text.secondary">
+              Also
+            </Typography>
+          )}
+          <Stack spacing={0.5} sx={{ mt: 0.25 }}>
+            {alsoEls.map((c) => (
+              <CommitmentChip key={c.id} c={c} />
+            ))}
+          </Stack>
+        </Box>
+      )}
+
+      {blocks.length === 0 && alsoEls.length === 0 && (
+        <Typography variant="caption" color="text.disabled">
+          —
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/libs/react/storybook-fixtures/src/index.ts
+++ b/libs/react/storybook-fixtures/src/index.ts
@@ -14,6 +14,7 @@ export * from './registrations';
 export * from './students';
 export * from './lessons';
 export * from './lesson-blocks';
+export * from './my-week';
 export * from './invoices';
 export * from './etsy-listings';
 export * from './teacher-payouts';

--- a/libs/react/storybook-fixtures/src/my-week.ts
+++ b/libs/react/storybook-fixtures/src/my-week.ts
@@ -1,0 +1,83 @@
+import type { GetMyWeekResponse } from '@maple/ts/firebase/api-types';
+
+/**
+ * Mock getMyWeek response for the My Week tab. The week starts Sun 2026-07-19;
+ * times are ISO-UTC that map to the intended ET wall-clock (EDT = UTC-4).
+ */
+export const mockMyWeekResponse: GetMyWeekResponse = {
+  unlinked: false,
+  blocks: [
+    {
+      id: 'blk-tue',
+      teacherId: 'instructor-001',
+      dayOfWeek: 2, // Tuesday
+      startMinutes: 15 * 60, // 3:00 PM
+      endMinutes: 18 * 60, // 6:00 PM
+      label: 'Tue afternoons',
+    },
+  ],
+  commitments: [
+    // Two lessons inside the Tuesday block.
+    {
+      id: 'lesson-1',
+      title: 'Music Lesson',
+      category: 'lesson',
+      startDateTime: '2026-07-21T19:00:00Z', // Tue 3:00 PM ET
+      endDateTime: '2026-07-21T19:30:00Z',
+      room: 'spruce',
+      ownership: 'mine',
+      cadence: 'recurring',
+      unattributed: false,
+    },
+    {
+      id: 'lesson-2',
+      title: 'Music Lesson',
+      category: 'lesson',
+      startDateTime: '2026-07-21T19:30:00Z', // Tue 3:30 PM ET
+      endDateTime: '2026-07-21T20:00:00Z',
+      room: 'spruce',
+      ownership: 'mine',
+      cadence: 'one-off',
+      unattributed: false,
+    },
+    // A lesson with no block on Wednesday → flagged.
+    {
+      id: 'lesson-3',
+      title: 'Music Lesson',
+      category: 'lesson',
+      startDateTime: '2026-07-22T20:00:00Z', // Wed 4:00 PM ET
+      endDateTime: '2026-07-22T20:30:00Z',
+      room: 'spruce',
+      ownership: 'mine',
+      cadence: 'one-off',
+      unattributed: true,
+    },
+    // A class the teacher teaches (Thursday).
+    {
+      id: 'class-1',
+      title: 'Watercolor Basics',
+      category: 'class',
+      startDateTime: '2026-07-23T14:00:00Z', // Thu 10:00 AM ET
+      endDateTime: '2026-07-23T15:30:00Z',
+      room: 'spruce',
+      ownership: 'mine',
+      cadence: 'recurring',
+      unattributed: false,
+    },
+    // A shared store-wide jam (Friday).
+    {
+      id: 'jam-1',
+      title: 'Friday Jam',
+      category: 'jam',
+      startDateTime: '2026-07-24T22:00:00Z', // Fri 6:00 PM ET
+      endDateTime: '2026-07-25T00:00:00Z',
+      room: 'spruce',
+      ownership: 'shared',
+      cadence: 'recurring',
+      unattributed: false,
+    },
+  ],
+};
+
+/** Week start (local Sunday) matching mockMyWeekResponse. */
+export const mockMyWeekStart = new Date(2026, 6, 19);

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -356,6 +356,7 @@ export type {
 export type {
   MyWeekOwnership,
   MyWeekCadence,
+  MyWeekBlock,
   MyWeekCommitment,
   GetMyWeekRequest,
   GetMyWeekResponse,

--- a/libs/ts/firebase/api-types/src/lib/my-week.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/my-week.types.ts
@@ -9,7 +9,17 @@
  * parses them) — unlike Date fields, ISO survives JSON serialization
  * unambiguously.
  */
-import type { CalendarEventType, Room } from '@maple/ts/domain';
+import type { CalendarEventType, LessonBlock, Room } from '@maple/ts/domain';
+
+/**
+ * A lesson block serialized for the wire — the fit-relevant fields only.
+ * LessonBlock's Date fields (createdAt/updatedAt) don't survive JSON cleanly
+ * and aren't needed to render or slot the week.
+ */
+export type MyWeekBlock = Pick<
+  LessonBlock,
+  'id' | 'teacherId' | 'dayOfWeek' | 'startMinutes' | 'endMinutes' | 'label'
+>;
 
 /** Whether a commitment belongs to the caller or is a shared store-wide event. */
 export type MyWeekOwnership = 'mine' | 'shared';
@@ -37,6 +47,12 @@ export interface MyWeekCommitment {
   room: Room | null;
   ownership: MyWeekOwnership;
   cadence: MyWeekCadence;
+  /**
+   * True only for `mine` lesson commitments that aren't attributed to a
+   * fitting block (#689) — the "needs a block" flag. Always false for
+   * classes, shared events, and block-attributed lessons.
+   */
+  unattributed: boolean;
 }
 
 export interface GetMyWeekRequest {
@@ -50,6 +66,8 @@ export interface GetMyWeekRequest {
 
 export interface GetMyWeekResponse {
   commitments: MyWeekCommitment[];
+  /** The caller's own weekly blocks — the containers the week is laid out in. */
+  blocks: MyWeekBlock[];
   /** True when the caller isn't linked to any instructor record (no "mine"). */
   unlinked: boolean;
 }


### PR DESCRIPTION
Closes #685. **PR 4 of 5** of the teacher weekly-availability epic (#683) — the Week tab, the surface that lets Katie see her whole week at a glance.

## Backend
- **`getMyWeek` extended**: response now includes the teacher's **`blocks`** (serialized to fit-relevant fields — Date fields don't survive JSON) and a per-commitment **`unattributed`** flag, computed by joining the week's lessons + blocks with `isLessonUnattributed` (#689). No new Firestore index (reuses `teacherId + scheduledAt`, already required by getMyDay).

## Frontend
- **`useMyWeek(weekStart)`** data hook (mirrors `useMyDay`; refetches on week change).
- **My Day is now tabbed**: **Today** (unchanged) + **Week**.
- **`MyWeek`** component:
  - 7 day columns (Sun–Sat, responsive → 2-up / 1-up on smaller screens).
  - The teacher's **blocks render as containers with 30-minute slots** (each filled by a lesson or shown "open") — the core thing Katie asked for.
  - Everything else (classes, jams, store hours, Music Together, out-of-block/unattributed lessons) lists under **"Also"** per day.
  - **Color-coded** by category (MUI palette convention, matching `RoomScheduleAgenda`); `mine`=solid / `shared`=outlined; one-offs faded; **unattributed** = warning + ⚠.
  - **Sticky category toggles** (localStorage) and a **prev / this / next** week stepper.

## Verification (all local)
- ✅ App typecheck · ✅ all 4 function codebases build · ✅ Firestore index analyzer (no new index) · ✅ 9 backend unit tests · ✅ **full Storybook suite — 440 play tests** (incl. new MyWeek toggle + week-step interaction tests) · ✅ ESLint + Prettier.

Purely additive (new tab + additive response fields) — low risk. Branched off `origin/main`. Last in the stack: **#687** Openings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
