### PR TITLE
chore(music-together): rebrand display name to "Music Together Maple & Spruce"

### DIFF
--- a/libs/firebase/maple-functions/calendar-music-together-feed/src/lib/calendar-music-together-feed.spec.ts
+++ b/libs/firebase/maple-functions/calendar-music-together-feed/src/lib/calendar-music-together-feed.spec.ts
@@ -62,7 +62,7 @@ describe('calendarMusicTogetherFeed', () => {
     expect(mocks.findPublicByType).toHaveBeenCalledWith('musictogether');
     expect(mocks.generateIcsFeed).toHaveBeenCalledWith(
       [{ id: 'e1' }],
-      'Music Together with Maple & Spruce'
+      'Music Together Maple & Spruce'
     );
     expect(res.statusCode).toBe(200);
     expect(res.body).toBe('BEGIN:VCALENDAR');

--- a/libs/firebase/maple-functions/calendar-music-together-feed/src/lib/calendar-music-together-feed.ts
+++ b/libs/firebase/maple-functions/calendar-music-together-feed/src/lib/calendar-music-together-feed.ts
@@ -25,7 +25,7 @@ export const calendarMusicTogetherFeed = onRequest(
     try {
       const events =
         await CalendarEventRepository.findPublicByType('musictogether');
-      const ics = generateIcsFeed(events, 'Music Together with Maple & Spruce');
+      const ics = generateIcsFeed(events, 'Music Together Maple & Spruce');
 
       Object.entries(ICS_FEED_HEADERS).forEach(([key, value]) => {
         response.setHeader(key, value);

--- a/tools/seed-email-templates.ts
+++ b/tools/seed-email-templates.ts
@@ -693,7 +693,7 @@ const musicTogetherConfirmationHtml = `<!DOCTYPE html>
 <body>
 <div class="wrapper">
   <div class="header">
-    <h1>Music Together with Maple &amp; Spruce</h1>
+    <h1>Music Together Maple &amp; Spruce</h1>
   </div>
   <div class="content">
     <h2>You're registered!</h2>
@@ -749,7 +749,7 @@ const musicTogetherConfirmationHtml = `<!DOCTYPE html>
       or call <a href="tel:+13043144506" style="color: #6B7B5E;">304-314-4506</a>.</p>
   </div>
   <div class="footer">
-    <strong style="color: #4A3728;">Music Together with Maple &amp; Spruce</strong><br>
+    <strong style="color: #4A3728;">Music Together Maple &amp; Spruce</strong><br>
     Morgantown, WV<br>
     <a href="mailto:musictogether@mapleandsprucefolkarts.com">musictogether@mapleandsprucefolkarts.com</a> | <a href="tel:+13043144506">304-314-4506</a><br>
     <span style="font-size: 12px; color: #999;">Music Together with Maple &amp; Spruce LLC is licensed by Music Together Worldwide. Music Together is a registered trademark.</span>
@@ -779,7 +779,7 @@ const musicTogetherInstallmentFailedHtml = `<!DOCTYPE html>
 <body>
 <div class="wrapper">
   <div class="header">
-    <h1>Music Together with Maple &amp; Spruce</h1>
+    <h1>Music Together Maple &amp; Spruce</h1>
   </div>
   <div class="content">
     <h2>We couldn't process your payment</h2>
@@ -801,7 +801,7 @@ const musicTogetherInstallmentFailedHtml = `<!DOCTYPE html>
       or call <a href="tel:+13043144506" style="color: #6B7B5E;">304-314-4506</a>.</p>
   </div>
   <div class="footer">
-    <strong style="color: #4A3728;">Music Together with Maple &amp; Spruce</strong><br>
+    <strong style="color: #4A3728;">Music Together Maple &amp; Spruce</strong><br>
     Morgantown, WV<br>
     <a href="mailto:musictogether@mapleandsprucefolkarts.com">musictogether@mapleandsprucefolkarts.com</a> | <a href="tel:+13043144506">304-314-4506</a><br>
     <span style="font-size: 12px; color: #999;">Music Together with Maple &amp; Spruce LLC is licensed by Music Together Worldwide. Music Together is a registered trademark.</span>
@@ -834,7 +834,7 @@ const musicTogetherReminderHtml = `<!DOCTYPE html>
 <body>
 <div class="wrapper">
   <div class="header">
-    <h1>Music Together with Maple &amp; Spruce</h1>
+    <h1>Music Together Maple &amp; Spruce</h1>
   </div>
   <div class="content">
     <h2>See you today!</h2>
@@ -868,7 +868,7 @@ const musicTogetherReminderHtml = `<!DOCTYPE html>
       or call <a href="tel:+13043144506" style="color: #6B7B5E;">304-314-4506</a>.</p>
   </div>
   <div class="footer">
-    <strong style="color: #4A3728;">Music Together with Maple &amp; Spruce</strong><br>
+    <strong style="color: #4A3728;">Music Together Maple &amp; Spruce</strong><br>
     Morgantown, WV<br>
     <a href="mailto:musictogether@mapleandsprucefolkarts.com">musictogether@mapleandsprucefolkarts.com</a> | <a href="tel:+13043144506">304-314-4506</a><br>
     <span style="font-size: 12px; color: #999;">Music Together with Maple &amp; Spruce LLC is licensed by Music Together Worldwide. Music Together is a registered trademark.</span>


### PR DESCRIPTION
## Why

MT Worldwide issued a new logo for the program that drops the "with" — the center is now branded **Music Together Maple & Spruce**. This updates the display name in the two repo-owned customer-facing surfaces.

## What changed

| Surface | Change |
|---|---|
| `tools/seed-email-templates.ts` | Header `<h1>` and footer signature block in all three MT emails (registration confirmation, installment payment failed, class reminder) |
| `calendar-music-together-feed` | ICS feed calendar name families see when they subscribe (+ its spec) |

## Deliberately NOT changed

These name the **registered entity**, not the brand, so they keep "with":

- The licensee credit line in each email footer — *"Music Together with Maple & Spruce LLC is licensed by Music Together Worldwide"*. That is the WV SOS registered name (Org ID 623596).
- The card-on-file authorization text in `MusicTogetherRegistrationWidget.tsx`, which names the entity charging the card.

If the LLC is ever renamed with the Secretary of State, those two strings should be updated in a follow-up.

## Verification

- `npx vitest run calendar-music-together-feed` — 3 passed (spec updated to assert the new feed name)
- `npx nx build functions-calendar --skip-nx-cache` — succeeds
- `grep -rn "Music Together with"` over `*.ts`/`*.tsx` returns only the 4 intentionally-preserved legal strings

## Note on the emails

`seed-email-templates.ts` is a seeding tool — the live templates live in Firestore. This PR changes the source; the seed script still needs to be run to push the new copy to the live templates.

## Related

The matching Webflow work (new logo asset across all MT pages, page/OG titles, body copy) is staged in the Designer and awaiting publish — it is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)