### PR TITLE
fix(my-day): Week tab degrades gracefully when getMyWeek omits blocks/commitments

### DIFF
--- a/libs/react/lessons/src/lib/MyWeek.stories.tsx
+++ b/libs/react/lessons/src/lib/MyWeek.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn, expect, userEvent, waitFor, within } from 'storybook/test';
+import type { GetMyWeekResponse } from '@maple/ts/firebase/api-types';
 import { MyWeek } from './MyWeek';
 import {
   mockMyWeekResponse,
@@ -46,6 +47,41 @@ export const Unlinked: Story = {
       status: 'success',
       data: { commitments: [], blocks: [], unlinked: true },
     },
+  },
+};
+
+// Regression: an older deployed getMyWeek (pre-#685) omits `blocks` (and
+// `unattributed`). The tab must degrade to an empty week, not white-screen.
+export const LegacyResponseMissingBlocks: Story = {
+  args: {
+    weekState: {
+      status: 'success',
+      // Intentionally the old shape: no `blocks`, commitments lack
+      // `unattributed`. Cast because the current type requires them.
+      data: {
+        commitments: mockMyWeekResponse.commitments.map((c) => ({
+          id: c.id,
+          title: c.title,
+          category: c.category,
+          startDateTime: c.startDateTime,
+          endDateTime: c.endDateTime,
+          room: c.room,
+          ownership: c.ownership,
+          cadence: c.cadence,
+        })),
+        unlinked: false,
+      } as unknown as GetMyWeekResponse,
+    },
+  },
+  play: async ({ canvas }) => {
+    // Renders the week (nav present) instead of throwing.
+    await expect(
+      canvas.getByRole('button', { name: /next week/i }),
+    ).toBeInTheDocument();
+    // Commitments outside a block still render (blocks defaulted to []).
+    await waitFor(() =>
+      expect(within(document.body).getByText(/Friday Jam/)).toBeInTheDocument(),
+    );
   },
 };
 

--- a/libs/react/lessons/src/lib/MyWeek.tsx
+++ b/libs/react/lessons/src/lib/MyWeek.tsx
@@ -220,7 +220,12 @@ export function MyWeek({
     );
   }
 
-  const { commitments, blocks } = weekState.data;
+  // Default missing fields to [] so a transient frontend/functions version
+  // skew (they deploy as separate jobs) degrades to an empty week instead of
+  // white-screening the whole page. `blocks` was added to the response in
+  // #685; an older deployed getMyWeek omits it.
+  const commitments = weekState.data.commitments ?? [];
+  const blocks = weekState.data.blocks ?? [];
   const visible = commitments.filter((c) => !hidden.has(c.category));
 
   return (


### PR DESCRIPTION
## What & why
Caught while reviewing the Week tab on **dev**: clicking **Week** white-screened the entire page. Root cause — the deployed `getMyWeek` was an **older build that doesn't return `blocks`** (added in #685), so `blocks.filter(...)` threw an uncaught `TypeError`.

Frontend (Vercel) and Cloud Functions (Firebase) deploy as **separate jobs**, so a brief version skew is always possible — and the *same* skew could white-screen **prod** when #709 promotes if the functions deploy lags the Vercel one. A missing response field should never take down the whole page.

## Fix
`MyWeek` defaults missing `commitments`/`blocks` to `[]`, so a skew degrades to an empty/partial week instead of crashing. Commitments that lack the newer `unattributed` field already read as falsy (fine).

Added a regression story **`LegacyResponseMissingBlocks`** that feeds the old response shape (no `blocks`, no `unattributed`) and asserts the tab renders (nav present, out-of-block commitments still show) rather than throwing.

## Verification
- ✅ `maple-spruce` typecheck
- ✅ MyWeek Storybook play tests — 7 (incl. the new regression)
- ✅ ESLint (0 errors), Prettier

Note: this hardens the frontend, but dev also needs `getMyWeek` **redeployed** (its #709 functions-deploy run was cancelled by a superseding merge) for the populated week to actually show data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)