### PR TITLE
perf(music-together): warm downstream public callables + interest-read minInstances

### DIFF
--- a/apps/webflow-components/src/CraftClubSignupWidget.tsx
+++ b/apps/webflow-components/src/CraftClubSignupWidget.tsx
@@ -12,7 +12,7 @@
  * No Next.js dependencies — Firebase is initialized explicitly from the `env`
  * prop (see firebase-init.ts).
  */
-import { useState, useMemo, useRef, useCallback } from 'react';
+import { useState, useMemo, useRef, useCallback, useEffect } from 'react';
 import {
   Box,
   Typography,
@@ -70,6 +70,11 @@ export function CraftClubSignupWidget({
   manageUrl,
 }: CraftClubSignupWidgetProps) {
   const functions = useMemo(() => getWidgetFunctions(env), [env]);
+
+  // Warm the eligibility check the family triggers seconds after landing.
+  useEffect(() => {
+    warmup(functions, 'checkCraftClubEligibility');
+  }, [functions]);
 
   const [step, setStep] = useState<Step>('enterEmail');
   const [email, setEmail] = useState('');

--- a/apps/webflow-components/src/MusicTogetherInterestWidget.spec.tsx
+++ b/apps/webflow-components/src/MusicTogetherInterestWidget.spec.tsx
@@ -40,6 +40,10 @@ vi.mock('./firebase-init', () => ({
   getWidgetFunctions: () => ({ __mock: true }),
 }));
 
+// Warmup is a fire-and-forget no-op in tests; otherwise its mount ping
+// registers as an addMusicTogetherInterest call.
+vi.mock('./lib/warmup', () => ({ warmup: vi.fn() }));
+
 vi.mock('firebase/functions', () => ({
   httpsCallable: (_fns: unknown, name: string) => (payload: unknown) => {
     calls[name] = payload;

--- a/apps/webflow-components/src/MusicTogetherInterestWidget.tsx
+++ b/apps/webflow-components/src/MusicTogetherInterestWidget.tsx
@@ -37,6 +37,7 @@ import type {
   AddMusicTogetherInterestResponse,
 } from '@maple/ts/firebase/api-types';
 import { getWidgetFunctions } from './firebase-init';
+import { warmup } from './lib/warmup';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const WIDGET_MAX_WIDTH = 560;
@@ -96,6 +97,8 @@ export function MusicTogetherInterestWidget({
   });
 
   useEffect(() => {
+    // Warm the downstream submit callable now; the family triggers it seconds later.
+    warmup(functions, 'addMusicTogetherInterest');
     let cancelled = false;
     (async () => {
       try {

--- a/apps/webflow-components/src/MusicTogetherRegistrationWidget.tsx
+++ b/apps/webflow-components/src/MusicTogetherRegistrationWidget.tsx
@@ -393,7 +393,9 @@ export function MusicTogetherRegistrationWidget({
     }
     // Warm the create function — the family will submit shortly after filling
     // out the form, by which point the container is up.
-    warmup(functions, 'createMusicTogetherRegistration');
+    // Warm both downstream mutations: the checkout create, and the waitlist
+    // capture (fired both when a section is full and in coming-soon mode).
+    warmup(functions, 'createMusicTogetherRegistration', 'addToMusicTogetherWaitlist');
 
     const load = async () => {
       setState({ status: 'loading' });

--- a/libs/firebase/maple-functions/get-public-music-together-sections/src/lib/get-public-music-together-sections.ts
+++ b/libs/firebase/maple-functions/get-public-music-together-sections/src/lib/get-public-music-together-sections.ts
@@ -18,8 +18,14 @@ import type {
   PublicMusicTogetherSectionOption,
 } from '@maple/ts/firebase/api-types';
 
+// Keep warm in prod only — the public interest widget fetches this on mount,
+// so a cold start would slow that form's first paint (warmup is too late).
+// Mirrors getPublicMusicTogetherSection. dev/emulator/CI run cold.
+const minInstances =
+  process.env['GCLOUD_PROJECT'] === 'maple-and-spruce' ? 1 : 0;
+
 export const getPublicMusicTogetherSections = Functions.endpoint
-  .withOptions({ concurrency: 80 })
+  .withOptions({ minInstances, concurrency: 80 })
   .handle<
     GetPublicMusicTogetherSectionsRequest,
     GetPublicMusicTogetherSectionsResponse


### PR DESCRIPTION
## What

Follow-up to the registration-load perf policy — preload the mutation callables each public widget triggers seconds after mount (free; no reserved capacity), and give the interest form's first-paint read a dedicated warm instance.

| Widget / fn | Change |
|---|---|
| MusicTogetherRegistrationWidget | warm `addToMusicTogetherWaitlist` too (covers full-section waitlist **and** the coming-soon email capture) — previously only `createMusicTogetherRegistration` |
| MusicTogetherInterestWidget | warm `addMusicTogetherInterest` on mount (was none) |
| CraftClubSignupWidget | warm `checkCraftClubEligibility` on mount (the first call after email entry) |
| `getPublicMusicTogetherSections` | env-gated `minInstances: 1` (prod) — the interest widget fetches it at first paint, mirroring `getPublicMusicTogetherSection` |

## Notes
- `minInstances` is prod-gated (`GCLOUD_PROJECT === 'maple-and-spruce'`); global `maxInstances` stays 1, so no added deploy-quota pressure. This is the 5th always-warm read (all form-gating), within the agreed 1–3-more budget.
- Widgets that newly use warmup mock `./lib/warmup` to a no-op in their specs, so the mount ping isn't counted as a real callable.
- M&S class `RegistrationWidget` already warms its downstream (`calculateRegistrationCost`/`createRegistration`) — unchanged.

## Tests
tsc clean; 4 affected spec files / 21 tests pass (MT registration, MT interest, Craft Club signup, public sections read).

🤖 Generated with [Claude Code](https://claude.com/claude-code)