### PR TITLE
fix(music-together): demo duration default + semester break deletion not saving

### DIFF
--- a/apps/maple-spruce/src/app/(admin)/music-together/DemoFormDialog.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/DemoFormDialog.tsx
@@ -71,7 +71,7 @@ export function DemoFormDialog({
       setDateTime('');
       setLocation('');
       setCapacity(String(DEFAULT_CAPACITY_FAMILIES));
-      setDuration('');
+      setDuration(String(MT_CLASS_DURATION_MINUTES));
       setNotes('');
       setVisible(false);
     }
@@ -84,7 +84,9 @@ export function DemoFormDialog({
         dateTime: fromLocalInput(dateTime),
         location: location.trim(),
         capacityFamilies: parseInt(capacity, 10),
-        durationMinutes: duration ? parseInt(duration, 10) : undefined,
+        durationMinutes: duration
+          ? parseInt(duration, 10)
+          : MT_CLASS_DURATION_MINUTES,
         notes: notes.trim() || undefined,
         visible,
       };

--- a/apps/maple-spruce/src/app/(admin)/music-together/SemesterFormDialog.stories.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/SemesterFormDialog.stories.tsx
@@ -165,6 +165,30 @@ export const EditsBreaksAndWeatherDates: Story = {
   },
 };
 
+/**
+ * Regression: removing a semester's only break must submit `breaks: []`, not
+ * `undefined` — otherwise the partial update omits the field and the deleted
+ * break stays stranded in Firestore ("the edit didn't save").
+ */
+export const ClearingABreakSubmitsEmptyArray: Story = {
+  args: { semester: mockSemester },
+  play: async ({ args }) => {
+    const canvas = await waitForDialog();
+    await userEvent.click(
+      canvas.getByRole('button', { name: /remove break 1/i })
+    );
+    await expect(canvas.queryByLabelText(/break 1 label/i)).toBeNull();
+    const save = canvas.getByRole('button', { name: /save/i });
+    await waitFor(() => expect(save).toBeEnabled());
+    await userEvent.click(save);
+    await waitFor(() =>
+      expect(args.onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ breaks: [] })
+      )
+    );
+  },
+};
+
 /** Touch every field, then submit — exercises each field's change handler. */
 export const FillsAllFields: Story = {
   play: async ({ args }) => {

--- a/apps/maple-spruce/src/app/(admin)/music-together/SemesterFormDialog.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/SemesterFormDialog.tsx
@@ -145,8 +145,12 @@ export function SemesterFormDialog({
           ? fromDateInput(enrollmentOpensAt)
           : undefined,
         notes: notes.trim() || undefined,
-        breaks: cleanBreaks.length > 0 ? cleanBreaks : undefined,
-        weatherMakeupDates: cleanWeather.length > 0 ? cleanWeather : undefined,
+        // Always send the arrays (even empty) — this is a full-form edit, so an
+        // emptied array must CLEAR the field. Sending `undefined` omits it from
+        // the partial update, leaving the old value (e.g. a deleted break)
+        // stranded in Firestore — which read as "the edit didn't save".
+        breaks: cleanBreaks,
+        weatherMakeupDates: cleanWeather,
       };
       await onSubmit(input);
     } catch (e) {

--- a/libs/ts/validation/src/lib/music-together-demo.validation.spec.ts
+++ b/libs/ts/validation/src/lib/music-together-demo.validation.spec.ts
@@ -16,6 +16,27 @@ describe('musicTogetherDemoValidation', () => {
     expect(result.hasErrors()).toBe(false);
   });
 
+  it('treats an absent duration as valid (undefined, null, or omitted)', () => {
+    // A blank duration field persists as null; a strict `!== undefined` guard
+    // used to let null reach enforce() and wrongly rejected the demo.
+    expect(
+      musicTogetherDemoValidation({ ...valid, durationMinutes: undefined }).hasErrors()
+    ).toBe(false);
+    expect(
+      musicTogetherDemoValidation({ ...valid, durationMinutes: null }).hasErrors()
+    ).toBe(false);
+    const { durationMinutes: _omit, ...noDuration } = valid;
+    expect(musicTogetherDemoValidation(noDuration).hasErrors()).toBe(false);
+  });
+
+  it('rejects a non-positive duration when one is given', () => {
+    expect(
+      musicTogetherDemoValidation({ ...valid, durationMinutes: 0 }).hasErrors(
+        'durationMinutes'
+      )
+    ).toBe(true);
+  });
+
   it('requires a dateTime', () => {
     const result = musicTogetherDemoValidation({ ...valid, dateTime: undefined });
     expect(result.hasErrors('dateTime')).toBe(true);

--- a/libs/ts/validation/src/lib/music-together-demo.validation.ts
+++ b/libs/ts/validation/src/lib/music-together-demo.validation.ts
@@ -51,7 +51,10 @@ export const musicTogetherDemoValidation = staticSuite(
     });
 
     test('durationMinutes', 'Duration must be greater than 0', () => {
-      if (data.durationMinutes !== undefined) {
+      // Loose `!= null` so a stored blank (persisted as null) is treated as
+      // absent — a strict `!== undefined` let null through to enforce() and
+      // rejected demos created without a duration.
+      if (data.durationMinutes != null) {
         enforce(data.durationMinutes).greaterThan(0);
       }
     });

--- a/libs/ts/validation/src/lib/music-together-demo.validation.ts
+++ b/libs/ts/validation/src/lib/music-together-demo.validation.ts
@@ -14,7 +14,9 @@ export interface MusicTogetherDemoValidationInput {
   dateTime?: Date | string;
   location?: string;
   capacityFamilies?: number;
-  durationMinutes?: number;
+  // number | null: a blank form field persists as null, and the suite is a
+  // runtime boundary that must accept the null it actually receives.
+  durationMinutes?: number | null;
   notes?: string;
   visible?: boolean;
 }


### PR DESCRIPTION
Two bugs from Stephanie's admin testing of the demo + semester features.

## 1. Demo "duration defaults to 45" errored when left blank
The field says *"Defaults to 45"*, but leaving it blank gave a validation error (typing 45 worked). Root cause: a blank duration persists as **`null`**, and the Vest guard was `if (data.durationMinutes !== undefined)` — the strict check let `null` through to `enforce(null).greaterThan(0)`, which fails. (`notes` avoids this with a truthy guard.)

**Fix:**
- Validation guard → `!= null` (treats null *and* undefined as absent).
- `DemoFormDialog` defaults a blank duration to `MT_CLASS_DURATION_MINUTES` on submit and **prefills the field to 45** so it matches the "defaults to 45" promise and stores a clean value.

## 2. Editing a semester's breaks "looked saved but didn't persist"
Deleting the Halloween break (and other break/weather-date edits that empty an array) appeared to save but reverted on reopen. Root cause: the dialog sent `breaks: cleanBreaks.length > 0 ? cleanBreaks : undefined` — an **emptied array became `undefined`**, so the partial `docRef.update()` omitted the field and the old array stayed in Firestore.

**Fix:** always send the date arrays (`breaks`, `weatherMakeupDates`) — it's a full-form edit, so an empty `[]` must *clear* the field.

## Tests
- Validation: null / undefined / omitted duration accepted; `0` still rejected. (12 pass)
- New play story `ClearingABreakSubmitsEmptyArray` asserts removing a break submits `breaks: []`. (17 dialog play tests pass)
- `nx typecheck maple-spruce` clean.

## Note (not fixed here)
Stephanie also asked for the **Spruce Room schedule to page beyond 8 weeks** — filing that as a separate enhancement. And this dialog still can't *clear* optional scalar fields (notes/dates) via update for the same partial-update reason; low-impact, noted for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)