### PR TITLE
feat(my-day): getMyWeek returns the standing/typical-week pattern (#685)

### DIFF
--- a/libs/firebase/maple-functions/get-my-week/src/lib/get-my-week.spec.ts
+++ b/libs/firebase/maple-functions/get-my-week/src/lib/get-my-week.spec.ts
@@ -22,7 +22,12 @@ vi.mock('@maple/firebase/database', () => ({
   LessonRepository: { findAll: mocks.findLessons },
 }));
 
-import { getMyWeek, buildCommitments, startOfWeek } from './get-my-week';
+import {
+  getMyWeek,
+  buildCommitments,
+  buildStandingSlots,
+  startOfWeek,
+} from './get-my-week';
 
 type Handler = (
   data: unknown,
@@ -35,6 +40,7 @@ type Handler = (
     category: string;
     unattributed: boolean;
   }>;
+  standing: Array<Record<string, unknown>>;
   blocks: Array<Record<string, unknown>>;
   unlinked: boolean;
 }>;
@@ -171,6 +177,75 @@ describe('buildCommitments', () => {
   });
 });
 
+describe('buildStandingSlots', () => {
+  // ISO-UTC instants that map to known ET wall-clock (EDT = UTC-4). Weekday /
+  // time are evaluated in America/New_York by the function.
+  const lookbackStart = new Date('2026-06-28T04:00:00Z');
+  const me = 'instr-katie';
+
+  it('emits one standing slot for a lesson recurring on the same ET weekday+time', () => {
+    // Three consecutive Tuesdays at 3:00 PM ET.
+    const events = [
+      event({
+        id: 'w1',
+        startDateTime: new Date('2026-07-07T19:00:00Z'),
+        ownerInstructorId: me,
+      }),
+      event({
+        id: 'w2',
+        startDateTime: new Date('2026-07-14T19:00:00Z'),
+        ownerInstructorId: me,
+      }),
+      event({
+        id: 'w3',
+        startDateTime: new Date('2026-07-21T19:00:00Z'),
+        ownerInstructorId: me,
+      }),
+    ];
+    const slots = buildStandingSlots(events, lookbackStart, me);
+    expect(slots).toHaveLength(1);
+    expect(slots[0]).toMatchObject({
+      weekday: 2, // Tuesday
+      startMinutes: 15 * 60,
+      durationMinutes: 30,
+      category: 'lesson',
+      ownership: 'mine',
+    });
+  });
+
+  it('excludes a one-off (seen in only one week)', () => {
+    const events = [
+      event({
+        id: 'once',
+        startDateTime: new Date('2026-07-21T19:00:00Z'),
+        ownerInstructorId: me,
+      }),
+    ];
+    expect(buildStandingSlots(events, lookbackStart, me)).toHaveLength(0);
+  });
+
+  it('marks a recurring shared event (weekly jam) as shared', () => {
+    const events = [
+      event({
+        id: 'j1',
+        startDateTime: new Date('2026-07-10T22:00:00Z'),
+        type: 'jam',
+        ownerInstructorId: null,
+      }),
+      event({
+        id: 'j2',
+        startDateTime: new Date('2026-07-17T22:00:00Z'),
+        type: 'jam',
+        ownerInstructorId: null,
+      }),
+    ];
+    const slots = buildStandingSlots(events, lookbackStart, me);
+    expect(slots).toHaveLength(1);
+    expect(slots[0].ownership).toBe('shared');
+    expect(slots[0].category).toBe('jam');
+  });
+});
+
 describe('getMyWeek handler', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -185,6 +260,7 @@ describe('getMyWeek handler', () => {
     const res = await handler({}, { uid: 'admin-uid' });
     expect(res.unlinked).toBe(true);
     expect(res.commitments).toEqual([]);
+    expect(res.standing).toEqual([]);
     expect(res.blocks).toEqual([]);
     expect(mocks.findByStartInRange).not.toHaveBeenCalled();
   });

--- a/libs/firebase/maple-functions/get-my-week/src/lib/get-my-week.ts
+++ b/libs/firebase/maple-functions/get-my-week/src/lib/get-my-week.ts
@@ -28,17 +28,26 @@ import {
   LessonBlockRepository,
   LessonRepository,
 } from '@maple/firebase/database';
-import { isLessonUnattributed } from '@maple/ts/domain';
+import {
+  DEFAULT_LESSON_TIME_ZONE,
+  isLessonUnattributed,
+  minutesOfDayInZone,
+  weekdayIndexInZone,
+} from '@maple/ts/domain';
 import type { CalendarEvent, LessonBlock } from '@maple/ts/domain';
 import type {
   GetMyWeekRequest,
   GetMyWeekResponse,
   MyWeekBlock,
   MyWeekCommitment,
+  MyWeekStandingSlot,
 } from '@maple/ts/firebase/api-types';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const LOOKBACK_WEEKS = 4;
+const TZ = DEFAULT_LESSON_TIME_ZONE;
+/** A slot is "standing" once it recurs in at least this many distinct weeks. */
+const STANDING_MIN_WEEKS = 2;
 
 /** Server-local start-of-week (Sunday 00:00) for a given instant. */
 export function startOfWeek(d: Date): Date {
@@ -117,6 +126,79 @@ export function buildCommitments(
     });
 }
 
+/**
+ * Synthesize the standing (typical) week from the lookback: recurring slots
+ * projected onto a generic Sun–Sat, independent of any concrete week's
+ * instances. A slot is standing when the same owner + category + weekday +
+ * clock-time appears in ≥2 distinct weeks across [lookbackStart, to). Weekday /
+ * clock are evaluated in the shop timezone so they align with lesson blocks
+ * (unlike the concrete `cadence` heuristic, which keys off server-local time).
+ * Pure — the handler supplies the same events it fetched for recurrence.
+ */
+export function buildStandingSlots(
+  events: CalendarEvent[],
+  lookbackStart: Date,
+  myInstructorId: string,
+): MyWeekStandingSlot[] {
+  interface Agg {
+    weeks: Set<number>;
+    representative: CalendarEvent;
+    weekday: number;
+    startMinutes: number;
+  }
+  const byKey = new Map<string, Agg>();
+
+  for (const e of events) {
+    const weekday = weekdayIndexInZone(e.startDateTime, TZ);
+    const startMinutes = minutesOfDayInZone(e.startDateTime, TZ);
+    const owner = e.ownerInstructorId ?? 'shared';
+    const key = `${owner}|${e.type}|${weekday}|${startMinutes}`;
+    const weekIndex = Math.floor(
+      (e.startDateTime.getTime() - lookbackStart.getTime()) / (7 * DAY_MS),
+    );
+    const agg = byKey.get(key);
+    if (!agg) {
+      byKey.set(key, {
+        weeks: new Set([weekIndex]),
+        representative: e,
+        weekday,
+        startMinutes,
+      });
+    } else {
+      agg.weeks.add(weekIndex);
+      // Keep the most recent occurrence for the title/duration.
+      if (
+        e.startDateTime.getTime() > agg.representative.startDateTime.getTime()
+      ) {
+        agg.representative = e;
+      }
+    }
+  }
+
+  const slots: MyWeekStandingSlot[] = [];
+  for (const [key, agg] of byKey) {
+    if (agg.weeks.size < STANDING_MIN_WEEKS) continue;
+    const e = agg.representative;
+    const durationMinutes = Math.max(
+      Math.round((e.endDateTime.getTime() - e.startDateTime.getTime()) / 60000),
+      1,
+    );
+    slots.push({
+      id: key,
+      weekday: agg.weekday,
+      startMinutes: agg.startMinutes,
+      durationMinutes,
+      category: e.type,
+      ownership: e.ownerInstructorId === myInstructorId ? 'mine' : 'shared',
+      title: e.title,
+    });
+  }
+  slots.sort(
+    (a, b) => a.weekday - b.weekday || a.startMinutes - b.startMinutes,
+  );
+  return slots;
+}
+
 /** Serialize a block for the wire (drop Date fields). */
 function toMyWeekBlock(block: LessonBlock): MyWeekBlock {
   return {
@@ -137,7 +219,7 @@ export const getMyWeek = createRoleFunction<
     const myInstructorId = await instructorIdForUser(context.uid);
     if (!myInstructorId) {
       // Not linked to any instructor (e.g. a pure admin) — no "mine" to anchor.
-      return { commitments: [], blocks: [], unlinked: true };
+      return { commitments: [], standing: [], blocks: [], unlinked: true };
     }
 
     const now = new Date();
@@ -175,6 +257,7 @@ export const getMyWeek = createRoleFunction<
 
     return {
       commitments,
+      standing: buildStandingSlots(events, lookbackStart, myInstructorId),
       blocks: blocks.map(toMyWeekBlock),
       unlinked: false,
     };

--- a/libs/react/lessons/src/lib/MyWeek.stories.tsx
+++ b/libs/react/lessons/src/lib/MyWeek.stories.tsx
@@ -44,7 +44,7 @@ export const Unlinked: Story = {
   args: {
     weekState: {
       status: 'success',
-      data: { commitments: [], blocks: [], unlinked: true },
+      data: { commitments: [], standing: [], blocks: [], unlinked: true },
     },
   },
 };

--- a/libs/react/storybook-fixtures/src/my-week.ts
+++ b/libs/react/storybook-fixtures/src/my-week.ts
@@ -6,6 +6,37 @@ import type { GetMyWeekResponse } from '@maple/ts/firebase/api-types';
  */
 export const mockMyWeekResponse: GetMyWeekResponse = {
   unlinked: false,
+  // The standing/typical-week pattern (recurring slots, no concrete date) —
+  // mirrors the recurring commitments below (the one-off lessons drop out).
+  standing: [
+    {
+      id: 'std-lesson-tue',
+      weekday: 2, // Tuesday
+      startMinutes: 15 * 60,
+      durationMinutes: 30,
+      category: 'lesson',
+      ownership: 'mine',
+      title: 'Music Lesson',
+    },
+    {
+      id: 'std-class-thu',
+      weekday: 4, // Thursday
+      startMinutes: 10 * 60,
+      durationMinutes: 90,
+      category: 'class',
+      ownership: 'mine',
+      title: 'Watercolor Basics',
+    },
+    {
+      id: 'std-jam-fri',
+      weekday: 5, // Friday
+      startMinutes: 18 * 60,
+      durationMinutes: 120,
+      category: 'jam',
+      ownership: 'shared',
+      title: 'Friday Jam',
+    },
+  ],
   blocks: [
     {
       id: 'blk-tue',

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -358,6 +358,7 @@ export type {
   MyWeekCadence,
   MyWeekBlock,
   MyWeekCommitment,
+  MyWeekStandingSlot,
   GetMyWeekRequest,
   GetMyWeekResponse,
 } from './my-week.types';

--- a/libs/ts/firebase/api-types/src/lib/my-week.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/my-week.types.ts
@@ -55,6 +55,29 @@ export interface MyWeekCommitment {
   unattributed: boolean;
 }
 
+/**
+ * A synthesized standing (typical-week) slot — a commitment that recurs on the
+ * same weekday + clock-time across the lookback, projected onto a generic
+ * Sun–Sat week with no concrete date. Powers the "Typical week" planning view
+ * (#685): a standing lesson shows in its slot even on a concrete week where its
+ * instance is cancelled or missing, and one-offs drop out entirely. Weekday /
+ * time are evaluated in the shop timezone (America/New_York) so they line up
+ * with lesson blocks.
+ */
+export interface MyWeekStandingSlot {
+  /** Stable id (the recurrence key: owner|category|weekday|startMinutes). */
+  id: string;
+  /** Weekday 0 (Sun) – 6 (Sat). */
+  weekday: number;
+  /** Start — minutes from midnight, shop timezone. */
+  startMinutes: number;
+  /** Duration in minutes, from a representative occurrence. */
+  durationMinutes: number;
+  category: CalendarEventType;
+  ownership: MyWeekOwnership;
+  title: string;
+}
+
 export interface GetMyWeekRequest {
   /** ISO instant for the start of the week (inclusive). Defaults to the
    *  current week's start (server-local Sunday 00:00) when omitted. */
@@ -65,7 +88,13 @@ export interface GetMyWeekRequest {
 }
 
 export interface GetMyWeekResponse {
+  /** Concrete commitments for the requested week (the "This week" view). */
   commitments: MyWeekCommitment[];
+  /**
+   * The standing/typical-week pattern — recurring slots on a generic Sun–Sat,
+   * independent of the concrete week's instances (the "Typical week" view).
+   */
+  standing: MyWeekStandingSlot[];
   /** The caller's own weekly blocks — the containers the week is laid out in. */
   blocks: MyWeekBlock[];
   /** True when the caller isn't linked to any instructor record (no "mine"). */


### PR DESCRIPTION
## What
Backend groundwork for the **"Typical week"** planning view (the heuristic week, not just concrete weeks). `getMyWeek` now also returns **`standing: MyWeekStandingSlot[]`** — the recurring slots projected onto a generic Sun–Sat week, synthesized from the ~4-week lookback it already fetches.

A slot is **standing** when the same `owner + category + weekday + clock-time` appears in **≥2 distinct weeks**. Key point: it's **independent of any concrete week's instances**, so a standing weekly lesson shows in its slot even on a week where the instance is cancelled/missing, and one-offs drop out entirely. This is what makes the planning view trustworthy (and feeds the Openings finder, #687).

Weekday/clock are evaluated in the **shop timezone (America/New_York)** so standing slots line up with lesson blocks. (The existing concrete `cadence` heuristic keys off server-local time and is left unchanged — it's just a display hint for fading one-offs.)

`MyWeekStandingSlot = { id, weekday, startMinutes, durationMinutes, category, ownership, title }`. Additive — no existing response field changes; `unlinked` returns `[]`.

## Why backend-first
Shipping/deploying this **before** the frontend that reads `standing` avoids the frontend/functions deploy-skew we just hit on the Week tab (new UI reading a field the old function doesn't return).

## Verification
- ✅ 12 unit tests (incl. `buildStandingSlots` tz cases — recurring → 1 slot, one-off → 0, shared jam → shared)
- ✅ All 4 function codebases build
- ✅ Firestore index analyzer clean (no new index)
- ✅ ESLint (0 errors)

Follow-up: frontend PR — calendar-grid week layout + a "This week / Typical week" toggle that renders `standing`. (Layout rewrite already drafted.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)