### PR TITLE
test(music-together): integration coverage for demos + semester array-clear

### DIFF
--- a/apps/functions-integration-tests-music-together/src/music-together-demo.spec.ts
+++ b/apps/functions-integration-tests-music-together/src/music-together-demo.spec.ts
@@ -1,0 +1,554 @@
+/**
+ * Integration tests for the Music Together demo-class functions (maple-core, no
+ * Square — demos are FREE). Runs the real callables + Firestore triggers in the
+ * emulator. Demos are the layer where two user-hit bugs lived that unit/
+ * interaction tests (which mock the repo/callable) could not catch:
+ *
+ *  1. A demo created with a BLANK duration (persisted as `null`) was rejected by
+ *     validation. Locked by the "blank-duration regression" block below — on the
+ *     pre-fix code the `durationMinutes: null` create 400s.
+ *  2. (semester array-clear — see music-together-semester.spec.ts.)
+ *
+ * Covers: admin CRUD round-trip + role gating, the blank-duration regression,
+ * the public read projection (visibility/recency filter + no RSVP PII), the
+ * capacity→waitlist RSVP flow with idempotency + admin read, and the
+ * `onMusicTogetherDemoWrite` calendar trigger (upsert on visible, remove on
+ * hide/delete).
+ */
+import {
+  createTestUser,
+  clearAuthEmulator,
+  clearFirestoreEmulator,
+  setFirestoreDoc,
+  getFirestoreDoc,
+  callFunction,
+  ADMIN_USER,
+  NON_ADMIN_USER,
+} from '@maple/firebase/integration-test-utils';
+import type { TestUser } from '@maple/firebase/integration-test-utils';
+import { MT_CLASS_DURATION_MINUTES } from '@maple/ts/domain';
+import type {
+  CreateMusicTogetherDemoRequest,
+  CreateMusicTogetherDemoResponse,
+  GetMusicTogetherDemosRequest,
+  GetMusicTogetherDemosResponse,
+  UpdateMusicTogetherDemoRequest,
+  UpdateMusicTogetherDemoResponse,
+  DeleteMusicTogetherDemoRequest,
+  DeleteMusicTogetherDemoResponse,
+  GetPublicMusicTogetherDemosRequest,
+  GetPublicMusicTogetherDemosResponse,
+  AddMusicTogetherDemoRsvpRequest,
+  AddMusicTogetherDemoRsvpResponse,
+  GetMusicTogetherDemoRsvpsRequest,
+  GetMusicTogetherDemoRsvpsResponse,
+} from '@maple/ts/firebase/api-types';
+
+const soon = new Date(Date.now() + 7 * 86_400_000);
+const past = new Date(Date.now() - 7 * 86_400_000);
+
+function createInput(
+  overrides: Partial<CreateMusicTogetherDemoRequest> = {}
+): CreateMusicTogetherDemoRequest {
+  return {
+    dateTime: soon,
+    location: 'Morgantown Public Library',
+    capacityFamilies: 8,
+    durationMinutes: 45,
+    visible: true,
+    ...overrides,
+  };
+}
+
+/**
+ * Poll Firestore until a calendar event doc reaches the expected presence
+ * (present=true → appears, present=false → removed). Firestore triggers in the
+ * emulator are async, so we retry with a bounded timeout instead of a fixed
+ * sleep.
+ */
+async function waitForCalendarEvent(
+  eventId: string,
+  present: boolean,
+  timeoutMs = 10_000
+): Promise<Record<string, unknown> | null> {
+  const start = Date.now();
+  let doc = await getFirestoreDoc('calendarEvents', eventId);
+  while (Boolean(doc) !== present && Date.now() - start < timeoutMs) {
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    doc = await getFirestoreDoc('calendarEvents', eventId);
+  }
+  return doc;
+}
+
+describe('MT demo admin CRUD', () => {
+  let admin: TestUser;
+  let nonAdmin: TestUser;
+
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+    admin = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
+    nonAdmin = await createTestUser(
+      NON_ADMIN_USER.email,
+      NON_ADMIN_USER.password
+    );
+    await setFirestoreDoc('admins', admin.uid, {
+      userId: admin.uid,
+      email: admin.email,
+    });
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  let createdId: string;
+
+  it('creates a demo (admin), round-trips through the list', async () => {
+    const created = await callFunction<
+      CreateMusicTogetherDemoRequest,
+      CreateMusicTogetherDemoResponse
+    >({
+      functionName: 'createMusicTogetherDemo',
+      data: createInput({ location: 'Created Library', notes: 'bring a shaker' }),
+      idToken: admin.idToken,
+    });
+
+    expect(created.status).toBe(200);
+    expect(created.data?.demo.id).toBeDefined();
+    expect(created.data?.demo.location).toBe('Created Library');
+    expect(created.data?.demo.notes).toBe('bring a shaker');
+    createdId = created.data!.demo.id;
+
+    const list = await callFunction<
+      GetMusicTogetherDemosRequest,
+      GetMusicTogetherDemosResponse
+    >({
+      functionName: 'getMusicTogetherDemos',
+      data: {},
+      idToken: admin.idToken,
+    });
+    expect(list.status).toBe(200);
+    expect(list.data?.demos.some((d) => d.id === createdId)).toBe(true);
+  });
+
+  it('updates a demo (admin), reads back the change', async () => {
+    const updated = await callFunction<
+      UpdateMusicTogetherDemoRequest,
+      UpdateMusicTogetherDemoResponse
+    >({
+      functionName: 'updateMusicTogetherDemo',
+      data: { id: createdId, location: 'Renamed Library', capacityFamilies: 5 },
+      idToken: admin.idToken,
+    });
+    expect(updated.status).toBe(200);
+    expect(updated.data?.demo.location).toBe('Renamed Library');
+    expect(updated.data?.demo.capacityFamilies).toBe(5);
+
+    const list = await callFunction<
+      GetMusicTogetherDemosRequest,
+      GetMusicTogetherDemosResponse
+    >({
+      functionName: 'getMusicTogetherDemos',
+      data: {},
+      idToken: admin.idToken,
+    });
+    const fromList = list.data?.demos.find((d) => d.id === createdId);
+    expect(fromList?.location).toBe('Renamed Library');
+    expect(fromList?.capacityFamilies).toBe(5);
+  });
+
+  it('deletes a demo (admin), gone from the list', async () => {
+    const deleted = await callFunction<
+      DeleteMusicTogetherDemoRequest,
+      DeleteMusicTogetherDemoResponse
+    >({
+      functionName: 'deleteMusicTogetherDemo',
+      data: { id: createdId },
+      idToken: admin.idToken,
+    });
+    expect(deleted.status).toBe(200);
+    expect(deleted.data?.deleted).toBe(true);
+
+    const list = await callFunction<
+      GetMusicTogetherDemosRequest,
+      GetMusicTogetherDemosResponse
+    >({
+      functionName: 'getMusicTogetherDemos',
+      data: {},
+      idToken: admin.idToken,
+    });
+    expect(list.data?.demos.some((d) => d.id === createdId)).toBe(false);
+  });
+
+  it('rejects create for a non-admin', async () => {
+    const result = await callFunction<CreateMusicTogetherDemoRequest>({
+      functionName: 'createMusicTogetherDemo',
+      data: createInput(),
+      idToken: nonAdmin.idToken,
+    });
+    expect(result.status).not.toBe(200);
+  });
+
+  it('rejects create for an unauthenticated caller', async () => {
+    const result = await callFunction<CreateMusicTogetherDemoRequest>({
+      functionName: 'createMusicTogetherDemo',
+      data: createInput(),
+    });
+    expect(result.status).not.toBe(200);
+  });
+
+  it('rejects a demo with a blank location', async () => {
+    const result = await callFunction<CreateMusicTogetherDemoRequest>({
+      functionName: 'createMusicTogetherDemo',
+      data: createInput({ location: '' }),
+      idToken: admin.idToken,
+    });
+    expect(result.status).not.toBe(200);
+  });
+
+  it('404s an update to an unknown demo', async () => {
+    const result = await callFunction<UpdateMusicTogetherDemoRequest>({
+      functionName: 'updateMusicTogetherDemo',
+      data: { id: 'does-not-exist', location: 'X' },
+      idToken: admin.idToken,
+    });
+    expect(result.status).not.toBe(200);
+  });
+});
+
+describe('createMusicTogetherDemo blank-duration regression (#714)', () => {
+  let admin: TestUser;
+
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+    admin = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
+    await setFirestoreDoc('admins', admin.uid, {
+      userId: admin.uid,
+      email: admin.email,
+    });
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  it('accepts a demo with durationMinutes OMITTED → effective 45', async () => {
+    const input = createInput({ location: 'Omitted Duration Library' });
+    delete (input as { durationMinutes?: number }).durationMinutes;
+
+    const created = await callFunction<
+      CreateMusicTogetherDemoRequest,
+      CreateMusicTogetherDemoResponse
+    >({
+      functionName: 'createMusicTogetherDemo',
+      data: input,
+      idToken: admin.idToken,
+    });
+    expect(created.status).toBe(200);
+    // Stored value is absent; the effective duration falls back to the default.
+    expect(created.data?.demo.durationMinutes ?? null).toBeNull();
+
+    // The public read computes the effective duration (45) via the domain helper.
+    const pub = await callFunction<
+      GetPublicMusicTogetherDemosRequest,
+      GetPublicMusicTogetherDemosResponse
+    >({ functionName: 'getPublicMusicTogetherDemos', data: {} });
+    const demo = pub.data?.demos.find((d) => d.id === created.data!.demo.id);
+    expect(demo?.durationMinutes).toBe(MT_CLASS_DURATION_MINUTES);
+  });
+
+  it('accepts a demo with durationMinutes: null → effective 45 (the #714 bug)', async () => {
+    const created = await callFunction<
+      CreateMusicTogetherDemoRequest,
+      CreateMusicTogetherDemoResponse
+    >({
+      functionName: 'createMusicTogetherDemo',
+      // Pre-fix, the Vest guard used a strict `!== undefined`, so this null
+      // reached enforce() and the create 400'd.
+      data: createInput({
+        location: 'Null Duration Library',
+        durationMinutes: null as unknown as number,
+      }),
+      idToken: admin.idToken,
+    });
+    expect(created.status).toBe(200);
+    expect(created.data?.demo.durationMinutes ?? null).toBeNull();
+
+    const pub = await callFunction<
+      GetPublicMusicTogetherDemosRequest,
+      GetPublicMusicTogetherDemosResponse
+    >({ functionName: 'getPublicMusicTogetherDemos', data: {} });
+    const demo = pub.data?.demos.find((d) => d.id === created.data!.demo.id);
+    expect(demo?.durationMinutes).toBe(MT_CLASS_DURATION_MINUTES);
+  });
+
+  it('still rejects durationMinutes: 0 (not a valid duration)', async () => {
+    const result = await callFunction<CreateMusicTogetherDemoRequest>({
+      functionName: 'createMusicTogetherDemo',
+      data: createInput({ location: 'Zero Duration', durationMinutes: 0 }),
+      idToken: admin.idToken,
+    });
+    expect(result.status).not.toBe(200);
+  });
+});
+
+describe('getPublicMusicTogetherDemos', () => {
+  let admin: TestUser;
+  let visibleId: string;
+
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+    admin = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
+    await setFirestoreDoc('admins', admin.uid, {
+      userId: admin.uid,
+      email: admin.email,
+    });
+
+    // Upcoming + visible → shown. Capacity 8, one confirmed RSVP → 7 remaining.
+    const visible = await callFunction<
+      CreateMusicTogetherDemoRequest,
+      CreateMusicTogetherDemoResponse
+    >({
+      functionName: 'createMusicTogetherDemo',
+      data: createInput({ location: 'Visible Upcoming Library' }),
+      idToken: admin.idToken,
+    });
+    visibleId = visible.data!.demo.id;
+
+    // Past + visible → excluded (date filter).
+    await callFunction<CreateMusicTogetherDemoRequest>({
+      functionName: 'createMusicTogetherDemo',
+      data: createInput({ location: 'Past Library', dateTime: past }),
+      idToken: admin.idToken,
+    });
+
+    // Upcoming + invisible → excluded (visibility filter).
+    await callFunction<CreateMusicTogetherDemoRequest>({
+      functionName: 'createMusicTogetherDemo',
+      data: createInput({ location: 'Hidden Library', visible: false }),
+      idToken: admin.idToken,
+    });
+
+    // A confirmed RSVP with PII that must NOT leak into the public projection.
+    await callFunction<
+      AddMusicTogetherDemoRsvpRequest,
+      AddMusicTogetherDemoRsvpResponse
+    >({
+      functionName: 'addMusicTogetherDemoRsvp',
+      data: {
+        demoId: visibleId,
+        name: 'Secret Family',
+        email: 'secret@test.com',
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  it('returns only upcoming visible demos with availability, and no RSVP PII', async () => {
+    const result = await callFunction<
+      GetPublicMusicTogetherDemosRequest,
+      GetPublicMusicTogetherDemosResponse
+    >({ functionName: 'getPublicMusicTogetherDemos', data: {} });
+
+    expect(result.status).toBe(200);
+    const demos = result.data!.demos;
+    // Exactly the one upcoming visible demo.
+    expect(demos).toHaveLength(1);
+    const demo = demos[0];
+    expect(demo.id).toBe(visibleId);
+    expect(demo.location).toBe('Visible Upcoming Library');
+    expect(demo.spotsRemaining).toBe(7); // 8 capacity − 1 confirmed
+    expect(demo.isFull).toBe(false);
+    expect(typeof demo.dateTime).toBe('string'); // serialized ISO
+
+    // No past / hidden demos leaked.
+    expect(demos.some((d) => d.location === 'Past Library')).toBe(false);
+    expect(demos.some((d) => d.location === 'Hidden Library')).toBe(false);
+
+    // The public projection carries only customer-safe fields — no RSVP PII.
+    expect(Object.keys(demo).sort()).toEqual(
+      ['dateTime', 'durationMinutes', 'id', 'isFull', 'location', 'spotsRemaining'].sort()
+    );
+    const serialized = JSON.stringify(result.data);
+    expect(serialized).not.toContain('secret@test.com');
+    expect(serialized).not.toContain('Secret Family');
+  });
+});
+
+describe('addMusicTogetherDemoRsvp capacity → waitlist', () => {
+  let admin: TestUser;
+  let demoId: string;
+
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+    admin = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
+    await setFirestoreDoc('admins', admin.uid, {
+      userId: admin.uid,
+      email: admin.email,
+    });
+
+    const created = await callFunction<
+      CreateMusicTogetherDemoRequest,
+      CreateMusicTogetherDemoResponse
+    >({
+      functionName: 'createMusicTogetherDemo',
+      data: createInput({ location: 'RSVP Library', capacityFamilies: 2 }),
+      idToken: admin.idToken,
+    });
+    demoId = created.data!.demo.id;
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  async function rsvp(
+    email: string,
+    name = 'Family ' + email
+  ): Promise<AddMusicTogetherDemoRsvpResponse | undefined> {
+    const result = await callFunction<
+      AddMusicTogetherDemoRsvpRequest,
+      AddMusicTogetherDemoRsvpResponse
+    >({
+      functionName: 'addMusicTogetherDemoRsvp',
+      data: { demoId, name, email },
+    });
+    expect(result.status).toBe(200);
+    return result.data;
+  }
+
+  it('confirms up to capacity, then waitlists; re-RSVP is idempotent', async () => {
+    const first = await rsvp('one@test.com');
+    expect(first).toEqual({ added: true, status: 'confirmed' });
+
+    const second = await rsvp('two@test.com');
+    expect(second).toEqual({ added: true, status: 'confirmed' });
+
+    // Third family is over the cap of 2 → waitlisted.
+    const third = await rsvp('three@test.com');
+    expect(third).toEqual({ added: true, status: 'waitlisted' });
+
+    // Re-RSVP the first family → idempotent, keeps its confirmed seat.
+    const repeat = await rsvp('one@test.com', 'One Again');
+    expect(repeat).toEqual({ added: false, status: 'confirmed' });
+  });
+
+  it('admin read groups 2 confirmed + 1 waitlisted for the demo', async () => {
+    const result = await callFunction<
+      GetMusicTogetherDemoRsvpsRequest,
+      GetMusicTogetherDemoRsvpsResponse
+    >({
+      functionName: 'getMusicTogetherDemoRsvps',
+      data: {},
+      idToken: admin.idToken,
+    });
+
+    expect(result.status).toBe(200);
+    const group = result.data!.demos.find((g) => g.demo.id === demoId)!;
+    expect(group).toBeDefined();
+    expect(group.confirmed).toHaveLength(2);
+    expect(group.waitlisted).toHaveLength(1);
+    expect(group.confirmed.map((r) => r.email).sort()).toEqual([
+      'one@test.com',
+      'two@test.com',
+    ]);
+    expect(group.waitlisted[0].email).toBe('three@test.com');
+  });
+
+  it('rejects the admin RSVP read for a non-admin', async () => {
+    const nonAdmin = await createTestUser(
+      NON_ADMIN_USER.email,
+      NON_ADMIN_USER.password
+    );
+    const result = await callFunction<GetMusicTogetherDemoRsvpsRequest>({
+      functionName: 'getMusicTogetherDemoRsvps',
+      data: {},
+      idToken: nonAdmin.idToken,
+    });
+    expect(result.status).not.toBe(200);
+  });
+});
+
+describe('onMusicTogetherDemoWrite calendar trigger', () => {
+  let admin: TestUser;
+
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+    admin = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
+    await setFirestoreDoc('admins', admin.uid, {
+      userId: admin.uid,
+      email: admin.email,
+    });
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  it('upserts a public calendar event for a visible demo, removed on hide + delete', async () => {
+    const created = await callFunction<
+      CreateMusicTogetherDemoRequest,
+      CreateMusicTogetherDemoResponse
+    >({
+      functionName: 'createMusicTogetherDemo',
+      data: createInput({ location: 'Trigger Library' }),
+      idToken: admin.idToken,
+    });
+    expect(created.status).toBe(200);
+    const demoId = created.data!.demo.id;
+    const eventId = `mt-demo-${demoId}`;
+
+    // Trigger fires → a public musictogether event appears at the stable id.
+    const event = await waitForCalendarEvent(eventId, true);
+    expect(event).not.toBeNull();
+    expect(event?.type).toBe('musictogether');
+    expect(event?.public).toBe(true);
+    // Free-text location is carried verbatim (demos are often offsite).
+    expect(event?.location).toBe('Trigger Library');
+    expect(event?.sourceRef).toBe(`musicTogetherDemos/${demoId}`);
+
+    // Hiding the demo removes the calendar event.
+    const hidden = await callFunction<
+      UpdateMusicTogetherDemoRequest,
+      UpdateMusicTogetherDemoResponse
+    >({
+      functionName: 'updateMusicTogetherDemo',
+      data: { id: demoId, visible: false },
+      idToken: admin.idToken,
+    });
+    expect(hidden.status).toBe(200);
+    const afterHide = await waitForCalendarEvent(eventId, false);
+    expect(afterHide).toBeNull();
+
+    // Re-showing brings the event back, then deleting removes it for good.
+    await callFunction<UpdateMusicTogetherDemoRequest>({
+      functionName: 'updateMusicTogetherDemo',
+      data: { id: demoId, visible: true },
+      idToken: admin.idToken,
+    });
+    const afterShow = await waitForCalendarEvent(eventId, true);
+    expect(afterShow).not.toBeNull();
+
+    const deleted = await callFunction<DeleteMusicTogetherDemoRequest>({
+      functionName: 'deleteMusicTogetherDemo',
+      data: { id: demoId },
+      idToken: admin.idToken,
+    });
+    expect(deleted.status).toBe(200);
+    const afterDelete = await waitForCalendarEvent(eventId, false);
+    expect(afterDelete).toBeNull();
+  });
+});

--- a/apps/functions-integration-tests-music-together/src/music-together-semester.spec.ts
+++ b/apps/functions-integration-tests-music-together/src/music-together-semester.spec.ts
@@ -133,3 +133,91 @@ describe('MT semester admin CRUD', () => {
     expect(result.status).not.toBe(200);
   });
 });
+
+/**
+ * Regression: clearing a semester's `breaks` / `weatherMakeupDates` arrays must
+ * persist. The user hit "deleted a break, looked saved, but the old value stayed
+ * in Firestore." The dialog now sends an empty `[]` (a full-form edit) rather
+ * than `undefined`; this locks the SERVER contract that `[]` overwrites the
+ * stale value. Unit/interaction tests mock the callable+repo, so only a real
+ * callable + Firestore round-trip catches it.
+ */
+describe('MT semester array-clear round-trip', () => {
+  let admin: TestUser;
+
+  const halloweenBreak = {
+    label: 'Halloween',
+    startDate: new Date('2026-10-31T00:00:00.000Z'),
+    endDate: new Date('2026-10-31T00:00:00.000Z'),
+  };
+  const snowDay = new Date('2027-01-15T00:00:00.000Z');
+
+  beforeAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+    admin = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
+    await setFirestoreDoc('admins', admin.uid, {
+      userId: admin.uid,
+      email: admin.email,
+    });
+  });
+
+  afterAll(async () => {
+    await clearAuthEmulator();
+    await clearFirestoreEmulator();
+  });
+
+  let semesterId: string;
+
+  it('seeds a semester carrying a break + a weather makeup date', async () => {
+    const created = await callFunction<
+      CreateMusicTogetherSemesterRequest,
+      CreateMusicTogetherSemesterResponse
+    >({
+      functionName: 'createMusicTogetherSemester',
+      data: createInput({
+        name: 'Fall 2026 (breaks)',
+        breaks: [halloweenBreak],
+        weatherMakeupDates: [snowDay],
+      } as Partial<CreateMusicTogetherSemesterRequest>),
+      idToken: admin.idToken,
+    });
+
+    expect(created.status).toBe(200);
+    semesterId = created.data!.semester.id;
+    expect(created.data?.semester.breaks).toHaveLength(1);
+    expect(created.data?.semester.breaks?.[0].label).toBe('Halloween');
+    expect(created.data?.semester.weatherMakeupDates).toHaveLength(1);
+  });
+
+  it('clearing both arrays with [] persists — no stale values remain', async () => {
+    const updated = await callFunction<
+      { id: string; breaks: never[]; weatherMakeupDates: never[] },
+      UpdateMusicTogetherSemesterResponse
+    >({
+      functionName: 'updateMusicTogetherSemester',
+      data: { id: semesterId, breaks: [], weatherMakeupDates: [] },
+      idToken: admin.idToken,
+    });
+
+    expect(updated.status).toBe(200);
+    // The deleted break/date must be gone (not the stale old value). The repo
+    // reads an empty array back as absent, so accept empty-or-absent.
+    expect(updated.data?.semester.breaks ?? []).toEqual([]);
+    expect(updated.data?.semester.weatherMakeupDates ?? []).toEqual([]);
+
+    // Confirm via a fresh read too (the actual persisted state, not just the
+    // update's echo).
+    const list = await callFunction<
+      Record<string, never>,
+      GetMusicTogetherSemestersResponse
+    >({
+      functionName: 'getMusicTogetherSemesters',
+      data: {},
+      idToken: admin.idToken,
+    });
+    const fresh = list.data?.semesters.find((s) => s.id === semesterId);
+    expect(fresh?.breaks ?? []).toEqual([]);
+    expect(fresh?.weatherMakeupDates ?? []).toEqual([]);
+  });
+});

--- a/apps/maple-spruce/src/app/(admin)/music-together/DemoFormDialog.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/DemoFormDialog.tsx
@@ -71,7 +71,7 @@ export function DemoFormDialog({
       setDateTime('');
       setLocation('');
       setCapacity(String(DEFAULT_CAPACITY_FAMILIES));
-      setDuration('');
+      setDuration(String(MT_CLASS_DURATION_MINUTES));
       setNotes('');
       setVisible(false);
     }
@@ -84,7 +84,9 @@ export function DemoFormDialog({
         dateTime: fromLocalInput(dateTime),
         location: location.trim(),
         capacityFamilies: parseInt(capacity, 10),
-        durationMinutes: duration ? parseInt(duration, 10) : undefined,
+        durationMinutes: duration
+          ? parseInt(duration, 10)
+          : MT_CLASS_DURATION_MINUTES,
         notes: notes.trim() || undefined,
         visible,
       };

--- a/apps/maple-spruce/src/app/(admin)/music-together/SemesterFormDialog.stories.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/SemesterFormDialog.stories.tsx
@@ -165,6 +165,30 @@ export const EditsBreaksAndWeatherDates: Story = {
   },
 };
 
+/**
+ * Regression: removing a semester's only break must submit `breaks: []`, not
+ * `undefined` — otherwise the partial update omits the field and the deleted
+ * break stays stranded in Firestore ("the edit didn't save").
+ */
+export const ClearingABreakSubmitsEmptyArray: Story = {
+  args: { semester: mockSemester },
+  play: async ({ args }) => {
+    const canvas = await waitForDialog();
+    await userEvent.click(
+      canvas.getByRole('button', { name: /remove break 1/i })
+    );
+    await expect(canvas.queryByLabelText(/break 1 label/i)).toBeNull();
+    const save = canvas.getByRole('button', { name: /save/i });
+    await waitFor(() => expect(save).toBeEnabled());
+    await userEvent.click(save);
+    await waitFor(() =>
+      expect(args.onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ breaks: [] })
+      )
+    );
+  },
+};
+
 /** Touch every field, then submit — exercises each field's change handler. */
 export const FillsAllFields: Story = {
   play: async ({ args }) => {

--- a/apps/maple-spruce/src/app/(admin)/music-together/SemesterFormDialog.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/SemesterFormDialog.tsx
@@ -145,8 +145,12 @@ export function SemesterFormDialog({
           ? fromDateInput(enrollmentOpensAt)
           : undefined,
         notes: notes.trim() || undefined,
-        breaks: cleanBreaks.length > 0 ? cleanBreaks : undefined,
-        weatherMakeupDates: cleanWeather.length > 0 ? cleanWeather : undefined,
+        // Always send the arrays (even empty) — this is a full-form edit, so an
+        // emptied array must CLEAR the field. Sending `undefined` omits it from
+        // the partial update, leaving the old value (e.g. a deleted break)
+        // stranded in Firestore — which read as "the edit didn't save".
+        breaks: cleanBreaks,
+        weatherMakeupDates: cleanWeather,
       };
       await onSubmit(input);
     } catch (e) {

--- a/libs/ts/validation/src/lib/music-together-demo.validation.spec.ts
+++ b/libs/ts/validation/src/lib/music-together-demo.validation.spec.ts
@@ -16,6 +16,27 @@ describe('musicTogetherDemoValidation', () => {
     expect(result.hasErrors()).toBe(false);
   });
 
+  it('treats an absent duration as valid (undefined, null, or omitted)', () => {
+    // A blank duration field persists as null; a strict `!== undefined` guard
+    // used to let null reach enforce() and wrongly rejected the demo.
+    expect(
+      musicTogetherDemoValidation({ ...valid, durationMinutes: undefined }).hasErrors()
+    ).toBe(false);
+    expect(
+      musicTogetherDemoValidation({ ...valid, durationMinutes: null }).hasErrors()
+    ).toBe(false);
+    const { durationMinutes: _omit, ...noDuration } = valid;
+    expect(musicTogetherDemoValidation(noDuration).hasErrors()).toBe(false);
+  });
+
+  it('rejects a non-positive duration when one is given', () => {
+    expect(
+      musicTogetherDemoValidation({ ...valid, durationMinutes: 0 }).hasErrors(
+        'durationMinutes'
+      )
+    ).toBe(true);
+  });
+
   it('requires a dateTime', () => {
     const result = musicTogetherDemoValidation({ ...valid, dateTime: undefined });
     expect(result.hasErrors('dateTime')).toBe(true);

--- a/libs/ts/validation/src/lib/music-together-demo.validation.ts
+++ b/libs/ts/validation/src/lib/music-together-demo.validation.ts
@@ -51,7 +51,10 @@ export const musicTogetherDemoValidation = staticSuite(
     });
 
     test('durationMinutes', 'Duration must be greater than 0', () => {
-      if (data.durationMinutes !== undefined) {
+      // Loose `!= null` so a stored blank (persisted as null) is treated as
+      // absent — a strict `!== undefined` let null through to enforce() and
+      // rejected demos created without a duration.
+      if (data.durationMinutes != null) {
         enforce(data.durationMinutes).greaterThan(0);
       }
     });

--- a/libs/ts/validation/src/lib/music-together-demo.validation.ts
+++ b/libs/ts/validation/src/lib/music-together-demo.validation.ts
@@ -14,7 +14,9 @@ export interface MusicTogetherDemoValidationInput {
   dateTime?: Date | string;
   location?: string;
   capacityFamilies?: number;
-  durationMinutes?: number;
+  // number | null: a blank form field persists as null, and the suite is a
+  // runtime boundary that must accept the null it actually receives.
+  durationMinutes?: number | null;
   notes?: string;
   visible?: boolean;
 }


### PR DESCRIPTION
Closes the coverage gap behind Stephanie's two bugs. Both were **integration-shaped** (real callable + Firestore round-trip) — invisible to the mocked unit/interaction layers, which is exactly why they slipped through.

> **Stacked on #714** (the fixes) so the null-duration case passes against the fix. Base is the #714 branch; it auto-retargets to `main` when #714 merges. Review this for the *test* diff only.

## New: `music-together-demo.spec.ts` (the demo feature had zero integration coverage)
- **Admin CRUD round-trip** + role-gating (non-admin / unauthenticated / blank-location / 404)
- **Blank-duration regression (#714)** — `durationMinutes` omitted **and** `null` both create and read back as effective **45**; `0` still rejected (the `null` case is what 400'd pre-fix)
- **`getPublicMusicTogetherDemos`** — `spotsRemaining`/`isFull`, excludes past + invisible demos, and asserts **no RSVP PII** leaks into the projection
- **`addMusicTogetherDemoRsvp` capacity → waitlist** — cap 2: confirmed, confirmed, **waitlisted**; idempotent re-RSVP; admin read groups 2 confirmed + 1 waitlisted
- **`onMusicTogetherDemoWrite` trigger** — visible demo → public `calendarEvents/mt-demo-{id}` (type `musictogether`, verbatim free-text location); removed on hide + delete

## Extended: `music-together-semester.spec.ts`
- **breaks / weatherMakeupDates array-clear round-trip (Bug 2)** — update with `[]` reads back cleared, not the stale values. Locks the server contract of "the deleted break didn't save".

## Verified
Ran the full suite against real emulators (Java 21): **10 files, 82 tests pass, exit 0**. (`Function error` log lines are the expected negative-path rejections.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)