### PR TITLE
fix(functions): install @firebase/app so Cloud Run containers start (maple-square deploy crash)

### DIFF
--- a/libs/firebase/functions/src/lib/global-runtime-options.ts
+++ b/libs/firebase/functions/src/lib/global-runtime-options.ts
@@ -55,6 +55,32 @@
  * these globals, so a function that genuinely needs more headroom can raise
  * its own `maxInstances`.
  */
+/**
+ * PEER-DEP SHIM: force `@firebase/app` into every codebase's runtime bundle.
+ * ------------------------------------------------------------------------
+ * `firebase-functions/v2` eagerly `require()`s its Realtime-Database provider
+ * on import, which pulls in `firebase-admin/lib/database` →
+ * `@firebase/database-compat/dist/index.standalone.js`, and that file does a
+ * top-level `require('@firebase/app')`. `@firebase/app` is only a *peer*
+ * dependency of `@firebase/database-compat` — neither `firebase-admin` nor
+ * `firebase-functions` depends on it directly. Under pnpm's nested store the
+ * peer resolves, but Firebase Cloud Build installs each function's generated
+ * `package.json` with a FLAT resolver that does NOT auto-install a transitive
+ * package's unmet peer. The result: the deployed container throws
+ * `Cannot find module '@firebase/app'` at module load and never binds
+ * PORT 8080 — every function in the codebase fails its Cloud Run healthcheck.
+ * This was latent (nx-affected only redeploys changed functions) until a
+ * forced full redeploy of maple-square surfaced it after the firebase-admin
+ * 13→14 bump introduced the `database-compat` v2 peer.
+ *
+ * This side-effect import (kept because `@firebase/app` declares no
+ * `sideEffects: false`) makes esbuild emit a `require('@firebase/app')` into
+ * the bundle, so Nx's `generatePackageJson` lists it as a direct dependency
+ * of every codebase and Cloud Build installs it. `@firebase/app` is also a
+ * direct dependency in the root `package.json`. We never use Realtime
+ * Database — this only needs to resolve at load; it is never called.
+ */
+import '@firebase/app';
 import { setGlobalOptions } from 'firebase-functions/v2';
 
 /**

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
+    "@firebase/app": "^0.14.11",
     "@mui/icons-material": "^7.3.11",
     "@mui/material": "^7.3.11",
     "@mui/x-data-grid": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       '@emotion/styled':
         specifier: ^11.11.0
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.0.0))(@types/react@19.2.14)(react@19.0.0)
+      '@firebase/app':
+        specifier: ^0.14.11
+        version: 0.14.11
       '@mui/icons-material':
         specifier: ^7.3.11
         version: 7.3.11(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.0.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.0.0))(@types/react@19.2.14)(react@19.0.0))(@types/react@19.2.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/react@19.2.14)(react@19.0.0)


### PR DESCRIPTION
## Incident

A forced full redeploy (`deploy_all=true`) of the **maple-square** Firebase Functions codebase failed **every** function (all ~26: `squareWebhook`, `createRegistration`, `processPosSale`, `syncInvoiceToSquare`, `createProduct`, `chargeMusicTogetherInstallments`, craft-club subs, etc.) with:

> Could not create or update Cloud Run service `<fn>` … The user-provided container failed to start and listen on the port defined provided by the `PORT=8080` … within the allocated timeout.

Every function failing identically to bind PORT 8080 = the container process **crashes at module-load**, before the functions framework binds the port.

## Root cause (with proof)

`firebase-functions/v2` eagerly `require()`s its Realtime-Database provider on import, which pulls in `firebase-admin/lib/database` → `@firebase/database-compat/dist/index.standalone.js`, whose top-level `require('@firebase/app')` throws.

`@firebase/app` is only a **peer dependency** of `@firebase/database-compat` — neither `firebase-admin` nor `firebase-functions` depends on it directly:

```
@firebase/database-compat peerDependencies: { "@firebase/app": "0.x", "@firebase/app-compat": "0.x" }
```

pnpm's nested store resolves the peer locally (which is why local dev, emulators, and integration tests never caught it), but **Firebase Cloud Build installs each function's Nx-generated `package.json` with a flat resolver that does not auto-install a transitive package's unmet peer** — so the deployed container ships with `@firebase/app` missing entirely.

Reproduced deterministically by mirroring Cloud Build — fresh no-lockfile install from the generated `functions-square` `package.json`, then load the bundle the way the runtime does:

```
$ npm install --omit=dev   # from dist/apps/functions-square/package.json
$ node -e "require('./index.cjs')"
Error: Cannot find module '@firebase/app'
Require stack:
- node_modules/@firebase/database-compat/dist/index.standalone.js
- node_modules/firebase-admin/lib/database/index.js
- node_modules/firebase-functions/lib/common/providers/database.js
- node_modules/firebase-functions/lib/v2/providers/database.js
- node_modules/firebase-functions/lib/v2/index.js
- index.cjs
```

**Why latent, why now, why square:** introduced by the `firebase-admin` 13→14 bump (which brought `@firebase/database-compat` v2 and its peer). The deploy workflow computes nx-affected against `HEAD~1`, so per-merge deploys only redeploy *changed* functions — the break sat undeployed until a forced full redeploy of maple-square exercised a clean container build. **All 4 codebases carry the same latent crash** (they all import `firebase-functions/v2`); square is simply the one that got force-redeployed (the others were fail-fast-cancelled by the matrix).

## Fix

- Add `@firebase/app` as a direct dependency in root `package.json` (`^0.14.11`, already the version resolved in the tree — near-zero lockfile churn).
- Add a documented side-effect `import '@firebase/app'` to the shared `global-runtime-options.ts` that **every** codebase entry point already imports on its first line. `@firebase/app` declares no `sideEffects: false`, so esbuild retains the `require`, which makes Nx's `generatePackageJson` list `@firebase/app` as a direct dependency of **all 4** generated `package.json` files — so Cloud Build installs it.

We never use Realtime Database; this import only needs to resolve at load and is never called.

## Verification

- `nx run-many -t build` on all 4 codebases: clean.
- `@firebase/app: 0.14.11` now present in all 4 generated `package.json` files.
- Fresh no-lockfile `npm install` (Cloud Build-style) from the generated `functions-square` `package.json` + `require('index.cjs')`: **crashed before, loads clean after.**

No deploys triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)