### PR TITLE
feat(music-together): clickable table Names open the row's review modal

### DIFF
--- a/apps/maple-spruce/src/app/(admin)/music-together/DemoRsvpsDialog.stories.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/DemoRsvpsDialog.stories.tsx
@@ -162,3 +162,80 @@ export const EmptyState: Story = {
     await expect(canvas.getByText(/No RSVPs yet\./i)).toBeInTheDocument();
   },
 };
+
+/**
+ * Opening the viewer focused on a specific demo (its Name link was clicked on
+ * the admin page) scrolls that demo's group into view and briefly highlights
+ * it. Here the studio demo (`demo-2`) is focused.
+ */
+export const FocusedDemo: Story = {
+  args: {
+    demoRsvpsState: { status: 'success', data: withRsvps },
+    focusedDemoId: 'demo-2',
+  },
+  play: async () => {
+    const canvas = body();
+
+    // `scrollIntoView` is unimplemented in the test browser's jsdom-like DOM
+    // for some elements; define it so we can both avoid a throw and assert the
+    // focused group was scrolled to. (Object.assign throws on prototype props.)
+    const scrollIntoView = fn();
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      value: scrollIntoView,
+      configurable: true,
+      writable: true,
+    });
+
+    await waitFor(() =>
+      expect(canvas.getByRole('dialog')).toBeInTheDocument()
+    );
+
+    // The focused demo's group is rendered…
+    await expect(
+      canvas.getByText(/Maple & Spruce Studio/)
+    ).toBeInTheDocument();
+    await expect(canvas.getByText('Pat Lee')).toBeInTheDocument();
+
+    // …and it was scrolled into view on open.
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalled());
+  },
+};
+
+/**
+ * Focusing a demo that has NO RSVPs yet (the common case at launch) still
+ * renders that demo — clicking its Name link on the admin page must always land
+ * on the demo you clicked, even though the unfocused view hides empty demos.
+ */
+export const FocusedDemoWithNoRsvps: Story = {
+  args: {
+    demoRsvpsState: {
+      status: 'success',
+      data: {
+        demos: [
+          {
+            demo: { ...studioDemo, id: 'demo-3', location: 'Cheat Lake Library' },
+            confirmed: [],
+            waitlisted: [],
+          },
+          ...withRsvps.demos,
+        ],
+      },
+    },
+    focusedDemoId: 'demo-3',
+  },
+  play: async () => {
+    const canvas = body();
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      value: fn(),
+      configurable: true,
+      writable: true,
+    });
+    await waitFor(() =>
+      expect(canvas.getByRole('dialog')).toBeInTheDocument()
+    );
+    // The empty, focused demo renders (it would be filtered out unfocused)…
+    await expect(canvas.getByText(/Cheat Lake Library/)).toBeInTheDocument();
+    // …with a clear "no RSVPs" state rather than being missing.
+    await expect(canvas.getByText('None yet.')).toBeInTheDocument();
+  },
+};

--- a/apps/maple-spruce/src/app/(admin)/music-together/DemoRsvpsDialog.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/DemoRsvpsDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -34,6 +34,13 @@ interface Props {
   open: boolean;
   onClose: () => void;
   demoRsvpsState: RequestState<GetMusicTogetherDemoRsvpsResponse>;
+  /**
+   * When set (a demo's Name link was clicked on the admin page), the dialog
+   * scrolls that demo's group into view on open and briefly highlights it so
+   * the user lands on the right one. Left undefined by the global "Demo RSVPs"
+   * button — behavior is then unchanged (all groups, none focused).
+   */
+  focusedDemoId?: string;
 }
 
 /** Table-shaped placeholder shown while the RSVPs load. */
@@ -175,13 +182,56 @@ function DemoGroupSection({ group }: { group: MusicTogetherDemoRsvpGroup }) {
  * waitlisted, each with counts and a copy-emails button so Stephanie can
  * follow up.
  */
-export function DemoRsvpsDialog({ open, onClose, demoRsvpsState }: Props) {
+export function DemoRsvpsDialog({
+  open,
+  onClose,
+  demoRsvpsState,
+  focusedDemoId,
+}: Props) {
   const groups =
     demoRsvpsState.status === 'success' ? demoRsvpsState.data.demos : [];
-  // Only show demos that actually have at least one RSVP.
+  // Only show demos that actually have at least one RSVP...
   const withRsvps = groups.filter(
     (g) => g.confirmed.length + g.waitlisted.length > 0
   );
+  // ...but always include the focused demo (from a name-link click) even if it
+  // has no RSVPs yet, so clicking a demo's name always lands on that demo.
+  const focusedGroup = focusedDemoId
+    ? groups.find((g) => g.demo.id === focusedDemoId)
+    : undefined;
+  const rendered =
+    focusedGroup && !withRsvps.some((g) => g.demo.id === focusedGroup.demo.id)
+      ? [focusedGroup, ...withRsvps]
+      : withRsvps;
+
+  // Scroll the focused demo's group into view and briefly highlight it when the
+  // dialog opens. The highlight is a theme `action.selected` wash that fades
+  // back to transparent via a background-color transition.
+  const groupRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const [highlightedId, setHighlightedId] = useState<string | undefined>();
+
+  useEffect(() => {
+    if (!open || !focusedDemoId) {
+      setHighlightedId(undefined);
+      return;
+    }
+    // Defer to let the dialog + groups mount before scrolling/highlighting.
+    const scrollTimer = setTimeout(() => {
+      groupRefs.current[focusedDemoId]?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'start',
+      });
+      setHighlightedId(focusedDemoId);
+    }, 60);
+    return () => clearTimeout(scrollTimer);
+  }, [open, focusedDemoId]);
+
+  // Fade the highlight out shortly after it lands.
+  useEffect(() => {
+    if (!highlightedId) return;
+    const fadeTimer = setTimeout(() => setHighlightedId(undefined), 1600);
+    return () => clearTimeout(fadeTimer);
+  }, [highlightedId]);
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
@@ -192,15 +242,31 @@ export function DemoRsvpsDialog({ open, onClose, demoRsvpsState }: Props) {
         {demoRsvpsState.status === 'error' && (
           <Alert severity="error">{demoRsvpsState.error}</Alert>
         )}
-        {demoRsvpsState.status === 'success' && withRsvps.length === 0 && (
+        {demoRsvpsState.status === 'success' && rendered.length === 0 && (
           <Typography sx={{ p: 2 }} color="text.secondary">
             No RSVPs yet.
           </Typography>
         )}
-        {demoRsvpsState.status === 'success' && withRsvps.length > 0 && (
+        {demoRsvpsState.status === 'success' && rendered.length > 0 && (
           <Stack spacing={4} sx={{ mt: 1 }}>
-            {withRsvps.map((group) => (
-              <DemoGroupSection key={group.demo.id} group={group} />
+            {rendered.map((group) => (
+              <Box
+                key={group.demo.id}
+                ref={(el: HTMLDivElement | null) => {
+                  groupRefs.current[group.demo.id] = el;
+                }}
+                sx={{
+                  p: 1,
+                  borderRadius: 1,
+                  transition: 'background-color 0.6s ease',
+                  backgroundColor:
+                    highlightedId === group.demo.id
+                      ? 'action.selected'
+                      : 'transparent',
+                }}
+              >
+                <DemoGroupSection group={group} />
+              </Box>
             ))}
           </Stack>
         )}

--- a/apps/maple-spruce/src/app/(admin)/music-together/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/music-together/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, type ReactNode } from 'react';
 import {
   Box,
   Stack,
@@ -16,6 +16,7 @@ import {
   Alert,
   IconButton,
   Tooltip,
+  Link,
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
@@ -61,6 +62,46 @@ const fmtDate = (d?: Date) =>
 const fmtDay = (d?: Date) =>
   d ? new Date(d).toLocaleDateString(undefined, { dateStyle: 'medium' }) : '—';
 const fmtPrice = (cents: number) => `$${(cents / 100).toFixed(0)}`;
+
+/**
+ * The single, shared style for every Name-cell link across the three MT admin
+ * tables (Semesters, Sections, Demo Classes) so they read as one control. It's
+ * a real `<button>` (MUI `Link` with `component="button"`) so it's
+ * keyboard-focusable and announces the entity name as its accessible label;
+ * clicking opens that row's review modal. Left-aligned and inline so it doesn't
+ * grow the row height.
+ */
+function NameLink({
+  children,
+  onClick,
+}: {
+  children: ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <Link
+      component="button"
+      type="button"
+      variant="body2"
+      underline="hover"
+      color="primary"
+      onClick={onClick}
+      sx={{
+        textAlign: 'left',
+        verticalAlign: 'baseline',
+        cursor: 'pointer',
+        '&:focus-visible': {
+          outline: '2px solid',
+          outlineColor: 'primary.main',
+          outlineOffset: 2,
+          borderRadius: 0.5,
+        },
+      }}
+    >
+      {children}
+    </Link>
+  );
+}
 
 /**
  * A table-shaped loading placeholder that mirrors the real table's columns so
@@ -188,6 +229,10 @@ export default function MusicTogetherPage() {
   const { interestState } = useMusicTogetherInterest();
 
   const [isDemoRsvpsOpen, setIsDemoRsvpsOpen] = useState(false);
+  // When a demo Name link is clicked we open the (shared) Demo RSVPs viewer
+  // scrolled to that demo; the global toolbar button leaves this undefined so
+  // the viewer shows every demo group with none focused.
+  const [focusedDemoId, setFocusedDemoId] = useState<string | undefined>();
   const { demoRsvpsState } = useMusicTogetherDemoRsvps();
 
   const { demosState, countsByDemo, createDemo, updateDemo, deleteDemo } =
@@ -300,7 +345,10 @@ export default function MusicTogetherPage() {
           <Button
             variant="outlined"
             startIcon={<EventAvailableIcon />}
-            onClick={() => setIsDemoRsvpsOpen(true)}
+            onClick={() => {
+              setFocusedDemoId(undefined);
+              setIsDemoRsvpsOpen(true);
+            }}
           >
             Demo RSVPs
           </Button>
@@ -372,7 +420,16 @@ export default function MusicTogetherPage() {
           <TableBody>
             {semesters.map((sem) => (
               <TableRow key={sem.id}>
-                <TableCell>{sem.name}</TableCell>
+                <TableCell>
+                  <NameLink
+                    onClick={() => {
+                      setEditingSemester(sem);
+                      setIsSemesterFormOpen(true);
+                    }}
+                  >
+                    {sem.name}
+                  </NameLink>
+                </TableCell>
                 <TableCell>
                   {getMusicTogetherSeasonLabel(sem.season)} {sem.year}
                 </TableCell>
@@ -473,7 +530,11 @@ export default function MusicTogetherPage() {
           <TableBody>
             {sectionsState.data.map((section) => (
               <TableRow key={section.id}>
-                <TableCell>{section.name}</TableCell>
+                <TableCell>
+                  <NameLink onClick={() => setRosterSection(section)}>
+                    {section.name}
+                  </NameLink>
+                </TableCell>
                 <TableCell>
                   {section.semesterId
                     ? (semesterName.get(section.semesterId) ?? '—')
@@ -617,7 +678,16 @@ export default function MusicTogetherPage() {
               const waitlisted = counts?.waitlisted ?? 0;
               return (
                 <TableRow key={demo.id}>
-                  <TableCell>{fmtDate(demo.dateTime)}</TableCell>
+                  <TableCell>
+                    <NameLink
+                      onClick={() => {
+                        setFocusedDemoId(demo.id);
+                        setIsDemoRsvpsOpen(true);
+                      }}
+                    >
+                      {fmtDate(demo.dateTime)}
+                    </NameLink>
+                  </TableCell>
                   <TableCell>{demo.location}</TableCell>
                   <TableCell>{mtDemoDurationMinutes(demo)} min</TableCell>
                   <TableCell>{demo.capacityFamilies} families</TableCell>
@@ -716,8 +786,12 @@ export default function MusicTogetherPage() {
 
       <DemoRsvpsDialog
         open={isDemoRsvpsOpen}
-        onClose={() => setIsDemoRsvpsOpen(false)}
+        onClose={() => {
+          setIsDemoRsvpsOpen(false);
+          setFocusedDemoId(undefined);
+        }}
         demoRsvpsState={demoRsvpsState}
+        focusedDemoId={focusedDemoId}
       />
     </>
   );


### PR DESCRIPTION
On the admin **Music Together** page, each table's **Name** is now a styled, keyboard-accessible link that opens that row's review modal (existing row icons unchanged — the link is additive):

| Table | Name click opens |
|---|---|
| **Sections** | that section's **Roster** (registrations + waitlist) |
| **Semesters** | its **edit** dialog |
| **Demo Classes** | **Demo RSVPs**, focused on that demo (scrolls it into view + a brief highlight) |

## Focused-demo fix
`DemoRsvpsDialog` gains an optional `focusedDemoId`. The dialog otherwise hides demos with zero RSVPs, so a naive focus would open a dialog that doesn't contain the clicked demo. Now a focused demo is **always rendered** (with a clear "None yet." state) — so clicking a demo's name always lands on that demo, **even before anyone has signed up** (the common case right now). The global "Demo RSVPs" button clears the focus, so its behavior is unchanged.

## Styling
One shared `NameLink` (MUI `Link` as a real `<button>`, `variant="body2"`, `underline="hover"`, `color="primary"`, visible focus ring) used across all three tables, so they're identical. No hardcoded hex.

## Tests
`nx typecheck maple-spruce` passes; DemoRsvpsDialog play stories **8/8** (added `FocusedDemo` scroll/highlight + `FocusedDemoWithNoRsvps`); eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)