### PR TITLE
feat(my-day): "Typical week" toggle on the Week tab (#683)

### DIFF
--- a/libs/react/lessons/src/lib/MyWeek.stories.tsx
+++ b/libs/react/lessons/src/lib/MyWeek.stories.tsx
@@ -10,10 +10,11 @@ const meta = {
   component: MyWeek,
   title: 'Lessons/MyWeek',
   parameters: { layout: 'fullscreen' },
-  // The category toggle persists to localStorage; clear it so stories don't
-  // bleed hidden-category state into each other.
+  // The category + mode toggles persist to localStorage; clear them so stories
+  // don't bleed hidden-category / typical-vs-this state into each other.
   beforeEach: () => {
     localStorage.removeItem('myWeek.hiddenCategories');
+    localStorage.removeItem('myWeek.mode');
   },
   args: {
     weekStart: mockMyWeekStart,
@@ -58,6 +59,33 @@ export const StepsWeeks: Story = {
       canvas.getByRole('button', { name: /previous week/i }),
     );
     await expect(args.onPrevWeek).toHaveBeenCalledTimes(1);
+  },
+};
+
+export const SwitchesToTypicalWeek: Story = {
+  args: { weekState: { status: 'success', data: mockMyWeekResponse } },
+  play: async ({ canvas }) => {
+    const body = within(document.body);
+    // In "This week" the concrete week nav is present.
+    await expect(
+      canvas.getByRole('button', { name: /previous week/i }),
+    ).toBeInTheDocument();
+
+    // Flip to "Typical week".
+    await userEvent.click(
+      canvas.getByRole('button', { name: /typical week/i }),
+    );
+
+    // Week navigation is gone (a generic week has no prev/next).
+    await waitFor(() =>
+      expect(
+        canvas.queryByRole('button', { name: /previous week/i }),
+      ).not.toBeInTheDocument(),
+    );
+    // The typical-week caption explains one-offs are hidden…
+    await expect(body.getByText(/one-offs are hidden/i)).toBeInTheDocument();
+    // …and a standing slot (the Friday jam) still shows.
+    await expect(body.getByText(/Friday Jam/)).toBeInTheDocument();
   },
 };
 

--- a/libs/react/lessons/src/lib/MyWeek.tsx
+++ b/libs/react/lessons/src/lib/MyWeek.tsx
@@ -4,12 +4,20 @@
  * MyWeek — the teacher's week as a calendar (#685).
  *
  * A calendar-style week grid: a shared hourly time axis on the left and seven
- * day columns, with commitments absolutely positioned by time so the same hour
- * lines up horizontally across days. A teacher's weekly blocks render as shaded
+ * day columns, with items absolutely positioned by time so the same hour lines
+ * up horizontally across days. A teacher's weekly blocks render as shaded
  * background bands (the teaching windows) — open time is simply the empty space
  * in a band. Categories are color-coded and can be toggled off (sticky per
- * browser). Presentational — the page owns the data (`useMyWeek`) and week
- * navigation.
+ * browser).
+ *
+ * Two modes (#683):
+ *  - "This week" projects the concrete `commitments` for the navigated week.
+ *  - "Typical week" projects the synthesized `standing` slots onto a generic
+ *    Sun–Sat week — the recurring pattern from the last few weeks, with
+ *    one-offs dropped, so Katie can plan where a new student fits without a
+ *    concrete week's cancellations/gaps getting in the way.
+ *
+ * Presentational — the page owns the data (`useMyWeek`) and week navigation.
  */
 import { useEffect, useMemo, useState } from 'react';
 import {
@@ -20,6 +28,8 @@ import {
   IconButton,
   Skeleton,
   Stack,
+  ToggleButton,
+  ToggleButtonGroup,
   Typography,
 } from '@mui/material';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
@@ -37,6 +47,8 @@ import type {
   GetMyWeekResponse,
   MyWeekBlock,
   MyWeekCommitment,
+  MyWeekOwnership,
+  MyWeekStandingSlot,
 } from '@maple/ts/firebase/api-types';
 import { formatMinutes } from './block-format';
 
@@ -58,6 +70,9 @@ const DAY_MIN_PX = 116; // min day-column width before horizontal scroll kicks i
 const DEFAULT_START_MIN = 9 * 60;
 const DEFAULT_END_MIN = 18 * 60;
 
+/** Which projection of the week is shown. */
+type WeekMode = 'this' | 'typical';
+
 const CATEGORIES: CalendarEventType[] = [
   'lesson',
   'class',
@@ -67,6 +82,7 @@ const CATEGORIES: CalendarEventType[] = [
   'hours',
 ];
 const STORAGE_KEY = 'myWeek.hiddenCategories';
+const MODE_STORAGE_KEY = 'myWeek.mode';
 
 type PaletteColor = 'default' | 'primary' | 'secondary' | 'info' | 'success';
 
@@ -80,6 +96,26 @@ const CATEGORY_COLOR: Record<CalendarEventType, PaletteColor> = {
   hours: 'default',
 };
 
+/**
+ * The unit both modes render. Concrete commitments and standing slots both
+ * normalize into this so the grid, lane-packing, and styling are shared.
+ */
+interface WeekItem {
+  id: string;
+  /** Weekday 0 (Sun) – 6 (Sat), shop timezone. */
+  weekday: number;
+  /** Minutes from midnight, shop timezone. */
+  startMin: number;
+  endMin: number;
+  category: CalendarEventType;
+  ownership: MyWeekOwnership;
+  title: string;
+  /** "Needs a block" flag — only ever true for concrete lessons. */
+  unattributed: boolean;
+  /** A this-week-only occurrence; faded so standing items stand out. */
+  oneOff: boolean;
+}
+
 function startMinutesOf(iso: string): number {
   return minutesOfDayInZone(new Date(iso), TZ);
 }
@@ -88,8 +124,35 @@ function endMinutesOf(iso: string): number {
   // An event ending at exactly midnight reads as 0 in-zone; treat as end-of-day.
   return m === 0 ? 24 * 60 : m;
 }
-function weekdayOf(iso: string): number {
-  return weekdayIndexInZone(new Date(iso), TZ);
+
+/** Concrete commitment → normalized item (weekday/time resolved in-zone). */
+function commitmentToItem(c: MyWeekCommitment): WeekItem {
+  return {
+    id: c.id,
+    weekday: weekdayIndexInZone(new Date(c.startDateTime), TZ),
+    startMin: startMinutesOf(c.startDateTime),
+    endMin: endMinutesOf(c.endDateTime),
+    category: c.category,
+    ownership: c.ownership,
+    title: c.title,
+    unattributed: c.unattributed,
+    oneOff: c.cadence === 'one-off',
+  };
+}
+
+/** Standing (typical-week) slot → normalized item. Already generic-week. */
+function standingToItem(s: MyWeekStandingSlot): WeekItem {
+  return {
+    id: s.id,
+    weekday: s.weekday,
+    startMin: s.startMinutes,
+    endMin: s.startMinutes + s.durationMinutes,
+    category: s.category,
+    ownership: s.ownership,
+    title: s.title,
+    unattributed: false,
+    oneOff: false,
+  };
 }
 
 function formatWeekRange(weekStart: Date): string {
@@ -108,11 +171,11 @@ function formatHour(minutes: number): string {
 }
 
 /** Fill/border style for an item box from its category + ownership + flags. */
-function itemSx(c: MyWeekCommitment) {
-  const color: PaletteColor = c.unattributed
+function itemSx(item: WeekItem) {
+  const color: PaletteColor = item.unattributed
     ? // warning isn't in PaletteColor union but MUI resolves the token below
       ('warning' as PaletteColor)
-    : CATEGORY_COLOR[c.category];
+    : CATEGORY_COLOR[item.category];
   const isDefault = color === 'default';
   const base = isDefault
     ? { bgcolor: 'grey.300', color: 'text.primary', borderColor: 'grey.400' }
@@ -122,7 +185,7 @@ function itemSx(c: MyWeekCommitment) {
         borderColor: `${color}.main`,
       };
   // Shared store-wide events read as context (outlined, not filled).
-  if (c.ownership === 'shared' && !c.unattributed) {
+  if (item.ownership === 'shared' && !item.unattributed) {
     return {
       bgcolor: 'transparent',
       color: 'text.primary',
@@ -132,41 +195,32 @@ function itemSx(c: MyWeekCommitment) {
   return base;
 }
 
-interface LaidOutItem {
-  c: MyWeekCommitment;
-  startMin: number;
-  endMin: number;
-  lane: number;
-}
+type LaidOutItem = WeekItem & { lane: number };
 
 /** Greedy lane packing so overlapping items sit side-by-side, not on top. */
-function layoutDay(commitments: MyWeekCommitment[]): {
-  items: LaidOutItem[];
+function layoutDay(items: WeekItem[]): {
+  laidOut: LaidOutItem[];
   laneCount: number;
 } {
-  const sorted = commitments
-    .map((c) => ({
-      c,
-      startMin: startMinutesOf(c.startDateTime),
-      endMin: Math.max(
-        endMinutesOf(c.endDateTime),
-        startMinutesOf(c.startDateTime) + MIN_ITEM_MIN,
-      ),
-    }))
-    .sort((a, b) => a.startMin - b.startMin || a.endMin - b.endMin);
+  const sorted = [...items].sort(
+    (a, b) => a.startMin - b.startMin || a.endMin - b.endMin,
+  );
 
   const laneEnds: number[] = [];
-  const items: LaidOutItem[] = sorted.map((it) => {
+  const laidOut: LaidOutItem[] = sorted.map((it) => {
+    // Pack against the rendered height (min-clamped) so short items don't
+    // visually overlap the next one in the same lane.
+    const occupiedEnd = Math.max(it.endMin, it.startMin + MIN_ITEM_MIN);
     let lane = laneEnds.findIndex((end) => end <= it.startMin);
     if (lane === -1) {
       lane = laneEnds.length;
-      laneEnds.push(it.endMin);
+      laneEnds.push(occupiedEnd);
     } else {
-      laneEnds[lane] = it.endMin;
+      laneEnds[lane] = occupiedEnd;
     }
     return { ...it, lane };
   });
-  return { items, laneCount: Math.max(1, laneEnds.length) };
+  return { laidOut, laneCount: Math.max(1, laneEnds.length) };
 }
 
 export function MyWeek({
@@ -177,12 +231,15 @@ export function MyWeek({
   onThisWeek,
 }: MyWeekProps) {
   const [hidden, setHidden] = useState<Set<CalendarEventType>>(new Set());
+  const [mode, setMode] = useState<WeekMode>('this');
 
   // Sticky toggle state (per browser). Read after mount to avoid SSR mismatch.
   useEffect(() => {
     try {
       const raw = localStorage.getItem(STORAGE_KEY);
       if (raw) setHidden(new Set(JSON.parse(raw) as CalendarEventType[]));
+      const rawMode = localStorage.getItem(MODE_STORAGE_KEY);
+      if (rawMode === 'typical' || rawMode === 'this') setMode(rawMode);
     } catch {
       /* ignore malformed storage */
     }
@@ -202,13 +259,31 @@ export function MyWeek({
     });
   };
 
-  const data = weekState.status === 'success' ? weekState.data : undefined;
-  const commitments = data?.commitments ?? [];
-  const blocks = data?.blocks ?? [];
-  const visible = commitments.filter((c) => !hidden.has(c.category));
+  const changeMode = (next: WeekMode | null) => {
+    if (!next) return; // ignore de-selecting the active button
+    setMode(next);
+    try {
+      localStorage.setItem(MODE_STORAGE_KEY, next);
+    } catch {
+      /* ignore */
+    }
+  };
 
-  // Grid bounds: the union of block windows + visible commitment times, snapped
-  // to whole hours. Recomputed only when the inputs change.
+  const data = weekState.status === 'success' ? weekState.data : undefined;
+  const blocks = data?.blocks ?? [];
+
+  // The items for the active mode, normalized + category-filtered.
+  const visible = useMemo(() => {
+    const raw =
+      mode === 'typical'
+        ? (data?.standing ?? []).map(standingToItem)
+        : (data?.commitments ?? []).map(commitmentToItem);
+    return raw.filter((i) => !hidden.has(i.category));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [weekState, mode, hidden]);
+
+  // Grid bounds: the union of block windows + visible item times, snapped to
+  // whole hours. Recomputed only when the inputs change.
   const [gridStart, gridEnd] = useMemo(() => {
     let lo = Infinity;
     let hi = -Infinity;
@@ -216,9 +291,9 @@ export function MyWeek({
       lo = Math.min(lo, b.startMinutes);
       hi = Math.max(hi, b.endMinutes);
     }
-    for (const c of visible) {
-      lo = Math.min(lo, startMinutesOf(c.startDateTime));
-      hi = Math.max(hi, endMinutesOf(c.endDateTime));
+    for (const i of visible) {
+      lo = Math.min(lo, i.startMin);
+      hi = Math.max(hi, i.endMin);
     }
     if (!Number.isFinite(lo)) return [DEFAULT_START_MIN, DEFAULT_END_MIN];
     return [
@@ -226,58 +301,70 @@ export function MyWeek({
       Math.min(24 * 60, Math.ceil(hi / 60) * 60),
     ];
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [weekState, hidden]);
+  }, [weekState, visible]);
 
   const gridHeight = (gridEnd - gridStart) * PX_PER_MIN;
   const hours: number[] = [];
   for (let h = gridStart; h <= gridEnd; h += 60) hours.push(h);
 
-  const header = (
-    <Stack
-      direction="row"
-      spacing={1}
-      alignItems="center"
-      flexWrap="wrap"
+  const modeToggle = (
+    <ToggleButtonGroup
+      value={mode}
+      exclusive
+      size="small"
+      onChange={(_e, v: WeekMode | null) => changeMode(v)}
+      aria-label="Week view mode"
       sx={{ mb: 2 }}
     >
-      <IconButton aria-label="Previous week" onClick={onPrevWeek} size="small">
-        <ChevronLeftIcon />
-      </IconButton>
-      <Button
-        size="small"
-        startIcon={<TodayIcon />}
-        onClick={onThisWeek}
-        variant="outlined"
-      >
+      <ToggleButton value="this" aria-label="This week">
         This week
-      </Button>
-      <IconButton aria-label="Next week" onClick={onNextWeek} size="small">
-        <ChevronRightIcon />
-      </IconButton>
-      <Typography variant="subtitle1" sx={{ ml: 1, fontWeight: 600 }}>
-        {formatWeekRange(weekStart)}
-      </Typography>
-    </Stack>
+      </ToggleButton>
+      <ToggleButton value="typical" aria-label="Typical week">
+        Typical week
+      </ToggleButton>
+    </ToggleButtonGroup>
   );
 
-  const toggles = (
-    <Stack direction="row" flexWrap="wrap" sx={{ mb: 2, gap: 1 }}>
-      {CATEGORIES.map((cat) => {
-        const on = !hidden.has(cat);
-        return (
-          <Chip
-            key={cat}
-            label={getCalendarEventTypeLabel(cat)}
-            size="small"
-            color={on ? CATEGORY_COLOR[cat] : 'default'}
-            variant={on ? 'filled' : 'outlined'}
-            onClick={() => toggleCategory(cat)}
-            aria-pressed={on}
-            sx={{ opacity: on ? 1 : 0.5 }}
-          />
-        );
-      })}
-    </Stack>
+  // Week navigation only makes sense for a concrete week.
+  const weekNav =
+    mode === 'this' ? (
+      <Stack
+        direction="row"
+        spacing={1}
+        alignItems="center"
+        flexWrap="wrap"
+        sx={{ mb: 2 }}
+      >
+        <IconButton aria-label="Previous week" onClick={onPrevWeek} size="small">
+          <ChevronLeftIcon />
+        </IconButton>
+        <Button
+          size="small"
+          startIcon={<TodayIcon />}
+          onClick={onThisWeek}
+          variant="outlined"
+        >
+          Today
+        </Button>
+        <IconButton aria-label="Next week" onClick={onNextWeek} size="small">
+          <ChevronRightIcon />
+        </IconButton>
+        <Typography variant="subtitle1" sx={{ ml: 1, fontWeight: 600 }}>
+          {formatWeekRange(weekStart)}
+        </Typography>
+      </Stack>
+    ) : (
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Your recurring lessons and classes from the last few weeks, on a generic
+        week. One-offs are hidden.
+      </Typography>
+    );
+
+  const header = (
+    <>
+      {modeToggle}
+      {weekNav}
+    </>
   );
 
   if (weekState.status === 'loading') {
@@ -313,12 +400,44 @@ export function MyWeek({
     );
   }
 
+  const toggles = (
+    <Stack direction="row" flexWrap="wrap" sx={{ mb: 2, gap: 1 }}>
+      {CATEGORIES.map((cat) => {
+        const on = !hidden.has(cat);
+        return (
+          <Chip
+            key={cat}
+            label={getCalendarEventTypeLabel(cat)}
+            size="small"
+            color={on ? CATEGORY_COLOR[cat] : 'default'}
+            variant={on ? 'filled' : 'outlined'}
+            onClick={() => toggleCategory(cat)}
+            aria-pressed={on}
+            sx={{ opacity: on ? 1 : 0.5 }}
+          />
+        );
+      })}
+    </Stack>
+  );
+
+  // Typical mode with nothing recurring yet — explain rather than show an empty
+  // grid (blocks alone aren't a "typical week").
+  const emptyTypical =
+    mode === 'typical' && (data?.standing ?? []).length === 0;
+
   const columnsTemplate = `${TIME_AXIS_PX}px repeat(7, minmax(${DAY_MIN_PX}px, 1fr))`;
 
   return (
     <Box>
       {header}
       {toggles}
+
+      {emptyTypical && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          No recurring pattern yet. A lesson or class shows up here once it
+          repeats on the same weekday and time for about two weeks.
+        </Alert>
+      )}
 
       <Box sx={{ overflowX: 'auto', pb: 1 }}>
         {/* Day-of-week header row */}
@@ -346,16 +465,19 @@ export function MyWeek({
                 <Typography variant="overline" sx={{ lineHeight: 1.2 }}>
                   {short}
                 </Typography>
-                <Typography
-                  variant="caption"
-                  color="text.secondary"
-                  sx={{ display: 'block' }}
-                >
-                  {date.toLocaleDateString(undefined, {
-                    month: 'numeric',
-                    day: 'numeric',
-                  })}
-                </Typography>
+                {/* Concrete dates only belong to a concrete week. */}
+                {mode === 'this' && (
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ display: 'block' }}
+                  >
+                    {date.toLocaleDateString(undefined, {
+                      month: 'numeric',
+                      day: 'numeric',
+                    })}
+                  </Typography>
+                )}
               </Box>
             );
           })}
@@ -392,9 +514,7 @@ export function MyWeek({
             <DayColumn
               key={short}
               blocks={blocks.filter((b) => b.dayOfWeek === dayIndex)}
-              commitments={visible.filter(
-                (c) => weekdayOf(c.startDateTime) === dayIndex,
-              )}
+              items={visible.filter((i) => i.weekday === dayIndex)}
               gridStart={gridStart}
               gridEnd={gridEnd}
               gridHeight={gridHeight}
@@ -409,20 +529,20 @@ export function MyWeek({
 
 function DayColumn({
   blocks,
-  commitments,
+  items,
   gridStart,
   gridEnd,
   gridHeight,
   hours,
 }: {
   blocks: MyWeekBlock[];
-  commitments: MyWeekCommitment[];
+  items: WeekItem[];
   gridStart: number;
   gridEnd: number;
   gridHeight: number;
   hours: number[];
 }) {
-  const { items, laneCount } = layoutDay(commitments);
+  const { laidOut, laneCount } = layoutDay(items);
 
   return (
     <Box
@@ -479,20 +599,21 @@ function DayColumn({
         );
       })}
 
-      {/* Positioned commitments */}
-      {items.map(({ c, startMin, endMin, lane }) => {
-        const top = (startMin - gridStart) * PX_PER_MIN;
-        const height = Math.max(endMin - startMin, MIN_ITEM_MIN) * PX_PER_MIN;
+      {/* Positioned items */}
+      {laidOut.map((item) => {
+        const top = (item.startMin - gridStart) * PX_PER_MIN;
+        const height =
+          Math.max(item.endMin - item.startMin, MIN_ITEM_MIN) * PX_PER_MIN;
         const widthPct = 100 / laneCount;
         return (
           <Box
-            key={c.id}
-            title={`${formatMinutes(startMin)} ${c.title}`}
+            key={item.id}
+            title={`${formatMinutes(item.startMin)} ${item.title}`}
             sx={{
               position: 'absolute',
               top,
               height: height - 1,
-              left: `calc(${lane * widthPct}% + 1px)`,
+              left: `calc(${item.lane * widthPct}% + 1px)`,
               width: `calc(${widthPct}% - 3px)`,
               px: 0.5,
               py: 0.1,
@@ -502,8 +623,8 @@ function DayColumn({
               fontSize: 11,
               lineHeight: 1.25,
               cursor: 'default',
-              opacity: c.cadence === 'one-off' ? 0.55 : 1,
-              ...itemSx(c),
+              opacity: item.oneOff ? 0.55 : 1,
+              ...itemSx(item),
             }}
           >
             <Box
@@ -513,11 +634,11 @@ function DayColumn({
                 whiteSpace: 'nowrap',
               }}
             >
-              {formatMinutes(startMin)}
+              {formatMinutes(item.startMin)}
             </Box>{' '}
             <Box component="span">
-              {c.unattributed ? '⚠ ' : ''}
-              {c.title}
+              {item.unattributed ? '⚠ ' : ''}
+              {item.title}
             </Box>
           </Box>
         );


### PR DESCRIPTION
## What

Adds a **This week / Typical week** mode toggle to the teacher's Week tab. The `standing` (typical-week) field has been deployed on dev since #716 but nothing rendered it — this is the frontend that consumes it, and the last piece of the "see the typical week, not just concrete weeks" ask from the epic.

- **This week** — the existing concrete-week calendar grid (unchanged behavior).
- **Typical week** — projects the synthesized `standing` slots onto a generic Sun–Sat week: the recurring pattern from the last ~few weeks, with one-offs dropped, so Katie can plan where a new student fits without a concrete week's cancellations/gaps in the way.

## How

- Normalizes both concrete commitments and standing slots into one internal `WeekItem` shape, so the calendar grid, lane-packing, and category color styling are fully shared between the two modes.
- Typical mode hides week navigation (a generic week has no prev/next), drops concrete dates from the day-of-week header, and shows a short caption. When there's no recurring pattern yet (e.g. a fresh instructor), an info alert explains what makes something appear.
- Mode is sticky per browser (localStorage), mirroring the category toggles.
- Renames the week-nav reset button to **Today** so it doesn't collide with the new **This week** mode button.

## Verification

- `SwitchesToTypicalWeek` Storybook play test: flips the toggle, asserts week-nav disappears, the one-offs-hidden caption shows, and a standing slot (Friday jam) renders. **All 7 MyWeek play tests pass.**
- `maple-spruce` typecheck green.
- Visual review to follow on dev after merge/deploy (per the usual flow).

Part of epic #683. Presentational only — no backend/callable change; reads the already-deployed `standing` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)