### PR TITLE
fix(ci): batch function deploys and make the retry loop actually run (#723)

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -320,9 +320,10 @@ jobs:
       # submit Cloud Functions operations to the same project at once,
       # saturating the per-project operation queue and triggering 409
       # "unable to queue the operation" races that SILENTLY drop functions
-      # (firebase deploy still exits 0). Serializing — plus the 409-aware
-      # retry in the deploy step below — makes a full deploy reliable. Normal
-      # merges touch only 1–2 codebases, so the cost lands on rare full deploys.
+      # (firebase deploy still exits 0). Serializing — plus the batching and
+      # retry in tools/deploy-functions-batched.sh — makes a full deploy
+      # reliable. Normal merges touch only 1–2 codebases, so the cost lands on
+      # rare full deploys.
       max-parallel: 1
       # One codebase failing shouldn't cancel the others mid-deploy.
       fail-fast: false
@@ -383,44 +384,26 @@ jobs:
 
       - name: Deploy functions group to Dev
         if: matrix.functions != ''
-        # Retry up to 3 times. The upload step regularly hits transient
-        # GCS 5xx (storage.googleapis.com → /gcf-v2-uploads/…). A single
-        # 503 used to fail-fast the whole matrix and force a manual
-        # re-run-failed-jobs — three attempts with a 30s gap absorbs
-        # the noise we've seen in practice.
-        run: |
-          set -o pipefail
-          # Two failure modes to absorb:
-          #   1. Transient GCS 5xx during upload → non-zero exit.
-          #   2. 409 "unable to queue the operation" races: firebase deploy
-          #      exits 0 but SILENTLY drops the contended functions. So we also
-          #      scan for that exact marker and retry until a clean run — on
-          #      retry the contended operations have cleared and the dropped
-          #      functions deploy. We deliberately do NOT match "already exists"
-          #      / "failed to create": those are benign (the function IS
-          #      deployed; firebase just mis-tracked create vs update) and would
-          #      make the retry loop never converge. Genuine create/build
-          #      failures exit non-zero and are caught above.
-          for attempt in 1 2 3 4; do
-            # Keyless WIF access token (minted by the auth step) — the Admin SDK
-            # can't consume the external_account credential file, but it accepts
-            # a plain bearer token via --token.
-            pnpm exec firebase deploy \
-              --only ${{ matrix.functions }} \
-              --project maple-and-spruce-dev \
-              --force \
-              --token "${{ steps.auth.outputs.access_token }}" 2>&1 | tee /tmp/fb-deploy.log
-            status=${PIPESTATUS[0]}
-            if [ "$status" -eq 0 ] && ! grep -qiE 'unable to queue the operation' /tmp/fb-deploy.log; then
-              exit 0
-            fi
-            if [ $attempt -lt 4 ]; then
-              echo "::warning::firebase deploy attempt $attempt incomplete (exit=$status or 409 contention); retrying in 30s"
-              sleep 30
-            fi
-          done
-          echo "::error::firebase deploy failed or left functions undeployed after 4 attempts"
-          exit 1
+        # Batched + retried by tools/deploy-functions-batched.sh — see that
+        # script for the full rationale (#723). Two things it fixes:
+        #
+        #   1. The retry loop that used to live inline here NEVER RAN. Actions
+        #      executes `run:` as `bash -e {0}`; with the step's own
+        #      `set -o pipefail`, a failing `firebase deploy | tee` aborted the
+        #      script before `${PIPESTATUS[0]}` was read. A child script gets a
+        #      fresh shell, so the caller's `-e` can't reach into it.
+        #   2. One `firebase deploy` over ~165 maple-core functions blows the
+        #      uncappable 60-writes/60s gen-2 quota and spikes regional CPU.
+        #      The script batches instead — Google's own first remedy.
+        #
+        # Keyless WIF access token (minted by the auth step) — the Admin SDK
+        # can't consume the external_account credential file, but firebase
+        # accepts a plain bearer token via --token. Passed by env (not argv)
+        # so it never lands in a process listing.
+        env:
+          FIREBASE_DEPLOY_TOKEN: ${{ steps.auth.outputs.access_token }}
+          FN_TARGETS: ${{ matrix.functions }}
+        run: ./tools/deploy-functions-batched.sh "$FN_TARGETS" maple-and-spruce-dev
 
       - name: Skip empty function group
         if: matrix.functions == ''
@@ -835,9 +818,10 @@ jobs:
       # submit Cloud Functions operations to the same project at once,
       # saturating the per-project operation queue and triggering 409
       # "unable to queue the operation" races that SILENTLY drop functions
-      # (firebase deploy still exits 0). Serializing — plus the 409-aware
-      # retry in the deploy step below — makes a full deploy reliable. Normal
-      # merges touch only 1–2 codebases, so the cost lands on rare full deploys.
+      # (firebase deploy still exits 0). Serializing — plus the batching and
+      # retry in tools/deploy-functions-batched.sh — makes a full deploy
+      # reliable. Normal merges touch only 1–2 codebases, so the cost lands on
+      # rare full deploys.
       max-parallel: 1
       # One codebase failing shouldn't cancel the others mid-deploy.
       fail-fast: false
@@ -898,28 +882,12 @@ jobs:
 
       - name: Deploy functions group
         if: matrix.functions != ''
-        # Same retry shape as deploy_functions_dev — see there for rationale.
-        run: |
-          set -o pipefail
-          # 409-aware retry — see deploy_functions_dev for the rationale.
-          for attempt in 1 2 3 4; do
-            # Keyless WIF access token via --token — see deploy_functions_dev.
-            pnpm exec firebase deploy \
-              --only ${{ matrix.functions }} \
-              --project maple-and-spruce \
-              --force \
-              --token "${{ steps.auth.outputs.access_token }}" 2>&1 | tee /tmp/fb-deploy.log
-            status=${PIPESTATUS[0]}
-            if [ "$status" -eq 0 ] && ! grep -qiE 'unable to queue the operation' /tmp/fb-deploy.log; then
-              exit 0
-            fi
-            if [ $attempt -lt 4 ]; then
-              echo "::warning::firebase deploy attempt $attempt incomplete (exit=$status or 409 contention); retrying in 30s"
-              sleep 30
-            fi
-          done
-          echo "::error::firebase deploy failed or left functions undeployed after 4 attempts"
-          exit 1
+        # Same batched deploy as deploy_functions_dev — see there, and
+        # tools/deploy-functions-batched.sh, for the rationale (#723).
+        env:
+          FIREBASE_DEPLOY_TOKEN: ${{ steps.auth.outputs.access_token }}
+          FN_TARGETS: ${{ matrix.functions }}
+        run: ./tools/deploy-functions-batched.sh "$FN_TARGETS" maple-and-spruce
 
       - name: Skip empty function group
         if: matrix.functions == ''

--- a/tools/deploy-functions-batched.sh
+++ b/tools/deploy-functions-batched.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# Deploy a list of Firebase function targets in rate-limit-friendly batches.
+#
+# Usage:
+#   FIREBASE_DEPLOY_TOKEN=<access-token> \
+#     tools/deploy-functions-batched.sh <comma-separated-targets> <project-id>
+#
+# e.g. tools/deploy-functions-batched.sh \
+#        "functions:maple-core:getClasses,functions:maple-core:createClass" \
+#        maple-and-spruce-dev
+#
+# ---------------------------------------------------------------------------
+# Why this is a separate script and not an inline `run:` block
+# ---------------------------------------------------------------------------
+# GitHub Actions runs `run:` blocks as `bash -e {0}`. The previous inline
+# version added `set -o pipefail` and then did:
+#
+#     firebase deploy ... | tee log
+#     status=${PIPESTATUS[0]}      # <- never reached
+#
+# With `-e` + pipefail, a failing deploy aborted the step *before* PIPESTATUS
+# was read, so the 4-attempt retry loop never ran once in its entire life
+# (issue #723: zero `attempt N incomplete` warnings across every failed run,
+# each function logged `updating ...` exactly once). Only the exit-0 +
+# "unable to queue the operation" path ever retried.
+#
+# A child script gets a fresh shell, so the caller's `-e` cannot reach in here.
+# We deliberately do NOT `set -e` below: failures are handled explicitly.
+#
+# ---------------------------------------------------------------------------
+# Why batching
+# ---------------------------------------------------------------------------
+# https://docs.cloud.google.com/functions/quotas
+#
+#   "Insufficient quota generally occurs due to use of a CI/CD system that
+#    deploys many functions concurrently or sequentially at a high rate, or use
+#    of the Firebase CLI to deploy multiple functions simultaneously."
+#
+# Two quotas bite, and neither is solved by buying more:
+#
+#   * gen-2 API WRITE quota is 60 per 60 seconds and CANNOT be increased.
+#   * "Total CPU allocation" is a *rate* ("total sum of user-requested CPU
+#     across function instances over a 1 minute period"), not a standing
+#     reservation — which is why the console reads ~0.5% at idle while a wide
+#     deploy still fails with "Container Healthcheck failed. Quota exceeded for
+#     total allowable CPU per project per region."
+#
+# firebase-tools hardcodes deploy concurrency at 40 (release/index.js) with no
+# env override, so one `firebase deploy` over ~165 maple-core functions is
+# guaranteed to breach both. Google's own first remedy is "reduce deployment
+# velocity" — that's what the batching below does.
+#
+# Normal merges touch a handful of functions and stay a single batch; the cost
+# lands only on full-fleet deploys, which today fail outright.
+
+set -uo pipefail
+
+TARGETS="${1:-}"
+PROJECT="${2:-}"
+
+if [ -z "$TARGETS" ]; then
+  echo "No function targets supplied — nothing to deploy."
+  exit 0
+fi
+
+if [ -z "$PROJECT" ]; then
+  echo "::error::deploy-functions-batched.sh: missing project id (arg 2)"
+  exit 2
+fi
+
+if [ -z "${FIREBASE_DEPLOY_TOKEN:-}" ]; then
+  echo "::error::deploy-functions-batched.sh: FIREBASE_DEPLOY_TOKEN is not set"
+  exit 2
+fi
+
+# Batch of 30 keeps each burst under the uncappable 60-writes/60s ceiling with
+# room for the poll traffic. Matches the batch size the Upcover writeup landed
+# on after hitting the same wall at ~60 functions.
+BATCH_SIZE="${FN_DEPLOY_BATCH_SIZE:-30}"
+# Pause between batches. The write quota is a per-minute window, so a short
+# gap is enough once each batch is bounded.
+BATCH_PAUSE="${FN_DEPLOY_BATCH_PAUSE:-20}"
+MAX_ATTEMPTS="${FN_DEPLOY_MAX_ATTEMPTS:-4}"
+# Generic retry backoff (transient GCS 5xx on upload, 409 queue contention).
+RETRY_BACKOFF="${FN_DEPLOY_RETRY_BACKOFF:-30}"
+# Quota errors need to outlast the 1-minute quota window, so back off longer.
+QUOTA_BACKOFF="${FN_DEPLOY_QUOTA_BACKOFF:-90}"
+# Overridable so the spec can substitute a stub binary.
+FIREBASE_CMD="${FN_DEPLOY_FIREBASE_CMD:-pnpm exec firebase}"
+
+# Split the comma-separated target list into an array.
+IFS=',' read -ra ALL_TARGETS <<<"$TARGETS"
+TOTAL=${#ALL_TARGETS[@]}
+TOTAL_BATCHES=$(((TOTAL + BATCH_SIZE - 1) / BATCH_SIZE))
+
+echo "Deploying $TOTAL function target(s) to $PROJECT in $TOTAL_BATCHES batch(es) of up to $BATCH_SIZE."
+
+# Deploy one batch, retrying on failure. Echoes progress; returns non-zero when
+# every attempt has been exhausted.
+deploy_batch() {
+  local batch="$1" label="$2"
+  local log status attempt backoff
+
+  log="$(mktemp)"
+  # shellcheck disable=SC2064  # expand $log now, not at trap time
+  trap "rm -f '$log'" RETURN
+
+  for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+    echo "--- $label, attempt $attempt/$MAX_ATTEMPTS"
+
+    # Unquoted on purpose: FIREBASE_CMD is a command line ("pnpm exec firebase")
+    # that must word-split. The token is passed but never echoed.
+    # shellcheck disable=SC2086
+    $FIREBASE_CMD deploy \
+      --only "$batch" \
+      --project "$PROJECT" \
+      --force \
+      --token "$FIREBASE_DEPLOY_TOKEN" 2>&1 | tee "$log"
+    status=${PIPESTATUS[0]}
+
+    # firebase exits 0 while SILENTLY dropping functions that lost a 409 race
+    # for the operation queue, so a clean exit code is not sufficient. We
+    # deliberately do NOT match "already exists" / "failed to create": those
+    # are benign (the function IS deployed, firebase just mis-tracked create vs
+    # update) and would make this loop never converge.
+    if [ "$status" -eq 0 ] && ! grep -qiE 'unable to queue the operation' "$log"; then
+      echo "--- $label succeeded"
+      return 0
+    fi
+
+    if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+      break
+    fi
+
+    # A quota breach needs to outlast the 1-minute quota window; anything else
+    # (GCS 5xx on upload, 409 contention, WIF token flake — #636) clears fast.
+    if grep -qiE 'Quota exceeded|HTTP Error: 429' "$log"; then
+      backoff="$QUOTA_BACKOFF"
+      echo "::warning::$label hit a quota limit (exit=$status); backing off ${backoff}s"
+    else
+      backoff="$RETRY_BACKOFF"
+      echo "::warning::$label incomplete (exit=$status or 409 contention); retrying in ${backoff}s"
+    fi
+    sleep "$backoff"
+  done
+
+  echo "::error::$label failed after $MAX_ATTEMPTS attempts"
+  return 1
+}
+
+batch_index=0
+for ((i = 0; i < TOTAL; i += BATCH_SIZE)); do
+  batch_index=$((batch_index + 1))
+  chunk_arr=("${ALL_TARGETS[@]:i:BATCH_SIZE}")
+  # Re-join this slice with commas for --only.
+  chunk="$(
+    IFS=','
+    echo "${chunk_arr[*]}"
+  )"
+
+  if ! deploy_batch "$chunk" "batch $batch_index/$TOTAL_BATCHES (${#chunk_arr[@]} function(s))"; then
+    exit 1
+  fi
+
+  # No trailing pause after the final batch.
+  if [ "$batch_index" -lt "$TOTAL_BATCHES" ]; then
+    echo "--- pausing ${BATCH_PAUSE}s before the next batch (write quota is 60/60s)"
+    sleep "$BATCH_PAUSE"
+  fi
+done
+
+echo "All $TOTAL_BATCHES batch(es) deployed successfully."

--- a/tools/deploy-functions-batched.spec.ts
+++ b/tools/deploy-functions-batched.spec.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+/**
+ * Behavioural spec for tools/deploy-functions-batched.sh (#723).
+ *
+ * The script is exercised for real (bash, child process) with a stub standing
+ * in for `firebase`. The stub records every `--only` list it was handed and
+ * replays a caller-supplied plan of exit codes + output, which lets us assert
+ * batching, retry, and backoff-selection without touching Google Cloud.
+ *
+ * The important regression here is the retry loop running AT ALL: the previous
+ * inline `run:` version was killed by GitHub Actions' `bash -e` before it could
+ * read PIPESTATUS, so a non-zero `firebase deploy` never retried once.
+ */
+
+const SCRIPT = resolve(__dirname, 'deploy-functions-batched.sh');
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'fn-deploy-spec-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/**
+ * Write a stub `firebase` whose Nth invocation takes the Nth line of `plan`
+ * (the last line repeats forever). Line format: `<exitCode> <stdout text>`.
+ */
+function writeStub(plan: string[]): string {
+  const stub = join(dir, 'firebase-stub.sh');
+  writeFileSync(join(dir, 'plan.txt'), plan.join('\n') + '\n');
+  writeFileSync(
+    stub,
+    `#!/usr/bin/env bash
+# Record the --only value for this invocation.
+only=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--only" ]; then only="$arg"; fi
+  prev="$arg"
+done
+echo "$only" >> "${join(dir, 'calls.txt')}"
+
+count=$(wc -l < "${join(dir, 'calls.txt')}" | tr -d ' ')
+total=$(wc -l < "${join(dir, 'plan.txt')}" | tr -d ' ')
+if [ "$count" -gt "$total" ]; then count="$total"; fi
+line=$(sed -n "\${count}p" "${join(dir, 'plan.txt')}")
+
+code="\${line%% *}"
+message="\${line#* }"
+echo "$message"
+exit "$code"
+`,
+    { mode: 0o755 },
+  );
+  return stub;
+}
+
+function run(
+  targets: string,
+  plan: string[],
+  env: Record<string, string> = {},
+): { status: number | null; output: string; calls: string[] } {
+  const stub = writeStub(plan);
+  const result = spawnSync('bash', [SCRIPT, targets, 'maple-and-spruce-dev'], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      FIREBASE_DEPLOY_TOKEN: 'stub-token',
+      FN_DEPLOY_FIREBASE_CMD: `bash ${stub}`,
+      // Keep the suite fast — the backoff *choice* is asserted via the warning
+      // text rather than by wall-clock.
+      FN_DEPLOY_BATCH_PAUSE: '0',
+      FN_DEPLOY_RETRY_BACKOFF: '0',
+      FN_DEPLOY_QUOTA_BACKOFF: '0',
+      ...env,
+    },
+  });
+  const callsFile = join(dir, 'calls.txt');
+  const calls = existsSync(callsFile)
+    ? readFileSync(callsFile, 'utf8').split('\n').filter(Boolean)
+    : [];
+  return {
+    status: result.status,
+    output: `${result.stdout}${result.stderr}`,
+    calls,
+  };
+}
+
+function targets(n: number): string {
+  return Array.from({ length: n }, (_, i) => `functions:maple-core:fn${i + 1}`).join(',');
+}
+
+describe('deploy-functions-batched.sh', () => {
+  it('deploys a small list in a single batch and exits 0', () => {
+    const { status, calls } = run(targets(3), ['0 Deploy complete!']);
+
+    expect(status).toBe(0);
+    expect(calls).toEqual(['functions:maple-core:fn1,functions:maple-core:fn2,functions:maple-core:fn3']);
+  });
+
+  it('splits a large list into batches of at most FN_DEPLOY_BATCH_SIZE', () => {
+    const { status, calls } = run(targets(65), ['0 Deploy complete!'], {
+      FN_DEPLOY_BATCH_SIZE: '10',
+    });
+
+    expect(status).toBe(0);
+    // 65 targets / 10 per batch = 7 batches, the last one short.
+    expect(calls).toHaveLength(7);
+    const sizes = calls.map((c) => c.split(',').length);
+    expect(sizes).toEqual([10, 10, 10, 10, 10, 10, 5]);
+    // Every target deployed exactly once, order preserved.
+    expect(calls.join(',').split(',')).toEqual(targets(65).split(','));
+  });
+
+  it('retries a batch that exits non-zero, then succeeds', () => {
+    // THE regression test for #723: under the old inline `run:` block, `bash -e`
+    // aborted the step here and attempt 2 never happened.
+    const { status, output, calls } = run(targets(2), [
+      '2 Error: There was an error deploying functions',
+      '0 Deploy complete!',
+    ]);
+
+    expect(status).toBe(0);
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toBe(calls[1]);
+    expect(output).toContain('attempt 2/4');
+  });
+
+  it('retries when firebase exits 0 but silently dropped functions to a 409', () => {
+    const { status, calls } = run(targets(2), [
+      '0 Error: unable to queue the operation',
+      '0 Deploy complete!',
+    ]);
+
+    expect(status).toBe(0);
+    expect(calls).toHaveLength(2);
+  });
+
+  it('uses the longer quota backoff when the log shows a quota breach', () => {
+    const { status, output } = run(targets(2), [
+      '2 Quota exceeded for total allowable CPU per project per region',
+      '0 Deploy complete!',
+    ]);
+
+    expect(status).toBe(0);
+    expect(output).toContain('hit a quota limit');
+    expect(output).not.toContain('or 409 contention');
+  });
+
+  it('uses the generic backoff for a non-quota failure', () => {
+    const { status, output } = run(targets(2), [
+      '1 Error: 503 from storage.googleapis.com',
+      '0 Deploy complete!',
+    ]);
+
+    expect(status).toBe(0);
+    expect(output).toContain('or 409 contention');
+    expect(output).not.toContain('hit a quota limit');
+  });
+
+  it('fails after exhausting attempts, and does not start later batches', () => {
+    const { status, output, calls } = run(targets(20), ['2 Error: nope'], {
+      FN_DEPLOY_BATCH_SIZE: '10',
+      FN_DEPLOY_MAX_ATTEMPTS: '3',
+    });
+
+    expect(status).toBe(1);
+    // 3 attempts at batch 1, then give up — batch 2 is never attempted.
+    expect(calls).toHaveLength(3);
+    expect(new Set(calls).size).toBe(1);
+    expect(output).toContain('failed after 3 attempts');
+  });
+
+  it('is a no-op (exit 0) when handed an empty target list', () => {
+    const { status, calls } = run('', ['0 Deploy complete!']);
+
+    expect(status).toBe(0);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('fails fast when the deploy token is missing', () => {
+    const stub = writeStub(['0 Deploy complete!']);
+    const result = spawnSync('bash', [SCRIPT, targets(1), 'maple-and-spruce-dev'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        FIREBASE_DEPLOY_TOKEN: '',
+        FN_DEPLOY_FIREBASE_CMD: `bash ${stub}`,
+      },
+    });
+
+    expect(result.status).toBe(2);
+    expect(`${result.stdout}${result.stderr}`).toContain('FIREBASE_DEPLOY_TOKEN is not set');
+  });
+
+  it('survives the caller having set -e (the bug that broke the old retry loop)', () => {
+    const stub = writeStub([
+      '2 Error: There was an error deploying functions',
+      '0 Deploy complete!',
+    ]);
+    // Reproduce GitHub Actions' `bash -e {0}` + the step's `set -o pipefail`.
+    const result = spawnSync(
+      'bash',
+      ['-e', '-c', `set -o pipefail; bash ${SCRIPT} "${targets(2)}" maple-and-spruce-dev`],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          FIREBASE_DEPLOY_TOKEN: 'stub-token',
+          FN_DEPLOY_FIREBASE_CMD: `bash ${stub}`,
+          FN_DEPLOY_BATCH_PAUSE: '0',
+          FN_DEPLOY_RETRY_BACKOFF: '0',
+          FN_DEPLOY_QUOTA_BACKOFF: '0',
+        },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    const calls = readFileSync(join(dir, 'calls.txt'), 'utf8').split('\n').filter(Boolean);
+    expect(calls).toHaveLength(2);
+  });
+});

--- a/tools/deploy-functions-batched.spec.ts
+++ b/tools/deploy-functions-batched.spec.ts
@@ -19,6 +19,9 @@ import { join, resolve } from 'node:path';
 
 const SCRIPT = resolve(__dirname, 'deploy-functions-batched.sh');
 
+/** Stub plan line for a clean `firebase deploy`. */
+const OK = '0 Deploy complete!';
+
 let dir: string;
 
 beforeEach(() => {
@@ -69,12 +72,12 @@ function run(
   env: Record<string, string> = {},
 ): { status: number | null; output: string; calls: string[] } {
   const stub = writeStub(plan);
-  const result = spawnSync('bash', [SCRIPT, targets, 'maple-and-spruce-dev'], {
+  const result = spawnSync('/bin/bash', [SCRIPT, targets, 'maple-and-spruce-dev'], {
     encoding: 'utf8',
     env: {
       ...process.env,
       FIREBASE_DEPLOY_TOKEN: 'stub-token',
-      FN_DEPLOY_FIREBASE_CMD: `bash ${stub}`,
+      FN_DEPLOY_FIREBASE_CMD: `/bin/bash ${stub}`,
       // Keep the suite fast — the backoff *choice* is asserted via the warning
       // text rather than by wall-clock.
       FN_DEPLOY_BATCH_PAUSE: '0',
@@ -100,14 +103,14 @@ function targets(n: number): string {
 
 describe('deploy-functions-batched.sh', () => {
   it('deploys a small list in a single batch and exits 0', () => {
-    const { status, calls } = run(targets(3), ['0 Deploy complete!']);
+    const { status, calls } = run(targets(3), [OK]);
 
     expect(status).toBe(0);
     expect(calls).toEqual(['functions:maple-core:fn1,functions:maple-core:fn2,functions:maple-core:fn3']);
   });
 
   it('splits a large list into batches of at most FN_DEPLOY_BATCH_SIZE', () => {
-    const { status, calls } = run(targets(65), ['0 Deploy complete!'], {
+    const { status, calls } = run(targets(65), [OK], {
       FN_DEPLOY_BATCH_SIZE: '10',
     });
 
@@ -125,7 +128,7 @@ describe('deploy-functions-batched.sh', () => {
     // aborted the step here and attempt 2 never happened.
     const { status, output, calls } = run(targets(2), [
       '2 Error: There was an error deploying functions',
-      '0 Deploy complete!',
+      OK,
     ]);
 
     expect(status).toBe(0);
@@ -137,7 +140,7 @@ describe('deploy-functions-batched.sh', () => {
   it('retries when firebase exits 0 but silently dropped functions to a 409', () => {
     const { status, calls } = run(targets(2), [
       '0 Error: unable to queue the operation',
-      '0 Deploy complete!',
+      OK,
     ]);
 
     expect(status).toBe(0);
@@ -147,7 +150,7 @@ describe('deploy-functions-batched.sh', () => {
   it('uses the longer quota backoff when the log shows a quota breach', () => {
     const { status, output } = run(targets(2), [
       '2 Quota exceeded for total allowable CPU per project per region',
-      '0 Deploy complete!',
+      OK,
     ]);
 
     expect(status).toBe(0);
@@ -158,7 +161,7 @@ describe('deploy-functions-batched.sh', () => {
   it('uses the generic backoff for a non-quota failure', () => {
     const { status, output } = run(targets(2), [
       '1 Error: 503 from storage.googleapis.com',
-      '0 Deploy complete!',
+      OK,
     ]);
 
     expect(status).toBe(0);
@@ -180,20 +183,20 @@ describe('deploy-functions-batched.sh', () => {
   });
 
   it('is a no-op (exit 0) when handed an empty target list', () => {
-    const { status, calls } = run('', ['0 Deploy complete!']);
+    const { status, calls } = run('', [OK]);
 
     expect(status).toBe(0);
     expect(calls).toHaveLength(0);
   });
 
   it('fails fast when the deploy token is missing', () => {
-    const stub = writeStub(['0 Deploy complete!']);
-    const result = spawnSync('bash', [SCRIPT, targets(1), 'maple-and-spruce-dev'], {
+    const stub = writeStub([OK]);
+    const result = spawnSync('/bin/bash', [SCRIPT, targets(1), 'maple-and-spruce-dev'], {
       encoding: 'utf8',
       env: {
         ...process.env,
         FIREBASE_DEPLOY_TOKEN: '',
-        FN_DEPLOY_FIREBASE_CMD: `bash ${stub}`,
+        FN_DEPLOY_FIREBASE_CMD: `/bin/bash ${stub}`,
       },
     });
 
@@ -204,18 +207,18 @@ describe('deploy-functions-batched.sh', () => {
   it('survives the caller having set -e (the bug that broke the old retry loop)', () => {
     const stub = writeStub([
       '2 Error: There was an error deploying functions',
-      '0 Deploy complete!',
+      OK,
     ]);
     // Reproduce GitHub Actions' `bash -e {0}` + the step's `set -o pipefail`.
     const result = spawnSync(
-      'bash',
-      ['-e', '-c', `set -o pipefail; bash ${SCRIPT} "${targets(2)}" maple-and-spruce-dev`],
+      '/bin/bash',
+      ['-e', '-c', `set -o pipefail; /bin/bash ${SCRIPT} "${targets(2)}" maple-and-spruce-dev`],
       {
         encoding: 'utf8',
         env: {
           ...process.env,
           FIREBASE_DEPLOY_TOKEN: 'stub-token',
-          FN_DEPLOY_FIREBASE_CMD: `bash ${stub}`,
+          FN_DEPLOY_FIREBASE_CMD: `/bin/bash ${stub}`,
           FN_DEPLOY_BATCH_PAUSE: '0',
           FN_DEPLOY_RETRY_BACKOFF: '0',
           FN_DEPLOY_QUOTA_BACKOFF: '0',


### PR DESCRIPTION
## Summary

`deploy_functions_dev` has been failing intermittently with `Container Healthcheck failed.
Quota exceeded for total allowable CPU per project per region`, under a storm of 429s on the
per-minute mutation quota. Two independent causes, both fixed here.

### 1. The retry loop never ran — not once

Actions executes `run:` blocks as `bash -e {0}`. The step then added `set -o pipefail`, so a
failing `firebase deploy | tee` aborted the script **before** `status=${PIPESTATUS[0]}` was read.

Evidence from run 30649581444:

- `##[warning]firebase deploy attempt N incomplete` appears **0 times** in either failed job log
- each function logs `updating Node.js 22 (2nd Gen) function` exactly once (calendar job: 9
  lines for 9 functions, not 36)
- step ends `##[error]Process completed with exit code 2` — firebase's own exit code, passed through

Only the exit-0 + `unable to queue the operation` path ever retried. That also explains #636:
WIF auth flakes exit non-zero, so they were never retried either.

### 2. No batching, against a quota that cannot be raised

[Cloud Run functions quotas](https://docs.cloud.google.com/functions/quotas):

> Insufficient quota generally occurs due to use of a CI/CD system that deploys many functions
> concurrently or sequentially at a high rate, or use of the Firebase CLI to deploy multiple
> functions simultaneously.

Its first remedy is **reduce deployment velocity**. Two facts:

- The gen-2 API write quota is **60 per 60 seconds and cannot be increased**.
- "Total CPU allocation" is a *rate* — "total sum of user-requested CPU across function
  instances over a **1 minute period**" — not a standing reservation. That's why the console
  reads ~0.5% at idle while a wide deploy still fails.

We have ~215 functions. A shared-lib change marks all of them affected, and `maple-core` alone
fires ~165 updates in one `firebase deploy` (firebase-tools hardcodes deploy concurrency 40 in
`release/index.js`, no env override).

## Changes

- **New `tools/deploy-functions-batched.sh`** — splits the `--only` target list into batches of
  30 deployed sequentially, per-batch retry, longer backoff when the log shows a quota/429 error
  than for a generic flake. Running it as a child script makes the `-e` fix structural: a fresh
  shell means the caller's `-e` cannot reach in.
- **Both deploy jobs call it** — `deploy_functions_dev` and `deploy_functions_prod` had drifted
  into near-duplicate inline copies of the same broken loop. Now one implementation.
- Token moved from argv to env so it can't appear in a process listing.
- Stale comments about the "409-aware retry in the deploy step" updated.

Tunable via env if the batch size needs adjusting without a code change:
`FN_DEPLOY_BATCH_SIZE`, `FN_DEPLOY_BATCH_PAUSE`, `FN_DEPLOY_MAX_ATTEMPTS`,
`FN_DEPLOY_RETRY_BACKOFF`, `FN_DEPLOY_QUOTA_BACKOFF`.

Normal merges touch a handful of functions and stay a single batch — the cost lands only on
full-fleet deploys, which today fail outright.

## Testing

`tools/deploy-functions-batched.spec.ts` — 10 specs driving the real script through `bash` with
a stub standing in for `firebase` that records every `--only` list and replays a plan of exit
codes:

- single batch for a small list
- 65 targets at batch size 10 → 7 batches sized `[10,10,10,10,10,10,5]`, every target once, order preserved
- **retries after a non-zero exit** ← the regression test for cause 1
- retries on exit-0 + `unable to queue the operation`
- picks the quota backoff on a quota breach, the generic one otherwise
- exhausts attempts, exits 1, and does **not** start later batches
- no-op on an empty target list; exits 2 on a missing token
- **runs correctly when the caller has `set -e` + `set -o pipefail`** ← reproduces the exact
  Actions shell that broke the old loop

```
Test Files  1 passed (1)
     Tests  10 passed (10)
```

Also `bash -n` clean. The end-to-end proof is the next full-fleet deploy on merge.

## Not in scope

~215 single-purpose functions is the actual root cause; this makes the pipeline survive it.
Consolidation tracked in #724.

Closes #723
Closes #636
