### PR TITLE
docs: ADR-029 domain routers + function-count ratchet + queue: max on deploys (#724)

### DIFF
--- a/.claude/rules/firebase-functions.md
+++ b/.claude/rules/firebase-functions.md
@@ -20,6 +20,29 @@ Cloud Function libraries **MUST** follow this naming pattern:
 
 For the full creation procedure, use the `create-cloud-function` skill.
 
+## Prefer a route on a domain router over a new function (ADR-029)
+
+**Default to adding a route on an existing domain router, not a new function library.**
+
+Every function library is a separate Cloud Run service. The gen-2 deploy write quota is
+**60 per 60 seconds and cannot be increased**, so the function count sets a hard floor on how
+long a full deploy takes — at 215 functions that floor is already ~4 minutes, and wide deploys
+have been failing outright. See ADR-029 and epic #724.
+
+CI enforces this as a ratchet (`build-check.yml` → `function-count` job):
+
+```bash
+npx tsx tools/check-function-count.ts        # fails if the count moved either way
+npx tsx tools/check-function-count.ts --fix  # commit the new baseline
+```
+
+Going **down** fails too — that's deliberate. Consolidation only sticks if the win is committed
+to `function-count-baseline.json`, otherwise a later PR silently reclaims the headroom.
+
+A genuinely new function is still fine when it needs materially different runtime options
+(`memory`, `timeoutSeconds`, `minInstances`, `secrets`) from everything in its domain — those are
+properties of the function, not the route. Raise the baseline deliberately in that PR and say why.
+
 ## Codebases
 
 Functions are split into 4 Firebase codebases to reduce cold start times:

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -108,6 +108,32 @@ jobs:
         # integration-tests step). Other CI jobs use it via `npx tsx`.
         run: npx tsx tools/check-firestore-indexes.ts
 
+  function-count:
+    name: Function Count
+    needs: [install]
+    runs-on: ubuntu-latest
+    if: github.repository == 'Maple-and-Spruce/maple-and-spruce'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      # One Cloud Run service per function library. The gen-2 deploy write
+      # quota is 60/60s and CANNOT be raised, so the function count sets a
+      # hard floor on how long a full deploy takes. ADR-029 consolidates
+      # endpoints into domain routers (#724); this ratchet stops the count
+      # drifting back up while that work is in flight. Resolve either
+      # direction with: npx tsx tools/check-function-count.ts --fix
+      - name: Check Cloud Function count ratchet
+        run: npx tsx tools/check-function-count.ts
+
   callable-roles:
     name: Callable Roles
     needs: [install]

--- a/docs/architecture/DECISIONS.md
+++ b/docs/architecture/DECISIONS.md
@@ -1156,6 +1156,120 @@ Plain RBAC: a `Role` enum (`admin`, `mt-teacher`, `clerk`, `lesson-teacher`), a 
 
 ---
 
+## ADR-029: Domain Routers — One HTTP Function per (Domain × Codebase), not per Endpoint
+
+**Status:** Accepted
+**Date:** 2026-08-02
+
+### Context
+We deploy **215 single-purpose functions** (`libs/firebase/maple-functions/*`), nearly all CRUD
+endpoints: `getClasses`, `createClass`, `updateClass`, `deleteClass`, `getDiscounts`, … Each is a
+separate Cloud Run service with its own revision, health check, deploy write op, and CPU burst.
+
+`deploy_functions_dev` has been failing repeatedly (`Container Healthcheck failed. Quota exceeded
+for total allowable CPU per project per region`, under a storm of 429s). Two quota facts, from
+[Cloud Run functions quotas](https://docs.cloud.google.com/functions/quotas):
+
+- The gen-2 API **WRITE quota is 60 per 60 seconds and cannot be increased**. At 215 functions a
+  full deploy needs ≥4 minutes of pure API writes, permanently.
+- "Total CPU allocation" is a **per-minute rate** ("total sum of user-requested CPU across function
+  instances over a 1 minute period"), not a standing reservation — which is why the console reads
+  ~0.5% at idle while a wide deploy still fails.
+
+Google's own first remedy is *"reduce deployment velocity"*, and it names CI systems deploying many
+functions at once as the cause. PR #725 batches the deploy, but that is a mitigation whose cost
+grows linearly with function count. Community datapoints put the pain threshold at
+[~60 functions, with 150+ taking ~45 minutes to deploy](https://groups.google.com/g/firebase-talk/c/Ym14sCZXHMA);
+the [Upcover writeup](https://blog.haroldadmin.com/posts/selective-redeployments-cloud-functions)
+hit CLI rate limits at ~60 and had to build batching plus per-function hashing to cope.
+
+Two repo-specific findings materially change the cost/benefit here:
+
+1. **We are already plain HTTP, not `onCall`.** `Functions.endpoint.handle()`
+   (`libs/firebase/functions/src/lib/functions.utility.ts`) builds an `onRequest` function and
+   hand-rolls CORS, Bearer-token verification, the role gate, Vest validation, uniqueness checks,
+   the warmup sentinel, and the `{ data: … }` request/response envelope that makes the client's
+   `httpsCallable` work. Consolidation is therefore a **routing** change, not a protocol change —
+   the middleware chain already exists and is ours.
+2. **The cold-start objection is already paid.** `apps/functions/src/index.ts` top-level re-exports
+   all ~165 core functions, so every maple-core container already evaluates every core function
+   module at cold start. This is the known Firebase failure mode — [when all functions share a
+   single index, every cold start loads every function's dependencies](https://github.com/hursey013/better-firebase-functions).
+   Grouping endpoints into a router does not add bundle weight we aren't already carrying.
+
+### Decision
+Group endpoints into **domain routers**: one `onRequest` function per (domain × codebase), with an
+Express `Router` dispatching to the existing handlers. Firebase explicitly supports this — the
+HTTPS function interface accepts `(req, res) => void`, which `express.Router`/`Application`
+satisfy, and [Firebase Hosting's docs](https://firebase.google.com/docs/hosting/functions) note
+that with Express routing "the function name is added as a prefix to the URL paths in the app you
+define."
+
+The existing `FunctionBuilder` chain (auth → role → validation → uniqueness → warmup → envelope)
+becomes **per-route router middleware**, unchanged in semantics. Clients migrate from
+`httpsCallable(functions, 'name')` to `httpsCallableFromURL(functions, '<routerUrl>/<route>')`,
+which preserves the callable envelope and ergonomics.
+
+Target: **215 → ~25 functions.**
+
+**Routers are per (domain × codebase), not per domain.** A codebase is a separate deployable, and
+our domains cut across them — Music Together spans all four (core 25, square 4, calendar 2, sync 2),
+Craft Club straddles core and square. A "one router per domain" plan cannot work as stated without
+first revisiting the codebase split (ADR-026).
+
+### Rationale
+- Attacks the actual cause. Batching (#725) makes a 215-function deploy survivable; it cannot make
+  it fast, because the 60/60s write quota is a hard floor that scales with function count.
+- Cheap in this codebase specifically: the middleware exists, the wire format is already
+  `{ data: … }`, and the container already loads the whole codebase.
+- **gen-2 concurrency makes fewer, hotter functions better for cold starts, not worse.** With
+  `concurrency: 80`, one instance serves many requests; consolidating raises per-function traffic
+  and lowers the cold-start hit rate. The v1 intuition ("one instance per request, so keep
+  functions small") does not apply.
+- Restores an optimization we currently forfeit: firebase-tools' skip-unchanged deploy is gated on
+  `!want[id].targetedByOnly` (`release/planner.js`), and *any* `--only` filter — including a bare
+  codebase filter — marks every endpoint targeted. Fewer functions means fewer targets regardless.
+- Domain-sized routers are the middle of the
+  [lambdalith-vs-single-focus](https://urielbitton.substack.com/p/lambdaliths-vs-lambda-single-focus)
+  spectrum: they capture the deploy/ops win without the "one crash takes down everything" and
+  "everything scales together" failure modes of a single app-wide function.
+
+### Alternatives Considered
+- **Raise the quotas.** The write quota is explicitly not increasable, and the CPU quota is a rate
+  we breach only during deploys. Worth taking the free CPU bump as a stopgap; it is not a fix.
+- **Batching alone (#725).** Shipped, and necessary regardless — but its cost grows linearly and it
+  leaves a ≥4-minute write-quota floor in place.
+- **A single `{ action, payload }` dispatcher per codebase (4 functions).** Maximal deploy win, but
+  every endpoint shares one URL, one log stream, one IAM identity, and one blast radius; every
+  change redeploys everything. Too coarse — loses the observability and isolation that make
+  incidents debuggable.
+- **Lazy exports (`better-firebase-functions` style).** Fixes cold-start module loading, not
+  function count or deploy time. Complementary; worth doing separately, not a substitute.
+- **Move to Cloud Run services directly.** Larger migration, and we would rebuild the
+  auth/validation/secrets ergonomics `FunctionBuilder` already gives us.
+- **Do nothing.** Function count only grows with the roadmap; every new endpoint makes the deploy
+  slower and the quota breach more likely.
+
+### Consequences
+- Deploy write ops drop ~215 → ~25, taking a full deploy under the 60/60s quota in a single batch.
+- **Blast radius widens to the domain.** An unhandled crash takes down the instance serving that
+  domain's routes, where today it takes down one endpoint. Domain-sized boundaries bound this;
+  route handlers must not throw past the middleware's error envelope.
+- **Runtime options become per-router.** `memory`, `timeoutSeconds`, `minInstances`, and `secrets`
+  are properties of the function, so co-located routes share them. A route needing materially
+  different limits stays its own function — that is the documented escape hatch, not a failure.
+- Per-route observability must be added deliberately (a route label in logs), since the function
+  name no longer identifies the endpoint.
+- Client call sites (`libs/react/data/`, the Webflow registration widget) migrate to
+  `httpsCallableFromURL`. Old functions stay live until their call sites move.
+- Retired functions must be deleted manually (`firebase functions:delete`) — CI does not prune.
+- A CI ratchet (`tools/check-function-count.ts`) prevents the count from growing while this is
+  in progress.
+- Revisit if: a domain's routes diverge sharply in memory/timeout/secret needs, or a router's
+  route count makes its cold start measurably worse than the per-endpoint baseline.
+
+---
+
 ## ADR-XXX: [Title]
 
 **Status:** Proposed | Accepted | Deprecated | Superseded
@@ -1179,4 +1293,4 @@ What becomes easier or harder as a result?
 
 ---
 
-*Last updated: 2026-07-16 (ADR-028 added for plain RBAC with Firestore role docs)*
+*Last updated: 2026-08-02 (ADR-029 added for domain routers over per-endpoint functions)*

--- a/function-count-baseline.json
+++ b/function-count-baseline.json
@@ -1,0 +1,3 @@
+{
+  "maxFunctions": 215
+}

--- a/tools/check-function-count.spec.ts
+++ b/tools/check-function-count.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { evaluate, countFunctionLibs } from './check-function-count';
+
+describe('evaluate', () => {
+  it('passes when the count sits exactly on the baseline', () => {
+    const verdict = evaluate(215, 215);
+
+    expect(verdict.ok).toBe(true);
+    expect(verdict.message).toContain('215');
+  });
+
+  it('fails when a new function is added, and points at the router pattern', () => {
+    const verdict = evaluate(216, 215);
+
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) return;
+    expect(verdict.kind).toBe('grew');
+    expect(verdict.message).toContain('went UP');
+    expect(verdict.message).toContain('ADR-029');
+    // Must tell the reader the escape hatch exists, not just say no.
+    expect(verdict.message).toContain('--fix');
+  });
+
+  it('fails when functions are removed but the baseline was not lowered', () => {
+    // This is what makes it a ratchet rather than a ceiling — the improvement
+    // has to be committed or a later PR silently reclaims the headroom.
+    const verdict = evaluate(202, 215);
+
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) return;
+    expect(verdict.kind).toBe('shrank');
+    expect(verdict.message).toContain('went DOWN');
+    expect(verdict.message).toContain('--fix');
+  });
+
+  it('treats a large consolidation the same as a small one', () => {
+    const verdict = evaluate(25, 215);
+
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) return;
+    expect(verdict.kind).toBe('shrank');
+  });
+});
+
+describe('countFunctionLibs', () => {
+  it('counts directories and ignores loose files', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fn-count-'));
+    try {
+      mkdirSync(join(dir, 'get-classes'));
+      mkdirSync(join(dir, 'create-class'));
+      mkdirSync(join(dir, 'delete-class'));
+      writeFileSync(join(dir, 'README.md'), '# not a function\n');
+      writeFileSync(join(dir, '.DS_Store'), '');
+
+      expect(countFunctionLibs(dir)).toBe(3);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns 0 for an empty directory', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fn-count-empty-'));
+    try {
+      expect(countFunctionLibs(dir)).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('the committed baseline', () => {
+  it('matches the real function-library count in this repo', () => {
+    // The guard is worthless if the checked-in baseline has drifted from
+    // reality — this spec fails the moment they diverge.
+    const baseline = require('../function-count-baseline.json') as {
+      maxFunctions: number;
+    };
+
+    expect(countFunctionLibs()).toBe(baseline.maxFunctions);
+  });
+});

--- a/tools/check-function-count.ts
+++ b/tools/check-function-count.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env npx tsx
+/**
+ * Cloud Function count ratchet (ADR-029, epic #724).
+ *
+ * We deploy one Cloud Run service per function library under
+ * `libs/firebase/maple-functions/`. At 215 of them a full deploy needs >=4
+ * minutes of pure API writes, because the gen-2 write quota is 60 per 60
+ * seconds and CANNOT be increased:
+ *   https://docs.cloud.google.com/functions/quotas
+ *
+ * ADR-029 consolidates endpoints into domain routers to bring that count down.
+ * That work spans many PRs, so this guard exists to stop the count drifting
+ * back up while it's in flight — otherwise consolidation removes 20 functions
+ * while feature work adds 15 and the number never moves.
+ *
+ * It is a RATCHET, not a ceiling: going *under* the baseline is also a failure,
+ * because the win must be committed to `function-count-baseline.json` to be
+ * locked in. Both directions are one command to resolve:
+ *
+ *   npx tsx tools/check-function-count.ts          # check (CI runs this)
+ *   npx tsx tools/check-function-count.ts --fix    # write the new baseline
+ */
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const REPO_ROOT = resolve(__dirname, '..');
+const FUNCTIONS_DIR = join(REPO_ROOT, 'libs/firebase/maple-functions');
+const BASELINE_FILE = join(REPO_ROOT, 'function-count-baseline.json');
+
+export interface Baseline {
+  /** Highest allowed number of function libraries. Only ever goes down. */
+  maxFunctions: number;
+}
+
+export type Verdict =
+  | { ok: true; message: string }
+  | { ok: false; kind: 'grew' | 'shrank'; message: string };
+
+/**
+ * Compare the observed function count against the committed baseline.
+ * Pure — the file system lives in `main()`.
+ */
+export function evaluate(count: number, baseline: number): Verdict {
+  if (count > baseline) {
+    return {
+      ok: false,
+      kind: 'grew',
+      message:
+        `Function count went UP: ${count} (baseline ${baseline}).\n\n` +
+        `Adding a new single-purpose Cloud Function contradicts ADR-029 — we are\n` +
+        `consolidating endpoints into domain routers (#724) because the gen-2 write\n` +
+        `quota (60/60s) cannot be raised and already floors a full deploy at ~4 min.\n\n` +
+        `Add the endpoint as a route on the relevant domain router instead. If it\n` +
+        `genuinely needs its own function (materially different memory, timeout, or\n` +
+        `secrets — see ADR-029 "Consequences"), raise the baseline deliberately:\n` +
+        `  npx tsx tools/check-function-count.ts --fix`,
+    };
+  }
+
+  if (count < baseline) {
+    return {
+      ok: false,
+      kind: 'shrank',
+      message:
+        `Function count went DOWN: ${count} (baseline ${baseline}). Nice — lock it in:\n` +
+        `  npx tsx tools/check-function-count.ts --fix\n\n` +
+        `The baseline is a ratchet; committing the drop is what stops the count\n` +
+        `creeping back up on a later PR.`,
+    };
+  }
+
+  return { ok: true, message: `Function count at baseline: ${count}.` };
+}
+
+/** Count function libraries (one deployed Cloud Run service each). */
+export function countFunctionLibs(dir: string = FUNCTIONS_DIR): number {
+  return readdirSync(dir, { withFileTypes: true }).filter((e) => e.isDirectory())
+    .length;
+}
+
+function readBaseline(): number {
+  const raw = JSON.parse(readFileSync(BASELINE_FILE, 'utf8')) as Baseline;
+  if (typeof raw.maxFunctions !== 'number') {
+    throw new Error(`${BASELINE_FILE} is missing a numeric "maxFunctions"`);
+  }
+  return raw.maxFunctions;
+}
+
+function main(): void {
+  const count = countFunctionLibs();
+
+  if (process.argv.includes('--fix')) {
+    const baseline: Baseline = { maxFunctions: count };
+    writeFileSync(BASELINE_FILE, `${JSON.stringify(baseline, null, 2)}\n`);
+    console.log(`Baseline updated to ${count}.`);
+    return;
+  }
+
+  const verdict = evaluate(count, readBaseline());
+  if (verdict.ok) {
+    console.log(verdict.message);
+    return;
+  }
+  console.error(verdict.message);
+  process.exit(1);
+}
+
+// Only run when invoked directly, so the spec can import the pure helpers.
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Summary

Records the architecture decision behind epic #724 and adds the guard that keeps it from
regressing while the work is in flight. No runtime code changes.

## ADR-029: Domain Routers — One HTTP Function per (Domain × Codebase)

**Decision:** group endpoints into domain routers — one `onRequest` function per
(domain × codebase), with an Express `Router` dispatching to the existing handlers. Target
215 → ~25.

Two findings from *this* codebase changed the shape of the decision, and both make it much
cheaper than the generic advice implies:

1. **We are already plain HTTP, not `onCall`.** `Functions.endpoint.handle()` builds an
   `onRequest` function and already hand-rolls CORS, Bearer-token verification, the role gate,
   Vest validation, uniqueness checks, the warmup sentinel, and the `{ data: … }` envelope that
   makes the client's `httpsCallable` work. Consolidation is a **routing** change, not a protocol
   change. Clients move to `httpsCallableFromURL`.
2. **The cold-start objection is already paid.** `apps/functions/src/index.ts` top-level re-exports
   all ~165 core functions, so every maple-core container already evaluates every core module at
   cold start. Grouping routes adds no bundle weight we aren't already carrying.

And one constraint that invalidates the plan as originally written in #724:

> **Routers are per (domain × codebase), not per domain.** A codebase is a separate deployable and
> our domains cut across them — Music Together spans all four (core 25, square 4, calendar 2,
> sync 2); Craft Club straddles core and square. "One router per domain" cannot work without
> revisiting ADR-026 first.

### Evidence it's checked against

- [Cloud Run functions quotas](https://docs.cloud.google.com/functions/quotas) — gen-2 write quota
  is **60/60s and cannot be increased**; "Total CPU allocation" is a per-minute *rate*; Google's
  first listed remedy is "reduce deployment velocity"
- [Firebase Hosting + Cloud Functions](https://firebase.google.com/docs/hosting/functions) —
  Express apps in HTTPS functions are officially supported; the function name prefixes the routes
- [Deploying 150+ functions is very slow](https://groups.google.com/g/firebase-talk/c/Ym14sCZXHMA)
  and [the Upcover writeup](https://blog.haroldadmin.com/posts/selective-redeployments-cloud-functions)
  — pain starts ~60 functions, 150+ → ~45 min deploys
- [Lambdaliths vs single-focus functions](https://urielbitton.substack.com/p/lambdaliths-vs-lambda-single-focus)
  — the case *against*, taken seriously: shared scaling, wider blast radius, higher memory. This is
  why the decision is domain-sized routers rather than one app-wide function, and why those costs
  are written into "Consequences" rather than waved off.

The ADR also records what was rejected and why: raising quotas (write quota can't be raised),
batching alone (#725 — linear cost, ≥4 min floor remains), a single `{action, payload}` dispatcher
per codebase (too coarse — one URL, one log stream, one blast radius), lazy exports (fixes cold
start, not count), and moving to raw Cloud Run.

**Honest gap:** Google does not publish an explicit "consolidate your functions" recommendation.
The strongest official support is the quota page's "reduce deployment velocity" plus the Hosting
docs' Express endorsement; the rest is practitioner evidence. Called out rather than overstated.

## Ratchet

`tools/check-function-count.ts`, wired into `build-check.yml` as a `Function Count` job, with the
baseline in `function-count-baseline.json` (seeded at the real 215).

It fails in **both** directions:

- **Up** — a new single-purpose function contradicts ADR-029; the message points at the router
  pattern and at the deliberate escape hatch (materially different memory/timeout/secrets).
- **Down** — the win has to be committed to the baseline, or a later PR silently reclaims the
  headroom. That is what makes it a ratchet rather than a ceiling.

Both resolve with `npx tsx tools/check-function-count.ts --fix`.

Also documented in `.claude/rules/firebase-functions.md`, which auto-loads on function paths — so
an agent adding a function sees it before writing the code, not at CI.

## Testing

`tools/check-function-count.spec.ts` — 7 specs: at/above/below baseline verdicts and their
messages, directory counting ignoring loose files, empty dir, and a guard asserting the
**committed baseline matches the real repo count** (so the check can't silently drift).

Exercised the real script end to end:

```
$ npx tsx tools/check-function-count.ts
Function count at baseline: 215.                      exit=0

$ mkdir libs/firebase/maple-functions/__tmp-fake-fn && npx tsx tools/check-function-count.ts
Function count went UP: 216 (baseline 215). ...       exit=1
```

39/39 tools specs pass, ESLint clean on both new files, `build-check.yml` parses and the new job
resolves.

Refs #724

---

## Added: `queue: max` on the deploy concurrency group

Separate bug found while validating the above, folded in because it's two lines and blocks the
same epic.

`firebase-functions-merge.yml` used `concurrency: { group: deploy-on-merge, cancel-in-progress: false }`.
GitHub's default is `queue: single` — **only one run may be pending, and a third queued run cancels
the second outright**:

> "By default, any existing `pending` job or workflow in the same concurrency group will be
> canceled and the new queued job or workflow will take its place."
> — [GitHub docs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency)

`cancel-in-progress: false` only protects the **running** run. A full deploy takes 15–30 minutes,
so any two merges landing in that window silently stranded the middle one — cancelled with zero
jobs ever started, nothing deployed, and `nx-affected` can't recover it because the next run diffs
against `HEAD~1`.

Two live examples from today, both cancelled with zero jobs:

- `30764774505` — the #725 merge
- `30764954396` — **#703, the MT Square production cutover**

`queue: max` lets up to 100 runs wait in FIFO order instead. Mutually exclusive with
`cancel-in-progress: true`; we use `false`, so it composes.

This matters much more with an agent team merging steadily than with occasional manual merges,
which is why it lands alongside the ADR.

**Verified before landing:** a rejected concurrency key would mean *no deploys at all*, so I
proved the parser accepts it first — a throwaway probe workflow carrying the identical
concurrency block, pushed and run green ([run 30766414665](https://github.com/Maple-and-Spruce/maple-and-spruce/actions/runs/30766414665)), then deleted in the same PR.
