### PR TITLE
fix(webflow): draft dev-synced classes so a full-site publish can't leak them

### DIFF
--- a/libs/firebase/webflow/src/lib/class.service.spec.ts
+++ b/libs/firebase/webflow/src/lib/class.service.spec.ts
@@ -373,6 +373,26 @@ describe('ClassService', () => {
       );
     });
 
+    it('creates a DEV item as a draft so a full-site publish never makes it live', async () => {
+      mockClient.collections.items.listItems.mockResolvedValue({ items: [] });
+      mockClient.collections.items.createItem.mockResolvedValue({
+        id: 'wf-dev-item',
+        fieldData: { slug: 'pottery-101-dev' },
+      });
+
+      await service.syncClass({
+        classEntity: mockClass,
+        publish: false,
+        isDev: true,
+      });
+
+      expect(mockClient.collections.items.createItem).toHaveBeenCalledWith(
+        COLLECTION_ID,
+        expect.objectContaining({ isDraft: true })
+      );
+      expect(mockClient.collections.items.publishItem).not.toHaveBeenCalled();
+    });
+
     it('updates an existing Webflow item when class already exists', async () => {
       mockClient.collections.items.listItems.mockResolvedValue({
         items: [

--- a/libs/firebase/webflow/src/lib/class.service.ts
+++ b/libs/firebase/webflow/src/lib/class.service.ts
@@ -288,11 +288,11 @@ export class ClassService {
     });
 
     if (existingItemId) {
-      webflowSlug = await this.updateItem(existingItemId, fieldData);
+      webflowSlug = await this.updateItem(existingItemId, fieldData, isDev);
       webflowItemId = existingItemId;
       isNew = false;
     } else {
-      const newItem = await this.createItem(fieldData);
+      const newItem = await this.createItem(fieldData, isDev);
       webflowItemId = newItem.id;
       webflowSlug = extractSlug(newItem);
       isNew = true;
@@ -431,11 +431,14 @@ export class ClassService {
   }
 
   private async createItem(
-    fieldData: ClassWebflowFieldData
+    fieldData: ClassWebflowFieldData,
+    isDev: boolean
   ): Promise<WebflowItemWithId> {
+    // Dev-synced items are kept as drafts so a full-site publish can never make
+    // them live (mirrors the MT section/demo sync). Prod items are non-draft.
     const response = await this.client.collections.items.createItem(
       this.collectionId,
-      { isArchived: false, isDraft: false, fieldData }
+      { isArchived: false, isDraft: isDev, fieldData }
     );
 
     if (!response.id) {
@@ -452,7 +455,8 @@ export class ClassService {
    */
   private async updateItem(
     itemId: string,
-    fieldData: ClassWebflowFieldData
+    fieldData: ClassWebflowFieldData,
+    isDev: boolean
   ): Promise<string> {
     // Omit `slug` on update — Webflow auto-suffixes slug collisions on
     // create (e.g. `name-94fde` when `name` is taken), but on update it
@@ -464,7 +468,7 @@ export class ClassService {
       itemId,
       {
         isArchived: false,
-        isDraft: false,
+        isDraft: isDev,
         fieldData: fieldDataWithoutSlug,
       }
     );


### PR DESCRIPTION
## The leak
The class→Webflow sync hardcoded `isDraft: false` on create/update. So dev/CI test classes (tagged `is-dev-environment`) were created **non-draft**, and a routine **full-site publish** swept them live — producing **live, indexable dev class detail pages** (e.g. `/classes/intro-to-pottery`, `/classes/pos-dev-smoke-class-…`). List filters hid them from *listings*, but not from their own detail pages.

The MT **section** and **demo** syncs already draft their dev items (which is why the dev MT Section never leaked). This brings the **class** sync in line.

## Fix
`createItem` / `updateItem` now set **`isDraft = isDev`**: dev-synced classes stay in the CMS (reviewable — the dev-sync signal is preserved) but **never publish a live page**, so a full-site publish can't expose them. Prod classes are unchanged (`isDraft: false` + published).

## Not included here
The **already-published** dev classes are handled separately by **unpublishing** them (→ draft; not deleted, per the "keep the dev data for review" decision). This PR only stops recurrence.

## Tests
Added a service test: `syncClass({isDev:true})` → `createItem` called with `isDraft:true` and `publishItem` not called. 40 class-service tests pass; `nx build functions-sync` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)