### PR TITLE
fix(ci): re-land queue: max, and stop PR pushes stacking 19-job runs

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -5,6 +5,23 @@ on:
     branches:
       - '**'
 
+# One in-flight run per PR. This workflow fans out to 19 jobs (builds, unit +
+# Storybook coverage, four E2E suites, integration-test matrix), so every push
+# to a PR used to start a second full copy while the first kept burning
+# runners — and both raced for the same shared dev resources.
+#
+# `cancel-in-progress: true` is correct HERE and wrong on the deploy workflow:
+# a superseded PR result is worthless (the branch already moved on), whereas a
+# half-cancelled deploy leaves functions stranded. Note this is the opposite
+# setting from `deploy-on-merge` in firebase-functions-merge.yml, deliberately.
+#
+# `github.ref` is the PR's merge ref, so each PR gets its own group and PRs
+# never cancel each other. Matters most with several agents iterating on
+# separate PRs at once.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   NX_DAEMON: 'false'
 

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -11,6 +11,13 @@ on:
 env:
   NX_DAEMON: 'false'
 
+# Same rationale as build-check.yml: one in-flight run per ref, superseded
+# pushes cancelled. Chromatic snapshots are metered, so a cancelled duplicate
+# run is also saved quota — this repo has hit the free-tier snapshot cap.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   chromatic:
     name: Visual Regression Testing

--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -57,8 +57,31 @@ env:
 # producing flaky failures whose root cause is invisible from the job
 # logs. `cancel-in-progress: false` lets the in-flight run finish — we
 # never want to cancel a deploy halfway.
+#
+# `queue: max` is load-bearing, NOT cosmetic. GitHub's default is
+# `queue: single`, which keeps only ONE run pending: when a third run
+# queues, the second is CANCELLED outright.
+#
+#   "By default, any existing `pending` job or workflow in the same
+#    concurrency group will be canceled and the new queued job or
+#    workflow will take its place."
+#   https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency
+#
+# `cancel-in-progress: false` only protects the RUNNING run — it does
+# nothing for pending ones. A full deploy takes 15–30 min, so any two
+# merges landing inside that window silently stranded the middle one:
+# cancelled with zero jobs ever started, nothing deployed, and
+# nx-affected won't recover it because the next run diffs HEAD~1.
+# That is how #703 (MT Square production cutover) and the #725 merge
+# both reached main without ever deploying.
+#
+# `queue: max` makes up to 100 runs wait in FIFO order instead. It is
+# mutually exclusive with `cancel-in-progress: true`; we use false, so
+# it composes. Syntax verified against the live Actions parser before
+# landing here (throwaway probe workflow, run 30766414665).
 concurrency:
   group: deploy-on-merge
+  queue: max
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary

Two concurrency fixes with **opposite** settings, deliberately.

### 1. `queue: max` on `deploy-on-merge` — re-land

This was written for #726 but landed on the branch **~3 minutes after that PR was merged**, so it never reached main. PR #726 contains exactly one commit; `queue: max` is absent from `origin/main`.

Confirmed by behaviour rather than inference — the merge runs for #726 (`30766301320`) and #727 (`30766309246`) were **both cancelled with zero jobs started**, which is precisely the failure this fixes.

GitHub's concurrency default is `queue: single`: only one run may be pending, and a third queued run cancels the second outright.

> "By default, any existing `pending` job or workflow in the same concurrency group will be canceled and the new queued job or workflow will take its place."
> — [GitHub docs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency)

`cancel-in-progress: false` only protects the **running** run. A full deploy takes 15–30 min, so any two merges inside that window strand the middle one — nothing deployed, and `nx-affected` can't recover it because the next run diffs against `HEAD~1`. That is how #703's Square production cutover reached main without deploying.

Syntax was verified against the live Actions parser before it was ever written — a throwaway probe workflow carrying the identical concurrency block, run green ([30766414665](https://github.com/Maple-and-Spruce/maple-and-spruce/actions/runs/30766414665)), then deleted. A rejected concurrency key invalidates the workflow file and would mean *no deploys at all*.

### 2. Per-ref concurrency on the two `pull_request` workflows

`build-check.yml` fans out to **19 jobs** (builds, unit + Storybook coverage, four E2E suites, an integration-test matrix) and had **no concurrency group at all**. Every push to a PR started a second full copy while the first kept burning runners, and both raced for the same shared dev resources.

`chromatic.yml` had none either — and its snapshots are metered, which is why UI checks currently sit at `Update your plan to resume`. Cancelling superseded runs saves quota directly.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

`cancel-in-progress: true` is correct **here** and wrong on the deploy workflow: a superseded PR result is worthless because the branch already moved on, whereas a half-cancelled deploy strands functions. Grouping on `github.ref` means PRs never cancel each other.

This is the streamlining that matters most once several agents iterate on separate PRs at once (#724).

## Testing

All three workflow files parse, and the resolved concurrency blocks are:

| workflow | group | setting | jobs |
|---|---|---|---|
| `build-check.yml` | `${{ github.workflow }}-${{ github.ref }}` | `cancel-in-progress: true` | 19 |
| `chromatic.yml` | `${{ github.workflow }}-${{ github.ref }}` | `cancel-in-progress: true` | 1 |
| `firebase-functions-merge.yml` | `deploy-on-merge` | `queue: max`, `cancel-in-progress: false` | 13 |

This PR's own checks exercise change 2 directly: pushing again should cancel the prior run rather than stack a second one.

Change 1 can only be observed after merge, on the next two closely-spaced merges — the previously-pending run should stay `pending` instead of flipping to `cancelled`.

Refs #724