### PR TITLE
fix(lessons): subject-verb agreement in block-fit warning

### DIFF
--- a/libs/react/lessons/src/lib/ScheduleLessonDialog.tsx
+++ b/libs/react/lessons/src/lib/ScheduleLessonDialog.tsx
@@ -239,10 +239,11 @@ export function ScheduleLessonDialog({
     const outside = dates.filter(
       (d) => !lessonFitsBlock(d, durationMinutes.value, b),
     );
+    const one = outside.length === 1;
     return outside.length > 0
-      ? `${outside.length} lesson time${
-          outside.length === 1 ? '' : 's'
-        } fall outside this block (${formatBlockOption(b)}) and will be rejected on save.`
+      ? `${outside.length} lesson time${one ? '' : 's'} fall${
+          one ? 's' : ''
+        } outside this block (${formatBlockOption(b)}) and will be rejected on save.`
       : null;
   });
 


### PR DESCRIPTION
## What

The Schedule Lesson dialog's block-fit warning pluralized the noun but left the verb fixed, so the singular case read:

> **1 lesson time _fall_ outside this block…**

Now reads **"1 lesson time _falls_ outside…"** while the plural stays **"2 lesson times fall outside…"**.

Spotted driving the real schedule flow on dev (`business-dev`) during the #683 walkthrough.

## Change

`ScheduleLessonDialog.tsx` — toggle the verb ending (`fall`/`falls`) on the same singular check that already toggles the noun's `s`.

## Verification

- `maple-spruce` typecheck green.
- All 9 `ScheduleLessonDialog` Storybook play tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)