### PR TITLE
fix(music-together): pin mtDemoDisplayLabel to Eastern Time

### DIFF
--- a/libs/ts/domain/src/lib/music-together-demo.spec.ts
+++ b/libs/ts/domain/src/lib/music-together-demo.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { mtDemoDisplayLabel } from './music-together-demo';
+
+describe('mtDemoDisplayLabel', () => {
+  it('formats the demo time in Eastern Time regardless of runtime timezone', () => {
+    // 14:00 UTC on 2026-09-15 = 10:00 AM EDT. On Cloud Functions (UTC runtime)
+    // this used to render "2:00 PM"; the label must pin America/New_York.
+    const label = mtDemoDisplayLabel({
+      dateTime: new Date('2026-09-15T14:00:00Z'),
+      location: 'Morgantown Public Library',
+    });
+    expect(label).toContain('10:00 AM');
+    expect(label).not.toContain('2:00 PM');
+    expect(label).toContain('Morgantown Public Library');
+  });
+
+  it('omits the separator when there is no location', () => {
+    const label = mtDemoDisplayLabel({
+      dateTime: new Date('2026-09-15T14:00:00Z'),
+      location: '',
+    });
+    expect(label).toContain('10:00 AM');
+    expect(label).not.toContain('·');
+  });
+});

--- a/libs/ts/domain/src/lib/music-together-demo.ts
+++ b/libs/ts/domain/src/lib/music-together-demo.ts
@@ -133,6 +133,10 @@ export function mtDemoDisplayLabel(
     day: 'numeric',
     hour: 'numeric',
     minute: '2-digit',
+    // Pin to ET — otherwise the label uses the runtime TZ (UTC on Cloud
+    // Functions), so the synced Webflow item name/slug showed the wrong time.
+    // Matches the date-display/time-display fields.
+    timeZone: 'America/New_York',
   });
   return demo.location ? `${when} · ${demo.location}` : when;
 }


### PR DESCRIPTION
Found during dev-portal validation of the demo→Webflow sync.

`mtDemoDisplayLabel` used `toLocaleString(...)` with **no `timeZone`**, so it formatted in the runtime timezone — **UTC on Cloud Functions**. The sync uses this label for the MT Demos item **name/slug**, so a 10:00 AM ET demo synced as **"Tue, Sep 15, 2:00 PM · …"**. The dedicated `date-display`/`time-display` fields already pin `America/New_York` (and correctly read "10:00–10:45 AM"), so only the name/slug were wrong.

**Fix:** pin `mtDemoDisplayLabel` to `America/New_York`, matching the other display fields. Correct for both the server sync and the admin UI (all demo times are ET).

Added `music-together-demo.spec.ts` asserting the label renders ET even under `TZ=UTC` (2 tests pass).

After this deploys, re-syncing the demos (backfill / re-save) will produce correct ET names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)