### PR TITLE
feat(web): redirect mt.mapleandsprucefolkarts.com to /music-together

### DIFF
--- a/docs/architecture/DECISIONS.md
+++ b/docs/architecture/DECISIONS.md
@@ -1270,6 +1270,76 @@ first revisiting the codebase split (ADR-026).
 
 ---
 
+## ADR-030: Vanity Subdomain Redirects via `vercel.json`, not DNS or Webflow
+
+**Status:** Accepted
+**Date:** 2026-08-02
+
+### Context
+Marketing wants short, speakable subdomains that land on deep pages of the Webflow site — the
+first being `mt.mapleandsprucefolkarts.com` → `/music-together`. These go in Instagram bios, on
+printed cards, in QR codes, and as Meta ad destinations, so they must work over **HTTPS** and must
+**preserve `?utm_*` query strings** for lead attribution (see `tallyLeadWebhook`, PR #429).
+
+DNS is on Namecheap BasicDNS. The apex and `www` point at Webflow; `business.` already CNAMEs to
+Vercel; mail is Google Workspace.
+
+### Decision
+Add a host-scoped 301 to the root `vercel.json` on the existing `maple-and-spruce-maple-spruce`
+Vercel project, and CNAME the subdomain at Namecheap to that project.
+
+```json
+{
+  "source": "/((?!\\.well-known).*)",
+  "has": [{ "type": "host", "value": "mt.mapleandsprucefolkarts.com" }],
+  "destination": "https://mapleandsprucefolkarts.com/music-together",
+  "statusCode": 301
+}
+```
+
+`vercel.json` redirects resolve in Vercel's edge routing phase, **before** the filesystem, the
+Next.js app, and any middleware — so the vanity host never touches admin-app code.
+
+### Rationale
+- DNS stays at Namecheap; only one CNAME is added per vanity host.
+- Free auto-renewing TLS, and Vercel forwards the source query string onto the destination.
+- Reuses the Namecheap→Vercel CNAME pattern already proven by `business.`.
+- `statusCode: 301` rather than `permanent: true` — Vercel maps `permanent` to a **308**. Google
+  treats them alike, but link scrapers and SEO tools handle 301 more predictably, and these are
+  marketing links.
+- `(?!\.well-known)` keeps ACME challenge paths out of the catch-all so cert issuance and renewal
+  are unaffected.
+- Scoping with `has: host` means the rule is inert on every other domain on the project, so more
+  vanity hosts can be added as sibling entries without colliding.
+
+### Alternatives Considered
+- **Namecheap URL Redirect Record.** Two minutes of work, but the service serves no TLS on the
+  source host — `https://mt.…` fails with a certificate error, breaking every link written as
+  `https://`. It also drops query strings, which silently breaks ad attribution.
+- **An extra custom domain on Webflow.** Does not work: subdomains are *exempt* from Webflow's
+  default-domain 301 ("Subdomains are not affected by default domains"), so `mt.…` would serve a
+  full duplicate copy of the site rather than redirecting. Webflow's own 301 rules are path-only
+  and cannot be scoped to a hostname, so the only rule that would reach `/music-together` is
+  `/` → `/music-together`, which would break the real homepage.
+- **Cloudflare Redirect Rules.** Works well and is the usual recommendation, but requires moving
+  nameservers off Namecheap and recreating every record — including Google Workspace MX and the
+  SPF/DKIM/DMARC TXTs. Too much blast radius for one vanity link.
+- **A separate single-purpose Vercel project.** Isolates the link from admin-app deploys, but needs
+  a second project plus its own deploy path. The isolation argument is weaker than it looks: a
+  later failed deploy does not take the redirect down, because the last good production deployment
+  keeps serving it. Not worth the extra moving part.
+
+### Consequences
+- Adding a vanity host is now: one `redirects` entry, one `vercel domains add`, one Namecheap CNAME.
+- The rule ships on the admin app's deploy cadence, so a *change* to a vanity redirect waits for a
+  successful `deploy_vercel_prod`. Existing redirects keep serving from the last good deployment.
+- **Order matters when adding a host:** deploy the redirect rule *before* pointing DNS at Vercel.
+  A hostname that resolves to the project without a matching rule serves the admin app instead.
+- Webflow remains unaware of these hostnames — they must never be added as Webflow custom domains,
+  or the duplicate-content problem above reappears.
+
+---
+
 ## ADR-XXX: [Title]
 
 **Status:** Proposed | Accepted | Deprecated | Superseded
@@ -1293,4 +1363,4 @@ What becomes easier or harder as a result?
 
 ---
 
-*Last updated: 2026-08-02 (ADR-029 added for domain routers over per-endpoint functions)*
+*Last updated: 2026-08-02 (ADR-030 added for vanity subdomain redirects via vercel.json)*

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,16 @@
   "outputDirectory": "apps/maple-spruce/.next",
   "installCommand": "corepack enable && pnpm install",
   "framework": "nextjs",
+  "redirects": [
+    {
+      "source": "/((?!\\.well-known).*)",
+      "has": [
+        { "type": "host", "value": "mt.mapleandsprucefolkarts.com" }
+      ],
+      "destination": "https://mapleandsprucefolkarts.com/music-together",
+      "statusCode": 301
+    }
+  ],
   "git": {
     "deploymentEnabled": {
       "main": false


### PR DESCRIPTION
Adds a host-scoped 301 so `mt.mapleandsprucefolkarts.com` lands on the Music Together page over HTTPS, with `?utm_*` query strings intact.

```json
{
  "source": "/((?!\\.well-known).*)",
  "has": [{ "type": "host", "value": "mt.mapleandsprucefolkarts.com" }],
  "destination": "https://mapleandsprucefolkarts.com/music-together",
  "statusCode": 301
}
```

`vercel.json` redirects resolve in Vercel's edge routing phase — before the filesystem, the Next.js app, and any middleware — so the vanity host never touches admin-app code.

### Why these specifics

- **`statusCode: 301`, not `permanent: true`** — Vercel maps `permanent` to a **308**. Google treats them alike, but link scrapers and SEO tools handle 301 more predictably, and these go in Instagram bios, on printed cards, and as Meta ad destinations.
- **`(?!\.well-known)`** keeps ACME challenge paths out of the catch-all, so cert issuance and renewal are unaffected.
- **`has: host` scoping** leaves every other domain on the project inert, and lets future vanity hosts be added as sibling entries without colliding. The deployment URL keeps serving the admin app as usual.

### Why not the simpler options

| Option | Verdict |
|--------|---------|
| Namecheap **URL Redirect Record** | No TLS on the source host — `https://mt.…` fails with a cert error, breaking every link written as `https://`. Also drops query strings, silently breaking ad attribution. |
| **Webflow** extra custom domain | Doesn't work. Subdomains are *exempt* from Webflow's default-domain 301, so `mt.…` would serve a full duplicate copy of the site. Webflow's 301 rules are path-only and can't be host-scoped — the only rule reaching `/music-together` is `/` → `/music-together`, which breaks the real homepage. |
| **Cloudflare** Redirect Rules | Works, but needs nameservers moved off Namecheap and every record recreated, including Google Workspace MX and the SPF/DKIM/DMARC TXTs. Too much blast radius for one link. |
| **Separate Vercel project** | Considered for deploy isolation, but a failed future deploy doesn't take the redirect down — the last good production deployment keeps serving it. Not worth a second project. |

Recorded as **ADR-030**.

### Verification

Route pattern compiled against the v6-era path-to-regexp that Vercel's route compiler uses:

| Path | Result |
|------|--------|
| `/` | redirects |
| `/foo`, `/foo/bar` | redirects |
| `/.well-known/acme-challenge/…` | passes through |

Confirmed prod is publicly reachable (no Vercel deployment protection on production), so the vanity host won't hit an SSO gate.

### Rollout order (important)

This PR must **deploy before** DNS is pointed at Vercel. A hostname that resolves to the project without a matching rule serves the admin app instead.

1. Merge → `deploy_vercel_prod` ships the rule
2. `vercel domains add mt.mapleandsprucefolkarts.com`
3. Namecheap → Advanced DNS → CNAME, host `mt`, value = the `…vercel-dns-###.com` target Vercel prints
4. Verify:
   ```sh
   curl -sI https://mt.mapleandsprucefolkarts.com | grep -iE '^(HTTP|location)'
   curl -sI "https://mt.mapleandsprucefolkarts.com/?utm_source=test" | grep -i ^location
   ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)