### PR TITLE
feat(my-day): show other teachers' blocks (room taken) + exclude from openings

### DIFF
--- a/libs/firebase/maple-functions/get-my-week/src/lib/get-my-week.spec.ts
+++ b/libs/firebase/maple-functions/get-my-week/src/lib/get-my-week.spec.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   findByStartInRange: vi.fn(),
   findBlocks: vi.fn(),
   findLessons: vi.fn(),
+  findInstructors: vi.fn(),
 }));
 
 vi.mock('@maple/firebase/functions', () => ({
@@ -20,11 +21,13 @@ vi.mock('@maple/firebase/database', () => ({
   CalendarEventRepository: { findByStartInRange: mocks.findByStartInRange },
   LessonBlockRepository: { findAll: mocks.findBlocks },
   LessonRepository: { findAll: mocks.findLessons },
+  InstructorRepository: { findAll: mocks.findInstructors },
 }));
 
 import {
   getMyWeek,
   buildCommitments,
+  buildOtherBlocks,
   buildStandingSlots,
   startOfWeek,
 } from './get-my-week';
@@ -42,6 +45,7 @@ type Handler = (
   }>;
   standing: Array<Record<string, unknown>>;
   blocks: Array<Record<string, unknown>>;
+  otherBlocks: Array<Record<string, unknown>>;
   unlinked: boolean;
 }>;
 const handler = getMyWeek as unknown as Handler;
@@ -246,6 +250,39 @@ describe('buildStandingSlots', () => {
   });
 });
 
+describe('buildOtherBlocks', () => {
+  const block = (id: string, teacherId: string, dayOfWeek: number) => ({
+    id,
+    teacherId,
+    dayOfWeek,
+    startMinutes: 900,
+    endMinutes: 1080,
+    label: 'Tue',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+
+  it('excludes the caller’s own blocks', () => {
+    const blocks = [block('a', 'me', 2), block('b', 'other', 3)];
+    const result = buildOtherBlocks(blocks, 'me', new Map([['other', 'Sam']]));
+    expect(result.map((b) => b.id)).toEqual(['b']);
+    expect(result[0].teacherName).toBe('Sam');
+  });
+
+  it('falls back to a generic name when the teacher is unknown', () => {
+    const result = buildOtherBlocks([block('b', 'ghost', 2)], 'me', new Map());
+    expect(result[0].teacherName).toBe('Another teacher');
+  });
+
+  it('sorts by weekday then start', () => {
+    const b1 = { ...block('late', 'x', 4), startMinutes: 1000 };
+    const b2 = { ...block('early', 'x', 4), startMinutes: 800 };
+    const b3 = block('sun', 'x', 0);
+    const result = buildOtherBlocks([b1, b2, b3], 'me', new Map());
+    expect(result.map((b) => b.id)).toEqual(['sun', 'early', 'late']);
+  });
+});
+
 describe('getMyWeek handler', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -253,6 +290,7 @@ describe('getMyWeek handler', () => {
     mocks.findByStartInRange.mockResolvedValue([]);
     mocks.findBlocks.mockResolvedValue([]);
     mocks.findLessons.mockResolvedValue([]);
+    mocks.findInstructors.mockResolvedValue([]);
   });
 
   it('returns unlinked with no commitments or blocks when the caller has no instructor', async () => {
@@ -262,7 +300,63 @@ describe('getMyWeek handler', () => {
     expect(res.commitments).toEqual([]);
     expect(res.standing).toEqual([]);
     expect(res.blocks).toEqual([]);
+    expect(res.otherBlocks).toEqual([]);
     expect(mocks.findByStartInRange).not.toHaveBeenCalled();
+  });
+
+  it('splits blocks into own vs other teachers’ (with names)', async () => {
+    const mine = {
+      id: 'blk-mine',
+      teacherId: 'instr-katie',
+      dayOfWeek: 2,
+      startMinutes: 900,
+      endMinutes: 1080,
+      label: 'Tue',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const theirs = {
+      id: 'blk-sam',
+      teacherId: 'instr-sam',
+      dayOfWeek: 2,
+      startMinutes: 960,
+      endMinutes: 1020,
+      label: 'Tue',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    mocks.findBlocks.mockResolvedValue([mine, theirs]);
+    mocks.findInstructors.mockResolvedValue([
+      { id: 'instr-katie', name: 'Katie' },
+      { id: 'instr-sam', name: 'Sam' },
+    ]);
+
+    const res = await handler(
+      { from: '2026-07-19T00:00:00', to: '2026-07-26T00:00:00' },
+      { uid: 'katie-uid' },
+    );
+
+    expect(res.blocks).toEqual([
+      {
+        id: 'blk-mine',
+        teacherId: 'instr-katie',
+        dayOfWeek: 2,
+        startMinutes: 900,
+        endMinutes: 1080,
+        label: 'Tue',
+      },
+    ]);
+    expect(res.otherBlocks).toEqual([
+      {
+        id: 'blk-sam',
+        teacherId: 'instr-sam',
+        dayOfWeek: 2,
+        startMinutes: 960,
+        endMinutes: 1020,
+        label: 'Tue',
+        teacherName: 'Sam',
+      },
+    ]);
   });
 
   it('returns the teacher’s serialized blocks and flags unattributed lessons', async () => {

--- a/libs/firebase/maple-functions/get-my-week/src/lib/get-my-week.ts
+++ b/libs/firebase/maple-functions/get-my-week/src/lib/get-my-week.ts
@@ -25,6 +25,7 @@ import {
 } from '@maple/firebase/functions';
 import {
   CalendarEventRepository,
+  InstructorRepository,
   LessonBlockRepository,
   LessonRepository,
 } from '@maple/firebase/database';
@@ -40,6 +41,7 @@ import type {
   GetMyWeekResponse,
   MyWeekBlock,
   MyWeekCommitment,
+  MyWeekOtherBlock,
   MyWeekStandingSlot,
 } from '@maple/ts/firebase/api-types';
 
@@ -199,6 +201,26 @@ export function buildStandingSlots(
   return slots;
 }
 
+/**
+ * Blocks owned by other teachers, serialized with the owner's display name.
+ * There's one contested lesson room, so these windows are time the caller can't
+ * schedule into. Pure — the handler supplies the fetched blocks + name lookup.
+ * Sorted by weekday then start for a stable render.
+ */
+export function buildOtherBlocks(
+  allBlocks: LessonBlock[],
+  myInstructorId: string,
+  teacherNameById: Map<string, string>,
+): MyWeekOtherBlock[] {
+  return allBlocks
+    .filter((b) => b.teacherId !== myInstructorId)
+    .map((b) => ({
+      ...toMyWeekBlock(b),
+      teacherName: teacherNameById.get(b.teacherId) ?? 'Another teacher',
+    }))
+    .sort((a, b) => a.dayOfWeek - b.dayOfWeek || a.startMinutes - b.startMinutes);
+}
+
 /** Serialize a block for the wire (drop Date fields). */
 function toMyWeekBlock(block: LessonBlock): MyWeekBlock {
   return {
@@ -219,7 +241,13 @@ export const getMyWeek = createRoleFunction<
     const myInstructorId = await instructorIdForUser(context.uid);
     if (!myInstructorId) {
       // Not linked to any instructor (e.g. a pure admin) — no "mine" to anchor.
-      return { commitments: [], standing: [], blocks: [], unlinked: true };
+      return {
+        commitments: [],
+        standing: [],
+        blocks: [],
+        otherBlocks: [],
+        unlinked: true,
+      };
     }
 
     const now = new Date();
@@ -232,17 +260,29 @@ export const getMyWeek = createRoleFunction<
     );
 
     // One range query over [lookbackStart, to) for recurrence classification,
-    // plus the teacher's blocks and this week's lessons to flag unattributed
-    // ones (#689).
-    const [events, blocks, lessons] = await Promise.all([
+    // ALL teachers' blocks (mine anchor the layout; others mark room-taken
+    // time), this week's lessons to flag unattributed ones (#689), and
+    // instructors for the other-block owner names.
+    const [events, allBlocks, lessons, instructors] = await Promise.all([
       CalendarEventRepository.findByStartInRange(lookbackStart, to),
-      LessonBlockRepository.findAll({ teacherId: myInstructorId }),
+      LessonBlockRepository.findAll(),
       LessonRepository.findAll({ teacherId: myInstructorId, from, to }),
+      InstructorRepository.findAll(),
     ]);
+
+    const myBlocks = allBlocks.filter((b) => b.teacherId === myInstructorId);
+    const teacherNameById = new Map(
+      instructors.map((i) => [i.id, i.name]),
+    );
+    const otherBlocks = buildOtherBlocks(
+      allBlocks,
+      myInstructorId,
+      teacherNameById,
+    );
 
     const unattributedRefs = new Set(
       lessons
-        .filter((lesson) => isLessonUnattributed(lesson, blocks))
+        .filter((lesson) => isLessonUnattributed(lesson, myBlocks))
         .map((lesson) => `lessons/${lesson.id}`),
     );
 
@@ -258,7 +298,8 @@ export const getMyWeek = createRoleFunction<
     return {
       commitments,
       standing: buildStandingSlots(events, lookbackStart, myInstructorId),
-      blocks: blocks.map(toMyWeekBlock),
+      blocks: myBlocks.map(toMyWeekBlock),
+      otherBlocks,
       unlinked: false,
     };
   },

--- a/libs/react/lessons/src/lib/MyOpenings.stories.tsx
+++ b/libs/react/lessons/src/lib/MyOpenings.stories.tsx
@@ -16,14 +16,19 @@ type Story = StoryObj<typeof MyOpenings>;
 export const Populated: Story = {
   args: { weekState: { status: 'success', data: mockMyWeekResponse } },
   play: async ({ canvas }) => {
-    // The Tuesday block (3–6 PM) minus the recurring 3:00–3:30 lesson leaves
-    // 3:30–6:00 PM open, fitting all three lesson lengths…
+    // The Tuesday block (3–6 PM) minus the recurring 3:00–3:30 lesson AND
+    // another teacher's 4–5 PM room booking leaves two openings: 3:30–4:00 and
+    // 5:00–6:00.
     await waitFor(() =>
       expect(canvas.getByText('Tuesday')).toBeInTheDocument(),
     );
-    await expect(canvas.getByText(/3:30 PM – 6:00 PM/)).toBeInTheDocument();
-    await expect(canvas.getByText(/fits 30 · 45 · 60 min/)).toBeInTheDocument();
-    // …and the one-off 3:30 make-up shows as a this-week heads-up, not a
+    await expect(canvas.getByText(/3:30 PM – 4:00 PM/)).toBeInTheDocument();
+    await expect(canvas.getByText(/5:00 PM – 6:00 PM/)).toBeInTheDocument();
+    // The other teacher's 4–5 PM window is excluded, not offered.
+    await expect(
+      canvas.queryByText(/4:00 PM – 5:00 PM/),
+    ).not.toBeInTheDocument();
+    // The one-off 3:30 make-up shows as a this-week heads-up, not a
     // disqualifier.
     await expect(canvas.getByText(/⚠ Music Lesson.*this week/)).toBeInTheDocument();
   },
@@ -42,6 +47,7 @@ const noBlocks: GetMyWeekResponse = {
   commitments: [],
   standing: [],
   blocks: [],
+  otherBlocks: [],
 };
 
 export const NoBlocks: Story = {
@@ -80,6 +86,7 @@ const fullyBooked: GetMyWeekResponse = {
     },
   ],
   commitments: [],
+  otherBlocks: [],
 };
 
 export const FullyBooked: Story = {
@@ -94,7 +101,13 @@ export const Unlinked: Story = {
   args: {
     weekState: {
       status: 'success',
-      data: { commitments: [], standing: [], blocks: [], unlinked: true },
+      data: {
+        commitments: [],
+        standing: [],
+        blocks: [],
+        otherBlocks: [],
+        unlinked: true,
+      },
     },
   },
 };

--- a/libs/react/lessons/src/lib/MyOpenings.tsx
+++ b/libs/react/lessons/src/lib/MyOpenings.tsx
@@ -49,7 +49,12 @@ function endMinutesOf(iso: string): number {
   return m === 0 ? 24 * 60 : m;
 }
 
-/** The teacher's recurring lesson occupancy, projected onto a generic week. */
+/**
+ * What removes time from the teacher's blocks: their own recurring lessons
+ * (this week's recurring commitments ∪ the standing pattern) AND other
+ * teachers' blocks — the shared Spruce Room is taken then, so those windows
+ * aren't offerable either. All projected onto a generic week.
+ */
 function occupiedIntervals(data: GetMyWeekResponse): OccupiedInterval[] {
   const fromCommitments = data.commitments
     .filter(
@@ -70,7 +75,12 @@ function occupiedIntervals(data: GetMyWeekResponse): OccupiedInterval[] {
       startMinutes: s.startMinutes,
       endMinutes: s.startMinutes + s.durationMinutes,
     }));
-  return [...fromCommitments, ...fromStanding];
+  const fromOtherBlocks = data.otherBlocks.map((b) => ({
+    weekday: b.dayOfWeek,
+    startMinutes: b.startMinutes,
+    endMinutes: b.endMinutes,
+  }));
+  return [...fromCommitments, ...fromStanding, ...fromOtherBlocks];
 }
 
 interface OneOff {

--- a/libs/react/lessons/src/lib/MyWeek.stories.tsx
+++ b/libs/react/lessons/src/lib/MyWeek.stories.tsx
@@ -33,6 +33,17 @@ export const Populated: Story = {
   },
 };
 
+export const ShowsOtherTeacherBlock: Story = {
+  args: { weekState: { status: 'success', data: mockMyWeekResponse } },
+  play: async ({ canvas }) => {
+    // Another teacher's window renders as a "room taken" band (the shared
+    // Spruce Room is unavailable then).
+    await waitFor(() =>
+      expect(canvas.getByText(/Sam · room taken/)).toBeInTheDocument(),
+    );
+  },
+};
+
 export const Loading: Story = {
   args: { weekState: { status: 'loading' } },
 };
@@ -45,7 +56,13 @@ export const Unlinked: Story = {
   args: {
     weekState: {
       status: 'success',
-      data: { commitments: [], standing: [], blocks: [], unlinked: true },
+      data: {
+        commitments: [],
+        standing: [],
+        blocks: [],
+        otherBlocks: [],
+        unlinked: true,
+      },
     },
   },
 };

--- a/libs/react/lessons/src/lib/MyWeek.tsx
+++ b/libs/react/lessons/src/lib/MyWeek.tsx
@@ -47,6 +47,7 @@ import type {
   GetMyWeekResponse,
   MyWeekBlock,
   MyWeekCommitment,
+  MyWeekOtherBlock,
   MyWeekOwnership,
   MyWeekStandingSlot,
 } from '@maple/ts/firebase/api-types';
@@ -271,6 +272,7 @@ export function MyWeek({
 
   const data = weekState.status === 'success' ? weekState.data : undefined;
   const blocks = data?.blocks ?? [];
+  const otherBlocks = data?.otherBlocks ?? [];
 
   // The items for the active mode, normalized + category-filtered.
   const visible = useMemo(() => {
@@ -287,7 +289,7 @@ export function MyWeek({
   const [gridStart, gridEnd] = useMemo(() => {
     let lo = Infinity;
     let hi = -Infinity;
-    for (const b of blocks) {
+    for (const b of [...blocks, ...otherBlocks]) {
       lo = Math.min(lo, b.startMinutes);
       hi = Math.max(hi, b.endMinutes);
     }
@@ -514,6 +516,7 @@ export function MyWeek({
             <DayColumn
               key={short}
               blocks={blocks.filter((b) => b.dayOfWeek === dayIndex)}
+              otherBlocks={otherBlocks.filter((b) => b.dayOfWeek === dayIndex)}
               items={visible.filter((i) => i.weekday === dayIndex)}
               gridStart={gridStart}
               gridEnd={gridEnd}
@@ -529,6 +532,7 @@ export function MyWeek({
 
 function DayColumn({
   blocks,
+  otherBlocks,
   items,
   gridStart,
   gridEnd,
@@ -536,6 +540,7 @@ function DayColumn({
   hours,
 }: {
   blocks: MyWeekBlock[];
+  otherBlocks: MyWeekOtherBlock[];
   items: WeekItem[];
   gridStart: number;
   gridEnd: number;
@@ -596,6 +601,57 @@ function DayColumn({
               borderRadius: 0.5,
             }}
           />
+        );
+      })}
+
+      {/* Other teachers' blocks — the shared room is taken then, so the caller
+          can't schedule here. Hatched + labeled, rendered over own bands. */}
+      {otherBlocks.map((b) => {
+        const top =
+          (Math.max(b.startMinutes, gridStart) - gridStart) * PX_PER_MIN;
+        const height =
+          (Math.min(b.endMinutes, gridEnd) -
+            Math.max(b.startMinutes, gridStart)) *
+          PX_PER_MIN;
+        if (height <= 0) return null;
+        return (
+          <Box
+            key={b.id}
+            title={`${b.teacherName} · ${formatMinutes(
+              b.startMinutes,
+            )}–${formatMinutes(b.endMinutes)} · room taken`}
+            sx={(theme) => ({
+              position: 'absolute',
+              left: 1,
+              right: 1,
+              top,
+              height,
+              overflow: 'hidden',
+              borderRadius: 0.5,
+              border: '1px solid',
+              borderColor: 'divider',
+              bgcolor: 'action.disabledBackground',
+              backgroundImage: `repeating-linear-gradient(45deg, ${theme.palette.action.disabled} 0, ${theme.palette.action.disabled} 1px, transparent 1px, transparent 7px)`,
+            })}
+          >
+            <Box
+              component="span"
+              sx={{
+                display: 'block',
+                px: 0.5,
+                pt: 0.1,
+                fontSize: 10,
+                lineHeight: 1.2,
+                fontWeight: 600,
+                color: 'text.secondary',
+                whiteSpace: 'nowrap',
+                textOverflow: 'ellipsis',
+                overflow: 'hidden',
+              }}
+            >
+              {b.teacherName} · room taken
+            </Box>
+          </Box>
         );
       })}
 

--- a/libs/react/storybook-fixtures/src/my-week.ts
+++ b/libs/react/storybook-fixtures/src/my-week.ts
@@ -47,6 +47,19 @@ export const mockMyWeekResponse: GetMyWeekResponse = {
       label: 'Tue afternoons',
     },
   ],
+  // Another teacher owns the shared room Tue 4–5 PM — inside our Tuesday block,
+  // so that hour isn't offerable (shown hatched; carved out of openings).
+  otherBlocks: [
+    {
+      id: 'blk-sam-tue',
+      teacherId: 'instructor-002',
+      dayOfWeek: 2, // Tuesday
+      startMinutes: 16 * 60, // 4:00 PM
+      endMinutes: 17 * 60, // 5:00 PM
+      label: 'Tue afternoons',
+      teacherName: 'Sam',
+    },
+  ],
   commitments: [
     // Two lessons inside the Tuesday block.
     {

--- a/libs/ts/firebase/api-types/src/lib/index.ts
+++ b/libs/ts/firebase/api-types/src/lib/index.ts
@@ -357,6 +357,7 @@ export type {
   MyWeekOwnership,
   MyWeekCadence,
   MyWeekBlock,
+  MyWeekOtherBlock,
   MyWeekCommitment,
   MyWeekStandingSlot,
   GetMyWeekRequest,

--- a/libs/ts/firebase/api-types/src/lib/my-week.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/my-week.types.ts
@@ -21,6 +21,17 @@ export type MyWeekBlock = Pick<
   'id' | 'teacherId' | 'dayOfWeek' | 'startMinutes' | 'endMinutes' | 'label'
 >;
 
+/**
+ * Another teacher's block, surfaced to the caller as context. There is one
+ * contested lesson room (Spruce), so another teacher's weekly window is time
+ * the caller can't schedule a lesson into — shown in the week as an
+ * "unavailable" band and subtracted from the caller's openings.
+ */
+export interface MyWeekOtherBlock extends MyWeekBlock {
+  /** Display name of the teacher whose window this is. */
+  teacherName: string;
+}
+
 /** Whether a commitment belongs to the caller or is a shared store-wide event. */
 export type MyWeekOwnership = 'mine' | 'shared';
 
@@ -97,6 +108,12 @@ export interface GetMyWeekResponse {
   standing: MyWeekStandingSlot[];
   /** The caller's own weekly blocks — the containers the week is laid out in. */
   blocks: MyWeekBlock[];
+  /**
+   * Other teachers' blocks — time the shared Spruce Room is spoken for, so the
+   * caller can't schedule then. Shown as context in the week and subtracted
+   * from openings.
+   */
+  otherBlocks: MyWeekOtherBlock[];
   /** True when the caller isn't linked to any instructor record (no "mine"). */
   unlinked: boolean;
 }


### PR DESCRIPTION
## What

There's one contested lesson room (Spruce — the model comment says so, `Room = 'spruce'`), so another teacher's weekly block is time you **can't schedule into**. This surfaces those windows for Katie and other instructors.

Requested: *"instructors need to see the other lesson blocks they can't schedule during; color coding would help."* Decisions confirmed with the requester: **one muted "room taken" style + teacher name** (not per-teacher colors), and **Openings excludes** those windows.

## Changes

- **Backend (`getMyWeek`):** returns a new `otherBlocks` field — every block not owned by the caller, serialized with the owner's display name (joined from `InstructorRepository`). Now fetches *all* blocks + instructors and splits mine-vs-others. The caller's own blocks stay in `blocks` (no breaking change). New pure `buildOtherBlocks()` helper.
- **Week view:** other teachers' blocks render as a hatched **"<name> · room taken"** band — visually distinct from your own shaded block band and the category-colored lessons. Included in the grid bounds.
- **Openings:** other teachers' block windows are folded into the occupied intervals, so a slot the room is already spoken for is never offered. E.g. a 3–6 block with another teacher at 4–5 → openings **3:30–4:00 + 5:00–6:00**, not 3:30–6:00.

## No new Firestore index

`LessonBlockRepository.findAll()` (unfiltered) and `InstructorRepository.findAll()` are plain collection reads — the analyzer confirms all 175 index-requiring queries are still covered.

## Verification

- **16** `getMyWeek` unit tests (added `buildOtherBlocks` cases + a mine/others split-with-names handler test).
- **14** `MyWeek` + `MyOpenings` Storybook play tests (added `ShowsOtherTeacherBlock`; updated Openings `Populated` to assert the 4–5 exclusion + split).
- `maple-spruce` typecheck, `maple-core` build, Firestore index analyzer — all green.
- **Storybook visual pass** (Chrome): the hatched "Sam · room taken" band and the openings split both render correctly.

Follow-up to the #683 epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)