### PR TITLE
feat(students): row "⋯" action menu (schedule/invoice) + linkify name

### DIFF
--- a/apps/maple-spruce/src/app/(admin)/students/page.tsx
+++ b/apps/maple-spruce/src/app/(admin)/students/page.tsx
@@ -10,10 +10,134 @@ import {
   Typography,
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
-import type { CreateStudentInput, RequestState, Student } from '@maple/ts/domain';
+import type {
+  CreateInvoiceInput,
+  CreateLessonInput,
+  CreateLessonSeriesInput,
+  CreateStudentInput,
+  Instructor,
+  LessonBlock,
+  RequestState,
+  Student,
+  UpdateInvoiceInput,
+} from '@maple/ts/domain';
 import { DeleteConfirmDialog } from '@maple/react/ui';
 import { StudentForm, StudentList } from '@maple/react/students';
-import { useInstructors, useLessons, useStudents } from '../../../hooks';
+import { ScheduleLessonDialog } from '@maple/react/lessons';
+import { InvoiceBuilderDialog } from '@maple/react/invoices';
+import {
+  useInstructors,
+  useInvoices,
+  useLessonBlocks,
+  useLessons,
+  useStudents,
+} from '../../../hooks';
+
+/** Duration default from a student's registered lesson length. */
+function defaultDurationFor(student: Student): 30 | 45 | 60 {
+  if (student.registeredLessonLength === '45-min') return 45;
+  if (student.registeredLessonLength === '60-min') return 60;
+  return 30;
+}
+
+/**
+ * Opens the schedule-lesson dialog for one student, owning that student's
+ * lesson hook. Mounted only while scheduling, so the per-student fetch is lazy.
+ */
+function ScheduleLessonLauncher({
+  student,
+  instructors,
+  blocks,
+  onClose,
+}: {
+  student: Student;
+  instructors: Instructor[];
+  blocks: LessonBlock[];
+  onClose: () => void;
+}) {
+  const { createLesson, createLessonSeries } = useLessons({
+    studentId: student.id,
+  });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleCreateSingle = async (input: CreateLessonInput) => {
+    setIsSubmitting(true);
+    try {
+      await createLesson(input);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+  const handleCreateSeries = async (input: CreateLessonSeriesInput) => {
+    setIsSubmitting(true);
+    try {
+      await createLessonSeries(input);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <ScheduleLessonDialog
+      open
+      onClose={onClose}
+      studentId={student.id}
+      defaultTeacherId={student.primaryTeacherId}
+      instructors={instructors}
+      blocks={blocks}
+      defaultDurationMinutes={defaultDurationFor(student)}
+      onCreateSingle={handleCreateSingle}
+      onCreateSeries={handleCreateSeries}
+      isSubmitting={isSubmitting}
+    />
+  );
+}
+
+/** Opens the create-invoice dialog for one student, owning its invoice hook. */
+function InvoiceLauncher({
+  student,
+  onClose,
+}: {
+  student: Student;
+  onClose: () => void;
+}) {
+  const { createInvoice, updateInvoice } = useInvoices({
+    studentId: student.id,
+  });
+  const { lessonsState } = useLessons({ studentId: student.id });
+  const lessons =
+    lessonsState.status === 'success' ? lessonsState.data : [];
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleCreate = async (input: CreateInvoiceInput) => {
+    setIsSubmitting(true);
+    try {
+      await createInvoice(input);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+  const handleUpdate = async (input: UpdateInvoiceInput) => {
+    setIsSubmitting(true);
+    try {
+      await updateInvoice(input);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <InvoiceBuilderDialog
+      open
+      onClose={onClose}
+      studentId={student.id}
+      lessons={lessons}
+      onCreate={handleCreate}
+      onUpdate={handleUpdate}
+      isSubmitting={isSubmitting}
+    />
+  );
+}
 
 type HopeFilter = 'all' | 'hope' | 'private';
 
@@ -29,11 +153,14 @@ export default function StudentsPage() {
   // from their scheduled lessons. The roster is small, so one unscoped fetch
   // is fine.
   const { lessonsState } = useLessons({});
+  const { lessonBlocksState } = useLessonBlocks();
 
   const instructors =
     instructorsState.status === 'success' ? instructorsState.data : [];
   const lessons =
     lessonsState.status === 'success' ? lessonsState.data : undefined;
+  const blocks =
+    lessonBlocksState.status === 'success' ? lessonBlocksState.data : [];
 
   // Form dialog state
   const [isFormOpen, setIsFormOpen] = useState(false);
@@ -43,6 +170,10 @@ export default function StudentsPage() {
   // Delete dialog state
   const [studentToDelete, setStudentToDelete] = useState<Student | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+
+  // Row-action launchers (schedule / invoice) — one student at a time.
+  const [scheduleFor, setScheduleFor] = useState<Student | null>(null);
+  const [invoiceFor, setInvoiceFor] = useState<Student | null>(null);
 
   // Hope Scholarship filter — client-side since roster is small.
   const [hopeFilter, setHopeFilter] = useState<HopeFilter>('all');
@@ -164,8 +295,26 @@ export default function StudentsPage() {
         lessons={lessons}
         onEdit={handleOpenForm}
         onDelete={handleOpenDelete}
+        onScheduleLesson={setScheduleFor}
+        onCreateInvoice={setInvoiceFor}
         detailHrefBase="/students"
       />
+
+      {scheduleFor && (
+        <ScheduleLessonLauncher
+          student={scheduleFor}
+          instructors={instructors}
+          blocks={blocks}
+          onClose={() => setScheduleFor(null)}
+        />
+      )}
+
+      {invoiceFor && (
+        <InvoiceLauncher
+          student={invoiceFor}
+          onClose={() => setInvoiceFor(null)}
+        />
+      )}
 
       <StudentForm
         open={isFormOpen}

--- a/libs/react/students/src/lib/StudentList.stories.tsx
+++ b/libs/react/students/src/lib/StudentList.stories.tsx
@@ -22,6 +22,8 @@ const meta = {
   args: {
     onEdit: fn(),
     onDelete: fn(),
+    onScheduleLesson: fn(),
+    onCreateInvoice: fn(),
     instructors,
     lessons: mockLessons,
   },
@@ -95,7 +97,20 @@ export const InactiveStudent: Story = {
 // INTERACTION TESTS
 // ============================================================
 
-export const EditButtonCallsOnEdit: Story = {
+/** Open a student's "⋯" action menu and return the portal query scope. */
+async function openRowMenu(canvasElement: HTMLElement) {
+  const canvas = within(canvasElement);
+  await userEvent.click(
+    canvas.getByRole('button', { name: /actions for/i }),
+  );
+  const menu = within(document.body);
+  await waitFor(() =>
+    expect(menu.getByRole('menu')).toBeInTheDocument(),
+  );
+  return menu;
+}
+
+export const EditFromMenuCallsOnEdit: Story = {
   args: {
     studentsState: {
       status: 'success',
@@ -103,11 +118,8 @@ export const EditButtonCallsOnEdit: Story = {
     } as RequestState<Student[]>,
   },
   play: async ({ args, canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    const editButton = canvas.getByRole('button', { name: /edit/i });
-    await userEvent.click(editButton);
-
+    const menu = await openRowMenu(canvasElement);
+    await userEvent.click(menu.getByRole('menuitem', { name: /^edit$/i }));
     await waitFor(() => {
       expect(args.onEdit).toHaveBeenCalledTimes(1);
       expect(args.onEdit).toHaveBeenCalledWith(mockStudent);
@@ -115,7 +127,7 @@ export const EditButtonCallsOnEdit: Story = {
   },
 };
 
-export const DeleteButtonCallsOnDelete: Story = {
+export const DeleteFromMenuCallsOnDelete: Story = {
   args: {
     studentsState: {
       status: 'success',
@@ -123,15 +135,53 @@ export const DeleteButtonCallsOnDelete: Story = {
     } as RequestState<Student[]>,
   },
   play: async ({ args, canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    const deleteButton = canvas.getByRole('button', { name: /delete/i });
-    await userEvent.click(deleteButton);
-
+    const menu = await openRowMenu(canvasElement);
+    await userEvent.click(menu.getByRole('menuitem', { name: /^delete$/i }));
     await waitFor(() => {
       expect(args.onDelete).toHaveBeenCalledTimes(1);
       expect(args.onDelete).toHaveBeenCalledWith(mockStudent);
     });
+  },
+};
+
+export const ScheduleFromMenu: Story = {
+  args: {
+    studentsState: {
+      status: 'success',
+      data: [mockStudent],
+    } as RequestState<Student[]>,
+  },
+  play: async ({ args, canvasElement }) => {
+    const menu = await openRowMenu(canvasElement);
+    await expect(
+      menu.getByRole('menuitem', { name: /schedule lesson/i }),
+    ).toBeInTheDocument();
+    await userEvent.click(
+      menu.getByRole('menuitem', { name: /schedule lesson/i }),
+    );
+    await waitFor(() => {
+      expect(args.onScheduleLesson).toHaveBeenCalledWith(mockStudent);
+    });
+  },
+};
+
+export const InvoiceDisabledForHope: Story = {
+  args: {
+    studentsState: {
+      status: 'success',
+      data: [mockStudentHope],
+    } as RequestState<Student[]>,
+  },
+  play: async ({ args, canvasElement }) => {
+    const menu = await openRowMenu(canvasElement);
+    const invoiceItem = menu.getByRole('menuitem', {
+      name: /create invoice/i,
+    });
+    // Hope students can't be invoiced — the item is disabled (and thus
+    // unclickable: MUI sets pointer-events: none), so onCreateInvoice can't
+    // fire.
+    await expect(invoiceItem).toHaveAttribute('aria-disabled', 'true');
+    await expect(args.onCreateInvoice).not.toHaveBeenCalled();
   },
 };
 

--- a/libs/react/students/src/lib/StudentList.tsx
+++ b/libs/react/students/src/lib/StudentList.tsx
@@ -1,12 +1,17 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import {
   Alert,
   Box,
   Chip,
+  Divider,
   IconButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
   Paper,
   Stack,
   Tooltip,
@@ -15,6 +20,9 @@ import {
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import StarsIcon from '@mui/icons-material/Stars';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import EventIcon from '@mui/icons-material/Event';
+import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
 import {
   DataGrid,
   type GridColDef,
@@ -36,6 +44,10 @@ interface StudentListProps {
   instructors: Instructor[];
   onEdit: (student: Student) => void;
   onDelete: (student: Student) => void;
+  /** Open the schedule-lesson flow for a student. Omit to hide the action. */
+  onScheduleLesson?: (student: Student) => void;
+  /** Open the create-invoice flow for a student. Omit to hide the action. */
+  onCreateInvoice?: (student: Student) => void;
   /**
    * If provided, the student name links to this path plus the student's id
    * (e.g. `/students`). Leave undefined to render a plain name.
@@ -105,11 +117,91 @@ function buildScheduleByStudent(
   return result;
 }
 
+/** Per-row "⋯" menu consolidating a student's actions. Owns its own anchor. */
+function RowActionsMenu({
+  student,
+  isHopeScholarship,
+  onEdit,
+  onDelete,
+  onScheduleLesson,
+  onCreateInvoice,
+}: {
+  student: Student;
+  isHopeScholarship: boolean;
+  onEdit: (student: Student) => void;
+  onDelete: (student: Student) => void;
+  onScheduleLesson?: (student: Student) => void;
+  onCreateInvoice?: (student: Student) => void;
+}) {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const close = () => setAnchorEl(null);
+  const run = (fn: () => void) => () => {
+    close();
+    fn();
+  };
+
+  return (
+    <>
+      <Tooltip title="Actions">
+        <IconButton
+          size="small"
+          aria-label={`Actions for ${student.name}`}
+          aria-haspopup="menu"
+          onClick={(e) => setAnchorEl(e.currentTarget)}
+        >
+          <MoreVertIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={close}>
+        {onScheduleLesson && (
+          <MenuItem onClick={run(() => onScheduleLesson(student))}>
+            <ListItemIcon>
+              <EventIcon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText>Schedule lesson</ListItemText>
+          </MenuItem>
+        )}
+        {onCreateInvoice && (
+          <MenuItem
+            onClick={run(() => onCreateInvoice(student))}
+            disabled={isHopeScholarship}
+          >
+            <ListItemIcon>
+              <ReceiptLongIcon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText>
+              {isHopeScholarship ? 'Create invoice (Hope)' : 'Create invoice'}
+            </ListItemText>
+          </MenuItem>
+        )}
+        {(onScheduleLesson || onCreateInvoice) && <Divider />}
+        <MenuItem onClick={run(() => onEdit(student))}>
+          <ListItemIcon>
+            <EditIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Edit</ListItemText>
+        </MenuItem>
+        <MenuItem
+          onClick={run(() => onDelete(student))}
+          sx={{ color: 'error.main' }}
+        >
+          <ListItemIcon>
+            <DeleteIcon fontSize="small" color="error" />
+          </ListItemIcon>
+          <ListItemText>Delete</ListItemText>
+        </MenuItem>
+      </Menu>
+    </>
+  );
+}
+
 export function StudentList({
   studentsState,
   instructors,
   onEdit,
   onDelete,
+  onScheduleLesson,
+  onCreateInvoice,
   detailHrefBase,
   lessons,
 }: StudentListProps) {
@@ -158,20 +250,31 @@ export function StudentList({
         minWidth: 160,
         renderCell: (params: GridRenderCellParams<StudentRow>) => {
           const { student } = params.row;
-          const name = (
-            <Typography variant="body2" sx={{ fontWeight: 500 }}>
-              {student.name}
-            </Typography>
-          );
-          return detailHrefBase ? (
+          if (!detailHrefBase) {
+            return (
+              <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                {student.name}
+              </Typography>
+            );
+          }
+          // Decorated as a link so the detail page (schedule/invoice/history)
+          // is discoverable.
+          return (
             <Link
               href={`${detailHrefBase}/${student.id}`}
-              style={{ textDecoration: 'none', color: 'inherit' }}
+              style={{ textDecoration: 'none' }}
             >
-              {name}
+              <Typography
+                variant="body2"
+                sx={{
+                  fontWeight: 600,
+                  color: 'primary.main',
+                  '&:hover': { textDecoration: 'underline' },
+                }}
+              >
+                {student.name}
+              </Typography>
             </Link>
-          ) : (
-            name
           );
         },
       },
@@ -316,31 +419,24 @@ export function StudentList({
         align: 'right',
         headerAlign: 'right',
         renderCell: (params: GridRenderCellParams<StudentRow>) => (
-          <Stack direction="row" spacing={0.5}>
-            <Tooltip title="Edit">
-              <IconButton
-                onClick={() => onEdit(params.row.student)}
-                size="small"
-                aria-label="Edit"
-              >
-                <EditIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Delete">
-              <IconButton
-                onClick={() => onDelete(params.row.student)}
-                size="small"
-                aria-label="Delete"
-                color="error"
-              >
-                <DeleteIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-          </Stack>
+          <RowActionsMenu
+            student={params.row.student}
+            isHopeScholarship={params.row.isHopeScholarship}
+            onEdit={onEdit}
+            onDelete={onDelete}
+            onScheduleLesson={onScheduleLesson}
+            onCreateInvoice={onCreateInvoice}
+          />
         ),
       },
     ],
-    [detailHrefBase, onEdit, onDelete]
+    [
+      detailHrefBase,
+      onEdit,
+      onDelete,
+      onScheduleLesson,
+      onCreateInvoice,
+    ]
   );
 
   if (studentsState.status === 'error') {


### PR DESCRIPTION
## What

Katie asked to **schedule a lesson and create an invoice directly from the students table**, and to make the detail page more discoverable. This adds a per-row action menu and links the student name.

## Changes

- **Per-row "⋯" menu** consolidating all row actions (per the requested "single action dropdown"): **Schedule lesson**, **Create invoice** (disabled for Hope-scholarship students, matching the detail page), then **Edit** and **Delete**. Replaces the standalone Edit/Delete icons. New optional `onScheduleLesson` / `onCreateInvoice` props; a small `RowActionsMenu` owns its own anchor state per row.
- **Student name → link** (brand `primary` color + hover underline) so the detail page (full lesson/invoice history) is obviously clickable.
- The students page opens the **existing** `ScheduleLessonDialog` and `InvoiceBuilderDialog` via small **per-student launcher components** that lazily instantiate that student's `useLessons` / `useInvoices` hooks — mounted only while the dialog is open, so there's no N-hooks-per-row cost.

No backend or callable changes — reuses the dialogs and hooks already used on the detail page.

## Verification

- **14** `StudentList` Storybook play tests: Edit/Delete now go through the menu, Schedule fires `onScheduleLesson`, and Create invoice is **disabled for Hope** students.
- `maple-spruce` typecheck green.
- Visual review to follow on dev (the link decoration + menu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)