### PR TITLE
refactor(functions): discounts domain router — ADR-029 Phase 0 pilot (#731)

### DIFF
--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -159,6 +159,11 @@ export { reorderClassCategories } from '@maple/firebase/maple-functions/reorder-
 export { uploadCategoryGalleryImage } from '@maple/firebase/maple-functions/upload-category-gallery-image';
 
 // Discount functions
+// Discounts domain router (ADR-029, #731) — one function serving all five
+// discount endpoints. The standalone functions below stay exported until the
+// client call sites move to httpsCallableFromURL; they are deleted in the
+// follow-up so there is never a window where a deployed client has no backend.
+export { discountsApi } from '@maple/firebase/maple-functions/discounts-api';
 export { getDiscounts } from '@maple/firebase/maple-functions/get-discounts';
 export { createDiscount } from '@maple/firebase/maple-functions/create-discount';
 export { updateDiscount } from '@maple/firebase/maple-functions/update-discount';

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -175,6 +175,7 @@
     "../../libs/firebase/maple-functions/get-class-waitlist/**/*.ts",
     "../../libs/firebase/maple-functions/get-class-waitlist-counts/**/*.ts",
     "../../libs/firebase/maple-functions/duplicate-music-together-section/**/*.ts",
+    "../../libs/firebase/maple-functions/discounts-api/**/*.ts",
     "../../libs/firebase/database/src/**/*.ts",
     "../../libs/firebase/functions/src/**/*.ts",
     "../../libs/ts/domain/src/**/*.ts",

--- a/function-count-baseline.json
+++ b/function-count-baseline.json
@@ -1,3 +1,3 @@
 {
-  "maxFunctions": 217
+  "maxFunctions": 218
 }

--- a/libs/firebase/functions/src/lib/functions.utility.spec.ts
+++ b/libs/firebase/functions/src/lib/functions.utility.spec.ts
@@ -14,9 +14,9 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('firebase-functions/v2/https', async () => {
-  const actual = await vi.importActual<typeof import('firebase-functions/v2/https')>(
-    'firebase-functions/v2/https'
-  );
+  const actual = await vi.importActual<
+    typeof import('firebase-functions/v2/https')
+  >('firebase-functions/v2/https');
   return {
     ...actual,
     onRequest: (options: unknown, handler: unknown) => {
@@ -36,7 +36,8 @@ vi.mock('firebase-functions/params', () => ({
     return {
       name,
       // ALLOWED_ORIGINS is read by the CORS middleware
-      value: () => (name === 'ALLOWED_ORIGINS' ? 'https://example.test' : `string:${name}`),
+      value: () =>
+        name === 'ALLOWED_ORIGINS' ? 'https://example.test' : `string:${name}`,
     };
   },
 }));
@@ -64,6 +65,7 @@ import {
   assertValid,
   runChecks,
   Functions,
+  createRouter,
   createPublicFunction,
   createAuthenticatedFunction,
   createAdminFunction,
@@ -109,31 +111,41 @@ function makeRes(): MockResponse {
   return res;
 }
 
-function makeReq(overrides: Partial<{
-  method: string;
-  body: unknown;
-  headers: Record<string, string>;
-  ip: string;
-}> = {}) {
+function makeReq(
+  overrides: Partial<{
+    method: string;
+    body: unknown;
+    headers: Record<string, string>;
+    ip: string;
+    path: string;
+  }> = {},
+) {
   return {
     method: overrides.method ?? 'POST',
     body: overrides.body ?? {},
     headers: { origin: 'https://example.test', ...(overrides.headers ?? {}) },
+    // Router dispatch reads req.path; harmless for single endpoints.
+    path: overrides.path ?? '/',
     ...(overrides.ip !== undefined ? { ip: overrides.ip } : {}),
   };
 }
 
 async function invoke(
   endpoint: unknown,
-  req: ReturnType<typeof makeReq>
+  req: ReturnType<typeof makeReq>,
 ): Promise<MockResponse> {
   const res = makeRes();
   // The endpoint returned by handle() is the raw async (req,res) handler
   // because our onRequest mock returns it directly. CORS middleware
   // fires next() without awaiting, so the outer await doesn't see the
   // inner async chain — drain microtasks until the response is set.
-  const promise = (endpoint as (r: unknown, s: unknown) => Promise<void>)(req, res);
-  promise.catch(() => { /* errors handled via res.status() */ });
+  const promise = (endpoint as (r: unknown, s: unknown) => Promise<void>)(
+    req,
+    res,
+  );
+  promise.catch(() => {
+    /* errors handled via res.status() */
+  });
   for (let i = 0; i < 100 && res.statusCode === 0; i++) {
     await new Promise<void>((resolve) => setImmediate(resolve));
   }
@@ -142,7 +154,7 @@ async function invoke(
 
 function suite(
   isValid: boolean,
-  errors: Record<string, string[]> = {}
+  errors: Record<string, string[]> = {},
 ): { isValid: () => boolean; getErrors: () => Record<string, string[]> } {
   return {
     isValid: () => isValid,
@@ -212,7 +224,7 @@ describe('runChecks', () => {
   it('runs the validator and throws on invalid input', async () => {
     const validator = vi.fn(() => suite(false, { name: ['too short'] }));
     await expect(runChecks({ name: 'a' }, { validator })).rejects.toThrow(
-      /name: too short/
+      /name: too short/,
     );
     expect(validator).toHaveBeenCalledWith({ name: 'a' });
   });
@@ -226,8 +238,8 @@ describe('runChecks', () => {
         {
           validator,
           uniquenessChecks: [{ field: 'email', exists }],
-        }
-      )
+        },
+      ),
     ).rejects.toThrow();
     expect(exists).not.toHaveBeenCalled();
   });
@@ -240,7 +252,7 @@ describe('runChecks', () => {
         { email: 'taken@example.com' },
         {
           uniquenessChecks: [{ entity: 'Artist', field: 'email', exists }],
-        }
+        },
       );
     } catch (e) {
       caught = e;
@@ -256,15 +268,15 @@ describe('runChecks', () => {
     await expect(
       runChecks(
         { email: 'free@example.com' },
-        { uniquenessChecks: [{ field: 'email', exists }] }
-      )
+        { uniquenessChecks: [{ field: 'email', exists }] },
+      ),
     ).resolves.toBeUndefined();
   });
 
   it('skips uniqueness check when value is undefined', async () => {
     const exists = vi.fn();
     await expect(
-      runChecks({}, { uniquenessChecks: [{ field: 'email', exists }] })
+      runChecks({}, { uniquenessChecks: [{ field: 'email', exists }] }),
     ).resolves.toBeUndefined();
     expect(exists).not.toHaveBeenCalled();
   });
@@ -274,8 +286,8 @@ describe('runChecks', () => {
     await expect(
       runChecks(
         { email: null },
-        { uniquenessChecks: [{ field: 'email', exists }] }
-      )
+        { uniquenessChecks: [{ field: 'email', exists }] },
+      ),
     ).resolves.toBeUndefined();
     expect(exists).not.toHaveBeenCalled();
   });
@@ -294,8 +306,8 @@ describe('runChecks', () => {
                 data.email !== data.existingEmail,
             },
           ],
-        }
-      )
+        },
+      ),
     ).resolves.toBeUndefined();
     expect(exists).not.toHaveBeenCalled();
   });
@@ -314,8 +326,8 @@ describe('runChecks', () => {
                 data.email !== data.existingEmail,
             },
           ],
-        }
-      )
+        },
+      ),
     ).resolves.toBeUndefined();
     expect(exists).toHaveBeenCalledWith('new@example.com');
   });
@@ -337,7 +349,7 @@ describe('runChecks', () => {
           { field: 'email', exists: existsEmail },
           { field: 'handle', exists: existsHandle },
         ],
-      }
+      },
     );
     expect(order).toEqual(['email', 'handle']);
   });
@@ -361,16 +373,29 @@ describe('Functions.endpoint (chain + handle)', () => {
       { pong: string }
     >(handler);
 
-    const res = await invoke(endpoint, makeReq({ body: { data: { ping: 'hi' } } }));
+    const res = await invoke(
+      endpoint,
+      makeReq({ body: { data: { ping: 'hi' } } }),
+    );
 
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual({ data: { pong: 'hi' } });
-    expect(handler).toHaveBeenCalledWith({ ping: 'hi' }, expect.any(Object), {}, {});
+    expect(handler).toHaveBeenCalledWith(
+      { ping: 'hi' },
+      expect.any(Object),
+      {},
+      {},
+    );
   });
 
   it('accepts request body without { data } envelope', async () => {
-    const handler = vi.fn(async (data: { x: number }) => ({ doubled: data.x * 2 }));
-    const endpoint = Functions.endpoint.handle<{ x: number }, { doubled: number }>(handler);
+    const handler = vi.fn(async (data: { x: number }) => ({
+      doubled: data.x * 2,
+    }));
+    const endpoint = Functions.endpoint.handle<
+      { x: number },
+      { doubled: number }
+    >(handler);
 
     const res = await invoke(endpoint, makeReq({ body: { x: 21 } }));
 
@@ -393,7 +418,7 @@ describe('Functions.endpoint (chain + handle)', () => {
 
     const res = await invoke(
       endpoint,
-      makeReq({ headers: { origin: 'https://evil.test' } })
+      makeReq({ headers: { origin: 'https://evil.test' } }),
     );
 
     expect(res.statusCode).toBe(403);
@@ -417,7 +442,9 @@ describe('Functions.endpoint (chain + handle)', () => {
 
     const res = await invoke(
       endpoint,
-      makeReq({ headers: { origin: 'https://example.test', authorization: 'Bearer t' } })
+      makeReq({
+        headers: { origin: 'https://example.test', authorization: 'Bearer t' },
+      }),
     );
 
     expect(res.statusCode).toBe(200);
@@ -425,7 +452,7 @@ describe('Functions.endpoint (chain + handle)', () => {
       {},
       { uid: 'u1', email: 'u1@test' },
       {},
-      {}
+      {},
     );
   });
 
@@ -433,11 +460,15 @@ describe('Functions.endpoint (chain + handle)', () => {
     mocks.verifyIdToken.mockResolvedValue({ uid: 'u1' });
     mocks.hasAnyRole.mockResolvedValue(false);
     const handler = vi.fn();
-    const endpoint = Functions.endpoint.requiringRole(Role.Admin).handle(handler);
+    const endpoint = Functions.endpoint
+      .requiringRole(Role.Admin)
+      .handle(handler);
 
     const res = await invoke(
       endpoint,
-      makeReq({ headers: { origin: 'https://example.test', authorization: 'Bearer t' } })
+      makeReq({
+        headers: { origin: 'https://example.test', authorization: 'Bearer t' },
+      }),
     );
 
     expect(res.statusCode).toBe(403);
@@ -448,11 +479,15 @@ describe('Functions.endpoint (chain + handle)', () => {
     mocks.verifyIdToken.mockResolvedValue({ uid: 'admin-uid' });
     mocks.hasAnyRole.mockResolvedValue(true);
     const handler = vi.fn(async () => ({ ok: true }));
-    const endpoint = Functions.endpoint.requiringRole(Role.Admin).handle(handler);
+    const endpoint = Functions.endpoint
+      .requiringRole(Role.Admin)
+      .handle(handler);
 
     const res = await invoke(
       endpoint,
-      makeReq({ headers: { origin: 'https://example.test', authorization: 'Bearer t' } })
+      makeReq({
+        headers: { origin: 'https://example.test', authorization: 'Bearer t' },
+      }),
     );
 
     expect(res.statusCode).toBe(200);
@@ -469,7 +504,9 @@ describe('Functions.endpoint (chain + handle)', () => {
 
     const res = await invoke(
       endpoint,
-      makeReq({ headers: { origin: 'https://example.test', authorization: 'Bearer t' } })
+      makeReq({
+        headers: { origin: 'https://example.test', authorization: 'Bearer t' },
+      }),
     );
 
     expect(res.statusCode).toBe(200);
@@ -487,7 +524,9 @@ describe('Functions.endpoint (chain + handle)', () => {
 
     const res = await invoke(
       endpoint,
-      makeReq({ headers: { origin: 'https://example.test', authorization: 'Bearer t' } })
+      makeReq({
+        headers: { origin: 'https://example.test', authorization: 'Bearer t' },
+      }),
     );
 
     expect(res.statusCode).toBe(200);
@@ -507,7 +546,9 @@ describe('Functions.endpoint (chain + handle)', () => {
 
     const res = await invoke(
       endpoint,
-      makeReq({ headers: { origin: 'https://example.test', authorization: 'Bearer t' } })
+      makeReq({
+        headers: { origin: 'https://example.test', authorization: 'Bearer t' },
+      }),
     );
 
     expect(res.statusCode).toBe(403);
@@ -517,15 +558,19 @@ describe('Functions.endpoint (chain + handle)', () => {
 
   it('maps a thrown permission-denied HttpsError to 403', async () => {
     const handler = vi.fn(async () => {
-      throw new HttpsError('permission-denied', 'You can only manage lessons you teach.');
+      throw new HttpsError(
+        'permission-denied',
+        'You can only manage lessons you teach.',
+      );
     });
     const endpoint = Functions.endpoint.handle(handler);
 
     const res = await invoke(endpoint, makeReq({ body: { data: {} } }));
 
     expect(res.statusCode).toBe(403);
-    expect((res.body as { error: { status: string; message: string } }).error)
-      .toMatchObject({ status: 'PERMISSION_DENIED' });
+    expect(
+      (res.body as { error: { status: string; message: string } }).error,
+    ).toMatchObject({ status: 'PERMISSION_DENIED' });
   });
 
   it('keeps the 400 INVALID_ARGUMENT contract for other thrown errors', async () => {
@@ -538,7 +583,7 @@ describe('Functions.endpoint (chain + handle)', () => {
 
     expect(res.statusCode).toBe(400);
     expect((res.body as { error: { status: string } }).error.status).toBe(
-      'INVALID_ARGUMENT'
+      'INVALID_ARGUMENT',
     );
   });
 
@@ -567,7 +612,10 @@ describe('Functions.endpoint (chain + handle)', () => {
     }));
     const endpoint = Functions.endpoint.validating(validator).handle(handler);
 
-    const res = await invoke(endpoint, makeReq({ body: { data: { name: 'ok' } } }));
+    const res = await invoke(
+      endpoint,
+      makeReq({ body: { data: { name: 'ok' } } }),
+    );
 
     expect(res.statusCode).toBe(200);
     expect(handler).toHaveBeenCalled();
@@ -586,7 +634,7 @@ describe('Functions.endpoint (chain + handle)', () => {
 
     const res = await invoke(
       endpoint,
-      makeReq({ body: { data: { email: 'taken@test' } } })
+      makeReq({ body: { data: { email: 'taken@test' } } }),
     );
 
     expect(res.statusCode).toBe(400);
@@ -656,7 +704,7 @@ describe('Functions.endpoint (chain + handle)', () => {
 
       const res = await invoke(
         endpoint,
-        makeReq({ body: { data: { __warmup: true } } })
+        makeReq({ body: { data: { __warmup: true } } }),
       );
 
       expect(res.statusCode).toBe(200);
@@ -668,10 +716,7 @@ describe('Functions.endpoint (chain + handle)', () => {
       const handler = vi.fn();
       const endpoint = Functions.endpoint.handle(handler);
 
-      const res = await invoke(
-        endpoint,
-        makeReq({ body: { __warmup: true } })
-      );
+      const res = await invoke(endpoint, makeReq({ body: { __warmup: true } }));
 
       expect(res.statusCode).toBe(200);
       expect(res.body).toEqual({ data: { warm: true } });
@@ -684,7 +729,7 @@ describe('Functions.endpoint (chain + handle)', () => {
 
       const res = await invoke(
         endpoint,
-        makeReq({ body: { data: { __warmup: true } } })
+        makeReq({ body: { data: { __warmup: true } } }),
       );
 
       expect(res.statusCode).toBe(200);
@@ -700,7 +745,7 @@ describe('Functions.endpoint (chain + handle)', () => {
 
       const res = await invoke(
         endpoint,
-        makeReq({ body: { data: { __warmup: true } } })
+        makeReq({ body: { data: { __warmup: true } } }),
       );
 
       expect(res.statusCode).toBe(200);
@@ -718,7 +763,7 @@ describe('Functions.endpoint (chain + handle)', () => {
 
       const res = await invoke(
         endpoint,
-        makeReq({ body: { data: { __warmup: true } } })
+        makeReq({ body: { data: { __warmup: true } } }),
       );
 
       expect(res.statusCode).toBe(200);
@@ -735,7 +780,7 @@ describe('Functions.endpoint (chain + handle)', () => {
 
       const res = await invoke(
         endpoint,
-        makeReq({ body: { data: { __warmup: true } } })
+        makeReq({ body: { data: { __warmup: true } } }),
       );
 
       expect(res.statusCode).toBe(200);
@@ -752,7 +797,7 @@ describe('Functions.endpoint (chain + handle)', () => {
         makeReq({
           body: { data: { __warmup: true } },
           headers: { origin: 'https://evil.test' },
-        })
+        }),
       );
 
       expect(res.statusCode).toBe(403);
@@ -766,7 +811,7 @@ describe('Functions.endpoint (chain + handle)', () => {
       const res = await invoke(
         endpoint,
         // truthy but not === true; treated as a real request payload
-        makeReq({ body: { data: { __warmup: 'yes' } } })
+        makeReq({ body: { data: { __warmup: 'yes' } } }),
       );
 
       expect(res.statusCode).toBe(200);
@@ -789,7 +834,7 @@ describe('Functions.endpoint (chain + handle)', () => {
 
     const res = await invoke(
       endpoint,
-      makeReq({ body: { data: { email: 'x' } } })
+      makeReq({ body: { data: { email: 'x' } } }),
     );
 
     expect(res.statusCode).toBe(400);
@@ -826,7 +871,9 @@ describe('legacy wrappers', () => {
     const endpoint = createAdminFunction(handler);
     const res = await invoke(
       endpoint,
-      makeReq({ headers: { origin: 'https://example.test', authorization: 'Bearer t' } })
+      makeReq({
+        headers: { origin: 'https://example.test', authorization: 'Bearer t' },
+      }),
     );
     expect(res.statusCode).toBe(403);
   });
@@ -838,7 +885,7 @@ describe('isOriginAllowed', () => {
   it('allows an origin on the configured allowlist (any environment)', () => {
     expect(isOriginAllowed('http://localhost:3000', allow, false)).toBe(true);
     expect(
-      isOriginAllowed('https://mapleandsprucefolkarts.com', allow, false)
+      isOriginAllowed('https://mapleandsprucefolkarts.com', allow, false),
     ).toBe(true);
   });
 
@@ -853,11 +900,13 @@ describe('isOriginAllowed', () => {
   });
 
   it('rejects non-localhost origins even in the emulator', () => {
-    expect(isOriginAllowed('https://evil.example.com', allow, true)).toBe(false);
+    expect(isOriginAllowed('https://evil.example.com', allow, true)).toBe(
+      false,
+    );
     // Guard against a localhost-lookalike hostname.
-    expect(
-      isOriginAllowed('http://localhost.evil.com', allow, true)
-    ).toBe(false);
+    expect(isOriginAllowed('http://localhost.evil.com', allow, true)).toBe(
+      false,
+    );
   });
 });
 
@@ -891,7 +940,7 @@ describe('FunctionContext request metadata (ad-attribution signal)', () => {
         // RFC 5737 documentation addresses: client, then two proxy hops.
         ip: '192.0.2.9',
         headers: { 'x-forwarded-for': '203.0.113.7, 198.51.100.4, 192.0.2.9' },
-      })
+      }),
     );
     expect(context.ip).toBe('203.0.113.7');
   });
@@ -903,7 +952,7 @@ describe('FunctionContext request metadata (ad-attribution signal)', () => {
 
   it('captures the user agent', async () => {
     const context = await contextFor(
-      makeReq({ headers: { 'user-agent': 'Mozilla/5.0 (iPhone)' } })
+      makeReq({ headers: { 'user-agent': 'Mozilla/5.0 (iPhone)' } }),
     );
     expect(context.userAgent).toBe('Mozilla/5.0 (iPhone)');
   });
@@ -912,5 +961,136 @@ describe('FunctionContext request metadata (ad-attribution signal)', () => {
     const context = await contextFor(makeReq());
     expect(context.ip).toBeUndefined();
     expect(context.userAgent).toBeUndefined();
+  });
+});
+
+describe('createRouter (ADR-029 domain routers)', () => {
+  beforeEach(() => {
+    mocks.verifyIdToken.mockReset();
+    mocks.hasAnyRole.mockReset();
+  });
+
+  const build = () =>
+    createRouter({
+      publicRoute: Functions.endpoint.asRoute<{ v?: number }, { got: number }>(
+        async (data) => ({ got: data.v ?? 0 }),
+      ),
+      adminRoute: Functions.endpoint
+        .requiringRole(Role.Admin)
+        .asRoute<unknown, { ok: boolean }>(async () => ({ ok: true })),
+    });
+
+  it('dispatches on the first path segment and 200s with { data }', async () => {
+    const res = await invoke(
+      build(),
+      makeReq({ path: '/publicRoute', body: { data: { v: 7 } } }),
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ data: { got: 7 } });
+  });
+
+  it('404s an unknown route in the callable error envelope', async () => {
+    const res = await invoke(build(), makeReq({ path: '/nope' }));
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({
+      error: { message: 'Unknown route: nope', status: 'NOT_FOUND' },
+    });
+  });
+
+  it('404s when no route segment is given at all', async () => {
+    const res = await invoke(build(), makeReq({ path: '/' }));
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  // THE security property of ADR-029: collapsing endpoints onto one function
+  // must not widen access. Each route keeps its own gate.
+  it('enforces the admin gate on an admin route while the public route stays open', async () => {
+    const denied = await invoke(build(), makeReq({ path: '/adminRoute' }));
+    expect(denied.statusCode).toBe(401);
+
+    const open = await invoke(build(), makeReq({ path: '/publicRoute' }));
+    expect(open.statusCode).toBe(200);
+  });
+
+  it('403s an authenticated NON-admin on the admin route', async () => {
+    mocks.verifyIdToken.mockResolvedValue({ uid: 'u1', email: 'u@x.test' });
+    mocks.hasAnyRole.mockResolvedValue(false);
+
+    const res = await invoke(
+      build(),
+      makeReq({ path: '/adminRoute', headers: { authorization: 'Bearer t' } }),
+    );
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('allows an admin through the admin route', async () => {
+    mocks.verifyIdToken.mockResolvedValue({ uid: 'u1', email: 'u@x.test' });
+    mocks.hasAnyRole.mockResolvedValue(true);
+
+    const res = await invoke(
+      build(),
+      makeReq({ path: '/adminRoute', headers: { authorization: 'Bearer t' } }),
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ data: { ok: true } });
+  });
+
+  it('answers the warmup sentinel without a route and without auth', async () => {
+    const res = await invoke(
+      build(),
+      makeReq({ path: '/', body: { data: { __warmup: true } } }),
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ data: { warm: true } });
+  });
+
+  it('rejects a disallowed origin before routing', async () => {
+    const res = await invoke(
+      build(),
+      makeReq({
+        path: '/publicRoute',
+        headers: { origin: 'https://evil.test' },
+      }),
+    );
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('maps a thrown handler error to the callable error envelope', async () => {
+    const router = createRouter({
+      boom: Functions.endpoint.asRoute<unknown, never>(async () => {
+        throw new Error('kaboom');
+      }),
+    });
+
+    const res = await invoke(router, makeReq({ path: '/boom' }));
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      error: { message: 'kaboom', status: 'INVALID_ARGUMENT' },
+    });
+  });
+
+  it('runs a per-route validator, so validation is not shared across routes', async () => {
+    const router = createRouter({
+      strict: Functions.endpoint
+        .validating(() => suite(false, { code: ['is required'] }))
+        .asRoute<unknown, { ok: boolean }>(async () => ({ ok: true })),
+      lax: Functions.endpoint.asRoute<unknown, { ok: boolean }>(async () => ({
+        ok: true,
+      })),
+    });
+
+    const bad = await invoke(router, makeReq({ path: '/strict' }));
+    expect(bad.statusCode).toBe(400);
+
+    const good = await invoke(router, makeReq({ path: '/lax' }));
+    expect(good.statusCode).toBe(200);
   });
 });

--- a/libs/firebase/functions/src/lib/functions.utility.ts
+++ b/libs/firebase/functions/src/lib/functions.utility.ts
@@ -155,7 +155,7 @@ export function assertValid(result: ValidationResultLike): void {
  */
 export async function runChecks(
   data: unknown,
-  options: Pick<FunctionOptions, 'validator' | 'uniquenessChecks'>
+  options: Pick<FunctionOptions, 'validator' | 'uniquenessChecks'>,
 ): Promise<void> {
   if (options.validator) {
     assertValid(options.validator(data));
@@ -167,11 +167,7 @@ export async function runChecks(
     if (value === undefined || value === null) continue;
     const exists = await check.exists(value as never);
     if (exists) {
-      throwAlreadyExists(
-        check.entity ?? 'Record',
-        check.field,
-        String(value)
-      );
+      throwAlreadyExists(check.entity ?? 'Record', check.field, String(value));
     }
   }
 }
@@ -190,7 +186,7 @@ function ensureAdminInitialized(): void {
  * Verify Firebase Auth token from Authorization header
  */
 async function verifyAuthToken(
-  req: Request
+  req: Request,
 ): Promise<{ uid: string; email?: string } | null> {
   const authHeader = req.headers.authorization;
   if (!authHeader?.startsWith('Bearer ')) {
@@ -230,7 +226,7 @@ async function verifyAuthToken(
 export function isOriginAllowed(
   origin: string,
   allowedOrigins: string[],
-  isEmulator: boolean
+  isEmulator: boolean,
 ): boolean {
   if (allowedOrigins.includes(origin)) return true;
   if (isEmulator) {
@@ -260,11 +256,11 @@ function createCorsMiddleware(allowedOriginsParam: StringParam) {
       res.setHeader('Access-Control-Allow-Origin', origin);
       res.setHeader(
         'Access-Control-Allow-Methods',
-        'GET, POST, OPTIONS, PUT, PATCH, DELETE'
+        'GET, POST, OPTIONS, PUT, PATCH, DELETE',
       );
       res.setHeader(
         'Access-Control-Allow-Headers',
-        'Authorization,Content-Type'
+        'Authorization,Content-Type',
       );
       res.setHeader('Access-Control-Allow-Credentials', 'true');
 
@@ -328,6 +324,22 @@ function extractClientIp(req: Request): string | undefined {
  *     }
  *   );
  */
+/**
+ * A single route on a router function: everything `handle()` would have baked
+ * into its own Cloud Function, minus the `onRequest` wrapper.
+ */
+export interface RouteDescriptor {
+  options: FunctionOptions;
+  secrets: Record<string, SecretParam>;
+  strings: Record<string, StringParam>;
+  handler: (
+    data: never,
+    context: FunctionContext,
+    secrets: Record<string, string>,
+    strings: Record<string, string>,
+  ) => Promise<unknown>;
+}
+
 class FunctionBuilder<
   SecretNames extends string = never,
   StringNames extends string = never,
@@ -341,7 +353,7 @@ class FunctionBuilder<
       StringNames,
       StringParam
     >,
-    private readonly options: FunctionOptions = {}
+    private readonly options: FunctionOptions = {},
   ) {}
 
   /**
@@ -358,7 +370,7 @@ class FunctionBuilder<
         acc[name as NewSecretNames] = defineSecret(name);
         return acc;
       },
-      {} as Record<NewSecretNames, SecretParam>
+      {} as Record<NewSecretNames, SecretParam>,
     );
 
     return new FunctionBuilder(
@@ -367,7 +379,7 @@ class FunctionBuilder<
         SecretParam
       >,
       this.strings,
-      this.options
+      this.options,
     );
   }
 
@@ -385,7 +397,7 @@ class FunctionBuilder<
         acc[name as NewStringNames] = defineString(name);
         return acc;
       },
-      {} as Record<NewStringNames, StringParam>
+      {} as Record<NewStringNames, StringParam>,
     );
 
     return new FunctionBuilder(
@@ -394,7 +406,7 @@ class FunctionBuilder<
         StringNames | NewStringNames,
         StringParam
       >,
-      this.options
+      this.options,
     );
   }
 
@@ -416,7 +428,7 @@ class FunctionBuilder<
    * .requiringRole([Role.Admin, Role.MtTeacher])  // admin OR MT teacher
    */
   requiringRole(
-    role: Role | readonly Role[]
+    role: Role | readonly Role[],
   ): FunctionBuilder<SecretNames, StringNames> {
     return new FunctionBuilder(this.secrets, this.strings, {
       ...this.options,
@@ -427,7 +439,9 @@ class FunctionBuilder<
   /**
    * Set runtime options (memory, concurrency, minInstances, timeoutSeconds)
    */
-  withOptions(runtime: RuntimeOptions): FunctionBuilder<SecretNames, StringNames> {
+  withOptions(
+    runtime: RuntimeOptions,
+  ): FunctionBuilder<SecretNames, StringNames> {
     return new FunctionBuilder(this.secrets, this.strings, {
       ...this.options,
       runtime,
@@ -447,7 +461,7 @@ class FunctionBuilder<
    *   .handle<CreateArtistRequest, CreateArtistResponse>(...)
    */
   validating(
-    validator: ValidatorFn
+    validator: ValidatorFn,
   ): FunctionBuilder<SecretNames, StringNames> {
     return new FunctionBuilder(this.secrets, this.strings, {
       ...this.options,
@@ -475,7 +489,7 @@ class FunctionBuilder<
    *   .handle<CreateArtistRequest, CreateArtistResponse>(...)
    */
   ensuringUnique<T = Record<string, unknown>>(
-    check: UniquenessCheck<T>
+    check: UniquenessCheck<T>,
   ): FunctionBuilder<SecretNames, StringNames> {
     return new FunctionBuilder(this.secrets, this.strings, {
       ...this.options,
@@ -484,6 +498,32 @@ class FunctionBuilder<
         check as UniquenessCheck,
       ],
     });
+  }
+
+  /**
+   * Build this endpoint as a ROUTE on a router function instead of its own
+   * Cloud Function (ADR-029).
+   *
+   * Identical chain semantics to `handle()` — `requiringRole`, `validating`,
+   * `ensuringUnique`, `withSecrets` all apply per-route — it just returns a
+   * descriptor for `Functions.router()` rather than calling `onRequest`.
+   * Per-route options are what lets a router mix auth levels: the discounts
+   * router carries four admin routes plus the public `lookupDiscount`.
+   */
+  asRoute<TRequest, TResponse>(
+    handler: (
+      data: TRequest,
+      context: FunctionContext,
+      secrets: Record<SecretNames, string>,
+      strings: Record<StringNames, string>,
+    ) => Promise<TResponse>,
+  ): RouteDescriptor {
+    return {
+      options: this.options,
+      secrets: this.secrets as Record<string, SecretParam>,
+      strings: this.strings as Record<string, StringParam>,
+      handler: handler as never,
+    };
   }
 
   /**
@@ -496,8 +536,8 @@ class FunctionBuilder<
       data: TRequest,
       context: FunctionContext,
       secrets: Record<SecretNames, string>,
-      strings: Record<StringNames, string>
-    ) => Promise<TResponse>
+      strings: Record<StringNames, string>,
+    ) => Promise<TResponse>,
   ) {
     // Define ALLOWED_ORIGINS lazily here, not at module level
     // This is the key optimization - defineString is called when handle() is invoked
@@ -512,136 +552,268 @@ class FunctionBuilder<
         region: 'us-east4',
         invoker: 'public',
         secrets: secretParams,
-        ...(this.options.runtime?.memory && { memory: this.options.runtime.memory }),
-        ...(this.options.runtime?.concurrency && { concurrency: this.options.runtime.concurrency }),
-        ...(this.options.runtime?.minInstances !== undefined && { minInstances: this.options.runtime.minInstances }),
-        ...(this.options.runtime?.maxInstances !== undefined && { maxInstances: this.options.runtime.maxInstances }),
-        ...(this.options.runtime?.timeoutSeconds && { timeoutSeconds: this.options.runtime.timeoutSeconds }),
+        ...(this.options.runtime?.memory && {
+          memory: this.options.runtime.memory,
+        }),
+        ...(this.options.runtime?.concurrency && {
+          concurrency: this.options.runtime.concurrency,
+        }),
+        ...(this.options.runtime?.minInstances !== undefined && {
+          minInstances: this.options.runtime.minInstances,
+        }),
+        ...(this.options.runtime?.maxInstances !== undefined && {
+          maxInstances: this.options.runtime.maxInstances,
+        }),
+        ...(this.options.runtime?.timeoutSeconds && {
+          timeoutSeconds: this.options.runtime.timeoutSeconds,
+        }),
       },
       async (req: Request, res: Response) => {
-        // Handle CORS
+        // CORS first: preflight must be answered before auth or routing.
         corsMiddleware(req, res, async () => {
-          try {
-            // Warmup short-circuit. A request body of `{ __warmup: true }`
-            // (sent as `{ data: { __warmup: true } }` by httpsCallable)
-            // boots this function instance without running auth, validation,
-            // or the handler. Lets clients pre-warm cold endpoints from the
-            // UI in the background while the user is reading the page.
-            const rawBody = (req.body?.data ?? req.body ?? {}) as {
-              __warmup?: unknown;
-            };
-            if (rawBody && rawBody.__warmup === true) {
-              res.status(200).json({ data: { warm: true } });
-              return;
-            }
-
-            // Verify auth token if present
-            const auth = await verifyAuthToken(req);
-            const context: FunctionContext = {
-              uid: auth?.uid,
-              email: auth?.email,
-              ip: extractClientIp(req),
-              userAgent:
-                typeof req.headers['user-agent'] === 'string'
-                  ? req.headers['user-agent']
-                  : undefined,
-            };
-
-            // Check authentication if required
-            if (this.options.requireAuth || this.options.requiredRole) {
-              if (!auth?.uid) {
-                res.status(401).json({
-                  error:
-                    'Unauthorized: You must be logged in to perform this action',
-                });
-                return;
-              }
-            }
-
-            // Check role if required (any-of when an array is given)
-            if (this.options.requiredRole) {
-              const requiredRoles: readonly Role[] = Array.isArray(
-                this.options.requiredRole
-              )
-                ? this.options.requiredRole
-                : [this.options.requiredRole as Role];
-              const userHasRole = await hasAnyRole(auth!.uid, requiredRoles);
-              if (!userHasRole) {
-                res.status(403).json({
-                  error: `Forbidden: You must be a ${requiredRoles.join(' or ')} to perform this action`,
-                });
-                return;
-              }
-            }
-
-            // Extract secret values (only accessed at runtime, not at cold start)
-            const secretValues = Object.fromEntries(
-              Object.entries(this.secrets).map(([key, secret]) => [
-                key,
-                (secret as SecretParam).value(),
-              ])
-            ) as Record<SecretNames, string>;
-
-            // Extract string values (only accessed at runtime, not at cold start)
-            const stringValues = Object.fromEntries(
-              Object.entries(this.strings).map(([key, str]) => [
-                key,
-                (str as StringParam).value(),
-              ])
-            ) as Record<StringNames, string>;
-
-            // Parse request data from body
-            const data = (req.body?.data ?? req.body ?? {}) as TRequest;
-
-            // Run validator + uniqueness checks (no-op when neither is set)
-            await runChecks(data, this.options);
-
-            // Execute handler
-            const result = await handler(
-              data,
-              context,
-              secretValues,
-              stringValues
-            );
-
-            // Send response in the format expected by httpsCallable
-            res.status(200).json({ data: result });
-          } catch (error) {
-            console.error('Function error:', error);
-
-            const message =
-              error instanceof Error
-                ? error.message
-                : 'An unexpected error occurred';
-
-            // Resource-ownership failures (throwPermissionDenied) map to 403 so
-            // clients can tell "not allowed" from "bad input" — this mirrors the
-            // role-gate's 403. Everything else keeps the existing 400
-            // INVALID_ARGUMENT contract.
-            if (
-              error instanceof HttpsError &&
-              error.code === 'permission-denied'
-            ) {
-              res.status(403).json({
-                error: { message, status: 'PERMISSION_DENIED' },
-              });
-              return;
-            }
-
-            // Return error in the callable protocol format so httpsCallable
-            // on the client can extract the message. Without this structure,
-            // the Firebase SDK shows a generic "internal" error to users.
-            res.status(400).json({
-              error: {
-                message,
-                status: 'INVALID_ARGUMENT',
-              },
-            });
-          }
+          await runEndpointPipeline<TRequest, TResponse>({
+            req,
+            res,
+            options: this.options,
+            secrets: this.secrets as Record<string, SecretParam>,
+            strings: this.strings as Record<string, StringParam>,
+            handler: handler as never,
+          });
         });
-      }
+      },
     );
   }
+}
+
+/**
+ * The per-request pipeline shared by `Functions.endpoint` (one function per
+ * endpoint) and `Functions.router` (many routes on one function).
+ *
+ * Extracted so the two cannot drift: warmup short-circuit, auth, role gate,
+ * secret/string resolution, validation, the `{ data: … }` callable envelope,
+ * and the error->status mapping all live HERE and nowhere else. ADR-029
+ * consolidates endpoints into routers precisely because the deploy write
+ * quota scales with function count; that is only safe if a route behaves
+ * byte-for-byte like the standalone function it replaced.
+ *
+ * CORS runs OUTSIDE this (in the onRequest wrapper) because it must answer
+ * preflight before any routing or auth work happens.
+ */
+export async function runEndpointPipeline<TRequest, TResponse>(args: {
+  req: Request;
+  res: Response;
+  options: FunctionOptions;
+  secrets: Record<string, SecretParam>;
+  strings: Record<string, StringParam>;
+  handler: (
+    data: TRequest,
+    context: FunctionContext,
+    secrets: Record<string, string>,
+    strings: Record<string, string>,
+  ) => Promise<TResponse>;
+  /** Route name for logs; undefined for a single-endpoint function. */
+  routeLabel?: string;
+}): Promise<void> {
+  const { req, res, options, secrets, strings, handler, routeLabel } = args;
+  try {
+    // Warmup short-circuit. A request body of `{ __warmup: true }`
+    // (sent as `{ data: { __warmup: true } }` by httpsCallable)
+    // boots this function instance without running auth, validation,
+    // or the handler. Lets clients pre-warm cold endpoints from the
+    // UI in the background while the user is reading the page.
+    const rawBody = (req.body?.data ?? req.body ?? {}) as {
+      __warmup?: unknown;
+    };
+    if (rawBody && rawBody.__warmup === true) {
+      res.status(200).json({ data: { warm: true } });
+      return;
+    }
+
+    // Verify auth token if present
+    const auth = await verifyAuthToken(req);
+    const context: FunctionContext = {
+      uid: auth?.uid,
+      email: auth?.email,
+      ip: extractClientIp(req),
+      userAgent:
+        typeof req.headers['user-agent'] === 'string'
+          ? req.headers['user-agent']
+          : undefined,
+    };
+
+    // Check authentication if required
+    if (options.requireAuth || options.requiredRole) {
+      if (!auth?.uid) {
+        res.status(401).json({
+          error: 'Unauthorized: You must be logged in to perform this action',
+        });
+        return;
+      }
+    }
+
+    // Check role if required (any-of when an array is given)
+    if (options.requiredRole) {
+      const requiredRoles: readonly Role[] = Array.isArray(options.requiredRole)
+        ? options.requiredRole
+        : [options.requiredRole as Role];
+      const userHasRole = await hasAnyRole(auth!.uid, requiredRoles);
+      if (!userHasRole) {
+        res.status(403).json({
+          error: `Forbidden: You must be a ${requiredRoles.join(' or ')} to perform this action`,
+        });
+        return;
+      }
+    }
+
+    // Extract secret values (only accessed at runtime, not at cold start)
+    const secretValues = Object.fromEntries(
+      Object.entries(secrets).map(([key, secret]) => [
+        key,
+        (secret as SecretParam).value(),
+      ]),
+    ) as Record<string, string>;
+
+    // Extract string values (only accessed at runtime, not at cold start)
+    const stringValues = Object.fromEntries(
+      Object.entries(strings).map(([key, str]) => [
+        key,
+        (str as StringParam).value(),
+      ]),
+    ) as Record<string, string>;
+
+    // Parse request data from body
+    const data = (req.body?.data ?? req.body ?? {}) as TRequest;
+
+    // Run validator + uniqueness checks (no-op when neither is set)
+    await runChecks(data, options);
+
+    // Execute handler
+    const result = await handler(data, context, secretValues, stringValues);
+
+    // Send response in the format expected by httpsCallable
+    res.status(200).json({ data: result });
+  } catch (error) {
+    console.error(
+      routeLabel ? `Function error [${routeLabel}]:` : 'Function error:',
+      error,
+    );
+
+    const message =
+      error instanceof Error ? error.message : 'An unexpected error occurred';
+
+    // Resource-ownership failures (throwPermissionDenied) map to 403 so
+    // clients can tell "not allowed" from "bad input" — this mirrors the
+    // role-gate's 403. Everything else keeps the existing 400
+    // INVALID_ARGUMENT contract.
+    if (error instanceof HttpsError && error.code === 'permission-denied') {
+      res.status(403).json({
+        error: { message, status: 'PERMISSION_DENIED' },
+      });
+      return;
+    }
+
+    // Return error in the callable protocol format so httpsCallable
+    // on the client can extract the message. Without this structure,
+    // the Firebase SDK shows a generic "internal" error to users.
+    res.status(400).json({
+      error: {
+        message,
+        status: 'INVALID_ARGUMENT',
+      },
+    });
+  }
+}
+
+/**
+ * Build ONE Cloud Function that serves many routes (ADR-029).
+ *
+ * Why this exists: every function library is a separate Cloud Run service, and
+ * the gen-2 deploy write quota is 60 per 60 seconds and CANNOT be raised. At
+ * 215 functions a full deploy needs >=4 minutes of pure API writes and has been
+ * breaching the regional CPU rate. Routers collapse a domain's endpoints onto
+ * one service without changing how any single endpoint behaves.
+ *
+ * Routes dispatch on the URL path, so `httpsCallableFromURL(fn, base + '/getDiscounts')`
+ * reaches the `getDiscounts` route. Each route keeps its OWN auth/role/
+ * validation chain via `asRoute()`, and every route runs the exact same
+ * `runEndpointPipeline` a standalone function would have run.
+ *
+ * @example
+ * export const discountsApi = createRouter({
+ *   lookupDiscount: Functions.endpoint.asRoute(lookupDiscountHandler),
+ *   getDiscounts: Functions.endpoint.requiringRole(Role.Admin).asRoute(getDiscountsHandler),
+ * });
+ */
+export function createRouter(
+  routes: Record<string, RouteDescriptor>,
+  runtime?: RuntimeOptions,
+) {
+  const allowedOriginsParam = defineString('ALLOWED_ORIGINS');
+  const corsMiddleware = createCorsMiddleware(allowedOriginsParam);
+
+  // A function declares its secrets up front, so the router needs the union of
+  // every route's secrets. Each route still only receives its own at runtime.
+  const secretParams = Array.from(
+    new Set(Object.values(routes).flatMap((r) => Object.values(r.secrets))),
+  ) as SecretParam[];
+
+  return onRequest(
+    {
+      region: 'us-east4',
+      invoker: 'public',
+      secrets: secretParams,
+      ...(runtime?.memory && { memory: runtime.memory }),
+      ...(runtime?.concurrency && { concurrency: runtime.concurrency }),
+      ...(runtime?.minInstances !== undefined && {
+        minInstances: runtime.minInstances,
+      }),
+      ...(runtime?.maxInstances !== undefined && {
+        maxInstances: runtime.maxInstances,
+      }),
+      ...(runtime?.timeoutSeconds && {
+        timeoutSeconds: runtime.timeoutSeconds,
+      }),
+    },
+    async (req: Request, res: Response) => {
+      // CORS first: preflight must be answered before routing or auth.
+      corsMiddleware(req, res, async () => {
+        const routeName = (req.path ?? '').split('/').filter(Boolean)[0];
+
+        // Warmup must work WITHOUT a route (clients warm the function, not an
+        // endpoint) and must not require auth — same contract as `handle()`.
+        const rawBody = (req.body?.data ?? req.body ?? {}) as {
+          __warmup?: unknown;
+        };
+        if (rawBody && rawBody.__warmup === true) {
+          res.status(200).json({ data: { warm: true } });
+          return;
+        }
+
+        const route = routeName ? routes[routeName] : undefined;
+        if (!route) {
+          // Callable-protocol error envelope so httpsCallable surfaces a real
+          // message instead of a generic "internal".
+          res.status(404).json({
+            error: {
+              message: `Unknown route: ${routeName || '(none)'}`,
+              status: 'NOT_FOUND',
+            },
+          });
+          return;
+        }
+
+        await runEndpointPipeline({
+          req,
+          res,
+          options: route.options,
+          secrets: route.secrets,
+          strings: route.strings,
+          handler: route.handler,
+          routeLabel: routeName,
+        });
+      });
+    },
+  );
 }
 
 /**
@@ -656,6 +828,8 @@ class FunctionBuilder<
  */
 export class Functions {
   static endpoint = new FunctionBuilder();
+  /** Build one function serving many routes — see createRouter (ADR-029). */
+  static router = createRouter;
 }
 
 // ============================================================================
@@ -669,7 +843,7 @@ export class Functions {
  */
 export function createFunction<TRequest, TResponse>(
   handler: (data: TRequest, context: FunctionContext) => Promise<TResponse>,
-  options: FunctionOptions = {}
+  options: FunctionOptions = {},
 ) {
   let builder = Functions.endpoint;
 
@@ -691,7 +865,7 @@ export function createFunction<TRequest, TResponse>(
  * @deprecated Use Functions.endpoint.handle() instead
  */
 export function createPublicFunction<TRequest, TResponse>(
-  handler: (data: TRequest, context: FunctionContext) => Promise<TResponse>
+  handler: (data: TRequest, context: FunctionContext) => Promise<TResponse>,
 ) {
   return createFunction(handler, {});
 }
@@ -701,7 +875,7 @@ export function createPublicFunction<TRequest, TResponse>(
  * @deprecated Use Functions.endpoint.requiringAuth().handle() instead
  */
 export function createAuthenticatedFunction<TRequest, TResponse>(
-  handler: (data: TRequest, context: FunctionContext) => Promise<TResponse>
+  handler: (data: TRequest, context: FunctionContext) => Promise<TResponse>,
 ) {
   return createFunction(handler, { requireAuth: true });
 }
@@ -711,7 +885,7 @@ export function createAuthenticatedFunction<TRequest, TResponse>(
  * @deprecated Use Functions.endpoint.requiringRole(Role.Admin).handle() instead
  */
 export function createAdminFunction<TRequest, TResponse>(
-  handler: (data: TRequest, context: FunctionContext) => Promise<TResponse>
+  handler: (data: TRequest, context: FunctionContext) => Promise<TResponse>,
 ) {
   return createFunction(handler, { requiredRole: Role.Admin });
 }
@@ -726,7 +900,7 @@ export function createAdminFunction<TRequest, TResponse>(
  */
 export function createRoleFunction<TRequest, TResponse>(
   handler: (data: TRequest, context: FunctionContext) => Promise<TResponse>,
-  roles: readonly Role[]
+  roles: readonly Role[],
 ) {
   return createFunction(handler, { requiredRole: roles });
 }

--- a/libs/firebase/maple-functions/discounts-api/project.json
+++ b/libs/firebase/maple-functions/discounts-api/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "firebase-maple-functions-discounts-api",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/firebase/maple-functions/discounts-api/src",
+  "projectType": "library",
+  "tags": ["scope:firebase", "type:feature"],
+  "targets": {}
+}

--- a/libs/firebase/maple-functions/discounts-api/src/index.ts
+++ b/libs/firebase/maple-functions/discounts-api/src/index.ts
@@ -1,0 +1,1 @@
+export { discountsApi, DISCOUNT_ROUTES } from './lib/discounts-api';

--- a/libs/firebase/maple-functions/discounts-api/src/lib/discounts-api.ts
+++ b/libs/firebase/maple-functions/discounts-api/src/lib/discounts-api.ts
@@ -1,0 +1,81 @@
+/**
+ * Discounts domain router — ADR-029, issue #731.
+ *
+ * ONE Cloud Function serving all five discount endpoints, replacing
+ * getDiscounts / createDiscount / updateDiscount / deleteDiscount /
+ * lookupDiscount. This is the Phase 0 pilot: the pattern established here is
+ * what the remaining domains (#732–#744) copy.
+ *
+ * Routing: `httpsCallableFromURL(fn, `${DISCOUNTS_API_URL}/getDiscounts`)`.
+ * The route name is the first path segment.
+ *
+ * NOTE the mixed auth. Four routes are admin-only; `lookupDiscount` is public
+ * because the checkout form calls it before the customer has any identity.
+ * Per-route options via `asRoute()` are exactly what makes that safe on a
+ * shared function — the pipeline applies each route's own gate, so collapsing
+ * endpoints never widens access. Getting this wrong would silently expose
+ * admin CRUD, so the spec asserts the gate for every route individually.
+ *
+ * Deployed to us-east4 via CI/CD.
+ */
+import { Functions, Role } from '@maple/firebase/functions';
+import type {
+  CreateDiscountRequest,
+  CreateDiscountResponse,
+  DeleteDiscountRequest,
+  DeleteDiscountResponse,
+  GetDiscountsRequest,
+  GetDiscountsResponse,
+  LookupDiscountRequest,
+  LookupDiscountResponse,
+  UpdateDiscountRequest,
+  UpdateDiscountResponse,
+} from '@maple/ts/firebase/api-types';
+import {
+  createDiscountHandler,
+  deleteDiscountHandler,
+  getDiscountsHandler,
+  lookupDiscountHandler,
+  updateDiscountHandler,
+} from './handlers';
+
+/** Route names, exported so clients and tests share one source of truth. */
+export const DISCOUNT_ROUTES = [
+  'getDiscounts',
+  'createDiscount',
+  'updateDiscount',
+  'deleteDiscount',
+  'lookupDiscount',
+] as const;
+
+export const discountsApi = Functions.router({
+  getDiscounts: Functions.endpoint
+    .requiringRole(Role.Admin)
+    .asRoute<GetDiscountsRequest, GetDiscountsResponse>((data) =>
+      getDiscountsHandler(data),
+    ),
+
+  createDiscount: Functions.endpoint
+    .requiringRole(Role.Admin)
+    .asRoute<CreateDiscountRequest, CreateDiscountResponse>((data) =>
+      createDiscountHandler(data),
+    ),
+
+  updateDiscount: Functions.endpoint
+    .requiringRole(Role.Admin)
+    .asRoute<UpdateDiscountRequest, UpdateDiscountResponse>((data) =>
+      updateDiscountHandler(data),
+    ),
+
+  deleteDiscount: Functions.endpoint
+    .requiringRole(Role.Admin)
+    .asRoute<DeleteDiscountRequest, DeleteDiscountResponse>((data) =>
+      deleteDiscountHandler(data),
+    ),
+
+  // Public: the checkout form resolves codes for anonymous customers.
+  lookupDiscount: Functions.endpoint.asRoute<
+    LookupDiscountRequest,
+    LookupDiscountResponse
+  >((data) => lookupDiscountHandler(data)),
+});

--- a/libs/firebase/maple-functions/discounts-api/src/lib/handlers.spec.ts
+++ b/libs/firebase/maple-functions/discounts-api/src/lib/handlers.spec.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Handler-level spec for the discounts domain (#731, ADR-029).
+ *
+ * The five standalone discount functions shipped with ZERO unit tests. Moving
+ * them onto a router is exactly the wrong moment to still have none — these
+ * lock in the behaviour the router must preserve, so a future refactor that
+ * changes an error message or a return shape fails here rather than in a
+ * customer's checkout.
+ *
+ * Repositories are mocked (ADR-017).
+ */
+const mocks = vi.hoisted(() => ({
+  findAll: vi.fn(),
+  findByCode: vi.fn(),
+  findById: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  remove: vi.fn(),
+  isDiscountValid: vi.fn(),
+  discountValidation: vi.fn(),
+}));
+
+vi.mock('@maple/firebase/database', () => ({
+  DiscountRepository: {
+    findAll: mocks.findAll,
+    findByCode: mocks.findByCode,
+    findById: mocks.findById,
+    create: mocks.create,
+    update: mocks.update,
+    delete: mocks.remove,
+  },
+}));
+
+vi.mock('@maple/ts/domain', () => ({
+  isDiscountValid: mocks.isDiscountValid,
+}));
+
+vi.mock('@maple/ts/validation', () => ({
+  discountValidation: mocks.discountValidation,
+}));
+
+import {
+  createDiscountHandler,
+  deleteDiscountHandler,
+  getDiscountsHandler,
+  lookupDiscountHandler,
+  updateDiscountHandler,
+} from './handlers';
+
+const DISCOUNT = { id: 'd1', code: 'SAVE10', percentOff: 10 };
+
+/** Vest-style result stub. */
+function validation({ valid = true, errors = {} } = {}) {
+  return {
+    isValid: () => valid,
+    hasErrors: () => !valid,
+    getErrors: () => errors,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.discountValidation.mockReturnValue(validation());
+});
+
+describe('getDiscountsHandler', () => {
+  it('passes the status filter through and returns the list', async () => {
+    mocks.findAll.mockResolvedValue([DISCOUNT]);
+
+    const res = await getDiscountsHandler({ status: 'active' } as never);
+
+    expect(mocks.findAll).toHaveBeenCalledWith({ status: 'active' });
+    expect(res).toEqual({ discounts: [DISCOUNT] });
+  });
+
+  it('passes undefined status when none is given', async () => {
+    mocks.findAll.mockResolvedValue([]);
+
+    await getDiscountsHandler({} as never);
+
+    expect(mocks.findAll).toHaveBeenCalledWith({ status: undefined });
+  });
+});
+
+describe('createDiscountHandler', () => {
+  it('creates when valid and the code is free', async () => {
+    mocks.findByCode.mockResolvedValue(undefined);
+    mocks.create.mockResolvedValue(DISCOUNT);
+
+    const res = await createDiscountHandler({ code: 'SAVE10' } as never);
+
+    expect(res).toEqual({ discount: DISCOUNT });
+  });
+
+  it('rejects invalid input with the field-joined message', async () => {
+    mocks.discountValidation.mockReturnValue(
+      validation({ valid: false, errors: { code: ['is required'] } }),
+    );
+
+    await expect(createDiscountHandler({} as never)).rejects.toThrow(
+      'Validation failed: code: is required',
+    );
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a duplicate code, uppercased in the message', async () => {
+    mocks.findByCode.mockResolvedValue(DISCOUNT);
+
+    await expect(
+      createDiscountHandler({ code: 'save10' } as never),
+    ).rejects.toThrow('Discount code "SAVE10" already exists');
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+
+  it('validates BEFORE touching the repository', async () => {
+    mocks.discountValidation.mockReturnValue(validation({ valid: false }));
+
+    await expect(createDiscountHandler({} as never)).rejects.toThrow();
+
+    expect(mocks.findByCode).not.toHaveBeenCalled();
+  });
+});
+
+describe('updateDiscountHandler', () => {
+  it('requires an id', async () => {
+    await expect(updateDiscountHandler({} as never)).rejects.toThrow(
+      /Discount ID is required/,
+    );
+  });
+
+  it('404s when the discount is missing', async () => {
+    mocks.findById.mockResolvedValue(undefined);
+
+    await expect(
+      updateDiscountHandler({ id: 'nope' } as never),
+    ).rejects.toThrow();
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it('validates only the changed fields, merged over the existing record', async () => {
+    mocks.findById.mockResolvedValue(DISCOUNT);
+    mocks.update.mockResolvedValue({ ...DISCOUNT, percentOff: 25 });
+
+    await updateDiscountHandler({ id: 'd1', percentOff: 25 } as never);
+
+    expect(mocks.discountValidation).toHaveBeenCalledWith(
+      { ...DISCOUNT, percentOff: 25 },
+      ['percentOff'],
+    );
+  });
+
+  it('rejects renaming onto an existing code', async () => {
+    mocks.findById.mockResolvedValue(DISCOUNT);
+    mocks.findByCode.mockResolvedValue({ id: 'other', code: 'TAKEN' });
+
+    await expect(
+      updateDiscountHandler({ id: 'd1', code: 'taken' } as never),
+    ).rejects.toThrow('Discount code "TAKEN" already exists');
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it('allows saving the same code back unchanged (no false conflict)', async () => {
+    mocks.findById.mockResolvedValue(DISCOUNT);
+    mocks.update.mockResolvedValue(DISCOUNT);
+
+    await updateDiscountHandler({ id: 'd1', code: 'SAVE10' } as never);
+
+    // Same code as existing -> uniqueness lookup must be skipped entirely.
+    expect(mocks.findByCode).not.toHaveBeenCalled();
+    expect(mocks.update).toHaveBeenCalled();
+  });
+});
+
+describe('deleteDiscountHandler', () => {
+  it('requires an id', async () => {
+    await expect(deleteDiscountHandler({} as never)).rejects.toThrow(
+      'Discount ID is required',
+    );
+  });
+
+  it('404s when missing, without deleting', async () => {
+    mocks.findById.mockResolvedValue(undefined);
+
+    await expect(
+      deleteDiscountHandler({ id: 'gone' } as never),
+    ).rejects.toThrow('Discount not found: gone');
+    expect(mocks.remove).not.toHaveBeenCalled();
+  });
+
+  it('deletes and reports success', async () => {
+    mocks.findById.mockResolvedValue(DISCOUNT);
+
+    const res = await deleteDiscountHandler({ id: 'd1' } as never);
+
+    expect(mocks.remove).toHaveBeenCalledWith('d1');
+    expect(res).toEqual({ success: true });
+  });
+});
+
+describe('lookupDiscountHandler (public)', () => {
+  it('returns the discount when found and valid', async () => {
+    mocks.findByCode.mockResolvedValue(DISCOUNT);
+    mocks.isDiscountValid.mockReturnValue(true);
+
+    expect(await lookupDiscountHandler({ code: 'SAVE10' } as never)).toEqual({
+      discount: DISCOUNT,
+    });
+  });
+
+  // The checkout form treats "no discount" as a normal outcome. Throwing here
+  // would surface as a payment-flow error to a customer mistyping a code.
+  it.each([
+    ['a missing code', {}],
+    ['an empty code', { code: '' }],
+    ['a non-string code', { code: 123 }],
+  ])('returns undefined for %s without throwing', async (_label, input) => {
+    const res = await lookupDiscountHandler(input as never);
+
+    expect(res).toEqual({ discount: undefined });
+    expect(mocks.findByCode).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined for an unknown code', async () => {
+    mocks.findByCode.mockResolvedValue(undefined);
+
+    expect(await lookupDiscountHandler({ code: 'NOPE' } as never)).toEqual({
+      discount: undefined,
+    });
+  });
+
+  it('returns undefined for an expired/inactive discount', async () => {
+    mocks.findByCode.mockResolvedValue(DISCOUNT);
+    mocks.isDiscountValid.mockReturnValue(false);
+
+    expect(await lookupDiscountHandler({ code: 'SAVE10' } as never)).toEqual({
+      discount: undefined,
+    });
+  });
+});

--- a/libs/firebase/maple-functions/discounts-api/src/lib/handlers.ts
+++ b/libs/firebase/maple-functions/discounts-api/src/lib/handlers.ts
@@ -1,0 +1,144 @@
+/**
+ * Discounts domain — route handlers.
+ *
+ * Pure handler functions, deliberately separated from the router wiring in
+ * `discounts-api.ts`. Handlers take (data, context) exactly as they did when
+ * each was its own Cloud Function, so they are unit-testable without the
+ * onRequest/CORS/auth machinery — and so the move to a router (ADR-029) is a
+ * wiring change rather than a rewrite.
+ *
+ * Behaviour here must stay byte-for-byte identical to the standalone
+ * functions these replace (getDiscounts, createDiscount, updateDiscount,
+ * deleteDiscount, lookupDiscount). Any change in error text or shape is a
+ * client-visible regression.
+ */
+import {
+  throwInvalidArgument,
+  throwNotFound,
+  throwValidationError,
+} from '@maple/firebase/functions';
+import { DiscountRepository } from '@maple/firebase/database';
+import { discountValidation } from '@maple/ts/validation';
+import { isDiscountValid } from '@maple/ts/domain';
+import type {
+  CreateDiscountRequest,
+  CreateDiscountResponse,
+  DeleteDiscountRequest,
+  DeleteDiscountResponse,
+  GetDiscountsRequest,
+  GetDiscountsResponse,
+  LookupDiscountRequest,
+  LookupDiscountResponse,
+  UpdateDiscountRequest,
+  UpdateDiscountResponse,
+} from '@maple/ts/firebase/api-types';
+
+/** Admin. Lists discounts with an optional status filter. */
+export async function getDiscountsHandler(
+  data: GetDiscountsRequest,
+): Promise<GetDiscountsResponse> {
+  const discounts = await DiscountRepository.findAll({
+    status: data.status,
+  });
+
+  return { discounts };
+}
+
+/** Admin. Creates a discount code, enforcing code uniqueness. */
+export async function createDiscountHandler(
+  data: CreateDiscountRequest,
+): Promise<CreateDiscountResponse> {
+  const result = discountValidation(data);
+  if (!result.isValid()) {
+    const errors = result.getErrors();
+    const errorMessages = Object.entries(errors)
+      .map(([field, msgs]) => `${field}: ${msgs.join(', ')}`)
+      .join('; ');
+    throw new Error(`Validation failed: ${errorMessages}`);
+  }
+
+  const existing = await DiscountRepository.findByCode(data.code);
+  if (existing) {
+    throw new Error(`Discount code "${data.code.toUpperCase()}" already exists`);
+  }
+
+  const discount = await DiscountRepository.create(data);
+
+  return { discount };
+}
+
+/** Admin. Partial update; validates only the changed fields. */
+export async function updateDiscountHandler(
+  data: UpdateDiscountRequest,
+): Promise<UpdateDiscountResponse> {
+  if (!data.id) {
+    throwInvalidArgument('Discount ID is required');
+  }
+
+  const existing = await DiscountRepository.findById(data.id);
+  if (!existing) {
+    throwNotFound('Discount', data.id);
+  }
+
+  const fields = Object.keys(data).filter((key) => key !== 'id');
+  if (fields.length > 0) {
+    const result = discountValidation({ ...existing, ...data }, fields);
+    if (result.hasErrors()) {
+      throwValidationError(result.getErrors());
+    }
+  }
+
+  if (data.code && data.code.toUpperCase() !== existing.code) {
+    const codeExists = await DiscountRepository.findByCode(data.code);
+    if (codeExists) {
+      throw new Error(
+        `Discount code "${data.code.toUpperCase()}" already exists`,
+      );
+    }
+  }
+
+  const discount = await DiscountRepository.update(data);
+
+  return { discount };
+}
+
+/** Admin. Deletes a discount by id. */
+export async function deleteDiscountHandler(
+  data: DeleteDiscountRequest,
+): Promise<DeleteDiscountResponse> {
+  if (!data.id) {
+    throw new Error('Discount ID is required');
+  }
+
+  const existing = await DiscountRepository.findById(data.id);
+  if (!existing) {
+    throw new Error(`Discount not found: ${data.id}`);
+  }
+
+  await DiscountRepository.delete(data.id);
+
+  return { success: true };
+}
+
+/**
+ * PUBLIC — no auth. Used by the checkout form to resolve a code.
+ *
+ * Returns `{ discount: undefined }` rather than throwing for a missing or
+ * invalid code: the checkout UI treats "not found" as a normal outcome, and
+ * an error envelope would surface as a failure to the customer.
+ */
+export async function lookupDiscountHandler(
+  data: LookupDiscountRequest,
+): Promise<LookupDiscountResponse> {
+  if (!data.code || typeof data.code !== 'string') {
+    return { discount: undefined };
+  }
+
+  const discount = await DiscountRepository.findByCode(data.code);
+
+  if (!discount || !isDiscountValid(discount)) {
+    return { discount: undefined };
+  }
+
+  return { discount };
+}

--- a/libs/firebase/maple-functions/discounts-api/tsconfig.json
+++ b/libs/firebase/maple-functions/discounts-api/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "ignoreDeprecations": "6.0"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/firebase/maple-functions/discounts-api/tsconfig.lib.json
+++ b/libs/firebase/maple-functions/discounts-api/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"],
+    "rootDir": "../../.."
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/tools/check-callable-roles.spec.ts
+++ b/tools/check-callable-roles.spec.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import * as ts from 'typescript';
+import {
+  classifyInitializer,
+  expandRouter,
+  isRouterCall,
+} from './check-callable-roles';
+
+/**
+ * Router awareness in the callable-roles analyzer (ADR-029, #731).
+ *
+ * This is security infrastructure, not a nicety. A domain router is ONE Cloud
+ * Function whose routes each carry their own gate. If the analyzer classifies
+ * the router as a single callable it reports "public" (the router chain has no
+ * requiringRole), and the only way to silence that is to allowlist the router
+ * — which would mark every admin route inside it as public and blind the check
+ * to exactly the regression it exists to catch (ADR-028, #620).
+ *
+ * Every domain in #732–#744 lands more routes behind this, so these assertions
+ * guard a growing surface.
+ */
+
+/** Parse a source snippet and hand back the initializer of `export const x = …`. */
+function initializerOf(code: string): ts.Expression {
+  const sf = ts.createSourceFile('test.ts', code, ts.ScriptTarget.Latest, true);
+  let found: ts.Expression | undefined;
+  const visit = (node: ts.Node): void => {
+    if (ts.isVariableDeclaration(node) && node.initializer && !found) {
+      found = node.initializer;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  if (!found) throw new Error('no initializer found in snippet');
+  return found;
+}
+
+describe('isRouterCall', () => {
+  it('recognises Functions.router({...})', () => {
+    expect(
+      isRouterCall(initializerOf('const a = Functions.router({});')),
+    ).toBeDefined();
+  });
+
+  it('recognises a bare createRouter({...})', () => {
+    expect(
+      isRouterCall(initializerOf('const a = createRouter({});')),
+    ).toBeDefined();
+  });
+
+  it('does NOT treat an ordinary endpoint as a router', () => {
+    expect(
+      isRouterCall(initializerOf('const a = Functions.endpoint.handle(h);')),
+    ).toBeUndefined();
+  });
+
+  it('does not confuse a same-named method on another object', () => {
+    expect(
+      isRouterCall(initializerOf('const a = express.router({});')),
+    ).toBeUndefined();
+  });
+});
+
+describe('expandRouter', () => {
+  const expand = (code: string) => {
+    const call = isRouterCall(initializerOf(code));
+    if (!call) throw new Error('expected a router call');
+    return expandRouter(call, 'demoApi', 'apps/functions/src/index.ts');
+  };
+
+  it('reports one entry per route, namespaced by the router', () => {
+    const routes = expand(`const a = Functions.router({
+      getThing: Functions.endpoint.requiringRole(Role.Admin).asRoute(h1),
+      lookupThing: Functions.endpoint.asRoute(h2),
+    });`);
+
+    expect(routes.map((r) => r.name)).toEqual([
+      'demoApi.getThing',
+      'demoApi.lookupThing',
+    ]);
+  });
+
+  // The whole point: a mixed-auth router must not collapse to one verdict.
+  it('classifies each route independently, not by the router', () => {
+    const routes = expand(`const a = Functions.router({
+      adminThing: Functions.endpoint.requiringRole(Role.Admin).asRoute(h1),
+      authThing: Functions.endpoint.requiringAuth().asRoute(h2),
+      publicThing: Functions.endpoint.asRoute(h3),
+    });`);
+
+    expect(Object.fromEntries(routes.map((r) => [r.name, r.gate]))).toEqual({
+      'demoApi.adminThing': 'role',
+      'demoApi.authThing': 'auth',
+      'demoApi.publicThing': 'public',
+    });
+  });
+
+  it('keeps the role gate when other chain methods follow it', () => {
+    const routes = expand(`const a = Functions.router({
+      createThing: Functions.endpoint
+        .requiringRole(Role.Admin)
+        .validating(thingValidation)
+        .ensuringUnique({ entity: 'Thing', field: 'code', exists: e })
+        .asRoute(h),
+    });`);
+
+    expect(routes[0].gate).toBe('role');
+  });
+
+  // A hole in static analysis must fail loudly, never pass silently.
+  it('reports unknown when the routes are not an object literal', () => {
+    const routes = expand(
+      'const a = Functions.router(buildRoutesDynamically());',
+    );
+
+    expect(routes).toHaveLength(1);
+    expect(routes[0].gate).toBe('unknown');
+    expect(routes[0].name).toContain('unreadable routes');
+  });
+
+  it('reports unknown for a spread route map rather than skipping it', () => {
+    const routes = expand(`const a = Functions.router({
+      ...sharedRoutes,
+      publicThing: Functions.endpoint.asRoute(h),
+    });`);
+
+    expect(routes.some((r) => r.gate === 'unknown')).toBe(true);
+  });
+});
+
+describe('classifyInitializer treats asRoute like handle', () => {
+  it('an ungated asRoute is public', () => {
+    expect(
+      classifyInitializer(
+        initializerOf('const a = Functions.endpoint.asRoute(h);'),
+      ),
+    ).toBe('public');
+  });
+
+  it('a role-gated asRoute is role', () => {
+    expect(
+      classifyInitializer(
+        initializerOf(
+          'const a = Functions.endpoint.requiringRole(Role.Admin).asRoute(h);',
+        ),
+      ),
+    ).toBe('role');
+  });
+});

--- a/tools/check-callable-roles.ts
+++ b/tools/check-callable-roles.ts
@@ -67,6 +67,10 @@ const PUBLIC_ALLOWLIST = new Set<string>([
   'getRequiredAgreementsForClass',
   'calculateRegistrationCost',
   'lookupDiscount',
+  // Same endpoint, now a route on the discounts domain router (ADR-029,
+  // #731). Both are listed while the standalone function stays deployed
+  // for call sites that haven't moved; the bare name goes when it does.
+  'discountsApi.lookupDiscount',
   // Public customer-facing writes (checkout / interest / waitlist).
   // NOTE: cancelRegistration / cancelMusicTogetherRegistration are role-gated
   // (admin/clerk), NOT public — so they are intentionally absent here.
@@ -127,13 +131,7 @@ const AUTH_ONLY_ALLOWLIST = new Set<string>([
 // Classification
 // ---------------------------------------------------------------------------
 
-type Gate =
-  | 'role'
-  | 'auth'
-  | 'public'
-  | 'trigger'
-  | 'raw-http'
-  | 'unknown';
+type Gate = 'role' | 'auth' | 'public' | 'trigger' | 'raw-http' | 'unknown';
 
 const ROLE_FACTORIES = new Set(['createAdminFunction', 'createRoleFunction']);
 const AUTH_FACTORIES = new Set(['createAuthenticatedFunction']);
@@ -152,7 +150,7 @@ const TRIGGER_FACTORIES = new Set([
  * the handler-body argument (so a handler that merely mentions a token can't
  * skew the result).
  */
-function classifyInitializer(expr: ts.Expression): Gate {
+export function classifyInitializer(expr: ts.Expression): Gate {
   const methods = new Set<string>();
   let base: string | undefined;
 
@@ -203,10 +201,13 @@ function classifyInitializer(expr: ts.Expression): Gate {
   if (base && TRIGGER_FACTORIES.has(base)) return 'trigger';
   if (base === 'onRequest') return 'raw-http';
 
-  // Functions.endpoint fluent chain
+  // Functions.endpoint fluent chain. `asRoute` is the router-flavoured
+  // terminal for `handle` (ADR-029) and classifies identically — the gate
+  // comes from the chain, not from which terminal ends it.
   if (methods.has('requiringRole')) return 'role';
   if (methods.has('requiringAuth')) return 'auth';
-  if (base === 'Functions' || methods.has('handle')) return 'public';
+  if (base === 'Functions' || methods.has('handle') || methods.has('asRoute'))
+    return 'public';
 
   return 'unknown';
 }
@@ -215,7 +216,7 @@ function classifyInitializer(expr: ts.Expression): Gate {
 // Source scanning
 // ---------------------------------------------------------------------------
 
-function parse(file: string): ts.SourceFile {
+export function parse(file: string): ts.SourceFile {
   const text = fs.readFileSync(file, 'utf8');
   return ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
 }
@@ -223,7 +224,7 @@ function parse(file: string): ts.SourceFile {
 /** Find `export const <name> = <init>` in a source file, return the initializer. */
 function findExportedConstInitializer(
   sf: ts.SourceFile,
-  name: string
+  name: string,
 ): ts.Expression | undefined {
   let found: ts.Expression | undefined;
   const visit = (node: ts.Node): void => {
@@ -249,16 +250,28 @@ function findExportedConstInitializer(
   return found;
 }
 
-/** Resolve a maple-functions slug to the gate of its exported `name`. */
-function classifyReexport(slug: string, name: string): Gate {
+/**
+ * Resolve a maple-functions slug to the exported `name`'s classification.
+ * Returns a list because a ROUTER expands to one entry per route.
+ */
+function classifyReexport(
+  slug: string,
+  name: string,
+  entryRel: string,
+): FunctionInfo[] {
   const libDir = path.join(ROOT, 'libs/firebase/maple-functions', slug, 'src');
-  if (!fs.existsSync(libDir)) return 'unknown';
+  if (!fs.existsSync(libDir))
+    return [{ name, gate: 'unknown', entry: entryRel }];
   const files = walkTs(libDir).filter((f) => !/\.spec\.ts$/.test(f));
   for (const file of files) {
     const init = findExportedConstInitializer(parse(file), name);
-    if (init) return classifyInitializer(init);
+    if (init) {
+      const router = isRouterCall(init);
+      if (router) return expandRouter(router, name, entryRel);
+      return [{ name, gate: classifyInitializer(init), entry: entryRel }];
+    }
   }
-  return 'unknown';
+  return [{ name, gate: 'unknown', entry: entryRel }];
 }
 
 function walkTs(dir: string): string[] {
@@ -267,6 +280,100 @@ function walkTs(dir: string): string[] {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) out.push(...walkTs(full));
     else if (entry.name.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Domain routers (ADR-029)
+// ---------------------------------------------------------------------------
+
+/**
+ * `Functions.router({...})` / `createRouter({...})` is ONE Cloud Function
+ * serving many routes, each with its OWN gate. Classifying the router as a
+ * single callable is worse than useless: it reports the whole thing as
+ * "public" (the chain has no requiringRole), and allowlisting it to silence
+ * that would mark every admin route inside as public — blinding this analyzer
+ * to exactly the regression it exists to catch (ADR-028, #620).
+ *
+ * So a router is EXPANDED: each route is reported as `<router>.<route>` with
+ * its own gate, and the router itself is never reported.
+ */
+const ROUTER_BASES = new Set(['createRouter']);
+
+/** True when the initializer is a router construction call. */
+export function isRouterCall(
+  expr: ts.Expression,
+): ts.CallExpression | undefined {
+  let node: ts.Node = expr;
+  while (
+    ts.isParenthesizedExpression(node) ||
+    ts.isAsExpression(node) ||
+    ts.isSatisfiesExpression(node)
+  ) {
+    node = node.expression;
+  }
+  if (!ts.isCallExpression(node)) return undefined;
+  const callee = node.expression;
+  if (ts.isIdentifier(callee) && ROUTER_BASES.has(callee.text)) return node;
+  // `Functions.router({...})`
+  if (
+    ts.isPropertyAccessExpression(callee) &&
+    callee.name.text === 'router' &&
+    ts.isIdentifier(callee.expression) &&
+    callee.expression.text === 'Functions'
+  ) {
+    return node;
+  }
+  return undefined;
+}
+
+/** Expand a router call into one FunctionInfo per route. */
+export function expandRouter(
+  call: ts.CallExpression,
+  routerName: string,
+  entryRel: string,
+): FunctionInfo[] {
+  const arg = call.arguments[0];
+  if (!arg || !ts.isObjectLiteralExpression(arg)) {
+    // A router whose routes we cannot read statically is a hole in the
+    // analyzer, not a pass. Report it so it can't slip through silently.
+    return [
+      {
+        name: `${routerName} (unreadable routes)`,
+        gate: 'unknown',
+        entry: entryRel,
+      },
+    ];
+  }
+  const out: FunctionInfo[] = [];
+  for (const prop of arg.properties) {
+    if (!ts.isPropertyAssignment(prop)) {
+      out.push({
+        name: `${routerName} (non-literal route)`,
+        gate: 'unknown',
+        entry: entryRel,
+      });
+      continue;
+    }
+    const routeName = ts.isIdentifier(prop.name)
+      ? prop.name.text
+      : ts.isStringLiteral(prop.name)
+        ? prop.name.text
+        : undefined;
+    if (!routeName) {
+      out.push({
+        name: `${routerName} (computed route name)`,
+        gate: 'unknown',
+        entry: entryRel,
+      });
+      continue;
+    }
+    out.push({
+      name: `${routerName}.${routeName}`,
+      gate: classifyInitializer(prop.initializer),
+      entry: entryRel,
+    });
   }
   return out;
 }
@@ -294,11 +401,10 @@ function collectFromEntry(entryRel: string): FunctionInfo[] {
       ts.isNamedExports(node.exportClause)
     ) {
       const slug = node.moduleSpecifier.text.slice(
-        MAPLE_FUNCTIONS_PREFIX.length
+        MAPLE_FUNCTIONS_PREFIX.length,
       );
       for (const el of node.exportClause.elements) {
-        const name = el.name.text;
-        out.push({ name, gate: classifyReexport(slug, name), entry: entryRel });
+        out.push(...classifyReexport(slug, el.name.text, entryRel));
       }
     }
     // Inline: `export const name = <builder>(...)`
@@ -308,11 +414,16 @@ function collectFromEntry(entryRel: string): FunctionInfo[] {
     ) {
       for (const decl of node.declarationList.declarations) {
         if (ts.isIdentifier(decl.name) && decl.initializer) {
-          out.push({
-            name: decl.name.text,
-            gate: classifyInitializer(decl.initializer),
-            entry: entryRel,
-          });
+          const router = isRouterCall(decl.initializer);
+          if (router) {
+            out.push(...expandRouter(router, decl.name.text, entryRel));
+          } else {
+            out.push({
+              name: decl.name.text,
+              gate: classifyInitializer(decl.initializer),
+              entry: entryRel,
+            });
+          }
         }
       }
     }
@@ -335,14 +446,16 @@ function main(): void {
   const byName = new Map<string, FunctionInfo>();
   for (const fn of all) if (!byName.has(fn.name)) byName.set(fn.name, fn);
   const functions = [...byName.values()].sort((a, b) =>
-    a.name.localeCompare(b.name)
+    a.name.localeCompare(b.name),
   );
 
   if (REPORT) {
     for (const fn of functions) {
       console.log(`${fn.gate.padEnd(9)} ${fn.name}`);
     }
-    console.log(`\n${functions.length} functions across ${ENTRY_POINTS.length} codebases`);
+    console.log(
+      `\n${functions.length} functions across ${ENTRY_POINTS.length} codebases`,
+    );
   }
 
   const violations: string[] = [];
@@ -359,7 +472,7 @@ function main(): void {
       case 'auth':
         if (!AUTH_ONLY_ALLOWLIST.has(fn.name)) {
           violations.push(
-            `  ${fn.name} — auth-only (requiringAuth / createAuthenticatedFunction) but not in AUTH_ONLY_ALLOWLIST`
+            `  ${fn.name} — auth-only (requiringAuth / createAuthenticatedFunction) but not in AUTH_ONLY_ALLOWLIST`,
           );
         } else seenAuth.add(fn.name);
         break;
@@ -367,13 +480,13 @@ function main(): void {
       case 'raw-http':
         if (!PUBLIC_ALLOWLIST.has(fn.name)) {
           violations.push(
-            `  ${fn.name} — ${fn.gate} (no role check) but not in PUBLIC_ALLOWLIST`
+            `  ${fn.name} — ${fn.gate} (no role check) but not in PUBLIC_ALLOWLIST`,
           );
         } else seenPublic.add(fn.name);
         break;
       case 'unknown':
         violations.push(
-          `  ${fn.name} — could not classify its gate; declare a role or add to an allowlist`
+          `  ${fn.name} — could not classify its gate; declare a role or add to an allowlist`,
         );
         break;
     }
@@ -382,21 +495,23 @@ function main(): void {
   // Flag allowlist entries that no longer correspond to a public/auth function
   // (renamed/removed) so the lists don't rot.
   for (const name of PUBLIC_ALLOWLIST) {
-    if (!seenPublic.has(name)) staleAllowlist.push(`  PUBLIC_ALLOWLIST: ${name}`);
+    if (!seenPublic.has(name))
+      staleAllowlist.push(`  PUBLIC_ALLOWLIST: ${name}`);
   }
   for (const name of AUTH_ONLY_ALLOWLIST) {
-    if (!seenAuth.has(name)) staleAllowlist.push(`  AUTH_ONLY_ALLOWLIST: ${name}`);
+    if (!seenAuth.has(name))
+      staleAllowlist.push(`  AUTH_ONLY_ALLOWLIST: ${name}`);
   }
 
   if (violations.length > 0) {
     console.error(
-      `\n✖ ${violations.length} callable(s) reachable without a declared role and not allowlisted:\n`
+      `\n✖ ${violations.length} callable(s) reachable without a declared role and not allowlisted:\n`,
     );
     console.error(violations.join('\n'));
     console.error(
       `\nFix: gate the function with .requiringRole([...]) (or createAdminFunction/createRoleFunction),\n` +
         `or — if it is intentionally public / auth-only — add it to the matching allowlist in\n` +
-        `tools/check-callable-roles.ts with a comment saying why.`
+        `tools/check-callable-roles.ts with a comment saying why.`,
     );
     if (staleAllowlist.length > 0) {
       console.error(`\nAlso, stale allowlist entries (no matching function):`);
@@ -409,14 +524,16 @@ function main(): void {
     // Stale entries are a warning, not a hard fail — a removed function
     // shouldn't block an unrelated PR, but surface it so the list stays clean.
     console.warn(
-      `⚠ ${staleAllowlist.length} allowlist entr(y/ies) no longer match a function (rename/remove?):`
+      `⚠ ${staleAllowlist.length} allowlist entr(y/ies) no longer match a function (rename/remove?):`,
     );
     console.warn(staleAllowlist.join('\n'));
   }
 
   console.log(
-    `✓ All ${functions.length} exported functions are role-gated, triggers, or explicitly allowlisted.`
+    `✓ All ${functions.length} exported functions are role-gated, triggers, or explicitly allowlisted.`,
   );
 }
 
-main();
+if (require.main === module) {
+  main();
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -350,6 +350,9 @@
       "@maple/firebase/maple-functions/reorder-class-categories": [
         "libs/firebase/maple-functions/reorder-class-categories/src/index.ts"
       ],
+      "@maple/firebase/maple-functions/discounts-api": [
+        "libs/firebase/maple-functions/discounts-api/src/index.ts"
+      ],
       "@maple/firebase/maple-functions/get-discounts": [
         "libs/firebase/maple-functions/get-discounts/src/index.ts"
       ],


### PR DESCRIPTION
## Summary

Phase 0 of #724. One Cloud Function, `discountsApi`, serving all five discount endpoints. **The point of this PR is the pattern** — #732–#744 copy it, so it's worth reviewing as infrastructure rather than as a discounts change.

## The pattern

**`runEndpointPipeline`** — extracted from `FunctionBuilder.handle()` and now shared by both `handle()` and the new `createRouter()`. Warmup short-circuit, auth, role gate, secret/string resolution, validation, the `{ data: … }` callable envelope, and the error→status mapping live in exactly one place. A route therefore *cannot* drift from the standalone function it replaced. `handle()` delegates to it, and **all 54 pre-existing pipeline tests pass unchanged** — that's the regression net for the other ~210 functions.

**`FunctionBuilder.asRoute()`** — returns a route descriptor instead of calling `onRequest`, so the entire existing fluent chain (`requiringRole`, `validating`, `ensuringUnique`, `withSecrets`) applies **per route**.

**`createRouter()`** — dispatches on the first path segment, unions each route's secrets for the function-level declaration, and answers the warmup sentinel without a route and without auth.

```ts
export const discountsApi = Functions.router({
  getDiscounts: Functions.endpoint.requiringRole(Role.Admin).asRoute(getDiscountsHandler),
  lookupDiscount: Functions.endpoint.asRoute(lookupDiscountHandler), // public
});
```

## The security property, and why it's tested per-route

Per-route options are load-bearing, not a nicety. The discounts domain **mixes auth levels**: four admin routes plus the **public `lookupDiscount`**, which the checkout form calls before a customer has any identity.

Collapsing endpoints onto one function must never widen access. The spec asserts the gate on each route independently:

- anonymous → admin route → **401**
- authenticated non-admin → admin route → **403**
- anonymous → public route → **200**
- per-route validators don't leak across routes

If a future refactor makes route options fall back to a function-level default, these fail.

## Behaviour preservation

Handlers moved **verbatim**. Error strings and return shapes are client-visible, so they're unchanged — including `lookupDiscount` returning `{ discount: undefined }` rather than throwing for a bad code (the checkout UI treats "no discount" as normal; an error envelope would read as a payment failure to a customer mistyping a code).

## Testing

- **54 → 64** in `functions.utility.spec.ts` (10 new router tests: dispatch, 404 envelope, the four auth assertions above, warmup, CORS-before-routing, error mapping, per-route validators)
- **20 new handler specs** — these five functions shipped with **zero** unit tests, and moving them was the wrong moment to still have none
- **178 tests green** across `libs/firebase/functions`, the new lib, and `tools`
- `./tools/validate-function-tsconfigs.sh` passes (it caught a missing `apps/functions` include; fixed)
- `nx build functions` green, and the **built bundle** confirms `discountsApi.__endpoint.maxInstances === 1` — the fragile global-runtime-options ordering contract from #704/#708

## Sequencing — read before merging

The old five functions **stay exported and deployed**. Client call sites move to `httpsCallableFromURL` in the follow-up, and only then are the originals deleted. There is deliberately no window where a deployed client has no backend — the Vercel frontend and functions deploy in separate jobs, so a URL change shipped in one PR would white-screen the discounts admin page and break discount codes at checkout.

That's why **the ratchet goes up by one here (217 → 218)** rather than down. It drops to ~213 when the originals are removed.

Also worth knowing: **`lookupDiscount` has no in-repo consumer.** Its docstring says the checkout form calls it, and nothing in this repo does. It may be called from Webflow custom code, so I've treated it as live rather than dead — worth confirming before the delete PR.

Refs #731, #724