### PR TITLE
docs: record prod storage bucket CORS config and commit cors.json

### DIFF
--- a/cors.json
+++ b/cors.json
@@ -1,0 +1,7 @@
+[
+  {
+    "origin": ["*"],
+    "method": ["GET"],
+    "maxAgeSeconds": 3600
+  }
+]

--- a/docs/guides/environment-setup.md
+++ b/docs/guides/environment-setup.md
@@ -120,6 +120,31 @@ Switch a config to prod with `gcloud config set project maple-and-spruce --confi
 
 **Claude Code auto-selects the config**: `.claude/settings.local.json` (personal, gitignored) sets `env.CLOUDSDK_ACTIVE_CONFIG_NAME = "maple"`, so every Bash call Claude makes in this repo uses the Maple & Spruce gcloud account/project automatically. Keep that file out of git (it's machine-specific) — if it ever shows as tracked, run `git rm --cached .claude/settings.local.json`.
 
+## Storage Bucket CORS
+
+Storage bucket CORS is **manual, per-project console/CLI state** — it is not covered by `firebase deploy`, not in `storage.rules`, and not recreated by CI. If a project's bucket is ever recreated, this has to be re-applied by hand or the admin portal silently stops rendering stored files.
+
+**Why it's needed**: `getSignedAgreement` returns V4 signed URLs on `storage.googleapis.com` (`get-signed-agreement.ts`). The admin portal fetches those cross-origin to render the signature image and agreement PDF, so the bucket must allow `GET` from the browser. Without it the detail view loads but the file silently fails to render.
+
+The config lives in `cors.json` at the repo root — read-only (`GET`), which is all a signed-URL fetch needs. The URL itself carries the authorization and expires, so the wildcard origin grants nothing without a valid signature.
+
+| Project | Bucket | CORS applied |
+|---------|--------|--------------|
+| Prod | `maple-and-spruce.firebasestorage.app` | Yes (manually, 2026-04-22) |
+| Dev | `maple-and-spruce-dev.firebasestorage.app` | **No** — see below |
+
+```bash
+# read current config
+gcloud storage buckets describe gs://<bucket> --format='value(cors_config)'
+
+# apply / re-apply
+gcloud storage buckets update gs://<bucket> --cors-file=cors.json
+```
+
+**Dev is intentionally flagged, not fixed**: dev's bucket has no CORS config, so signed-URL rendering that works in prod can fail locally and in the dev app. Applying the same file to dev is a one-liner (above) but it's a live infra change, so it's left as a deliberate decision rather than something a doc PR does silently.
+
+**Use `gcloud storage`, not `gsutil`**: the equivalents are `gsutil cors get/set`, but Google unbundles `gsutil` from the gcloud CLI in **March 2027** (it will need a separate PyPI install with its own auth). Nothing in this repo uses `gsutil`; keep it that way.
+
 ## Never Commit
 
 - Firebase service account keys


### PR DESCRIPTION
## What

Commits the `cors.json` that has been sitting untracked in the repo root, and documents the storage-bucket CORS state in `docs/guides/environment-setup.md`.

## Why

`cors.json` was created 2026-04-22 08:51 and never committed. Three minutes later came `b6ee56dc` ("fix: update Firestore record with final signature storage paths", #350), part of the same morning's signed-agreement detail view work (#349). It was applied by hand to prod and is **still live today**:

```
gs://maple-and-spruce.firebasestorage.app
  -> {'maxAgeSeconds': 3600, 'method': ['GET'], 'origin': ['*']}
```

Bucket CORS is manual per-project state. It is not covered by `firebase deploy`, not in `storage.rules`, and not recreated by CI. Undocumented, it would be silently lost if the bucket were ever recreated, and the admin portal would stop rendering signature images and agreement PDFs, since `getSignedAgreement` returns V4 signed URLs on `storage.googleapis.com` that the browser fetches cross-origin.

## Security note

The config is read-only (`GET`) with a wildcard origin. That grants nothing on its own: the signed URL carries the authorization and expires, so a browser without a valid signature gets nothing. CORS does not bypass the signature check.

## Dev drift (flagged, not fixed)

Dev's bucket has **no** CORS config:

```
gs://maple-and-spruce-dev.firebasestorage.app  -> (empty)
```

So signed-URL rendering can fail in dev where it works in prod. Applying the same file is a one-liner, but it is a live infra change, so this PR documents it rather than doing it silently:

```bash
gcloud storage buckets update gs://maple-and-spruce-dev.firebasestorage.app --cors-file=cors.json
```

## gsutil

The docs use `gcloud storage buckets describe/update`, not `gsutil cors get/set`. Google unbundles `gsutil` from the gcloud CLI in March 2027 (separate PyPI install, separate auth). Nothing in this repo uses `gsutil` and the added guidance keeps it that way. That deprecation notice is what surfaced this file; the documentation gap stands on its own.

## Test plan

Docs + config file only, no code paths touched. Verified against both live buckets with `gcloud storage buckets describe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)