### PR TITLE
fix(attribution): move tallyLeadWebhook to a tiny maple-webhooks codebase (fixes 10s Tally timeouts)

### DIFF
--- a/.claude/rules/firebase-functions.md
+++ b/.claude/rules/firebase-functions.md
@@ -45,7 +45,7 @@ properties of the function, not the route. Raise the baseline deliberately in th
 
 ## Codebases
 
-Functions are split into 4 Firebase codebases to reduce cold start times:
+Functions are split into 5 Firebase codebases to reduce cold start times:
 
 | Codebase | App Project | Heavy Deps | Entry Point |
 |----------|-------------|------------|-------------|
@@ -53,8 +53,44 @@ Functions are split into 4 Firebase codebases to reduce cold start times:
 | `maple-calendar` | `apps/functions-calendar/` | ical-generator | `apps/functions-calendar/src/index.ts` |
 | `maple-square` | `apps/functions-square/` | square SDK | `apps/functions-square/src/index.ts` |
 | `maple-sync` | `apps/functions-sync/` | webflow-api | `apps/functions-sync/src/index.ts` |
+| `maple-webhooks` | `apps/functions-webhooks/` | **none — keep it that way** | `apps/functions-webhooks/src/index.ts` |
 
 When adding a new function, export it from the correct codebase's entry point and add a mapping in `function-codebases.json` if it's not in `maple-core`.
+
+### Cold start is a per-codebase property (ADR-031)
+
+A codebase is one bundle. Every function in it loads the whole entry point on
+cold start, so **boot time is set by the heaviest sibling, not by the function
+being called**. Measured against prod on 2026-08-07 (invalid-signature probes,
+so no handler logic ran):
+
+| Codebase | Bundle | Cold | Warm |
+|----------|--------|------|------|
+| `maple-core` | 488kb | 14.4s | 1.0s |
+| `maple-sync` | 301kb | 6.3s | 1.3s |
+| `maple-webhooks` | 90kb | — | — |
+| `maple-calendar` | 30kb | 3.2s | 1.1s |
+
+This matters for any endpoint an external platform calls with a fixed timeout:
+
+- **Tally** hangs up at 10s and does **not** retry — a slow cold start is a
+  permanently lost lead. This is what put `tallyLeadWebhook` in `maple-webhooks`.
+- **Square** hangs up at 10s and *does* retry with backoff (see the 2026-05
+  504 storm). `squareWebhook` is still in `maple-core` and still boots in
+  ~14s — it survives on retries alone. Worth moving out.
+
+`maple-webhooks` only pays off while it stays small. Adding a function there
+that pulls firebase-admin repositories, the Square SDK, or webflow-api
+re-inflates the bundle and silently reintroduces the outage for every other
+webhook in it. If the new function's deps are heavier than
+firebase-functions + crypto + vest, give it its own codebase.
+
+### Bounding outbound calls on a webhook path
+
+`fetch` has no default timeout. On a handler with a delivery budget, always
+pass `AbortSignal.timeout(...)` — a hung upstream otherwise eats the whole
+budget from a *warm* instance. See `GA4_TIMEOUT_MS` / `META_TIMEOUT_MS` in
+`tally-lead-webhook.ts` and `MetaCapiConfig.timeoutMs`.
 
 ## No package.json in Libraries
 

--- a/.claude/skills/create-cloud-function/SKILL.md
+++ b/.claude/skills/create-cloud-function/SKILL.md
@@ -57,6 +57,7 @@ Determine which codebase your function belongs to based on its dependencies:
 - **Square SDK** → `apps/functions-square/src/index.ts` (codebase: `maple-square`)
 - **ical-generator** → `apps/functions-calendar/src/index.ts` (codebase: `maple-calendar`)
 - **webflow-api** → `apps/functions-sync/src/index.ts` (codebase: `maple-sync`)
+- **Third-party webhook with a short delivery timeout** (Tally, Square) and no heavy deps → `apps/functions-webhooks/src/index.ts` (codebase: `maple-webhooks`). Keep this bundle tiny — `maple-core` cold-starts in ~14s, which exceeds Tally's 10s budget. See ADR-031.
 - **Everything else** → `apps/functions/src/index.ts` (codebase: `maple-core`, default)
 
 Add the export to the correct entry point:

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -421,12 +421,13 @@ jobs:
           pnpm exec nx run functions-square:build
           pnpm exec nx run functions-sync:build
           pnpm exec nx run functions-calendar:build
+          pnpm exec nx run functions-webhooks:build
 
       - name: Create emulator .env
         run: |
           # Copy .env.dev to every codebase (has all shared project-level params)
           # Strip comments and blank lines — Firebase .env parser needs clean key=value pairs
-          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar; do
+          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks; do
             grep -v '^#' .env.dev | grep -v '^$' > "$dir/.env"
           done
 
@@ -438,7 +439,17 @@ jobs:
           echo "GA4_MEASUREMENT_ID=G-TEST-MOCK" >> dist/apps/functions/.env
           echo "META_PIXEL_ID=test-pixel-id" >> dist/apps/functions/.env
           echo "META_CAPI_API_VERSION=v20.0" >> dist/apps/functions/.env
-          printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\nTALLY_WEBHOOK_SECRET=test-tally-secret\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions/.secret.local
+          printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions/.secret.local
+
+          # maple-webhooks: tallyLeadWebhook declares these defineSecret params;
+          # without them the emulator silently waits on stdin for each one.
+          printf "TALLY_WEBHOOK_SECRET=test-tally-secret\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions-webhooks/.secret.local
+          # tallyLeadWebhook → GA4 + Meta CAPI mock servers
+          echo "GA4_BASE_URL=http://localhost:9995" >> dist/apps/functions-webhooks/.env
+          echo "META_CAPI_BASE_URL=http://localhost:9994" >> dist/apps/functions-webhooks/.env
+          echo "GA4_MEASUREMENT_ID=G-TEST-MOCK" >> dist/apps/functions-webhooks/.env
+          echo "META_PIXEL_ID=test-pixel-id" >> dist/apps/functions-webhooks/.env
+          echo "META_CAPI_API_VERSION=v20.0" >> dist/apps/functions-webhooks/.env
 
           # maple-square: Square mock server URL + fake secrets
           echo "SQUARE_BASE_URL=http://localhost:9997" >> dist/apps/functions-square/.env
@@ -568,6 +579,7 @@ jobs:
           pnpm exec nx run functions-square:build
           pnpm exec nx run functions-sync:build
           pnpm exec nx run functions-calendar:build
+          pnpm exec nx run functions-webhooks:build
 
       - name: Create emulator .env
         # Mirrors the integration-tests job, with one critical difference:
@@ -583,16 +595,19 @@ jobs:
         env:
           SQUARE_SANDBOX_ACCESS_TOKEN: ${{ secrets.SQUARE_SANDBOX_ACCESS_TOKEN }}
         run: |
-          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar; do
+          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks; do
             grep -v '^#' .env.dev | grep -v '^$' > "$dir/.env"
           done
 
           # maple-core: Etsy mock server URL + fake secrets
           echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions/.env
-          # tallyLeadWebhook (maple-core) declares these defineSecret params;
+          # maple-core: conversion functions declare these defineSecret params;
           # without them the emulator silently waits on stdin for each one.
-          printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\nTALLY_WEBHOOK_SECRET=test-tally-secret\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions/.secret.local
+          printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions/.secret.local
 
+          # maple-webhooks: tallyLeadWebhook declares these defineSecret params;
+          # without them the emulator silently waits on stdin for each one.
+          printf "TALLY_WEBHOOK_SECRET=test-tally-secret\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions-webhooks/.secret.local
           # maple-square: real Square sandbox (no SQUARE_BASE_URL → SDK
           # uses its built-in sandbox endpoint). Etsy still mocked.
           echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions-square/.env
@@ -604,7 +619,7 @@ jobs:
           echo "ETSY_TOKEN_URL=http://localhost:9998/v3/public/oauth/token" >> dist/apps/functions-sync/.env
           printf "WEBFLOW_API_TOKEN=mock-token\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions-sync/.secret.local
 
-          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar; do
+          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks; do
             EXISTING=$(grep '^ALLOWED_ORIGINS=' "$dir/.env" | head -1 | cut -d= -f2-)
             echo "ALLOWED_ORIGINS=$EXISTING,http://127.0.0.1:4173,http://localhost:4173" >> "$dir/.env"
           done
@@ -725,6 +740,7 @@ jobs:
           pnpm exec nx run functions-square:build
           pnpm exec nx run functions-sync:build
           pnpm exec nx run functions-calendar:build
+          pnpm exec nx run functions-webhooks:build
 
       - name: Create emulator .env
         # Copied VERBATIM from the registration-e2e job: we DON'T set
@@ -736,16 +752,19 @@ jobs:
         env:
           SQUARE_SANDBOX_ACCESS_TOKEN: ${{ secrets.SQUARE_SANDBOX_ACCESS_TOKEN }}
         run: |
-          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar; do
+          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks; do
             grep -v '^#' .env.dev | grep -v '^$' > "$dir/.env"
           done
 
           # maple-core: Etsy mock server URL + fake secrets
           echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions/.env
-          # tallyLeadWebhook (maple-core) declares these defineSecret params;
+          # maple-core: conversion functions declare these defineSecret params;
           # without them the emulator silently waits on stdin for each one.
-          printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\nTALLY_WEBHOOK_SECRET=test-tally-secret\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions/.secret.local
+          printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions/.secret.local
 
+          # maple-webhooks: tallyLeadWebhook declares these defineSecret params;
+          # without them the emulator silently waits on stdin for each one.
+          printf "TALLY_WEBHOOK_SECRET=test-tally-secret\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions-webhooks/.secret.local
           # maple-square: real Square sandbox (no SQUARE_BASE_URL → SDK
           # uses its built-in sandbox endpoint). Etsy still mocked.
           echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions-square/.env
@@ -872,6 +891,7 @@ jobs:
           pnpm exec nx run functions-square:build
           pnpm exec nx run functions-sync:build
           pnpm exec nx run functions-calendar:build
+          pnpm exec nx run functions-webhooks:build
 
       - name: Create emulator .env
         # Mirrors the Registration E2E job. No SQUARE_BASE_URL, so the Square
@@ -880,13 +900,16 @@ jobs:
         # placeholder; MT_SQUARE_ACCESS_TOKEN gets the REAL MT sandbox token.
         if: steps.gate.outputs.enabled == 'true'
         run: |
-          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar; do
+          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks; do
             grep -v '^#' .env.dev | grep -v '^$' > "$dir/.env"
           done
 
           echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions/.env
-          printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\nTALLY_WEBHOOK_SECRET=test-tally-secret\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions/.secret.local
+          printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions/.secret.local
 
+          # maple-webhooks: tallyLeadWebhook declares these defineSecret params;
+          # without them the emulator silently waits on stdin for each one.
+          printf "TALLY_WEBHOOK_SECRET=test-tally-secret\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions-webhooks/.secret.local
           echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions-square/.env
           printf "SQUARE_ACCESS_TOKEN=unused-mock-token\nMT_SQUARE_ACCESS_TOKEN=%s\nSQUARE_WEBHOOK_SIGNATURE_KEY=mock-key\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" "$MT_SQUARE_SANDBOX_ACCESS_TOKEN" > dist/apps/functions-square/.secret.local
 
@@ -895,7 +918,7 @@ jobs:
           echo "ETSY_TOKEN_URL=http://localhost:9998/v3/public/oauth/token" >> dist/apps/functions-sync/.env
           printf "WEBFLOW_API_TOKEN=mock-token\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions-sync/.secret.local
 
-          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar; do
+          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks; do
             EXISTING=$(grep '^ALLOWED_ORIGINS=' "$dir/.env" | head -1 | cut -d= -f2-)
             echo "ALLOWED_ORIGINS=$EXISTING,http://127.0.0.1:4173,http://localhost:4173" >> "$dir/.env"
           done
@@ -997,15 +1020,20 @@ jobs:
           pnpm exec nx run functions-square:build
           pnpm exec nx run functions-sync:build
           pnpm exec nx run functions-calendar:build
+          pnpm exec nx run functions-webhooks:build
 
       - name: Create emulator .env
         run: |
-          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar; do
+          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks; do
             grep -v '^#' .env.dev | grep -v '^$' > "$dir/.env"
           done
 
           # Mock secrets so the emulator doesn't stall on missing defineSecret params.
-          printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\nTALLY_WEBHOOK_SECRET=test\nGA4_API_SECRET=test\nMETA_CAPI_TOKEN=test\n" > dist/apps/functions/.secret.local
+          printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\nGA4_API_SECRET=test\nMETA_CAPI_TOKEN=test\n" > dist/apps/functions/.secret.local
+
+          # maple-webhooks: tallyLeadWebhook declares these defineSecret params;
+          # without them the emulator silently waits on stdin for each one.
+          printf "TALLY_WEBHOOK_SECRET=test\nGA4_API_SECRET=test\nMETA_CAPI_TOKEN=test\n" > dist/apps/functions-webhooks/.secret.local
           printf "SQUARE_ACCESS_TOKEN=mock-token\nMT_SQUARE_ACCESS_TOKEN=mock-token\nSQUARE_WEBHOOK_SIGNATURE_KEY=mock-key\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions-square/.secret.local
           printf "WEBFLOW_API_TOKEN=mock-token\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions-sync/.secret.local
 
@@ -1015,7 +1043,7 @@ jobs:
           echo "ETSY_API_BASE=http://127.0.0.1:1" >> dist/apps/functions-sync/.env
 
           # CORS: the app's callables come from the Next dev origin (localhost:3000).
-          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar; do
+          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks; do
             EXISTING=$(grep '^ALLOWED_ORIGINS=' "$dir/.env" | head -1 | cut -d= -f2-)
             echo "ALLOWED_ORIGINS=$EXISTING,http://localhost:3000,http://127.0.0.1:3000" >> "$dir/.env"
           done

--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -183,7 +183,7 @@ jobs:
             AFFECTED_LIBS=$(pnpm exec nx show projects | grep 'firebase-maple-functions-' || true)
           else
             # Check if any functions app is affected (e.g., env file changes)
-            FUNCTIONS_APP_AFFECTED=$(echo "$ALL_AFFECTED" | grep -E '^functions(-calendar|-square|-sync)?$' || true)
+            FUNCTIONS_APP_AFFECTED=$(echo "$ALL_AFFECTED" | grep -E '^functions(-calendar|-square|-sync|-webhooks)?$' || true)
 
             # Get affected function libraries
             AFFECTED_LIBS=$(echo "$ALL_AFFECTED" | grep 'firebase-maple-functions-' || true)
@@ -324,6 +324,7 @@ jobs:
             dist/apps/functions-calendar/
             dist/apps/functions-square/
             dist/apps/functions-sync/
+            dist/apps/functions-webhooks/
           include-hidden-files: true
           retention-days: 1
 

--- a/apps/functions-webhooks/project.json
+++ b/apps/functions-webhooks/project.json
@@ -1,0 +1,31 @@
+{
+  "name": "functions-webhooks",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/functions-webhooks/src",
+  "projectType": "application",
+  "tags": ["scope:firebase", "type:app"],
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "inputs": ["default", "functionsEnv"],
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/apps/functions-webhooks",
+        "main": "apps/functions-webhooks/src/index.ts",
+        "tsConfig": "apps/functions-webhooks/tsconfig.app.json",
+        "generatePackageJson": true,
+        "platform": "node",
+        "bundle": true,
+        "thirdParty": false,
+        "dependenciesFieldType": "dependencies",
+        "target": "node20",
+        "format": ["cjs"],
+        "outputFileName": "index.js",
+        "esbuildOptions": {
+          "minify": true,
+          "logLevel": "info"
+        }
+      }
+    }
+  }
+}

--- a/apps/functions-webhooks/src/index.ts
+++ b/apps/functions-webhooks/src/index.ts
@@ -1,0 +1,43 @@
+/**
+ * Firebase Cloud Functions — Third-Party Webhooks Codebase
+ *
+ * Endpoints called by external SaaS platforms that enforce a short delivery
+ * timeout and give us no say in it. Tally hangs up at 10s; Square at 10s.
+ * A cold start that blows that budget is a *dropped event*, not a slow one.
+ *
+ * Why these can't live in maple-core
+ * ----------------------------------
+ * A Firebase codebase is one bundle: every function in it loads the whole
+ * entry point on cold start, so boot time is set by the heaviest sibling,
+ * not by the function being called. Measured against prod (2026-08-07,
+ * invalid-signature probes, so handler logic never ran):
+ *
+ *   maple-core      14.4s cold / 1.0s warm   <- tallyLeadWebhook lived here
+ *   maple-sync       6.3s cold / 1.3s warm
+ *   maple-calendar   3.2s cold / 1.1s warm
+ *
+ * The Tally form draws roughly one signup a day, so this service is cold on
+ * essentially every real delivery — 14.4s against a 10s budget meant Tally
+ * recorded a `timeout of 10000ms exceeded` failure for nearly every lead,
+ * and Tally does not retry. Five leads were lost between 2026-07-30 and
+ * 2026-08-06 before anyone noticed.
+ *
+ * KEEP THIS BUNDLE SMALL — that is the entire point
+ * -------------------------------------------------
+ * Adding a function that pulls firebase-admin repositories, the Square SDK,
+ * or webflow-api re-inflates cold start for everything in here and silently
+ * reintroduces the outage. Before adding a function, ask whether its imports
+ * are as light as what's already here (firebase-functions, crypto, vest).
+ * If they aren't, it belongs in its own codebase.
+ */
+// MUST be first: sets global maxInstances before any function is defined.
+// See global-runtime-options.ts for the ordering contract.
+import '@maple/firebase/functions/global-runtime-options';
+
+// Deliberately no initializeApp() — nothing in this codebase touches
+// Firestore or Auth, and skipping admin init keeps the boot path short.
+
+// ============================================================================
+// Tally
+// ============================================================================
+export { tallyLeadWebhook } from '@maple/firebase/maple-functions/tally-lead-webhook';

--- a/apps/functions-webhooks/tsconfig.app.json
+++ b/apps/functions-webhooks/tsconfig.app.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": ["node"],
+    "rootDir": "../.."
+  },
+  "include": [
+    "src/**/*.ts",
+    "../../libs/firebase/maple-functions/tally-lead-webhook/**/*.ts",
+    "../../libs/firebase/meta-capi/src/**/*.ts",
+    "../../libs/firebase/functions/src/**/*.ts",
+    "../../libs/ts/validation/src/**/*.ts",
+    "../../libs/ts/domain/src/**/*.ts",
+    "../../libs/ts/firebase/api-types/src/**/*.ts"
+  ],
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.ts"
+  ]
+}

--- a/apps/functions-webhooks/tsconfig.json
+++ b/apps/functions-webhooks/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "es2020",
+    "lib": ["es2020"],
+    "types": ["node"],
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "noUnusedLocals": false,
+    "ignoreDeprecations": "6.0"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ]
+}

--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -266,8 +266,9 @@ export { getMyRoles } from '@maple/firebase/maple-functions/get-my-roles';
 export { grantRole } from '@maple/firebase/maple-functions/grant-role';
 export { revokeRole } from '@maple/firebase/maple-functions/revoke-role';
 
-// Lead attribution (Tally newsletter signups → GA4 Measurement Protocol + Meta CAPI)
-export { tallyLeadWebhook } from '@maple/firebase/maple-functions/tally-lead-webhook';
+// Lead attribution: tallyLeadWebhook now lives in the maple-webhooks codebase
+// (apps/functions-webhooks). Tally hangs up at 10s and this bundle takes ~14s
+// to cold start, so nearly every real signup was dropped. Do not move it back.
 // Meta Conversions API Purchase on confirmed class registrations — recovers
 // iOS/ITP-dropped and hosted-checkout conversions the browser Pixel misses.
 export { sendRegistrationConversion } from '@maple/firebase/maple-functions/send-registration-conversion';

--- a/apps/functions/tsconfig.app.json
+++ b/apps/functions/tsconfig.app.json
@@ -138,7 +138,6 @@
     "../../libs/firebase/maple-functions/list-users/**/*.ts",
     "../../libs/firebase/maple-functions/grant-admin-role/**/*.ts",
     "../../libs/firebase/maple-functions/revoke-admin-role/**/*.ts",
-    "../../libs/firebase/maple-functions/tally-lead-webhook/**/*.ts",
     "../../libs/firebase/maple-functions/send-registration-conversion/**/*.ts",
     "../../libs/firebase/maple-functions/send-music-together-conversion/**/*.ts",
     "../../libs/firebase/meta-capi/**/*.ts",

--- a/docs/architecture/DECISIONS.md
+++ b/docs/architecture/DECISIONS.md
@@ -1340,6 +1340,84 @@ Next.js app, and any middleware — so the vanity host never touches admin-app c
 
 ---
 
+## ADR-031: A Dedicated `maple-webhooks` Codebase for Timeout-Bound Third-Party Callers
+
+**Status:** Accepted
+**Date:** 2026-08-07
+
+### Context
+Tally emailed five "Webhooks integration needs attention" reports between 2026-07-30 and
+2026-08-06, one per day the newsletter form got a signup, all reading
+`timeout of 10000ms exceeded`.
+
+`tallyLeadWebhook` was healthy. Probing prod directly with invalid-signature requests — which
+return 401 before a single line of handler logic runs — isolated the cause as cold start, and
+showed it is a property of the **codebase**, not the function:
+
+| Codebase | Bundle | Cold | Warm |
+|----------|--------|------|------|
+| `maple-core` | 488kb | 14.4s | 1.0s |
+| `maple-sync` | 301kb | 6.3s | 1.3s |
+| `maple-calendar` | 30kb | 3.2s | 1.1s |
+
+A Firebase codebase is one bundle, and every function in it loads the whole entry point on boot,
+so a trivial function inherits the boot cost of its 165 heaviest siblings (`checkAdminStatus`
+measured 14.8s cold, matching `tallyLeadWebhook`).
+
+Two properties made this silent and total rather than intermittent:
+
+1. The form draws roughly **one signup a day**, so the Cloud Run service was cold for essentially
+   every real delivery. This was not a tail-latency problem; it was the common case.
+2. **Tally does not retry.** Square's 10s timeout produces a retry storm that eventually succeeds
+   (the 2026-05 504 incident); Tally's produces a permanently lost lead that must be resent by
+   hand from the events log.
+
+### Decision
+Add a fifth Firebase codebase, `maple-webhooks` (`apps/functions-webhooks/`), for endpoints called
+by external platforms on a fixed delivery budget, and move `tallyLeadWebhook` into it. Keep its
+dependency surface to firebase-functions + crypto + vest — the resulting bundle is 90kb.
+
+Separately, bound every outbound call on such a path with `AbortSignal.timeout(...)`; `fetch` has
+no default timeout, so a hung upstream can blow a 10s budget even from a warm instance.
+
+### Rationale
+Cold start is the only lever that actually moves here, and bundle size is the only lever on cold
+start. Isolation buys ~14.4s → low single digits, with margin against Tally's cutoff and no
+recurring cost. It also gives future timeout-bound integrations a correct default home instead of
+landing in `maple-core` and quietly inheriting a 14s boot.
+
+### Alternatives Considered
+- **`minInstances: 1` on the function** — keeps it warm (~1s) but pays for an idle instance 24/7 to
+  serve about one request a day, and every reserved instance counts against the regional
+  Total-CPU quota that already constrains deploys (see `global-runtime-options.ts`).
+  Rejected as expensive and quota-hostile for a once-daily endpoint.
+- **Move it to `maple-calendar` (3.2s) or `maple-sync` (6.3s)** — a three-line change and both fit
+  under 10s. Rejected: `maple-sync`'s margin is thin and shrinks as that codebase grows, and
+  neither is a defensible home for a lead webhook. The naming lie would outlive the fix.
+- **Ack fast and defer the beacons to a Firestore-triggered worker** (the `squareWebhook` →
+  `processCatalogSyncRequest` pattern). Rejected: it addresses handler duration, and the timeout
+  here happens *before the handler runs*. It would not have saved a single one of the five leads.
+- **Shrink `maple-core` itself** — the right long-term fix for the admin portal's latency too, but
+  it's an open-ended project and this was actively dropping leads.
+
+### Consequences
+- Five codebases now. Adding one touches `firebase.json`, `function-codebases.json`, the artifact
+  paths and affected-regex in `firebase-functions-merge.yml`, the build/env blocks in
+  `build-check.yml` and `tools/run-integration-tests.sh`, plus the hardcoded lists in
+  `validate-function-tsconfigs.sh` and `check-callable-roles.ts`. Deploys serialize per codebase,
+  so this adds one more sequential unit to a full redeploy.
+- **`maple-webhooks` only works while it stays small.** A function that pulls firebase-admin
+  repositories, the Square SDK, or webflow-api re-inflates the bundle and reintroduces the outage
+  for everything else in it. That constraint is documented at the entry point and in
+  `.claude/rules/firebase-functions.md`; if a new webhook is heavier, it gets its own codebase.
+- `squareWebhook` is still in `maple-core` at ~14s cold and survives only because Square retries.
+  It is the obvious next tenant, but it carries Firestore + Square deps, so it needs its own
+  codebase rather than a seat in this one.
+- The five already-failed submissions are not recovered by this change; they must be resent from
+  Tally's events log after deploy.
+
+---
+
 ## ADR-XXX: [Title]
 
 **Status:** Proposed | Accepted | Deprecated | Superseded

--- a/docs/architecture/ci-cd.md
+++ b/docs/architecture/ci-cd.md
@@ -94,7 +94,7 @@ The harness deploys to a dedicated Hosting site `maple-spruce-registration-test`
 
 ### Codebases
 
-Functions are split into 4 Firebase codebases to reduce cold start times (see ADR-026):
+Functions are split into 5 Firebase codebases to reduce cold start times (see ADR-026, ADR-031):
 
 | Codebase | App Project | Entry Point |
 |----------|-------------|-------------|
@@ -102,6 +102,14 @@ Functions are split into 4 Firebase codebases to reduce cold start times (see AD
 | `maple-calendar` | `apps/functions-calendar/` | `apps/functions-calendar/src/index.ts` |
 | `maple-square` | `apps/functions-square/` | `apps/functions-square/src/index.ts` |
 | `maple-sync` | `apps/functions-sync/` | `apps/functions-sync/src/index.ts` |
+| `maple-webhooks` | `apps/functions-webhooks/` | `apps/functions-webhooks/src/index.ts` |
+
+Adding a codebase means touching, at minimum: `firebase.json`, `function-codebases.json`
+(`codebaseProjects` + a `functionToCodebase` entry keyed by **Nx project name**), the
+artifact upload paths and the `^functions(-…)?$` affected-regex in
+`firebase-functions-merge.yml`, and the build + emulator-env blocks in
+`build-check.yml` and `tools/run-integration-tests.sh`. `tools/validate-function-tsconfigs.sh`
+and `tools/check-callable-roles.ts` also carry hardcoded codebase lists.
 
 ### How CI determines what to deploy
 

--- a/docs/reference/deployed-functions.md
+++ b/docs/reference/deployed-functions.md
@@ -1,7 +1,7 @@
 # Deployed Functions
 
 > All Cloud Functions deploy to `us-east4` (Northern Virginia).
-> Functions are split into 4 codebases to reduce cold start times.
+> Functions are split into 5 codebases to reduce cold start times.
 
 ## Codebase: `maple-core` (`apps/functions/`)
 
@@ -109,9 +109,6 @@ Core CRUD operations, auth, triggers, and admin functions. No heavy third-party 
 - `healthCheck`
 - `getSyncConflicts`, `getSyncConflictSummary`
 
-### Lead attribution (Tally → GA4 + Meta CAPI)
-- `tallyLeadWebhook` — HTTP endpoint (Tally newsletter-signup webhook). Verifies `tally-signature` HMAC, extracts hidden fields, fans out to GA4 Measurement Protocol (`generate_lead`) and Meta Conversions API (`Lead`). _(concurrency: 80, memory: 256MiB.)_ Manual setup: `docs/guides/tally-lead-webhook-setup.md`.
-
 ### Purchase attribution (class registration → Meta CAPI)
 - `sendRegistrationConversion` — Firestore trigger on `registrations/{id}`. On the `pending → confirmed` transition (paid `source:'web'` only), sends a server-side Meta Conversions API `Purchase` with `event_id = confirmationNumber` for dedup against the inline browser Pixel. Recovers conversions the client Pixel drops (iOS/Safari ITP, ad blockers) and the ones it never fires at all (the Square-hosted checkout fallback, which redirects off-site). Best-effort: CAPI failures are logged and swallowed. Reuses the `META_CAPI_TOKEN` secret + `META_PIXEL_ID`/`META_CAPI_*` params from `tallyLeadWebhook` — no new secret. Shared client: `@maple/firebase/meta-capi` (`libs/firebase/meta-capi/`).
 - `sendMusicTogetherConversion` — Firestore trigger on `musicTogetherRegistrations/{id}`. MT counterpart of `sendRegistrationConversion`: on the `pending → confirmed` transition of a paid MT registration, sends a Meta CAPI `Purchase` with `event_id = mt-<registrationId>`. **`value` is the amount actually charged at registration** — installment 1 for an installment plan, not full tuition (later installments are charged by `chargeMusicTogetherInstallments`). MT payments settle in a separate Square account but report into the SAME Maple & Spruce pixel, so it reuses the same `META_CAPI_TOKEN` secret + `META_*` params — no new secret. Best-effort: CAPI failures are logged and swallowed. Shared client: `@maple/firebase/meta-capi`.
@@ -176,6 +173,18 @@ Square SDK integration for payments, catalog management, and sync conflict resol
 - `createCraftClubSubscription` also emails a welcome on success.
 
 `squareWebhook` additionally handles `subscription.created` / `subscription.updated` — reconciles the member's status (ACTIVE/PAUSED/CANCELED/DEACTIVATED) and paid-through date from Square; idempotent on no-change.
+
+---
+
+## Codebase: `maple-webhooks` (`apps/functions-webhooks/`)
+
+Endpoints called by external SaaS platforms that enforce a short delivery
+timeout. Deliberately the smallest bundle in the repo (~90kb) because a
+codebase's cold start is set by its heaviest member — see ADR-031 before
+adding anything here.
+
+### Lead attribution (Tally → GA4 + Meta CAPI)
+- `tallyLeadWebhook` — HTTP endpoint (Tally newsletter-signup webhook). Verifies `tally-signature` HMAC, extracts hidden fields, fans out to GA4 Measurement Protocol (`generate_lead`) and Meta Conversions API (`Lead`), each bounded at 4s. _(concurrency: 80, memory: 256MiB.)_ Manual setup: `docs/guides/tally-lead-webhook-setup.md`. Moved out of `maple-core` in 2026-08 — that bundle cold-starts in ~14.4s against Tally's 10s cutoff, and Tally does not retry.
 
 ---
 

--- a/docs/sessions/SESSION.md
+++ b/docs/sessions/SESSION.md
@@ -6,6 +6,30 @@
 
 ## Current Status
 
+### Tally webhook timeouts — `maple-webhooks` codebase (2026-08-07)
+
+Tally reported five `timeout of 10000ms exceeded` failures (2026-07-30 → 2026-08-06), one per day
+the newsletter form got a signup. Cause was **cold start, not the handler**: prod probes returning
+401 (before any handler logic) took **14.4s** in `maple-core` vs 1.0s warm, against Tally's 10s
+cutoff. A codebase is one bundle, so `tallyLeadWebhook` was paying the boot cost of all 165
+maple-core functions — and at ~1 signup/day the service was cold for essentially every delivery.
+Tally does not retry, so each one was a lost lead.
+
+Fix: new `maple-webhooks` codebase (`apps/functions-webhooks/`, 90kb vs 488kb) holding just
+`tallyLeadWebhook`, plus `AbortSignal.timeout` on the GA4/Meta beacons. See ADR-031.
+
+**Follow-ups**:
+- **Resend the 5 failed submissions** from Tally's events log once deployed (they are not
+  recovered automatically), and confirm the leads reached MailerLite — only the GA4/Meta
+  attribution events were lost if Tally's MailerLite integration delivered independently.
+- Verify post-deploy that the function re-registered under the new codebase and that a cold call
+  now answers well under 10s.
+- `squareWebhook` has the same 10s budget and still lives in `maple-core` at ~14s cold; it
+  survives on Square's retries. Worth its own codebase (it carries Firestore + Square deps, so it
+  can't share `maple-webhooks`).
+
+---
+
 **Date**: 2026-06-26
 **Status**: Phase 4 complete; Phase 5 in progress. Spruce Room availability epic (#467) — PRs 1 & 2 shipped; adding the upcoming-schedule agenda (#504).
 

--- a/firebase.json
+++ b/firebase.json
@@ -26,6 +26,11 @@
       "source": "dist/apps/functions-sync",
       "runtime": "nodejs22",
       "codebase": "maple-sync"
+    },
+    {
+      "source": "dist/apps/functions-webhooks",
+      "runtime": "nodejs22",
+      "codebase": "maple-webhooks"
     }
   ],
   "hosting": [

--- a/function-codebases.json
+++ b/function-codebases.json
@@ -3,7 +3,8 @@
     "maple-core": "functions",
     "maple-calendar": "functions-calendar",
     "maple-square": "functions-square",
-    "maple-sync": "functions-sync"
+    "maple-sync": "functions-sync",
+    "maple-webhooks": "functions-webhooks"
   },
   "functionToCodebase": {
     "firebase-maple-functions-calendar-classes-feed": "maple-calendar",
@@ -56,7 +57,8 @@
     "firebase-maple-functions-update-craft-club-payment-method": "maple-square",
     "firebase-maple-functions-admin-pause-craft-club-subscription": "maple-square",
     "firebase-maple-functions-admin-resume-craft-club-subscription": "maple-square",
-    "firebase-maple-functions-admin-cancel-craft-club-subscription": "maple-square"
+    "firebase-maple-functions-admin-cancel-craft-club-subscription": "maple-square",
+    "firebase-maple-functions-tally-lead-webhook": "maple-webhooks"
   },
   "defaultCodebase": "maple-core"
 }

--- a/libs/firebase/maple-functions/tally-lead-webhook/src/lib/tally-lead-webhook.ts
+++ b/libs/firebase/maple-functions/tally-lead-webhook/src/lib/tally-lead-webhook.ts
@@ -12,9 +12,25 @@
  *   so GA4 attributes zero lead key-events to any source/medium.
  * - Meta only sees browser-side Pixel events, which iOS attribution drops.
  *
- * Tally retries 5xx, so we always answer 200 once we've validated the
- * payload. Downstream failures are logged but never block the ack — one
- * channel succeeding still beats zero.
+ * We always answer 200 once we've validated the payload. Downstream failures
+ * are logged but never block the ack — one channel succeeding still beats
+ * zero.
+ *
+ * THE 10-SECOND BUDGET
+ * --------------------
+ * Tally hangs up at 10s and records the submission as failed. It does NOT
+ * retry — a missed delivery is a permanently lost lead that has to be resent
+ * by hand from Tally's events log. Everything on this path is sized against
+ * that ceiling:
+ *
+ * - This function lives in the deliberately tiny `maple-webhooks` codebase
+ *   (apps/functions-webhooks), NOT maple-core. Boot time is set by the whole
+ *   codebase bundle, and maple-core measured 14.4s cold vs ~1s warm — the form
+ *   draws about one signup a day, so it was cold for nearly every real
+ *   delivery and Tally dropped five leads between 2026-07-30 and 2026-08-06.
+ * - Both beacons are bounded (see GA4_TIMEOUT_MS / META_TIMEOUT_MS); `fetch`
+ *   has no default timeout, so an unbounded hang would blow the budget even
+ *   from a warm instance.
  *
  * @see https://tally.so/help/webhooks
  * @see https://developers.google.com/analytics/devguides/collection/protocol/ga4
@@ -143,6 +159,13 @@ export function extractLead(
   };
 }
 
+/**
+ * Per-beacon ceiling. GA4 and Meta fire in parallel, so the pair costs at most
+ * this much of Tally's 10s delivery budget — leaving room for cold start.
+ */
+const GA4_TIMEOUT_MS = 4_000;
+const META_TIMEOUT_MS = 4_000;
+
 async function sendGa4Event(
   lead: TallyLeadValidationInput,
   config: { baseUrl: string; measurementId: string; apiSecret: string }
@@ -176,6 +199,10 @@ async function sendGa4Event(
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
+    // `fetch` has no default timeout. Both beacons are awaited before we ack,
+    // so a hung connection here would eat the 10s Tally allows us and lose the
+    // submission outright. Bail early instead and let the ack through.
+    signal: AbortSignal.timeout(GA4_TIMEOUT_MS),
   });
 
   if (!response.ok) {
@@ -212,7 +239,7 @@ function sendLeadToMeta(
     throw new Error('Cannot send Meta CAPI Lead without an email');
   }
 
-  return sendMetaCapiEvents(config, [
+  return sendMetaCapiEvents({ ...config, timeoutMs: META_TIMEOUT_MS }, [
     {
       eventName: 'Lead',
       actionSource: 'website',

--- a/libs/firebase/meta-capi/src/lib/meta-capi.ts
+++ b/libs/firebase/meta-capi/src/lib/meta-capi.ts
@@ -29,7 +29,17 @@ export interface MetaCapiConfig {
   apiVersion: string;
   pixelId: string;
   accessToken: string;
+  /**
+   * Abort the POST after this many ms. `fetch` has no default timeout, so a
+   * hung Graph API connection otherwise stalls the caller until the function
+   * itself times out — on a webhook with a short delivery budget that turns a
+   * slow beacon into a dropped event. Defaults to 5s.
+   */
+  timeoutMs?: number;
 }
+
+/** @see MetaCapiConfig.timeoutMs */
+export const DEFAULT_META_CAPI_TIMEOUT_MS = 5_000;
 
 export interface MetaCapiUserIdentifiers {
   email?: string;
@@ -152,6 +162,9 @@ export async function sendMetaCapiEvents(
     body: JSON.stringify({
       data: events.map((e) => buildCapiEvent(e, nowSeconds)),
     }),
+    signal: AbortSignal.timeout(
+      config.timeoutMs ?? DEFAULT_META_CAPI_TIMEOUT_MS
+    ),
   });
 
   if (!response.ok) {

--- a/tools/check-callable-roles.ts
+++ b/tools/check-callable-roles.ts
@@ -41,6 +41,7 @@ const ENTRY_POINTS = [
   'apps/functions-calendar/src/index.ts',
   'apps/functions-square/src/index.ts',
   'apps/functions-sync/src/index.ts',
+  'apps/functions-webhooks/src/index.ts',
 ];
 
 const MAPLE_FUNCTIONS_PREFIX = '@maple/firebase/maple-functions/';

--- a/tools/run-integration-tests.sh
+++ b/tools/run-integration-tests.sh
@@ -53,6 +53,7 @@ pnpm exec nx run functions:build
 pnpm exec nx run functions-square:build
 pnpm exec nx run functions-sync:build
 pnpm exec nx run functions-calendar:build
+pnpm exec nx run functions-webhooks:build
 
 # ---------------------------------------------------------------------------
 # 3. Set up .env and .secret.local for every codebase
@@ -66,7 +67,7 @@ pnpm exec nx run functions-calendar:build
 #    overrides.
 # ---------------------------------------------------------------------------
 echo "Setting up emulator environment..."
-for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar; do
+for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks; do
   # Strip comments and blank lines — Firebase .env parser needs clean key=value pairs
   grep -v '^#' .env.dev | grep -v '^$' > "$dir/.env"
 done
@@ -79,7 +80,17 @@ echo "META_CAPI_BASE_URL=http://localhost:$META_CAPI_MOCK_SERVER_PORT" >> dist/a
 echo "GA4_MEASUREMENT_ID=G-TEST-MOCK" >> dist/apps/functions/.env
 echo "META_PIXEL_ID=test-pixel-id" >> dist/apps/functions/.env
 echo "META_CAPI_API_VERSION=v20.0" >> dist/apps/functions/.env
-printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\nTALLY_WEBHOOK_SECRET=test-tally-secret\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions/.secret.local
+printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions/.secret.local
+
+# maple-webhooks: tallyLeadWebhook declares these defineSecret params;
+# without them the emulator silently waits on stdin for each one.
+printf "TALLY_WEBHOOK_SECRET=test-tally-secret\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions-webhooks/.secret.local
+# tallyLeadWebhook → GA4 + Meta CAPI mock servers
+echo "GA4_BASE_URL=http://localhost:$GA4_MOCK_SERVER_PORT" >> dist/apps/functions-webhooks/.env
+echo "META_CAPI_BASE_URL=http://localhost:$META_CAPI_MOCK_SERVER_PORT" >> dist/apps/functions-webhooks/.env
+echo "GA4_MEASUREMENT_ID=G-TEST-MOCK" >> dist/apps/functions-webhooks/.env
+echo "META_PIXEL_ID=test-pixel-id" >> dist/apps/functions-webhooks/.env
+echo "META_CAPI_API_VERSION=v20.0" >> dist/apps/functions-webhooks/.env
 
 # maple-square: Square mock server URL + fake secrets
 echo "SQUARE_BASE_URL=http://localhost:$SQUARE_MOCK_SERVER_PORT" >> dist/apps/functions-square/.env

--- a/tools/validate-function-tsconfigs.sh
+++ b/tools/validate-function-tsconfigs.sh
@@ -21,7 +21,7 @@ NC='\033[0m'
 
 ERRORS=0
 
-APP_DIRS=("apps/functions" "apps/functions-calendar" "apps/functions-square" "apps/functions-sync")
+APP_DIRS=("apps/functions" "apps/functions-calendar" "apps/functions-square" "apps/functions-sync" "apps/functions-webhooks")
 
 check_codebase() {
   local APP_DIR="$1"
@@ -101,7 +101,7 @@ if [[ ! -f "$MAPPING_FILE" ]]; then
 fi
 
 # Check that every non-core function export has a mapping
-NON_CORE_DIRS=("apps/functions-calendar" "apps/functions-square" "apps/functions-sync")
+NON_CORE_DIRS=("apps/functions-calendar" "apps/functions-square" "apps/functions-sync" "apps/functions-webhooks")
 for APP_DIR in "${NON_CORE_DIRS[@]}"; do
   ENTRY="${APP_DIR}/src/index.ts"
   [[ ! -f "$ENTRY" ]] && continue


### PR DESCRIPTION
## The reports

Tally sent five "Webhooks integration needs attention" emails, one per day the newsletter form got a signup, all reading `timeout of 10000ms exceeded`:

| Failing since | Failed submissions |
|---|---|
| 2026-07-30 07:51 | 1 |
| 2026-07-31 16:58 | 1 |
| 2026-08-01 14:59 | 1 |
| 2026-08-03 04:54 | 1 |
| 2026-08-06 07:10 | 1 |

## Diagnosis

The handler was fine. It was **cold start**, and it's a property of the *codebase*, not the function.

Probing prod with invalid-signature requests — these return 401 before a single line of handler logic runs — measured pure boot time:

| Codebase | Bundle | Cold | Warm |
|---|---|---|---|
| `maple-core` (`tallyLeadWebhook`) | 488kb | **14.4s** | 1.0s |
| `maple-core` (`checkAdminStatus`, control) | 488kb | 14.8s | 1.2s |
| `maple-sync` | 301kb | 6.3s | 1.3s |
| `maple-calendar` | 30kb | 3.2s | 1.1s |

A Firebase codebase is one bundle — every function in it loads the whole entry point on boot, so `tallyLeadWebhook` was paying for all 165 `maple-core` functions.

Two things made this total rather than intermittent:

1. The form draws about **one signup a day**, so the service was cold on essentially every real delivery. Not a tail-latency problem — the common case.
2. **Tally does not retry.** Square's 10s timeout produces a retry storm that eventually lands; Tally's produces a lost lead.

## Fix

- **New `maple-webhooks` codebase** (`apps/functions-webhooks/`, **90kb** vs 488kb) holding only `tallyLeadWebhook`. Deliberately dependency-light — the entry point and `.claude/rules/firebase-functions.md` both spell out that adding a firebase-admin/Square/Webflow function here re-inflates the bundle and undoes the fix.
- **Bounded beacons.** `fetch` has no default timeout, so a hung GA4/Meta connection could blow the 10s budget even warm. 4s each, in parallel; `MetaCapiConfig.timeoutMs` defaults to 5s for the other two CAPI callers.
- **Codebase wiring:** `firebase.json`, `function-codebases.json`, artifact paths + affected-regex in `firebase-functions-merge.yml`, build/env blocks in `build-check.yml` and `tools/run-integration-tests.sh`, plus `validate-function-tsconfigs.sh` and `check-callable-roles.ts`.
- **ADR-031** records the decision and the rejected alternatives (`minInstances`, moving to calendar/sync, ack-fast-and-defer).

## Verification

- 9/9 tally integration tests pass on real emulators — stack traces confirm execution from `dist/apps/functions-webhooks/index.cjs`, so the emulator loads all 5 codebases with the new env layout and nothing hangs on a missing `defineSecret`
- 578 unit tests pass; all 5 function codebases build; `validate-function-tsconfigs.sh`, `check-callable-roles.ts` (221 functions), and the function-count ratchet (217, unchanged) all pass

## After merge

1. **Resend the 5 failed submissions** from Tally's events log — this change doesn't recover them. Worth confirming the leads still reached MailerLite; if Tally's MailerLite integration delivered independently, only the GA4/Meta attribution events were lost.
2. Confirm the function re-registered under `maple-webhooks` and that a cold call now answers well under 10s.
3. `squareWebhook` has the same 10s budget and is still in `maple-core` at ~14s cold — it survives on Square's retries alone. It carries Firestore + Square deps, so it needs its own codebase rather than a seat in this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)