### PR TITLE
fix(square): move squareWebhook to its own maple-square-webhook codebase

### DIFF
--- a/.claude/rules/firebase-functions.md
+++ b/.claude/rules/firebase-functions.md
@@ -73,8 +73,14 @@ so no handler logic ran):
 | `maple-square` | 419kb | 7.5s, 12.0s | 1.2s |
 | `maple-sync` | 301kb | 6.3s | 1.3s |
 | `maple-square-webhook` | 141kb | — | — |
-| `maple-webhooks` | 90kb | — | — |
+| `maple-webhooks` | 90kb | 3.2s | 0.8s |
 | `maple-calendar` | 30kb | 3.2s | 1.1s |
+
+`maple-webhooks` is the post-fix measurement, taken 2026-08-07 after
+`tallyLeadWebhook` shipped: **14.4s → 3.2s cold**, ~7s of margin under Tally's
+10s cutoff. Verified with a same-project control (an idle `maple-core` function
+probed in the same window still cold-started), so the low number is a real cold
+start and not a warm instance.
 
 **Cold start is a distribution, not a number.** Two functions in the *same*
 `maple-square` bundle measured 7.5s and 12.0s — placement and image-cache state

--- a/.claude/rules/firebase-functions.md
+++ b/.claude/rules/firebase-functions.md
@@ -5,6 +5,8 @@ globs:
   - "apps/functions-calendar/**"
   - "apps/functions-square/**"
   - "apps/functions-sync/**"
+  - "apps/functions-webhooks/**"
+  - "apps/functions-square-webhook/**"
   - "libs/firebase/database/**"
 ---
 
@@ -45,7 +47,7 @@ properties of the function, not the route. Raise the baseline deliberately in th
 
 ## Codebases
 
-Functions are split into 5 Firebase codebases to reduce cold start times:
+Functions are split into 6 Firebase codebases to reduce cold start times:
 
 | Codebase | App Project | Heavy Deps | Entry Point |
 |----------|-------------|------------|-------------|
@@ -54,6 +56,7 @@ Functions are split into 5 Firebase codebases to reduce cold start times:
 | `maple-square` | `apps/functions-square/` | square SDK | `apps/functions-square/src/index.ts` |
 | `maple-sync` | `apps/functions-sync/` | webflow-api | `apps/functions-sync/src/index.ts` |
 | `maple-webhooks` | `apps/functions-webhooks/` | **none — keep it that way** | `apps/functions-webhooks/src/index.ts` |
+| `maple-square-webhook` | `apps/functions-square-webhook/` | firebase-admin (repositories only) | `apps/functions-square-webhook/src/index.ts` |
 
 When adding a new function, export it from the correct codebase's entry point and add a mapping in `function-codebases.json` if it's not in `maple-core`.
 
@@ -66,18 +69,30 @@ so no handler logic ran):
 
 | Codebase | Bundle | Cold | Warm |
 |----------|--------|------|------|
-| `maple-core` | 488kb | 14.4s | 1.0s |
+| `maple-core` | 488kb | 14.4s, 14.8s | 1.0s |
+| `maple-square` | 419kb | 7.5s, 12.0s | 1.2s |
 | `maple-sync` | 301kb | 6.3s | 1.3s |
+| `maple-square-webhook` | 141kb | — | — |
 | `maple-webhooks` | 90kb | — | — |
 | `maple-calendar` | 30kb | 3.2s | 1.1s |
+
+**Cold start is a distribution, not a number.** Two functions in the *same*
+`maple-square` bundle measured 7.5s and 12.0s — placement and image-cache state
+swing it by several seconds. Shrinking the bundle shifts the distribution down;
+it does not buy a guarantee. Budget for the bad tail, not the median.
 
 This matters for any endpoint an external platform calls with a fixed timeout:
 
 - **Tally** hangs up at 10s and does **not** retry — a slow cold start is a
   permanently lost lead. This is what put `tallyLeadWebhook` in `maple-webhooks`.
 - **Square** hangs up at 10s and *does* retry with backoff (see the 2026-05
-  504 storm). `squareWebhook` is still in `maple-core` and still boots in
-  ~14s — it survives on retries alone. Worth moving out.
+  504 storm). `squareWebhook` sat in `maple-square` (419kb), which booted in
+  7.5-12s — sometimes leaving under a second for the handler. It now has its
+  own `maple-square-webhook` codebase.
+
+Both webhooks are in *separate* codebases on purpose. `squareWebhook` needs
+`@maple/firebase/database`; sharing a bundle would push that weight onto
+`tallyLeadWebhook`, which has no retry to fall back on.
 
 `maple-webhooks` only pays off while it stays small. Adding a function there
 that pulls firebase-admin repositories, the Square SDK, or webflow-api
@@ -113,6 +128,8 @@ Each codebase has its own entry point:
 - Calendar ICS feeds: `apps/functions-calendar/src/index.ts`
 - Square integration: `apps/functions-square/src/index.ts`
 - Webflow sync: `apps/functions-sync/src/index.ts`
+- Third-party webhooks (Tally): `apps/functions-webhooks/src/index.ts`
+- Square webhook receiver: `apps/functions-square-webhook/src/index.ts`
 
 ## Runtime Options
 
@@ -127,7 +144,7 @@ Functions.endpoint
 
 `libs/firebase/functions/src/lib/global-runtime-options.ts` calls
 `setGlobalOptions({ maxInstances: GLOBAL_MAX_INSTANCES })` (currently **1**). Each of the
-4 entry points imports it on its **first line**, before any `export { … } from` re-export.
+6 entry points imports it on its **first line**, before any `export { … } from` re-export.
 
 **Why:** unset `maxInstances` inherits the gen-2 backend default of **100**, and Cloud Run's
 "Total CPU allocation, per project per region" quota reserves `maxInstances × cpu` per revision.

--- a/.claude/skills/create-cloud-function/SKILL.md
+++ b/.claude/skills/create-cloud-function/SKILL.md
@@ -57,7 +57,7 @@ Determine which codebase your function belongs to based on its dependencies:
 - **Square SDK** → `apps/functions-square/src/index.ts` (codebase: `maple-square`)
 - **ical-generator** → `apps/functions-calendar/src/index.ts` (codebase: `maple-calendar`)
 - **webflow-api** → `apps/functions-sync/src/index.ts` (codebase: `maple-sync`)
-- **Third-party webhook with a short delivery timeout** (Tally, Square) and no heavy deps → `apps/functions-webhooks/src/index.ts` (codebase: `maple-webhooks`). Keep this bundle tiny — `maple-core` cold-starts in ~14s, which exceeds Tally's 10s budget. See ADR-031.
+- **Third-party webhook with a short delivery timeout**, no heavy deps → `apps/functions-webhooks/src/index.ts` (codebase: `maple-webhooks`). Keep this bundle tiny — `maple-core` cold-starts in ~14s, which exceeds Tally's 10s budget. If the webhook needs repositories or an external SDK, give it its own codebase instead (as `maple-square-webhook` does) rather than inflating a shared one. See ADR-031.
 - **Everything else** → `apps/functions/src/index.ts` (codebase: `maple-core`, default)
 
 Add the export to the correct entry point:

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -422,12 +422,13 @@ jobs:
           pnpm exec nx run functions-sync:build
           pnpm exec nx run functions-calendar:build
           pnpm exec nx run functions-webhooks:build
+          pnpm exec nx run functions-square-webhook:build
 
       - name: Create emulator .env
         run: |
           # Copy .env.dev to every codebase (has all shared project-level params)
           # Strip comments and blank lines — Firebase .env parser needs clean key=value pairs
-          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks; do
+          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks dist/apps/functions-square-webhook; do
             grep -v '^#' .env.dev | grep -v '^$' > "$dir/.env"
           done
 
@@ -444,12 +445,16 @@ jobs:
           # maple-webhooks: tallyLeadWebhook declares these defineSecret params;
           # without them the emulator silently waits on stdin for each one.
           printf "TALLY_WEBHOOK_SECRET=test-tally-secret\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions-webhooks/.secret.local
+
           # tallyLeadWebhook → GA4 + Meta CAPI mock servers
           echo "GA4_BASE_URL=http://localhost:9995" >> dist/apps/functions-webhooks/.env
           echo "META_CAPI_BASE_URL=http://localhost:9994" >> dist/apps/functions-webhooks/.env
           echo "GA4_MEASUREMENT_ID=G-TEST-MOCK" >> dist/apps/functions-webhooks/.env
           echo "META_PIXEL_ID=test-pixel-id" >> dist/apps/functions-webhooks/.env
           echo "META_CAPI_API_VERSION=v20.0" >> dist/apps/functions-webhooks/.env
+
+          # maple-square-webhook: squareWebhook declares this defineSecret param.
+          printf "SQUARE_WEBHOOK_SIGNATURE_KEY=mock-key\n" > dist/apps/functions-square-webhook/.secret.local
 
           # maple-square: Square mock server URL + fake secrets
           echo "SQUARE_BASE_URL=http://localhost:9997" >> dist/apps/functions-square/.env
@@ -580,6 +585,7 @@ jobs:
           pnpm exec nx run functions-sync:build
           pnpm exec nx run functions-calendar:build
           pnpm exec nx run functions-webhooks:build
+          pnpm exec nx run functions-square-webhook:build
 
       - name: Create emulator .env
         # Mirrors the integration-tests job, with one critical difference:
@@ -595,7 +601,7 @@ jobs:
         env:
           SQUARE_SANDBOX_ACCESS_TOKEN: ${{ secrets.SQUARE_SANDBOX_ACCESS_TOKEN }}
         run: |
-          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks; do
+          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks dist/apps/functions-square-webhook; do
             grep -v '^#' .env.dev | grep -v '^$' > "$dir/.env"
           done
 
@@ -608,6 +614,9 @@ jobs:
           # maple-webhooks: tallyLeadWebhook declares these defineSecret params;
           # without them the emulator silently waits on stdin for each one.
           printf "TALLY_WEBHOOK_SECRET=test-tally-secret\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions-webhooks/.secret.local
+
+          # maple-square-webhook: squareWebhook declares this defineSecret param.
+          printf "SQUARE_WEBHOOK_SIGNATURE_KEY=mock-key\n" > dist/apps/functions-square-webhook/.secret.local
           # maple-square: real Square sandbox (no SQUARE_BASE_URL → SDK
           # uses its built-in sandbox endpoint). Etsy still mocked.
           echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions-square/.env
@@ -619,7 +628,7 @@ jobs:
           echo "ETSY_TOKEN_URL=http://localhost:9998/v3/public/oauth/token" >> dist/apps/functions-sync/.env
           printf "WEBFLOW_API_TOKEN=mock-token\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions-sync/.secret.local
 
-          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks; do
+          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks dist/apps/functions-square-webhook; do
             EXISTING=$(grep '^ALLOWED_ORIGINS=' "$dir/.env" | head -1 | cut -d= -f2-)
             echo "ALLOWED_ORIGINS=$EXISTING,http://127.0.0.1:4173,http://localhost:4173" >> "$dir/.env"
           done
@@ -741,6 +750,7 @@ jobs:
           pnpm exec nx run functions-sync:build
           pnpm exec nx run functions-calendar:build
           pnpm exec nx run functions-webhooks:build
+          pnpm exec nx run functions-square-webhook:build
 
       - name: Create emulator .env
         # Copied VERBATIM from the registration-e2e job: we DON'T set
@@ -752,7 +762,7 @@ jobs:
         env:
           SQUARE_SANDBOX_ACCESS_TOKEN: ${{ secrets.SQUARE_SANDBOX_ACCESS_TOKEN }}
         run: |
-          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks; do
+          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks dist/apps/functions-square-webhook; do
             grep -v '^#' .env.dev | grep -v '^$' > "$dir/.env"
           done
 
@@ -765,6 +775,9 @@ jobs:
           # maple-webhooks: tallyLeadWebhook declares these defineSecret params;
           # without them the emulator silently waits on stdin for each one.
           printf "TALLY_WEBHOOK_SECRET=test-tally-secret\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions-webhooks/.secret.local
+
+          # maple-square-webhook: squareWebhook declares this defineSecret param.
+          printf "SQUARE_WEBHOOK_SIGNATURE_KEY=mock-key\n" > dist/apps/functions-square-webhook/.secret.local
           # maple-square: real Square sandbox (no SQUARE_BASE_URL → SDK
           # uses its built-in sandbox endpoint). Etsy still mocked.
           echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions-square/.env
@@ -892,6 +905,7 @@ jobs:
           pnpm exec nx run functions-sync:build
           pnpm exec nx run functions-calendar:build
           pnpm exec nx run functions-webhooks:build
+          pnpm exec nx run functions-square-webhook:build
 
       - name: Create emulator .env
         # Mirrors the Registration E2E job. No SQUARE_BASE_URL, so the Square
@@ -900,7 +914,7 @@ jobs:
         # placeholder; MT_SQUARE_ACCESS_TOKEN gets the REAL MT sandbox token.
         if: steps.gate.outputs.enabled == 'true'
         run: |
-          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks; do
+          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks dist/apps/functions-square-webhook; do
             grep -v '^#' .env.dev | grep -v '^$' > "$dir/.env"
           done
 
@@ -910,6 +924,9 @@ jobs:
           # maple-webhooks: tallyLeadWebhook declares these defineSecret params;
           # without them the emulator silently waits on stdin for each one.
           printf "TALLY_WEBHOOK_SECRET=test-tally-secret\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions-webhooks/.secret.local
+
+          # maple-square-webhook: squareWebhook declares this defineSecret param.
+          printf "SQUARE_WEBHOOK_SIGNATURE_KEY=mock-key\n" > dist/apps/functions-square-webhook/.secret.local
           echo "ETSY_API_BASE=http://localhost:9998/v3/application" >> dist/apps/functions-square/.env
           printf "SQUARE_ACCESS_TOKEN=unused-mock-token\nMT_SQUARE_ACCESS_TOKEN=%s\nSQUARE_WEBHOOK_SIGNATURE_KEY=mock-key\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" "$MT_SQUARE_SANDBOX_ACCESS_TOKEN" > dist/apps/functions-square/.secret.local
 
@@ -918,7 +935,7 @@ jobs:
           echo "ETSY_TOKEN_URL=http://localhost:9998/v3/public/oauth/token" >> dist/apps/functions-sync/.env
           printf "WEBFLOW_API_TOKEN=mock-token\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions-sync/.secret.local
 
-          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks; do
+          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks dist/apps/functions-square-webhook; do
             EXISTING=$(grep '^ALLOWED_ORIGINS=' "$dir/.env" | head -1 | cut -d= -f2-)
             echo "ALLOWED_ORIGINS=$EXISTING,http://127.0.0.1:4173,http://localhost:4173" >> "$dir/.env"
           done
@@ -1021,10 +1038,11 @@ jobs:
           pnpm exec nx run functions-sync:build
           pnpm exec nx run functions-calendar:build
           pnpm exec nx run functions-webhooks:build
+          pnpm exec nx run functions-square-webhook:build
 
       - name: Create emulator .env
         run: |
-          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks; do
+          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks dist/apps/functions-square-webhook; do
             grep -v '^#' .env.dev | grep -v '^$' > "$dir/.env"
           done
 
@@ -1034,6 +1052,9 @@ jobs:
           # maple-webhooks: tallyLeadWebhook declares these defineSecret params;
           # without them the emulator silently waits on stdin for each one.
           printf "TALLY_WEBHOOK_SECRET=test\nGA4_API_SECRET=test\nMETA_CAPI_TOKEN=test\n" > dist/apps/functions-webhooks/.secret.local
+
+          # maple-square-webhook: squareWebhook declares this defineSecret param.
+          printf "SQUARE_WEBHOOK_SIGNATURE_KEY=mock-key\n" > dist/apps/functions-square-webhook/.secret.local
           printf "SQUARE_ACCESS_TOKEN=mock-token\nMT_SQUARE_ACCESS_TOKEN=mock-token\nSQUARE_WEBHOOK_SIGNATURE_KEY=mock-key\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions-square/.secret.local
           printf "WEBFLOW_API_TOKEN=mock-token\nETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\n" > dist/apps/functions-sync/.secret.local
 
@@ -1043,7 +1064,7 @@ jobs:
           echo "ETSY_API_BASE=http://127.0.0.1:1" >> dist/apps/functions-sync/.env
 
           # CORS: the app's callables come from the Next dev origin (localhost:3000).
-          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks; do
+          for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks dist/apps/functions-square-webhook; do
             EXISTING=$(grep '^ALLOWED_ORIGINS=' "$dir/.env" | head -1 | cut -d= -f2-)
             echo "ALLOWED_ORIGINS=$EXISTING,http://localhost:3000,http://127.0.0.1:3000" >> "$dir/.env"
           done

--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -183,7 +183,7 @@ jobs:
             AFFECTED_LIBS=$(pnpm exec nx show projects | grep 'firebase-maple-functions-' || true)
           else
             # Check if any functions app is affected (e.g., env file changes)
-            FUNCTIONS_APP_AFFECTED=$(echo "$ALL_AFFECTED" | grep -E '^functions(-calendar|-square|-sync|-webhooks)?$' || true)
+            FUNCTIONS_APP_AFFECTED=$(echo "$ALL_AFFECTED" | grep -E '^functions(-calendar|-square|-sync|-webhooks|-square-webhook)?$' || true)
 
             # Get affected function libraries
             AFFECTED_LIBS=$(echo "$ALL_AFFECTED" | grep 'firebase-maple-functions-' || true)
@@ -325,6 +325,7 @@ jobs:
             dist/apps/functions-square/
             dist/apps/functions-sync/
             dist/apps/functions-webhooks/
+            dist/apps/functions-square-webhook/
           include-hidden-files: true
           retention-days: 1
 

--- a/apps/functions-square-webhook/project.json
+++ b/apps/functions-square-webhook/project.json
@@ -1,0 +1,31 @@
+{
+  "name": "functions-square-webhook",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/functions-square-webhook/src",
+  "projectType": "application",
+  "tags": ["scope:firebase", "type:app"],
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "inputs": ["default", "functionsEnv"],
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/apps/functions-square-webhook",
+        "main": "apps/functions-square-webhook/src/index.ts",
+        "tsConfig": "apps/functions-square-webhook/tsconfig.app.json",
+        "generatePackageJson": true,
+        "platform": "node",
+        "bundle": true,
+        "thirdParty": false,
+        "dependenciesFieldType": "dependencies",
+        "target": "node20",
+        "format": ["cjs"],
+        "outputFileName": "index.js",
+        "esbuildOptions": {
+          "minify": true,
+          "logLevel": "info"
+        }
+      }
+    }
+  }
+}

--- a/apps/functions-square-webhook/src/index.ts
+++ b/apps/functions-square-webhook/src/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Firebase Cloud Functions — Square Webhook Codebase
+ *
+ * Square gives a webhook receiver 10 seconds to answer 2xx. Anything slower is
+ * recorded as `http_timeout` (surfaced as 504 in the Square dashboard) and
+ * starts an exponential-backoff retry chain lasting up to 24 hours.
+ *
+ * Why this isn't in maple-core (ADR-031)
+ * --------------------------------------
+ * A Firebase codebase is one bundle: every function loads the whole entry
+ * point on cold start, so boot time is set by the heaviest sibling. In
+ * maple-core (488kb) that measured **14.4s cold** against a 10s budget — the
+ * webhook could not answer in time from a cold instance, and only survived
+ * because Square retries until an instance is warm. That is what the 2026-05
+ * 504 storm looked like. Isolated here the bundle is ~141kb.
+ *
+ * Why not share `maple-webhooks` with tallyLeadWebhook
+ * ----------------------------------------------------
+ * This function pulls `@maple/firebase/database` (firebase-admin +
+ * repositories). Merging the two would push that cost onto tallyLeadWebhook,
+ * which has NO retry safety net — Tally drops a failed delivery permanently.
+ * Separate codebases keep each bundle honest.
+ *
+ * KEEP THIS BUNDLE SMALL. Handlers here should stay thin: validate, write to
+ * Firestore, ack. Long-running work belongs in a Firestore-triggered worker
+ * (the `CatalogSyncRequestRepository.requestRefresh()` →
+ * `processCatalogSyncRequest` and `PosSaleRequestRepository.enqueue()`
+ * patterns), not inline on the ack path.
+ */
+// MUST be first: sets global maxInstances before any function is defined.
+// See global-runtime-options.ts for the ordering contract.
+import '@maple/firebase/functions/global-runtime-options';
+import { getApps, initializeApp } from 'firebase-admin/app';
+
+if (getApps().length === 0) {
+  initializeApp();
+}
+
+// ============================================================================
+// Square
+// ============================================================================
+export { squareWebhook } from '@maple/firebase/maple-functions/square-webhook';

--- a/apps/functions-square-webhook/tsconfig.app.json
+++ b/apps/functions-square-webhook/tsconfig.app.json
@@ -1,0 +1,25 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": [
+      "node"
+    ],
+    "rootDir": "../.."
+  },
+  "include": [
+    "src/**/*.ts",
+    "../../libs/firebase/maple-functions/square-webhook/**/*.ts",
+    "../../libs/firebase/database/src/**/*.ts",
+    "../../libs/firebase/functions/src/**/*.ts",
+    "../../libs/ts/domain/src/**/*.ts",
+    "../../libs/ts/firebase/api-types/src/**/*.ts",
+    "../../libs/ts/validation/src/**/*.ts"
+  ],
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.ts"
+  ]
+}

--- a/apps/functions-square-webhook/tsconfig.json
+++ b/apps/functions-square-webhook/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "es2020",
+    "lib": ["es2020"],
+    "types": ["node"],
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "noUnusedLocals": false,
+    "ignoreDeprecations": "6.0"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ]
+}

--- a/apps/functions-square/src/index.ts
+++ b/apps/functions-square/src/index.ts
@@ -20,8 +20,11 @@ export { createProduct } from '@maple/firebase/maple-functions/create-product';
 export { updateProduct } from '@maple/firebase/maple-functions/update-product';
 export { uploadProductImage } from '@maple/firebase/maple-functions/upload-product-image';
 
-// Square webhook (HTTP endpoint, not callable)
-export { squareWebhook } from '@maple/firebase/maple-functions/square-webhook';
+// Square webhook: moved to the maple-square-webhook codebase
+// (apps/functions-square-webhook). Square's delivery deadline is 10s and this
+// bundle cold-starts in 7.5-12s, leaving little or no room for the handler.
+// The workers below stay here — they're Firestore-triggered, not on the ack
+// path, so their cold start costs nothing Square is waiting on. See ADR-031.
 
 // Async catalog sync worker (Firestore-triggered, debounced via lease).
 // Decoupled from squareWebhook so the webhook can ack within Square's

--- a/apps/functions-square/tsconfig.app.json
+++ b/apps/functions-square/tsconfig.app.json
@@ -10,7 +10,6 @@
     "../../libs/firebase/maple-functions/create-product/**/*.ts",
     "../../libs/firebase/maple-functions/update-product/**/*.ts",
     "../../libs/firebase/maple-functions/upload-product-image/**/*.ts",
-    "../../libs/firebase/maple-functions/square-webhook/**/*.ts",
     "../../libs/firebase/maple-functions/process-catalog-sync-request/**/*.ts",
     "../../libs/firebase/maple-functions/process-pos-sale/**/*.ts",
     "../../libs/firebase/maple-functions/create-registration/**/*.ts",

--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -268,7 +268,8 @@ export { revokeRole } from '@maple/firebase/maple-functions/revoke-role';
 
 // Lead attribution: tallyLeadWebhook now lives in the maple-webhooks codebase
 // (apps/functions-webhooks). Tally hangs up at 10s and this bundle takes ~14s
-// to cold start, so nearly every real signup was dropped. Do not move it back.
+// to cold start, so every signup landing on a cold instance was dropped.
+// Do not move it back.
 // Meta Conversions API Purchase on confirmed class registrations — recovers
 // iOS/ITP-dropped and hosted-checkout conversions the browser Pixel misses.
 export { sendRegistrationConversion } from '@maple/firebase/maple-functions/send-registration-conversion';

--- a/docs/architecture/DECISIONS.md
+++ b/docs/architecture/DECISIONS.md
@@ -1414,6 +1414,10 @@ landing in `maple-core` and quietly inheriting a 14s boot.
   ADR said it was in `maple-core` — it was actually in `maple-square` (419kb), which measured
   7.5-12.0s cold. Same class of problem, different bundle; it was given its own
   `maple-square-webhook` codebase in the follow-up (see ADR-032).
+- **Verified in prod 2026-08-07 after deploy: 14.4s → 3.2s cold** (0.77s warm), matching
+  `maple-calendar`'s 3.2s. Confirmed as a genuine cold start by probing an idle `maple-core`
+  function in the same window as a control. The codebase move deployed cleanly — firebase-tools
+  relabelled the function in place, with no `functions:delete` and no gap in availability.
 - The five already-failed submissions are not recovered by this change; they must be resent from
   Tally's events log after deploy. Verified 2026-08-07: all five leads (`drock865@gmail.com`,
   `christinepill@yahoo.com`, `a.umbel@protonmail.com`, `danielle.bradke@gmail.com`,

--- a/docs/architecture/DECISIONS.md
+++ b/docs/architecture/DECISIONS.md
@@ -1410,11 +1410,74 @@ landing in `maple-core` and quietly inheriting a 14s boot.
   repositories, the Square SDK, or webflow-api re-inflates the bundle and reintroduces the outage
   for everything else in it. That constraint is documented at the entry point and in
   `.claude/rules/firebase-functions.md`; if a new webhook is heavier, it gets its own codebase.
-- `squareWebhook` is still in `maple-core` at ~14s cold and survives only because Square retries.
-  It is the obvious next tenant, but it carries Firestore + Square deps, so it needs its own
-  codebase rather than a seat in this one.
+- `squareWebhook` has the same 10s budget. **Correction (2026-08-07):** the first draft of this
+  ADR said it was in `maple-core` — it was actually in `maple-square` (419kb), which measured
+  7.5-12.0s cold. Same class of problem, different bundle; it was given its own
+  `maple-square-webhook` codebase in the follow-up (see ADR-032).
 - The five already-failed submissions are not recovered by this change; they must be resent from
-  Tally's events log after deploy.
+  Tally's events log after deploy. Verified 2026-08-07: all five leads (`drock865@gmail.com`,
+  `christinepill@yahoo.com`, `a.umbel@protonmail.com`, `danielle.bradke@gmail.com`,
+  `paperruth@gmail.com`) **are** active subscribers in MailerLite, so no signups were lost —
+  Tally's MailerLite integration delivers independently of the webhook. Only the GA4
+  `generate_lead` and Meta `Lead` attribution events were dropped.
+
+---
+
+## ADR-032: `squareWebhook` Gets Its Own Codebase, Separate From `maple-webhooks`
+
+**Status:** Accepted
+**Date:** 2026-08-07
+
+### Context
+ADR-031 isolated `tallyLeadWebhook` after Tally dropped five leads to 10s delivery timeouts.
+`squareWebhook` runs against the same 10s ceiling (Square records `http_timeout`, shown as 504 in
+the dashboard, then retries with backoff for up to 24h — the 2026-05 storm).
+
+It was **not** in `maple-core`, as ADR-031's first draft claimed; it was in `maple-square` (419kb).
+Measured cold on 2026-08-07 with invalid-signature probes:
+
+| Function | Codebase | Bundle | Cold |
+|----------|----------|--------|------|
+| `squareWebhook` | `maple-square` | 419kb | 7.5s |
+| `syncInventoryToSquare` | `maple-square` | 419kb | 12.0s |
+
+Two functions, one bundle, a 4.5s spread — **cold start is a distribution, not a number**;
+placement and image-cache state dominate. 7.5s of boot leaves ~2.5s for a handler whose inventory
+path does a full `ProductRepository.findAll()` plus per-product writes. The 12.0s sample is over
+budget before the handler starts at all.
+
+### Decision
+Give `squareWebhook` its own codebase, `maple-square-webhook` (`apps/functions-square-webhook/`),
+at 141kb. Leave `processCatalogSyncRequest` and `processPosSale` in `maple-square` — they are
+Firestore-triggered workers, so their cold start is not on any deadline Square is waiting on.
+
+### Rationale
+Same lever as ADR-031, and the only one that moves: bundle size is what shifts the cold-start
+distribution. 419kb → 141kb buys real margin against a ceiling we do not control.
+
+### Alternatives Considered
+- **Put it in `maple-webhooks` alongside `tallyLeadWebhook`** — one fewer codebase, and the merged
+  bundle (~145kb) would still be under 10s for both. Rejected: `squareWebhook` needs
+  `@maple/firebase/database`, so this spends `tallyLeadWebhook`'s margin on a function that has
+  Square's retries as a safety net, while Tally has none. Asymmetric risk, so keep them apart —
+  exactly the rule ADR-031 wrote down.
+- **Ack fast, defer everything to Firestore workers** — the pattern already used for catalog sync
+  and POS sales. Still the right end state for the inline inventory/invoice/subscription paths,
+  but it doesn't help the failure mode that actually bites (timeout *before the handler runs*),
+  and it changes retry semantics on payment-adjacent code. Not worth bundling into this move.
+- **`minInstances: 1`** — rejected for the same quota and cost reasons as ADR-031.
+
+### Consequences
+- Six codebases. The per-codebase wiring cost from ADR-031 applies again, and a full redeploy gains
+  one more sequential unit.
+- The webhook URL is unchanged — `FirebaseProject.functionUrl()` is
+  `{base}/{functionName}`, independent of codebase — so Square's registered notification URL and
+  the HMAC signature (computed over that URL) keep working. **No Square dashboard change needed.**
+- `maple-square` keeps the Square SDK and the workers; only the receiver moved.
+- Moving a function between codebases relabels it in place. Watch the first deploy: if
+  firebase-tools declines to adopt the function under the new codebase, the fallback is
+  `firebase functions:delete squareWebhook` followed by a redeploy — which would drop webhook
+  deliveries in the gap, so it must be done deliberately, not as a reflex.
 
 ---
 

--- a/docs/architecture/ci-cd.md
+++ b/docs/architecture/ci-cd.md
@@ -94,7 +94,7 @@ The harness deploys to a dedicated Hosting site `maple-spruce-registration-test`
 
 ### Codebases
 
-Functions are split into 5 Firebase codebases to reduce cold start times (see ADR-026, ADR-031):
+Functions are split into 6 Firebase codebases to reduce cold start times (see ADR-026, ADR-031):
 
 | Codebase | App Project | Entry Point |
 |----------|-------------|-------------|
@@ -103,6 +103,7 @@ Functions are split into 5 Firebase codebases to reduce cold start times (see AD
 | `maple-square` | `apps/functions-square/` | `apps/functions-square/src/index.ts` |
 | `maple-sync` | `apps/functions-sync/` | `apps/functions-sync/src/index.ts` |
 | `maple-webhooks` | `apps/functions-webhooks/` | `apps/functions-webhooks/src/index.ts` |
+| `maple-square-webhook` | `apps/functions-square-webhook/` | `apps/functions-square-webhook/src/index.ts` |
 
 Adding a codebase means touching, at minimum: `firebase.json`, `function-codebases.json`
 (`codebaseProjects` + a `functionToCodebase` entry keyed by **Nx project name**), the

--- a/docs/reference/deployed-functions.md
+++ b/docs/reference/deployed-functions.md
@@ -1,7 +1,7 @@
 # Deployed Functions
 
 > All Cloud Functions deploy to `us-east4` (Northern Virginia).
-> Functions are split into 5 codebases to reduce cold start times.
+> Functions are split into 6 codebases to reduce cold start times.
 
 ## Codebase: `maple-core` (`apps/functions/`)
 

--- a/docs/sessions/SESSION.md
+++ b/docs/sessions/SESSION.md
@@ -18,15 +18,26 @@ Tally does not retry, so each one was a lost lead.
 Fix: new `maple-webhooks` codebase (`apps/functions-webhooks/`, 90kb vs 488kb) holding just
 `tallyLeadWebhook`, plus `AbortSignal.timeout` on the GA4/Meta beacons. See ADR-031.
 
-**Follow-ups**:
-- **Resend the 5 failed submissions** from Tally's events log once deployed (they are not
-  recovered automatically), and confirm the leads reached MailerLite — only the GA4/Meta
-  attribution events were lost if Tally's MailerLite integration delivered independently.
+**Findings / follow-ups**:
+- **No subscribers were lost.** All five affected leads are active in MailerLite (Tally's
+  MailerLite integration delivers independently of the webhook). Only the GA4 `generate_lead` and
+  Meta `Lead` attribution events were dropped. The five map exactly to Tally's reports — every
+  failure followed a 7.7-23h idle gap, and every delivery within ~6h of a previous one succeeded.
+- **Resending the 5 from Tally's events log is optional and low-value.** The handler stamps
+  `event_time` at send, so a resend today books the leads as today's conversions — it does not
+  restore the original dates. Only worth it for the Meta signal (the original `_fbc` click IDs
+  still identify the campaign). Must wait until the fix is actually deployed or it will just
+  time out again.
 - Verify post-deploy that the function re-registered under the new codebase and that a cold call
   now answers well under 10s.
-- `squareWebhook` has the same 10s budget and still lives in `maple-core` at ~14s cold; it
-  survives on Square's retries. Worth its own codebase (it carries Firestore + Square deps, so it
-  can't share `maple-webhooks`).
+
+### squareWebhook — `maple-square-webhook` codebase (2026-08-07)
+
+Follow-up to the above. `squareWebhook` was **not** in `maple-core` (an error in ADR-031's first
+draft) — it was in `maple-square` (419kb), measured **7.5s** cold, with a sibling in the same
+bundle at **12.0s**. Same 10s ceiling; it survives on Square's retries. Moved to its own 141kb
+`maple-square-webhook` codebase; the Firestore-triggered workers stay in `maple-square`. Webhook
+URL is unchanged, so no Square dashboard change is needed. See ADR-032.
 
 ---
 

--- a/firebase.json
+++ b/firebase.json
@@ -31,6 +31,11 @@
       "source": "dist/apps/functions-webhooks",
       "runtime": "nodejs22",
       "codebase": "maple-webhooks"
+    },
+    {
+      "source": "dist/apps/functions-square-webhook",
+      "runtime": "nodejs22",
+      "codebase": "maple-square-webhook"
     }
   ],
   "hosting": [

--- a/function-codebases.json
+++ b/function-codebases.json
@@ -4,7 +4,8 @@
     "maple-calendar": "functions-calendar",
     "maple-square": "functions-square",
     "maple-sync": "functions-sync",
-    "maple-webhooks": "functions-webhooks"
+    "maple-webhooks": "functions-webhooks",
+    "maple-square-webhook": "functions-square-webhook"
   },
   "functionToCodebase": {
     "firebase-maple-functions-calendar-classes-feed": "maple-calendar",
@@ -19,7 +20,7 @@
     "firebase-maple-functions-create-product": "maple-square",
     "firebase-maple-functions-update-product": "maple-square",
     "firebase-maple-functions-upload-product-image": "maple-square",
-    "firebase-maple-functions-square-webhook": "maple-square",
+    "firebase-maple-functions-square-webhook": "maple-square-webhook",
     "firebase-maple-functions-process-catalog-sync-request": "maple-square",
     "firebase-maple-functions-process-pos-sale": "maple-square",
     "firebase-maple-functions-create-registration": "maple-square",

--- a/libs/firebase/maple-functions/tally-lead-webhook/src/lib/tally-lead-webhook.ts
+++ b/libs/firebase/maple-functions/tally-lead-webhook/src/lib/tally-lead-webhook.ts
@@ -25,9 +25,11 @@
  *
  * - This function lives in the deliberately tiny `maple-webhooks` codebase
  *   (apps/functions-webhooks), NOT maple-core. Boot time is set by the whole
- *   codebase bundle, and maple-core measured 14.4s cold vs ~1s warm — the form
- *   draws about one signup a day, so it was cold for nearly every real
- *   delivery and Tally dropped five leads between 2026-07-30 and 2026-08-06.
+ *   codebase bundle, and maple-core measured 14.4s cold vs ~1s warm. Signups
+ *   arrive in small clusters a day or more apart, so the first delivery after
+ *   each idle gap paid full boot cost: of the 23 submissions between
+ *   2026-07-30 and 2026-08-06, all 5 failures followed a 7.7-23h gap and every
+ *   delivery within ~6h of a previous one succeeded.
  * - Both beacons are bounded (see GA4_TIMEOUT_MS / META_TIMEOUT_MS); `fetch`
  *   has no default timeout, so an unbounded hang would blow the budget even
  *   from a warm instance.

--- a/tools/check-callable-roles.ts
+++ b/tools/check-callable-roles.ts
@@ -42,6 +42,7 @@ const ENTRY_POINTS = [
   'apps/functions-square/src/index.ts',
   'apps/functions-sync/src/index.ts',
   'apps/functions-webhooks/src/index.ts',
+  'apps/functions-square-webhook/src/index.ts',
 ];
 
 const MAPLE_FUNCTIONS_PREFIX = '@maple/firebase/maple-functions/';

--- a/tools/run-integration-tests.sh
+++ b/tools/run-integration-tests.sh
@@ -54,6 +54,7 @@ pnpm exec nx run functions-square:build
 pnpm exec nx run functions-sync:build
 pnpm exec nx run functions-calendar:build
 pnpm exec nx run functions-webhooks:build
+pnpm exec nx run functions-square-webhook:build
 
 # ---------------------------------------------------------------------------
 # 3. Set up .env and .secret.local for every codebase
@@ -67,7 +68,7 @@ pnpm exec nx run functions-webhooks:build
 #    overrides.
 # ---------------------------------------------------------------------------
 echo "Setting up emulator environment..."
-for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks; do
+for dir in dist/apps/functions dist/apps/functions-square dist/apps/functions-sync dist/apps/functions-calendar dist/apps/functions-webhooks dist/apps/functions-square-webhook; do
   # Strip comments and blank lines — Firebase .env parser needs clean key=value pairs
   grep -v '^#' .env.dev | grep -v '^$' > "$dir/.env"
 done
@@ -85,12 +86,16 @@ printf "ETSY_API_KEY=fake\nETSY_SHARED_SECRET=fake\nGA4_API_SECRET=test-ga4-secr
 # maple-webhooks: tallyLeadWebhook declares these defineSecret params;
 # without them the emulator silently waits on stdin for each one.
 printf "TALLY_WEBHOOK_SECRET=test-tally-secret\nGA4_API_SECRET=test-ga4-secret\nMETA_CAPI_TOKEN=test-meta-token\n" > dist/apps/functions-webhooks/.secret.local
+
 # tallyLeadWebhook → GA4 + Meta CAPI mock servers
 echo "GA4_BASE_URL=http://localhost:$GA4_MOCK_SERVER_PORT" >> dist/apps/functions-webhooks/.env
 echo "META_CAPI_BASE_URL=http://localhost:$META_CAPI_MOCK_SERVER_PORT" >> dist/apps/functions-webhooks/.env
 echo "GA4_MEASUREMENT_ID=G-TEST-MOCK" >> dist/apps/functions-webhooks/.env
 echo "META_PIXEL_ID=test-pixel-id" >> dist/apps/functions-webhooks/.env
 echo "META_CAPI_API_VERSION=v20.0" >> dist/apps/functions-webhooks/.env
+
+# maple-square-webhook: squareWebhook declares this defineSecret param.
+printf "SQUARE_WEBHOOK_SIGNATURE_KEY=mock-key\\n" > dist/apps/functions-square-webhook/.secret.local
 
 # maple-square: Square mock server URL + fake secrets
 echo "SQUARE_BASE_URL=http://localhost:$SQUARE_MOCK_SERVER_PORT" >> dist/apps/functions-square/.env

--- a/tools/validate-function-tsconfigs.sh
+++ b/tools/validate-function-tsconfigs.sh
@@ -21,7 +21,7 @@ NC='\033[0m'
 
 ERRORS=0
 
-APP_DIRS=("apps/functions" "apps/functions-calendar" "apps/functions-square" "apps/functions-sync" "apps/functions-webhooks")
+APP_DIRS=("apps/functions" "apps/functions-calendar" "apps/functions-square" "apps/functions-sync" "apps/functions-webhooks" "apps/functions-square-webhook")
 
 check_codebase() {
   local APP_DIR="$1"
@@ -101,7 +101,7 @@ if [[ ! -f "$MAPPING_FILE" ]]; then
 fi
 
 # Check that every non-core function export has a mapping
-NON_CORE_DIRS=("apps/functions-calendar" "apps/functions-square" "apps/functions-sync" "apps/functions-webhooks")
+NON_CORE_DIRS=("apps/functions-calendar" "apps/functions-square" "apps/functions-sync" "apps/functions-webhooks" "apps/functions-square-webhook")
 for APP_DIR in "${NON_CORE_DIRS[@]}"; do
   ENTRY="${APP_DIR}/src/index.ts"
   [[ ! -f "$ENTRY" ]] && continue


### PR DESCRIPTION
Follow-up to #758 / ADR-031, which isolated `tallyLeadWebhook` after Tally dropped five leads to 10s delivery timeouts. `squareWebhook` runs against the same 10s ceiling.

## Correcting the record

ADR-031 said `squareWebhook` was in `maple-core`. **It wasn't** — it was in `maple-square`. The lookup I based that on used a camelCase key, but `function-codebases.json` is keyed by Nx project name, so it silently fell through to the default. Measured properly, with invalid-signature probes against prod (401 returns before any handler logic runs):

| Function | Codebase | Bundle | Cold |
|---|---|---|---|
| `squareWebhook` | `maple-square` | 419kb | **7.5s** |
| `syncInventoryToSquare` | `maple-square` | 419kb | **12.0s** |

Two functions, one bundle, a 4.5s spread — **cold start is a distribution, not a number**; placement and image-cache state dominate. 7.5s of boot leaves ~2.5s for a handler whose inventory path does a full `ProductRepository.findAll()` plus per-product writes. The 12.0s sample is over budget before the handler starts.

Unlike Tally, Square retries with backoff, so this has been self-healing rather than losing data — that's what the 2026-05 504 storm was.

## Change

- **New `maple-square-webhook` codebase** (`apps/functions-square-webhook/`, **141kb** vs 419kb) holding only `squareWebhook`. `processCatalogSyncRequest` and `processPosSale` stay in `maple-square` — they're Firestore-triggered, so their cold start isn't on any deadline Square is waiting on.
- **Deliberately not merged into `maple-webhooks`.** `squareWebhook` needs `@maple/firebase/database`; putting it beside `tallyLeadWebhook` would spend the margin of the one webhook that has *no* retry safety net. That asymmetry is the rule ADR-031 wrote down, so this follows it.
- **The webhook URL is unchanged.** `FirebaseProject.functionUrl()` is `{base}/{functionName}`, independent of codebase, so Square's registered notification URL and the HMAC computed over it keep working. **No Square dashboard change needed.**
- ADR-032 records the decision; ADR-031 gets the `maple-core` correction plus the MailerLite finding.

## Also corrects the Tally framing

Investigating the five reports end-to-end sharpened the picture, and ADR-031 overstated one point ("cold for essentially every delivery"):

| | |
|---|---|
| Failures | all 5 followed a **7.7–23h idle gap** |
| Deliveries within ~6h of a previous one | **0 failures** (18 of them) |
| Long-gap deliveries that still succeeded | 4 |

And the good news, now recorded in ADR-031: **all five affected leads are active subscribers in MailerLite.** Tally's MailerLite integration delivers independently of the webhook, so no signups were lost — only the GA4 `generate_lead` / Meta `Lead` attribution events.

## Verification

- Integration, on emulators: `class-square` **8/8**, `square` **45/45**, `tally-lead-webhook` **9/9**. Logs confirm `squareWebhook` executing from `dist/apps/functions-square-webhook/index.cjs` and verifying signatures against the unchanged URL.
- 59 unit tests; all **6** codebases build; `tsc --noEmit` clean on `functions-square` and the new codebase (esbuild doesn't typecheck, so the removed tsconfig include was checked explicitly); `validate-function-tsconfigs`, `check-callable-roles` (221), and the function-count ratchet (217, unchanged) all pass.
- ⚠️ My first local run showed 8 failures — that was the maple-core emulator runtime crashing locally ("Failed to load function"), which killed the Firestore triggers (processPosSale ran 3× vs 77× on a main baseline). A clean re-run passed 8/8. Worth knowing: `pos-sale-webhook.spec.ts` test **A** is independently flaky — it failed on the main baseline and passed here.

## Sequencing

Worth landing **after** #758's deploy is confirmed, since this repeats the same codebase-move mechanism. If firebase-tools declines to adopt a function under a new codebase, the fallback (`firebase functions:delete` + redeploy) drops deliveries in the gap, so it should be done deliberately — noted in ADR-032.

🤖 Generated with [Claude Code](https://claude.com/claude-code)