### PR TITLE
fix(deps): clear nanoid advisory, accept the unfixable image-size pair

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  nanoid@>=3.0.0 <4: '>=3.3.17 <4'
   lodash: '>=4.18.0'
   axios: '>=1.18.0'
   koa: '>=3.1.2'
@@ -8434,8 +8435,8 @@ packages:
   nan@2.26.2:
     resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -20577,7 +20578,7 @@ snapshots:
   nan@2.26.2:
     optional: true
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -21538,7 +21539,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,13 +24,36 @@ strictPeerDependencies: false
 # accepted go under a top-level `auditConfig.ignoreGhsas:` list, which
 # `pnpm audit --audit-level=high` (build-check.yml → Security Audit) honors.
 # Keep each entry justified; prefer an override every time one exists that
-# doesn't break the build. The list is currently empty — GHSA-mh99-v99m-4gvg
-# (brace-expansion OOM DoS) was accepted on 2026-07-24 because its only patch
-# was 5.0.8, whose CJS entry is API-incompatible with the 1.x/2.x consumers.
-# Upstream has since backported it to 1.1.17/2.1.3, so it is now fixed by the
-# brace-expansion overrides below and the ignore was removed on 2026-08-07.
+# doesn't break the build. (GHSA-mh99-v99m-4gvg, brace-expansion OOM DoS, was
+# accepted on 2026-07-24 and removed on 2026-08-07 once upstream backported
+# the fix to 1.1.17/2.1.3 — see the brace-expansion overrides below.)
+
+auditConfig:
+  ignoreGhsas:
+    # GHSA-w3rx-r6r6-pgpr (ICNS parser infinite loop) and GHSA-5p2g-fcmc-qvqq
+    # (JXL/HEIF parser infinite loops) in image-size. Both advisories declare
+    # a patch in ">=2.0.3", but **image-size 2.0.3 does not exist** — the npm
+    # registry's latest is 2.0.2 (dist-tags: latest 2.0.2, legacy 1.2.1), so
+    # an override to >=2.0.3 cannot resolve. Nothing to upgrade to yet.
+    #
+    # Accepted because the reachable paths are build tooling only:
+    # web > @nx/vite > @nx/vitest > vite > less > image-size (101 paths, all
+    # via less inside vite). `less` compiles stylesheets at build time in CI
+    # and dev; it never runs in a deployed Cloud Function or in the browser
+    # bundle, and it never parses attacker-supplied ICNS/JXL/HEIF images. The
+    # impact is a local DoS on our own build if we fed it a malicious image.
+    #
+    # Revisit once image-size publishes 2.0.3 and swap this for an override.
+    # Accepted 2026-08-07.
+    - GHSA-w3rx-r6r6-pgpr
+    - GHSA-5p2g-fcmc-qvqq
 
 overrides:
+  # GHSA-2v37-7h3g-55p8: nanoid custom generators can loop indefinitely when
+  # size is zero (patched in 3.3.17). Transitive dep of @nx/vite > @nx/vitest >
+  # vite > postcss > nanoid. Bounded to <4 because postcss depends on the 3.x
+  # line; nanoid 4+ is ESM-only and would break its CJS require. Added 2026-08-07.
+  nanoid@>=3.0.0 <4: '>=3.3.17 <4'
   # GHSA-r5fr-rjxr-66jc: Code injection via _.template. Transitive dep of html-webpack-plugin, pretty-error, firebase-tools, wait-on. Added 2026-04-01.
   lodash: '>=4.18.0'
   # GHSA-3p68-rc4w-qgx5 (SSRF via NO_PROXY bypass), GHSA-jr5f-v2jv-69x6


### PR DESCRIPTION
`pnpm audit --audit-level=high` — a **required** status check — went red again after #760, with three new high advisories. Split out from #759 so it unblocks every open PR rather than just the one that tripped over it.

## Fixed by override

**GHSA-2v37-7h3g-55p8** — `nanoid` custom generators loop indefinitely when size is zero. Patched in 3.3.17; resolves to **3.3.18**.

Reached via `@nx/vite > @nx/vitest > vite > postcss > nanoid`. Bounded to `<4` because postcss depends on the 3.x line and nanoid 4+ is ESM-only, which would break its CJS `require`.

## Accepted — because no fix exists

**GHSA-w3rx-r6r6-pgpr** (ICNS parser infinite loop) and **GHSA-5p2g-fcmc-qvqq** (JXL/HEIF parser infinite loops) in `image-size`.

Both advisories declare a patch in `>=2.0.3`, but **image-size 2.0.3 has not been published**:

```
$ npm view image-size@2.0.3 version
npm error 404 No match found for version 2.0.3
$ npm view image-size dist-tags
{ latest: '2.0.2', legacy: '1.2.1' }
```

So an override to `>=2.0.3` cannot resolve — there is nothing to upgrade to. This is the case `pnpm-workspace.yaml` already documents `auditConfig.ignoreGhsas` for, and the file's existing note describes the same accept-then-remove cycle used for `brace-expansion`.

Why it's acceptable: all 101 reachable paths run through `less` inside vite (`web > @nx/vite > @nx/vitest > vite > less > image-size`). `less` compiles stylesheets at build time in CI and dev. It never runs in a deployed Cloud Function or in the browser bundle, and it never parses attacker-supplied ICNS/JXL/HEIF input. Worst case is a DoS on our own build from an image we fed it ourselves.

The inline comment carries a revisit note to swap the ignore for an override once 2.0.3 ships.

## Verification

- `pnpm audit --audit-level=high` exits **0** (`2 high, both ignored`)
- all 5 function codebases **and** the `maple-spruce` web app build
- touched libs' unit tests pass (251)

Only `pnpm-workspace.yaml` and `pnpm-lock.yaml` change; no source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)