### PR TITLE
docs: record measured cold-start outcome for both webhook codebase moves

### DIFF
--- a/.claude/rules/firebase-functions.md
+++ b/.claude/rules/firebase-functions.md
@@ -64,37 +64,51 @@ When adding a new function, export it from the correct codebase's entry point an
 
 A codebase is one bundle. Every function in it loads the whole entry point on
 cold start, so **boot time is set by the heaviest sibling, not by the function
-being called**. Measured against prod on 2026-08-07 (invalid-signature probes,
-so no handler logic ran):
+being called**. Measured against prod with invalid-signature / unauthenticated
+probes, so no handler logic ran:
 
-| Codebase | Bundle | Cold | Warm |
-|----------|--------|------|------|
-| `maple-core` | 488kb | 14.4s, 14.8s | 1.0s |
-| `maple-square` | 419kb | 7.5s, 12.0s | 1.2s |
-| `maple-sync` | 301kb | 6.3s | 1.3s |
-| `maple-square-webhook` | 141kb | — | — |
-| `maple-webhooks` | 90kb | 3.2s | 0.8s |
-| `maple-calendar` | 30kb | 3.2s | 1.1s |
+| Codebase | Bundle | Cold (steady state) | Warm |
+|----------|--------|---------------------|------|
+| `maple-core` | 489kb | ~6.1s | 1.0s |
+| `maple-square` | 412kb | ~5.7s | 1.2s |
+| `maple-sync` | 301kb | 6.3s (single sample) | 1.3s |
+| `maple-square-webhook` | 141kb | ~3.4s | 1.0s |
+| `maple-webhooks` | 90kb | ~2.6s | 0.8s |
+| `maple-calendar` | 30kb | 3.2s (single sample) | 1.1s |
 
-`maple-webhooks` is the post-fix measurement, taken 2026-08-07 after
-`tallyLeadWebhook` shipped: **14.4s → 3.2s cold**, ~7s of margin under Tally's
-10s cutoff. Verified with a same-project control (an idle `maple-core` function
-probed in the same window still cold-started), so the low number is a real cold
-start and not a warm instance.
+Steady-state figures are from paired sampling on 2026-08-09 — every function probed in the
+same 30-minute window, three rounds, so regional load is held constant across bundles. The
+two rows marked *single sample* are unpaired one-offs from 2026-08-07 and are less
+trustworthy (see the traps below — `maple-calendar`'s 3.2s in particular sits below
+`maple-square-webhook` despite a far smaller bundle, which paired sampling would likely
+correct).
 
-**Cold start is a distribution, not a number.** Two functions in the *same*
-`maple-square` bundle measured 7.5s and 12.0s — placement and image-cache state
-swing it by several seconds. Shrinking the bundle shifts the distribution down;
-it does not buy a guarantee. Budget for the bad tail, not the median.
+**Cold start is a distribution, not a number.** The same function, unchanged, measured
+7.7s twice and then 3.4s twice; two functions in one bundle measured 7.5s and 12.0s.
+Shrinking the bundle shifts the distribution down — it does not buy a guarantee.
+Budget for the bad tail, not the median.
+
+**Two traps that will hand you a wrong number.** Both produced wrong conclusions on
+first measurement here, in opposite directions:
+
+1. **Probing soon after a deploy includes a container image pull.** That is where the
+   original "maple-core cold-starts in 14.4s" came from; steady state is ~6s. Wait for
+   the revision to settle before believing a number.
+2. **Repeated probing warms the regional image cache** even though instances still scale
+   to zero, so numbers drift *downward* across a session. For a webhook genuinely called
+   once a day, the pessimistic first-hit figure is the honest one to design against.
+
+So: **never conclude from a single probe.** Pair the function under test against a
+control in a different bundle, hit both in the same window, and repeat.
 
 This matters for any endpoint an external platform calls with a fixed timeout:
 
 - **Tally** hangs up at 10s and does **not** retry — a slow cold start is a
   permanently lost lead. This is what put `tallyLeadWebhook` in `maple-webhooks`.
 - **Square** hangs up at 10s and *does* retry with backoff (see the 2026-05
-  504 storm). `squareWebhook` sat in `maple-square` (419kb), which booted in
-  7.5-12s — sometimes leaving under a second for the handler. It now has its
-  own `maple-square-webhook` codebase.
+  504 storm). `squareWebhook` sat in `maple-square`, and now has its own
+  `maple-square-webhook` codebase: ~3.4s cold versus ~5.7s for the bundle it left,
+  measured in the same window.
 
 Both webhooks are in *separate* codebases on purpose. `squareWebhook` needs
 `@maple/firebase/database`; sharing a bundle would push that weight onto

--- a/docs/architecture/DECISIONS.md
+++ b/docs/architecture/DECISIONS.md
@@ -1415,7 +1415,11 @@ landing in `maple-core` and quietly inheriting a 14s boot.
   7.5-12.0s cold. Same class of problem, different bundle; it was given its own
   `maple-square-webhook` codebase in the follow-up (see ADR-032).
 - **Verified in prod 2026-08-07 after deploy: 14.4s → 3.2s cold** (0.77s warm), matching
-  `maple-calendar`'s 3.2s. Confirmed as a genuine cold start by probing an idle `maple-core`
+  `maple-calendar`'s 3.2s. **Amended 2026-08-09:** both of those figures were measured soon after a
+  deploy and so include a container image pull. Steady-state paired sampling puts `maple-core` at
+  ~6s and `maple-webhooks` at ~2.6s (see ADR-032). The direction and the fix are unchanged — the
+  magnitude was overstated, and ~6s plus two awaited beacons against a 10s ceiling is exactly the
+  marginal position that failed intermittently rather than always. Confirmed as a genuine cold start by probing an idle `maple-core`
   function in the same window as a control. The codebase move deployed cleanly — firebase-tools
   relabelled the function in place, with no `functions:delete` and no gap in availability.
 - The five already-failed submissions are not recovered by this change; they must be resent from
@@ -1478,10 +1482,42 @@ distribution. 419kb → 141kb buys real margin against a ceiling we do not contr
   `{base}/{functionName}`, independent of codebase — so Square's registered notification URL and
   the HMAC signature (computed over that URL) keep working. **No Square dashboard change needed.**
 - `maple-square` keeps the Square SDK and the workers; only the receiver moved.
-- Moving a function between codebases relabels it in place. Watch the first deploy: if
-  firebase-tools declines to adopt the function under the new codebase, the fallback is
-  `firebase functions:delete squareWebhook` followed by a redeploy — which would drop webhook
-  deliveries in the gap, so it must be done deliberately, not as a reflex.
+- Moving a function between codebases relabels it in place. **Confirmed on deploy 2026-08-09:**
+  firebase-tools adopted `squareWebhook` under `maple-square-webhook` with no
+  `firebase functions:delete` and no gap in availability (same as `tallyLeadWebhook` in #758).
+  The delete-and-recreate fallback was not needed and should stay a last resort — it drops
+  deliveries in the gap.
+
+### Measured outcome (2026-08-09, post-deploy)
+
+Paired cold-start probes — all four functions hit in the same 30-minute window, three rounds, so
+regional load is held roughly constant across bundles:
+
+| Bundle | Codebase | Probe function | Cold |
+|--------|----------|----------------|------|
+| 90kb | `maple-webhooks` | `tallyLeadWebhook` | 2.70s / 2.49s / 2.71s |
+| 141kb | `maple-square-webhook` | `squareWebhook` | 3.36s / 3.45s |
+| 412kb | `maple-square` | `syncInventoryToSquare` | 5.77s / 5.73s |
+| 489kb | `maple-core` | `checkAdminStatus` | 6.42s / 5.79s |
+
+Cold start rises monotonically with bundle size, so the lever is real. The like-for-like result
+for this ADR: **`squareWebhook` at ~3.4s versus ~5.7s for the bundle it left**, measured in the
+same window — roughly 2.3s of extra margin under Square's 10s ceiling.
+
+**Two measurement traps this exposed, both of which produced wrong conclusions first time:**
+
+1. **A probe taken shortly after a deploy includes a container image pull.** The 14.4s figure in
+   ADR-031 was measured minutes after a deploy and is NOT steady state; `maple-core`'s steady-state
+   cold start is ~6s. The inflated number over-explained the incident — at a true 14.4s every cold
+   Tally delivery would have failed, whereas only 5 of the 9 long-gap deliveries actually did.
+2. **Repeated probing warms the regional image cache even though instances scale to zero.**
+   `squareWebhook` measured 7.7s twice and then 3.4s twice, unchanged code. For a webhook invoked
+   about once a day the 7.7s-class number is arguably the realistic first-hit cost, and the 3.4s
+   figure is the optimistic one.
+
+Practical consequence: **never conclude from a single probe.** Pair the function under test against
+a control in another bundle, sample repeatedly, and treat cold start as a distribution whose tail
+is what blows a delivery budget.
 
 ---
 

--- a/docs/sessions/SESSION.md
+++ b/docs/sessions/SESSION.md
@@ -34,10 +34,16 @@ Fix: new `maple-webhooks` codebase (`apps/functions-webhooks/`, 90kb vs 488kb) h
 ### squareWebhook — `maple-square-webhook` codebase (2026-08-07)
 
 Follow-up to the above. `squareWebhook` was **not** in `maple-core` (an error in ADR-031's first
-draft) — it was in `maple-square` (419kb), measured **7.5s** cold, with a sibling in the same
-bundle at **12.0s**. Same 10s ceiling; it survives on Square's retries. Moved to its own 141kb
-`maple-square-webhook` codebase; the Firestore-triggered workers stay in `maple-square`. Webhook
-URL is unchanged, so no Square dashboard change is needed. See ADR-032.
+draft) — it was in `maple-square`. Same 10s ceiling; it survives on Square's retries. Moved to its
+own 141kb `maple-square-webhook` codebase; the Firestore-triggered workers stay in `maple-square`.
+Webhook URL is unchanged, so no Square dashboard change was needed. Shipped in #761.
+
+**Measured after deploy (2026-08-09), paired sampling:** `squareWebhook` ~3.4s cold vs ~5.7s for
+the `maple-square` bundle it left; `tallyLeadWebhook` ~2.6s vs ~6.1s for `maple-core`. Both moves
+delivered. Two corrections came out of this: the original "14.4s" for `maple-core` was measured
+minutes after a deploy and included an image pull (steady state ~6s), and a single probe is
+worthless — the same unchanged function read 7.7s twice then 3.4s twice as the regional image
+cache warmed. Always pair against a control and repeat. See ADR-032.
 
 ### Public-site SEO cleanup (2026-08-07)
 


### PR DESCRIPTION
Closes the loop on #758 and #761 with real post-deploy measurements, and corrects two numbers I got wrong along the way.

## Measured outcome

Paired sampling in prod — all four functions probed in the same 30-minute window, three rounds, so regional load is held constant across bundles (invalid-signature / unauthenticated probes, so no handler logic runs):

| Bundle | Codebase | Probe | Cold |
|---|---|---|---|
| 90kb | `maple-webhooks` | `tallyLeadWebhook` | 2.70s / 2.49s / 2.71s |
| 141kb | `maple-square-webhook` | `squareWebhook` | 3.36s / 3.45s |
| 412kb | `maple-square` | `syncInventoryToSquare` | 5.77s / 5.73s |
| 489kb | `maple-core` | `checkAdminStatus` | 6.42s / 5.79s |

Cold start rises monotonically with bundle size, so the lever is real and **both moves delivered**:

- `squareWebhook` **~3.4s vs ~5.7s** for the bundle it left (like-for-like, same window)
- `tallyLeadWebhook` **~2.6s vs ~6.1s** for `maple-core`

Also confirms firebase-tools adopted `squareWebhook` under its new codebase **in place** on deploy — no `functions:delete`, no availability gap, same as #758. ADR-032's forward-looking "watch the first deploy" note is replaced with the outcome.

## Two corrections

Both of these produced wrong conclusions on first measurement, in opposite directions, so they're written into `.claude/rules/firebase-functions.md` rather than just fixed in place:

1. **The "14.4s" for `maple-core` in ADR-031 was inflated.** It was probed minutes after a deploy, so it included a container image pull. Steady state is ~6s. The inflated figure over-explained the incident — at a true 14.4s *every* cold Tally delivery would have failed, whereas only 5 of the 9 long-gap deliveries actually did. ~6s plus two awaited beacons against a 10s ceiling is exactly the marginal position that fails intermittently.
2. **Repeated probing warms the regional image cache** even though instances still scale to zero. `squareWebhook` read 7.7s twice and then 3.4s twice with no code change. I briefly concluded from those first readings that #761 had bought nothing — that was wrong, and it was wrong because it rested on a single unpaired sample.

The rule now says plainly: never conclude from one probe; pair against a control in another bundle, hit both in the same window, and repeat. For a webhook genuinely invoked once a day, the pessimistic first-hit number is the honest one to design against.

Docs only — no code, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)